### PR TITLE
Added task map handling to the SmaplingProblem

### DIFF
--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -70,8 +70,7 @@ namespace exotica
         state, q);
 #endif
 
-    prob_->Update(q);
-    if (!prob_->getScene()->getCollisionScene()->isStateValid(self_collision_, margin_))
+    if (!prob_->isValid(q) || !prob_->getScene()->getCollisionScene()->isStateValid(self_collision_, margin_))
     {
       dist = -1;
       return false;

--- a/exotations/task_maps/task_map/src/Distance.cpp
+++ b/exotations/task_maps/task_map/src/Distance.cpp
@@ -43,7 +43,7 @@ namespace exotica
 
     void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     {
-        if(phi.rows() != Kinematics.Phi.rows()*3) throw_named("Wrong size of phi!");
+        if(phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
         for(int i=0;i<Kinematics.Phi.rows();i++)
         {
             phi(i) = Kinematics.Phi(i).p.Norm();

--- a/exotica/include/exotica/Problems/SamplingProblem.h
+++ b/exotica/include/exotica/Problems/SamplingProblem.h
@@ -39,15 +39,6 @@
 
 namespace exotica
 {
-
-  enum SamplingProblem_Type
-  {
-    OMPL_PROBLEM_GOAL = 0,
-    OMPL_PROBLEM_COSTS,
-    OMPL_PROBLEM_GOAL_BIAS,
-    OMPL_PROBLEM_SAMPLING_BIAS
-  };
-
   class SamplingProblem: public PlanningProblem, public Instantiable<SamplingProblemInitializer>
   {
     public:
@@ -57,8 +48,16 @@ namespace exotica
       virtual void Instantiate(SamplingProblemInitializer& init);
 
       void Update(Eigen::VectorXdRefConst x);
+      bool isValid(Eigen::VectorXdRefConst x);
 
       int getSpaceDim();
+
+      void setGoal(const std::string & task_name, Eigen::VectorXdRefConst goal);
+      void setThreshold(const std::string & task_name, Eigen::VectorXdRefConst threshold);
+      void setRho(const std::string & task_name, const double rho);
+      Eigen::VectorXd getGoal(const std::string & task_name);
+      Eigen::VectorXd getThreshold(const std::string & task_name);
+      double getRho(const std::string & task_name);
 
       std::vector<double>& getBounds();
       bool isCompoundStateSpace();
@@ -70,6 +69,17 @@ namespace exotica
       void setGoalState(Eigen::VectorXdRefConst qT);
 
       Eigen::VectorXd goal_;
+      Eigen::VectorXd Rho;
+      TaskSpaceVector y;
+      TaskSpaceVector Phi;
+      Eigen::VectorXd threshold_;
+
+      int PhiN;
+      int JN;
+      int NumTasks;
+      Eigen::MatrixXd S;
+      bool isValid_;
+
     private:
       std::vector<double> bounds_;
       bool compound_;

--- a/exotica/include/exotica/Problems/SamplingProblem.h
+++ b/exotica/include/exotica/Problems/SamplingProblem.h
@@ -78,7 +78,6 @@ namespace exotica
       int JN;
       int NumTasks;
       Eigen::MatrixXd S;
-      bool isValid_;
 
     private:
       std::vector<double> bounds_;

--- a/exotica/init/SamplingProblem.in
+++ b/exotica/init/SamplingProblem.in
@@ -1,5 +1,8 @@
 extend <exotica/PlanningProblem>
 Required Eigen::VectorXd Goal;
+Optional Eigen::VectorXd Rho = Eigen::VectorXd();
+Optional Eigen::VectorXd TaskGoal = Eigen::VectorXd();
+Optional Eigen::VectorXd Threshold = Eigen::VectorXd();
 Optional std::string LocalPlannerConfig = "";
 Optional Eigen::VectorXd FloatingBaseLowerLimits = Eigen::VectorXd();
 Optional Eigen::VectorXd FloatingBaseUpperLimits = Eigen::VectorXd();

--- a/exotica/resources/configs/ompl_solver_demo.xml
+++ b/exotica/resources/configs/ompl_solver_demo.xml
@@ -18,6 +18,17 @@
       </Scene>
     </PlanningScene>
 
+    <Maps>
+      <Distance Name="Distance">
+        <EndEffector>
+            <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0.1 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.35 -0.2 0.9 0 0 0 1"/>
+        </EndEffector>
+      </Distance>
+    </Maps>
+
+    <TaskGoal>0.42</TaskGoal>
+    <Rho>-1</Rho>
+
     <Goal>2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>
 

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -80,7 +80,7 @@ namespace exotica
         qNominal = init.NominalState;
 
         if(init.Rho.rows()>0 && init.Rho.rows()!=NumTasks) throw_named("Invalid size of Rho (" << init.Rho.rows() << ") expected: "<< NumTasks);
-        if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalid size of Rho (" << init.Goal.rows() << ") expected: "<< PhiN);
+        if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalid size of Goal (" << init.Goal.rows() << ") expected: "<< PhiN);
 
         if(init.Rho.rows()==NumTasks) Rho = init.Rho;
         if(init.Goal.rows()==PhiN) y.data = init.Goal;


### PR DESCRIPTION
- Sampling problem now uses task maps, rho and thresholds.
- ```isValid(x)``` method check for validity by computing `rho(Phi-y)<threshold`. Use negative `rho` to emulate the `>=` operator.
- OMPL solver now calls ```isValid```. If no task maps are defined, behaviour is the same as before.
- Fixed `Distance` task map. ```Update(x)``` was failing due to wrong indexing (```Update(x,J)``` overload was working fine).

Fixes #92