### PR TITLE
Added safe distance to the collision check 

### DIFF
--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -58,6 +58,7 @@ public:
         fcl::CollisionResult Result;
         CollisionSceneFCL* Scene;
         bool Self;
+        double SafeDistance;
     };
 
     CollisionSceneFCL();
@@ -77,8 +78,8 @@ public:
        * @param self Indicate if self collision check is required.
        * @return True, if the state is collision free..
        */
-    virtual bool isStateValid(bool self = true);
-    virtual bool isCollisionFree(const std::string& o1, const std::string& o2);
+    virtual bool isStateValid(bool self = true, double safe_distance = 0.0);
+    virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0);
 
     /**
        * @brief      Gets the collision world links.

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -52,6 +52,7 @@ public:
         fcl::CollisionResultd Result;
         CollisionSceneFCLLatest* Scene;
         bool Self;
+        double SafeDistance;
     };
 
     struct DistanceData
@@ -82,8 +83,8 @@ public:
        * @param self Indicate if self collision check is required.
        * @return True, if the state is collision free..
        */
-    virtual bool isStateValid(bool self = true);
-    virtual bool isCollisionFree(const std::string& o1, const std::string& o2);
+    virtual bool isStateValid(bool self = true, double safe_distance = 0.0);
+    virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0);
 
     ///
     /// \brief Computes collision distances.

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -71,7 +71,6 @@ namespace exotica
 
       virtual bool isValid(const ompl::base::State *state, double &dist) const;
 
-      double margin_;
     protected:
       SamplingProblem_ptr prob_;
   };

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
@@ -108,14 +108,12 @@ namespace exotica
       std::string algorithm_;
       std::string range_;
       std::string object_name_;
-      double margin_;
       Eigen::VectorXd qT_;
       int min_traj_length_;
 
       OMPLsolverInitializer init_;
     private:
       BASE_TYPE BaseType;
-      double init_margin_;
   };
 }
 

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -44,11 +44,6 @@ namespace exotica
       : ob::StateValidityChecker(si), prob_(prob)
   {
     Server_ptr server = Server::Instance();
-
-    margin_ = init.Margin;
-
-    HIGHLIGHT_NAMED("OMPLStateValidityChecker",
-                    "Initial Safety Margin: " << margin_);
   }
 
   bool OMPLStateValidityChecker::isValid(const ompl::base::State *state) const

--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -2,7 +2,6 @@ extend <exotica/MotionSolver>
 Required std::string Solver;
 Optional std::string Range = "1";
 Optional bool Smooth = true;
-Optional double Margin = 2.0;
 Optional std::string Algorithm = "RRTConnect";
 Optional std::string SamplingSpace = "ConfigurationSpace";
 Optional int MaxGoalSamplingAttempts = 500;

--- a/exotations/task_maps/task_map/init/CollisionCheck.in
+++ b/exotations/task_maps/task_map/init/CollisionCheck.in
@@ -1,2 +1,3 @@
 extend <exotica/TaskMap>
 Optional bool SelfCollision = false;
+Optional double SafeDistance = 0.0;

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -45,7 +45,7 @@ namespace exotica
   {
       if(phi.rows() != 1) throw_named("Wrong size of phi!");
       cscene_->updateCollisionObjectTransforms();
-      phi(0) = cscene_->isStateValid(init_.SelfCollision)?-1.0:0.0;
+      phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance)?-1.0:0.0;
   }
 
   void CollisionCheck::Instantiate(CollisionCheckInitializer& init)

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -84,7 +84,7 @@ public:
        * @param self Indicate if self collision check is required.
        * @return True, if the state is collision free..
        */
-    virtual bool isStateValid(bool self = true) = 0;
+    virtual bool isStateValid(bool self = true, double safe_distance = 0.0) = 0;
 
     ///
     /// @brief Checks if two objects are in collision.
@@ -92,7 +92,7 @@ public:
     /// @param o2 Name of object 2.
     /// @return True is the two objects are not colliding.
     ///
-    virtual bool isCollisionFree(const std::string& o1, const std::string& o2) {throw_pretty("Not implemented!");}
+    virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0) {throw_pretty("Not implemented!");}
 
     ///
     /// \brief Computes collision distances.

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -593,8 +593,8 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("loadSceneFile", &Scene::loadSceneFile);
     scene.def("getScene", &Scene::getScene);
     scene.def("cleanScene", &Scene::cleanScene);
-    scene.def("isStateValid", [](Scene* instance, bool self) {return instance->getCollisionScene()->isStateValid(self);}, py::arg("self")=true);
-    scene.def("isCollisionFree", [](Scene* instance, const std::string& o1, const std::string& o2) {return instance->getCollisionScene()->isCollisionFree(o1, o2);});
+    scene.def("isStateValid", [](Scene* instance, bool self, double safe_distance) {return instance->getCollisionScene()->isStateValid(self, safe_distance);}, py::arg("self")=true, py::arg("SafeDistance")=0.0);
+    scene.def("isCollisionFree", [](Scene* instance, const std::string& o1, const std::string& o2, double safe_distance) {return instance->getCollisionScene()->isCollisionFree(o1, o2, safe_distance);}, py::arg("Object1"), py::arg("Object2"), py::arg("SafeDistance")=0.0);
     scene.def("getCollisionDistance", [](Scene* instance, bool self) {return instance->getCollisionScene()->getCollisionDistance(self);}, py::arg("self")=true);
     scene.def("getCollisionDistance", [](Scene* instance, const std::string& o1, const std::string& o2) {return instance->getCollisionScene()->getCollisionDistance(o1, o2);}, py::arg("Object1"), py::arg("Object2"));
     scene.def("updateWorld", &Scene::updateWorld);


### PR DESCRIPTION
- Added safe distance to the collision check: if distance is > 0, additional computation is performed (as originally implemented by @wxmerkt.
- Moved margin from OMPL to the task map (this removes the procedure to automatically decrease the safety margin which was wrong as this changes the problem behind the scenes).

This fixes last point of #130.