### PR TITLE
Compute scene object frames in the kinematic tree

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -181,6 +181,7 @@ namespace exotica
               return ModelJointsNames;
             }
 
+            void UpdateModel();
             Eigen::VectorXd getModelState();
             std::map<std::string, double> getModelStateMap();
             void setModelState(Eigen::VectorXdRefConst x);
@@ -208,6 +209,7 @@ namespace exotica
             Eigen::VectorXd TreeState;
             robot_model::RobotModelPtr Model;
             std::vector<std::shared_ptr<KinematicElement>> Tree;
+            std::vector<std::shared_ptr<KinematicElement>> ModelTree;
             std::map<std::string, std::shared_ptr<KinematicElement>> TreeMap;
             std::shared_ptr<KinematicElement> Root;
             std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -112,6 +112,7 @@ namespace exotica
       KDL::Segment Segment;
       KDL::Frame Frame;
       std::vector<double> JointLimits;
+      shapes::ShapeConstPtr Shape;
   };
 
   struct KinematicFrame
@@ -181,7 +182,10 @@ namespace exotica
               return ModelJointsNames;
             }
 
+            void resetModel();
+            void AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr));
             void UpdateModel();
+
             Eigen::VectorXd getModelState();
             std::map<std::string, double> getModelStateMap();
             void setModelState(Eigen::VectorXdRefConst x);
@@ -189,6 +193,7 @@ namespace exotica
             Eigen::VectorXd getControlledState();
 
             std::vector<std::shared_ptr<KinematicElement>> getTree() {return Tree;}
+            std::vector<std::shared_ptr<KinematicElement>> getCollisionTree() {return CollisionTree;}
             std::map<std::string, std::shared_ptr<KinematicElement>> getTreeMap() {return TreeMap;}
             bool Debug;
 
@@ -201,6 +206,7 @@ namespace exotica
             void UpdateJ();
             void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);
 
+
             BASE_TYPE ModelBaseType;
             BASE_TYPE ControlledBaseType = BASE_TYPE::FIXED;
             int NumControlledJoints; //!< Number of controlled joints in the joint group.
@@ -211,6 +217,7 @@ namespace exotica
             std::vector<std::shared_ptr<KinematicElement>> Tree;
             std::vector<std::shared_ptr<KinematicElement>> ModelTree;
             std::map<std::string, std::shared_ptr<KinematicElement>> TreeMap;
+            std::vector<std::shared_ptr<KinematicElement>> CollisionTree;
             std::shared_ptr<KinematicElement> Root;
             std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;
             std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -350,6 +350,7 @@ namespace exotica
       void setModelState(Eigen::VectorXdRefConst x);
       void setModelState(std::map<std::string, double> x);
       std::string getGroupName();
+      void updateSceneFrames();
 
       BASE_TYPE getBaseType()
       {

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -350,6 +350,8 @@ namespace exotica
       void setModelState(Eigen::VectorXdRefConst x);
       void setModelState(std::map<std::string, double> x);
       std::string getGroupName();
+
+      /// \brief Updates exotica scene object frames from the MoveIt scene.
       void updateSceneFrames();
 
       BASE_TYPE getBaseType()

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -182,21 +182,22 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
     }
 
     AddElement(RobotKinematics.getRootSegment(), *(Tree.end()-1));
+    ModelTree = Tree;
+
+    UpdateModel();
 
     NumJoints = ModelJointsNames.size();
     NumControlledJoints = ControlledJointsNames.size();
     if (NumControlledJoints < 1) throw_pretty("No update joints specified!");
     ControlledJoints.resize(NumControlledJoints);
-    Root = Tree[0];
-    TreeState = Eigen::VectorXd::Zero(Tree.size());
     for(std::shared_ptr<KinematicElement> Joint : Tree)
     {
         Joint->ControlId = IsControlled(Joint);
         Joint->IsControlled = Joint->ControlId >= 0;
         if(Joint->IsControlled) ControlledJoints[Joint->ControlId] = Joint;
-        TreeMap[Joint->Segment.getName()] = Joint;
         ModelJointsMap[Joint->Segment.getJoint().getName()] = Joint;
-        if (Joint->IsControlled) {
+        if (Joint->IsControlled)
+        {
           ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
 
           // The ModelBaseType defined above refers to the base type of the
@@ -216,6 +217,16 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
     setJointLimits();
 }
 
+void KinematicTree::UpdateModel()
+{
+    Root = Tree[0];
+    TreeState = Eigen::VectorXd::Zero(Tree.size());
+    for(std::shared_ptr<KinematicElement> Joint : Tree)
+    {
+        TreeMap[Joint->Segment.getName()] = Joint;
+    }
+    debugTree.resize(Tree.size()-1);
+}
 void KinematicTree::AddElement(KDL::SegmentMap::const_iterator segment, std::shared_ptr<KinematicElement> parent)
 {
     std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent, segment->second.segment));

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -240,19 +240,19 @@ void KinematicTree::resetModel()
 
 void KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape)
 {
-    std::shared_ptr<KinematicElement> parent_emelent;
+    std::shared_ptr<KinematicElement> parent_element;
     if(parent=="")
     {
-        parent_emelent = Tree[0];
+        parent_element = Tree[0];
     }
     else
     {
         bool found = false;
-        for(auto element : Tree)
+        for(const auto& element : Tree)
         {
             if(element->Segment.getName()==parent)
             {
-                parent_emelent = element;
+                parent_element = element;
                 found = true;
                 break;
             }
@@ -261,14 +261,14 @@ void KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transfo
     }
     KDL::Frame transformKDL;
     tf::transformEigenToKDL(transform, transformKDL);
-    std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent_emelent, KDL::Segment(name, KDL::Joint(KDL::Joint::None), transformKDL)));
+    std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent_element, KDL::Segment(name, KDL::Joint(KDL::Joint::None), transformKDL)));
     if(shape)
     {
         NewElement->Shape = shape;
         CollisionTree.push_back(NewElement);
     }
     Tree.push_back(NewElement);
-    parent_emelent->Children.push_back(NewElement);
+    parent_element->Children.push_back(NewElement);
 }
 
 void KinematicTree::AddElement(KDL::SegmentMap::const_iterator segment, std::shared_ptr<KinematicElement> parent)

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -862,12 +862,11 @@ namespace exotica
           {
               // Use the first collision shape as the origin of the object
               Eigen::Affine3d objTransform = object.second->shape_poses_[0];
-              std::string objectName = object.first;
-              kinematica_.AddElement(objectName, objTransform);
+              kinematica_.AddElement(object.first, objTransform);
               for(int i=0; i<object.second->shape_poses_.size();i++)
               {
                   Eigen::Affine3d trans = objTransform.inverse()*object.second->shape_poses_[i];
-                  kinematica_.AddElement(objectName+"_collision_"+std::to_string(i), trans, objectName, object.second->shapes_[i]);
+                  kinematica_.AddElement(object.first+"_collision_"+std::to_string(i), trans, object.first, object.second->shapes_[i]);
               }
           }
           else


### PR DESCRIPTION
- Saves a copy of the robot model tree after loading/initialization.
- Adds ```KinematicTree::AddElement``` for adding extra frames to the kinematics solver.
- ```KinematicElement``` now contains a ```shapes::Shape``` in anticipation of directly feeding this into the ```CollisionScene```, bypassing moveit when setting up FCL.
- Adds ```Scene::updateSceneFrames``` to populate the kinematic tree with objects and colliding shapes currently in the moveit planning scene.

RViz now displays frames of collision shapes.