### PR TITLE
MotionSolver: be able to provide initial guess from Python

### DIFF
--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -96,17 +96,14 @@ namespace exotica
       virtual ~AICOsolver();
       /**
        * \brief Solves the problem
-       * @param q0 Start state.
-       * @param solution This will be filled with the solution in joint space.
-       * @return SUCESS if solution has been found, corresponding error code if not.
+       * @param solution Returned solution trajectory as a vector of joint configurations.
        */
       void Solve(Eigen::MatrixXd & solution);
 
       /**
        * \brief Solves the problem
        * @param q_init Trajectory initialisation.
-       * @param solution This will be filled with the solution in joint space.
-       * @return SUCESS if solution has been found, corresponding error code if not.
+       * @param solution Returned solution trajectory as a vector of joint configurations.
        */
       void Solve(const std::vector<Eigen::VectorXd>& q_init,
           Eigen::MatrixXd & solution);

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -101,14 +101,6 @@ namespace exotica
       void Solve(Eigen::MatrixXd & solution);
 
       /**
-       * \brief Solves the problem
-       * @param q_init Trajectory initialisation.
-       * @param solution Returned solution trajectory as a vector of joint configurations.
-       */
-      void Solve(const std::vector<Eigen::VectorXd>& q_init,
-          Eigen::MatrixXd & solution);
-
-      /**
        * \brief Binds the solver to a specific problem which must be pre-initalised
        * @param pointer Shared pointer to the motion planning problem
        * @return        Successful if the problem is a valid UnconstrainedTimeIndexedProblem

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -51,6 +51,7 @@ namespace exotica
         virtual void InstantiateBase(const Initializer& init);
         virtual void specifyProblem(PlanningProblem_ptr pointer);
         virtual void Solve(Eigen::MatrixXd & solution) = 0;
+        virtual void Solve(const std::vector<Eigen::VectorXd>& init, Eigen::MatrixXd & solution);
         PlanningProblem_ptr getProblem() {return problem_;}
         virtual std::string print(std::string prepend);
 

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -51,7 +51,6 @@ namespace exotica
         virtual void InstantiateBase(const Initializer& init);
         virtual void specifyProblem(PlanningProblem_ptr pointer);
         virtual void Solve(Eigen::MatrixXd & solution) = 0;
-        virtual void Solve(const std::vector<Eigen::VectorXd>& init, Eigen::MatrixXd & solution);
         PlanningProblem_ptr getProblem() {return problem_;}
         virtual std::string print(std::string prepend);
 

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -58,6 +58,8 @@ namespace exotica
       void setRho(const std::string & task_name, const double rho, int t = 0);
       Eigen::VectorXd getGoal(const std::string & task_name, int t = 0);
       double getRho(const std::string & task_name, int t = 0);
+      std::vector<Eigen::VectorXd> getInitialTrajectory();
+      void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
 
 
       int T; //!< Number of time steps
@@ -79,6 +81,8 @@ namespace exotica
       int JN;
       int NumTasks;
 
+    private:
+      std::vector<Eigen::VectorXd> InitialTrajectory;
   };
 
   typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;

--- a/exotica/src/MotionSolver.cpp
+++ b/exotica/src/MotionSolver.cpp
@@ -57,4 +57,10 @@ namespace exotica
     return ret;
   }
 
+  void MotionSolver::Solve(const std::vector<Eigen::VectorXd>& init,
+                           Eigen::MatrixXd& solution) {
+    throw_pretty(
+        "There exists no overload of this function for the current solver, "
+        "i.e. no ability to provide an initial guess.");
+  }
 }

--- a/exotica/src/MotionSolver.cpp
+++ b/exotica/src/MotionSolver.cpp
@@ -56,11 +56,4 @@ namespace exotica
     if (problem_) ret += "\n" + problem_->print(prepend + "    ");
     return ret;
   }
-
-  void MotionSolver::Solve(const std::vector<Eigen::VectorXd>& init,
-                           Eigen::MatrixXd& solution) {
-    throw_pretty(
-        "There exists no overload of this function for the current solver, "
-        "i.e. no ability to provide an initial guess.");
-  }
 }

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -130,6 +130,7 @@ namespace exotica
                                               << q_init_in[0].rows());
 
     InitialTrajectory = q_init_in;
+    setStartState(q_init_in[0]);
   }
 
   std::vector<Eigen::VectorXd> UnconstrainedTimeIndexedProblem::getInitialTrajectory() {

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -115,6 +115,25 @@ namespace exotica
       Phi = y;
       ydiff.assign(T, Eigen::VectorXd::Zero(JN));
       J.assign(T, Eigen::MatrixXd(JN, N));
+
+      // Set initial trajectory
+      InitialTrajectory.resize(T, getStartState());
+  }
+
+  void UnconstrainedTimeIndexedProblem::setInitialTrajectory(
+      const std::vector<Eigen::VectorXd> q_init_in) {
+    if (q_init_in.size() != T)
+      throw_pretty("Expected initial trajectory of length "
+                   << T << " but got " << q_init_in.size());
+    if (q_init_in[0].rows() != N)
+      throw_pretty("Expected states to have " << N << " rows but got "
+                                              << q_init_in[0].rows());
+
+    InitialTrajectory = q_init_in;
+  }
+
+  std::vector<Eigen::VectorXd> UnconstrainedTimeIndexedProblem::getInitialTrajectory() {
+    return InitialTrajectory;
   }
 
     double UnconstrainedTimeIndexedProblem::getDuration()

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -173,6 +173,12 @@ Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
     sol->Solve(ret);
     return ret;
 }
+Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol, const std::vector<Eigen::VectorXd>& q_init)
+{
+    Eigen::MatrixXd ret;
+    sol->Solve(q_init, ret);
+    return ret;
+}
 
 namespace pybind11 {
 namespace detail {
@@ -495,7 +501,14 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<MotionSolver, std::shared_ptr<MotionSolver>, Object> motionSolver(module, "MotionSolver");
     motionSolver.def("specifyProblem", &MotionSolver::specifyProblem, "Assign problem to the solver", py::arg("planningProblem"));
-    motionSolver.def("solve", [](std::shared_ptr<MotionSolver> sol){return Solve(sol);}, "Solve the problem");
+    motionSolver.def(
+        "solve", [](std::shared_ptr<MotionSolver> sol) { return Solve(sol); },
+        "Solve the problem");
+    motionSolver.def(
+        "solve",
+        [](std::shared_ptr<MotionSolver> sol,
+           const std::vector<Eigen::VectorXd>& q_init) { return Solve(sol, q_init); },
+        "Solve the problem");
     motionSolver.def("getProblem", &MotionSolver::getProblem, py::return_value_policy::reference_internal);
 
     py::class_<PlanningProblem, std::shared_ptr<PlanningProblem>, Object> planningProblem(module, "PlanningProblem");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -533,6 +533,10 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def_readwrite("W", &UnconstrainedTimeIndexedProblem::W);
     unconstrainedTimeIndexedProblem.def_readwrite("H", &UnconstrainedTimeIndexedProblem::H);
     unconstrainedTimeIndexedProblem.def_readwrite("Q", &UnconstrainedTimeIndexedProblem::Q);
+    unconstrainedTimeIndexedProblem.def_property(
+        "InitialTrajectory",
+        &UnconstrainedTimeIndexedProblem::getInitialTrajectory,
+        &UnconstrainedTimeIndexedProblem::setInitialTrajectory);
     unconstrainedTimeIndexedProblem.def_readonly("T", &UnconstrainedTimeIndexedProblem::T);
     unconstrainedTimeIndexedProblem.def_readonly("PhiN", &UnconstrainedTimeIndexedProblem::PhiN);
     unconstrainedTimeIndexedProblem.def_readonly("JN", &UnconstrainedTimeIndexedProblem::JN);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -173,12 +173,6 @@ Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
     sol->Solve(ret);
     return ret;
 }
-Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol, const std::vector<Eigen::VectorXd>& q_init)
-{
-    Eigen::MatrixXd ret;
-    sol->Solve(q_init, ret);
-    return ret;
-}
 
 namespace pybind11 {
 namespace detail {
@@ -503,11 +497,6 @@ PYBIND11_MODULE(_pyexotica, module)
     motionSolver.def("specifyProblem", &MotionSolver::specifyProblem, "Assign problem to the solver", py::arg("planningProblem"));
     motionSolver.def(
         "solve", [](std::shared_ptr<MotionSolver> sol) { return Solve(sol); },
-        "Solve the problem");
-    motionSolver.def(
-        "solve",
-        [](std::shared_ptr<MotionSolver> sol,
-           const std::vector<Eigen::VectorXd>& q_init) { return Solve(sol, q_init); },
         "Solve the problem");
     motionSolver.def("getProblem", &MotionSolver::getProblem, py::return_value_policy::reference_internal);
 


### PR DESCRIPTION
Allows passing an initial guess to an optimisation solver (if supported/implemented) from Python, e.g. for AICO