### PR TITLE
CollisionCheck taskmap

### DIFF
--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -74,7 +74,6 @@ namespace exotica
       double margin_;
     protected:
       SamplingProblem_ptr prob_;
-      bool self_collision_;
   };
 
 } /* namespace exotica */

--- a/exotations/solvers/ompl_imp_solver/init/OMPLImplementation.in
+++ b/exotations/solvers/ompl_imp_solver/init/OMPLImplementation.in
@@ -3,7 +3,6 @@ Optional std::string Algorithm = "RRTConnect";
 Optional std::string SamplingSpace = "ConfigurationSpace";
 Optional int MaxGoalSamplingAttempts = 500;
 Optional double Timeout = 60.0;
-Optional bool SelfCollisionCheck = false;
 Optional bool UseGoalBias = false;
 Optional double GoalBias = 0.5;
 Optional Eigen::VectorXd ImportanceWeights = Eigen::VectorXd();

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -46,7 +46,6 @@ namespace exotica
     Server_ptr server = Server::Instance();
 
     margin_ = init.Margin;
-    self_collision_ = init.SelfCollisionCheck;
 
     HIGHLIGHT_NAMED("OMPLStateValidityChecker",
                     "Initial Safety Margin: " << margin_);
@@ -70,7 +69,7 @@ namespace exotica
         state, q);
 #endif
 
-    if (!prob_->isValid(q) || !prob_->getScene()->getCollisionScene()->isStateValid(self_collision_))
+    if (!prob_->isValid(q))
     {
       dist = -1;
       return false;

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -20,6 +20,7 @@ AddInitializer(
   Identity
   SphereCollision
   Sphere
+  CollisionCheck
 )
 GenInitializers()
 
@@ -43,7 +44,8 @@ set(SOURCES
     src/JointLimit.cpp
     src/Distance.cpp
     src/Identity.cpp
-    src/SphereCollision.cpp)
+    src/SphereCollision.cpp
+    src/CollisionCheck.cpp)
 
 add_library(${PROJECT_NAME} ${SOURCES})
 

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -26,4 +26,7 @@
   <class name="exotica/JointLimit" type="exotica::JointLimit" base_class_type="exotica::TaskMap">
     <description>Joint limits</description>
   </class>
+  <class name="exotica/CollisionCheck" type="exotica::CollisionCheck" base_class_type="exotica::TaskMap">
+    <description>Collision checking</description>
+  </class>
 </library>

--- a/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
+++ b/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
@@ -1,0 +1,67 @@
+/*
+ *      Author: Vladimir Ivan
+ *
+ * Copyright (c) 2017, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef EXOTICA_GENERIC_COLLISIONCHECK_H
+#define EXOTICA_GENERIC_COLLISIONCHECK_H
+
+#include <exotica/TaskMap.h>
+#include <task_map/CollisionCheckInitializer.h>
+
+namespace exotica
+{
+  class CollisionCheck: public TaskMap, public Instantiable<CollisionCheckInitializer>
+  {
+    public:
+      CollisionCheck();
+      virtual ~CollisionCheck()
+      {
+      }
+
+      virtual void Instantiate(CollisionCheckInitializer& init);
+
+      virtual void assignScene(Scene_ptr scene);
+
+      void Initialize();
+
+      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+      virtual int taskSpaceDim();
+
+      Scene_ptr scene_;
+      CollisionScene_ptr cscene_;
+      CollisionCheckInitializer init_;
+
+  };
+
+  typedef std::shared_ptr<exotica::CollisionCheck> CollisionCheck_ptr;
+}
+#endif

--- a/exotations/task_maps/task_map/init/CollisionCheck.in
+++ b/exotations/task_maps/task_map/init/CollisionCheck.in
@@ -1,0 +1,2 @@
+extend <exotica/TaskMap>
+Optional bool SelfCollision = false;

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -1,0 +1,71 @@
+/*
+ *      Author: Vladimir Ivan
+ *
+ * Copyright (c) 2017, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "task_map/CollisionCheck.h"
+
+REGISTER_TASKMAP_TYPE("CollisionCheck", exotica::CollisionCheck);
+
+namespace exotica
+{
+  CollisionCheck::CollisionCheck()
+  {
+
+  }
+
+  void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+  {
+      if(phi.rows() != 1) throw_named("Wrong size of phi!");
+      cscene_->updateCollisionObjectTransforms();
+      phi(0) = cscene_->isStateValid(init_.SelfCollision)?-1.0:0.0;
+  }
+
+  void CollisionCheck::Instantiate(CollisionCheckInitializer& init)
+  {
+      init_ = init;
+  }
+
+  void CollisionCheck::assignScene(Scene_ptr scene)
+  {
+      scene_ = scene;
+      Initialize();
+  }
+
+  void CollisionCheck::Initialize()
+  {
+      cscene_ = scene_->getCollisionScene();
+  }
+
+  int CollisionCheck::taskSpaceDim()
+  {
+      return 1;
+  }
+}

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -152,6 +152,8 @@ namespace exotica
       ros::Publisher proxy_pub_;
 
       std::map<std::string, AttachedObject> attached_objects_;
+
+      bool force_collision_;
   };
   typedef std::shared_ptr<Scene> Scene_ptr;
 //  typedef std::map<std::string, Scene_ptr> Scene_map;

--- a/exotica/init/Scene.in
+++ b/exotica/init/Scene.in
@@ -4,3 +4,4 @@ Optional std::string RobotDescription = "robot_description";
 Optional std::string URDF = "";
 Optional std::string SRDF = "";
 Optional std::string CollisionScene = "CollisionSceneFCL";
+Optional bool AlwaysUpdateCollisionScene = false;

--- a/exotica/resources/configs/example_distance.xml
+++ b/exotica/resources/configs/example_distance.xml
@@ -14,6 +14,7 @@
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>
         <CollisionScene>CollisionSceneFCLLatest</CollisionScene>
+        <AlwaysUpdateCollisionScene>1</AlwaysUpdateCollisionScene>
       </Scene>
     </PlanningScene>
 

--- a/exotica/resources/configs/example_manipulate_ompl.xml
+++ b/exotica/resources/configs/example_manipulate_ompl.xml
@@ -16,6 +16,10 @@
       </Scene>
     </PlanningScene>
 
+    <Maps>
+      <CollisionCheck Name="Collision" SelfCollision="0" />
+    </Maps>
+
     <Goal>0 0 0 0 0 0 0</Goal>
   </SamplingProblem>
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -73,6 +73,7 @@ namespace exotica
       Object::InstatiateObject(init);
       name_ = object_name_;
       kinematica_.Debug = debug_;
+      force_collision_ = init.AlwaysUpdateCollisionScene;
       if(init.URDF=="" || init.SRDF=="")
       {
           Server::Instance()->getModel(init.RobotDescription, model_);
@@ -129,7 +130,7 @@ namespace exotica
   void Scene::Update(Eigen::VectorXdRefConst x)
   {
       kinematica_.Update(x);
-      collision_scene_->updateCollisionObjectTransforms();
+      if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
       if (debug_) publishScene();
   }
 
@@ -258,7 +259,7 @@ namespace exotica
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
-    collision_scene_->updateCollisionObjectTransforms();
+    if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
 
     if (debug_) publishScene();
   }
@@ -267,7 +268,7 @@ namespace exotica
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
-    collision_scene_->updateCollisionObjectTransforms();
+    if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
 
     if (debug_) publishScene();
   }


### PR DESCRIPTION
- Added a ```CollisionCheck``` task map.
- Made automatic updating of the ```CollisionScene``` optional and added ```AlwaysUpdateCollisionScene``` flag to the ```Scene``` initializer to enable this feature.
- Sampling problem no longer check for collisions automatically - removed the check from the OMPL validity checker. Add the task map to the problem to check for collisions.

This fixes #61.

Merge #126 first.
