### PR TITLE
Kinetic and 16.04 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fcl_catkin"]
 	path = fcl_catkin
-	url = https://github.com/wxmerkt/fcl_catkin.git
+	url = https://github.com/ipab-slmc/fcl_catkin.git

--- a/exotations/collision_scene_fcl/CMakeLists.txt
+++ b/exotations/collision_scene_fcl/CMakeLists.txt
@@ -8,31 +8,20 @@ find_package(catkin REQUIRED COMPONENTS
   geometric_shapes
 )
 
-# From Kinetic onwards, system installed FCL is used.
-# No CMake config is provided either, we have to use pkgconfig.
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES collision_scene_fcl
+  CATKIN_DEPENDS exotica geometric_shapes
+)
+
+# FCL 0.5.0 used in kinetic breaks the API.
+# The ROS_KINETIC flag takes care of that in our code.
 if ($ENV{ROS_DISTRO} MATCHES "(kinetic|lunar)")
-    find_package(PkgConfig)
-    pkg_check_modules(FCL REQUIRED fcl)
-    catkin_package(
-      INCLUDE_DIRS include
-      LIBRARIES collision_scene_fcl
-      CATKIN_DEPENDS exotica geometric_shapes
-    )
     add_definitions(-DROS_KINETIC)
-else()
-    find_package(catkin REQUIRED COMPONENTS
-      fcl
-    )
-    catkin_package(
-      INCLUDE_DIRS include
-      LIBRARIES collision_scene_fcl
-      CATKIN_DEPENDS exotica geometric_shapes fcl
-    )
 endif()
 
 include_directories(
   include
-  ${FCL_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -41,7 +30,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES} ${FCL_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/exotations/collision_scene_fcl/CMakeLists.txt
+++ b/exotations/collision_scene_fcl/CMakeLists.txt
@@ -6,18 +6,33 @@ add_compile_options(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   exotica
   geometric_shapes
-  fcl
 )
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES collision_scene_fcl
-  CATKIN_DEPENDS exotica geometric_shapes fcl
-
-)
+# From Kinetic onwards, system installed FCL is used.
+# No CMake config is provided either, we have to use pkgconfig.
+if ($ENV{ROS_DISTRO} MATCHES "(kinetic|lunar)")
+    find_package(PkgConfig)
+    pkg_check_modules(FCL REQUIRED fcl)
+    catkin_package(
+      INCLUDE_DIRS include
+      LIBRARIES collision_scene_fcl
+      CATKIN_DEPENDS exotica geometric_shapes
+    )
+    add_definitions(-DROS_KINETIC)
+else()
+    find_package(catkin REQUIRED COMPONENTS
+      fcl
+    )
+    catkin_package(
+      INCLUDE_DIRS include
+      LIBRARIES collision_scene_fcl
+      CATKIN_DEPENDS exotica geometric_shapes fcl
+    )
+endif()
 
 include_directories(
   include
+  ${FCL_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -26,7 +41,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+  ${catkin_LIBRARIES} ${FCL_LIBRARIES}
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/exotations/collision_scene_fcl/package.xml
+++ b/exotations/collision_scene_fcl/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>exotica</depend>
   <depend>geometric_shapes</depend>
-  <depend>fcl</depend>
 
   <export>
     <exotica plugin="${prefix}/exotica_plugins.xml" />

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -37,27 +37,6 @@ REGISTER_COLLISION_SCENE_TYPE("CollisionSceneFCL", exotica::CollisionSceneFCL)
 
 namespace fcl_convert
 {
-void fcl2Eigen(const fcl::Vec3f & fcl, Eigen::Vector3d & eigen)
-{
-    eigen(0) = fcl.data.vs[0];
-    eigen(1) = fcl.data.vs[1];
-    eigen(2) = fcl.data.vs[2];
-}
-
-void fcl2Eigen(const fcl::Transform3f & fcl, Eigen::Vector3d & eigen)
-{
-    eigen(0) = fcl.getTranslation().data.vs[0];
-    eigen(1) = fcl.getTranslation().data.vs[1];
-    eigen(2) = fcl.getTranslation().data.vs[2];
-}
-
-void fcl2EigenTranslation(const fcl::Vec3f & fcl, Eigen::Vector3d & eigen)
-{
-    eigen(0) = fcl.data.vs[0];
-    eigen(1) = fcl.data.vs[1];
-    eigen(2) = fcl.data.vs[2];
-}
-
 fcl::Transform3f KDL2fcl(const KDL::Frame& frame)
 {
     return fcl::Transform3f(fcl::Matrix3f(frame.M.data[0], frame.M.data[1], frame.M.data[2], frame.M.data[3], frame.M.data[4], frame.M.data[5], frame.M.data[6], frame.M.data[7], frame.M.data[8]), fcl::Vec3f(frame.p.x(), frame.p.y(), frame.p.z()));
@@ -113,7 +92,11 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
     // Maybe use cache here?
 
     shapes::ShapeConstPtr shape = element->Shape;
+#ifdef ROS_KINETIC
+    std::shared_ptr<fcl::CollisionGeometry> geometry;
+#else
     boost::shared_ptr<fcl::CollisionGeometry> geometry;
+#endif
     switch (shape->type)
     {
     case shapes::PLANE:

--- a/exotations/collision_scene_fcl_latest/CMakeLists.txt
+++ b/exotations/collision_scene_fcl_latest/CMakeLists.txt
@@ -4,15 +4,14 @@ project(collision_scene_fcl_latest)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  exotica
-  geometric_shapes
   fcl_catkin
+  geometric_shapes
 )
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES collision_scene_fcl_latest
-  CATKIN_DEPENDS exotica geometric_shapes fcl_catkin
+  CATKIN_DEPENDS fcl_catkin geometric_shapes
 )
 
 include_directories(

--- a/exotations/collision_scene_fcl_latest/CMakeLists.txt
+++ b/exotations/collision_scene_fcl_latest/CMakeLists.txt
@@ -3,6 +3,13 @@ project(collision_scene_fcl_latest)
 
 add_compile_options(-std=c++11)
 
+
+find_package(catkin REQUIRED COMPONENTS
+  exotica
+)
+
+set(exotica_INCLUDES ${catkin_INCLUDE_DIRS})
+
 find_package(catkin REQUIRED COMPONENTS
   fcl_catkin
   geometric_shapes
@@ -17,6 +24,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${exotica_INCLUDES}
 )
 
 add_library(${PROJECT_NAME}

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -227,7 +227,7 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     // GST_LIBCCD produces incorrect contacts. Probably due to incompatible version of libccd.
     data->Request.gjk_solver_type = fcl::GST_INDEP;
     data->Result.clear();
-    fcl::distance(o1,o2,data->Request, data->Result);
+    fcl::distance(o1, o2, data->Request, data->Result);
 
     CollisionProxy p;
     p.e1 = reinterpret_cast<KinematicElement*>(o1->getUserData());

--- a/exotations/solvers/ompl_imp_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_imp_solver/CMakeLists.txt
@@ -18,7 +18,7 @@ execute_process(
 
 if (${ROS_VERSION} MATCHES "(indigo|jade)")
   add_definitions(-DROS_INDIGO)
-else (${ROS_VERSION} MATCHES "(kinetic|lunar")
+else (${ROS_VERSION} MATCHES "(kinetic|lunar)")
   add_definitions(-DROS_KINETIC)
 endif()
 

--- a/exotations/solvers/ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_solver/CMakeLists.txt
@@ -11,8 +11,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Boost REQUIRED COMPONENTS system)
 
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 catkin_package(
-  INCLUDE_DIRS include 
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES ompl_base_solver
   CATKIN_DEPENDS exotica pluginlib ompl
 )

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   kdl_parser
   pluginlib
+  kdl_conversions
+  tf_conversions
   ${MSG_DEPS}
 )
 
@@ -59,7 +61,7 @@ GenInitializers()
 catkin_package(
   INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR} include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp message_runtime moveit_core moveit_ros_planning tf kdl_parser pluginlib
+  CATKIN_DEPENDS roscpp message_runtime moveit_core moveit_ros_planning tf kdl_parser pluginlib kdl_conversions tf_conversions
   CFG_EXTRAS Exotica.cmake AddInitializer.cmake
 )
 

--- a/exotica/cmake/Exotica.cmake
+++ b/exotica/cmake/Exotica.cmake
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Compiling using c++ 11 (required by EXOTica)")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--no-as-needed)
-set(CMAKE_SHARED_LINKER_FLAGS -Wl,--no-as-needed)
-set(CMAKE_MODULE_LINKER_FLAGS -Wl,--no-as-needed)
 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Only allows RelWithDebInfo" FORCE)
 SET(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE STRING "RelWithDebInfo" FORCE)

--- a/exotica/package.xml
+++ b/exotica/package.xml
@@ -25,4 +25,6 @@
   <depend>tf</depend>
   <depend>kdl_parser</depend>
   <depend>pluginlib</depend>
+  <depend>kdl_conversions</depend>
+  <depend>tf_conversions</depend>
 </package>

--- a/exotica_python/package.xml
+++ b/exotica_python/package.xml
@@ -11,4 +11,5 @@
   <depend>moveit_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>shape_msgs</depend>
+  <depend>python-matplotlib</depend>
 </package>

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -184,7 +184,7 @@ namespace detail {
 
         bool addPropertyFromDict(Property& target, PyObject* value_py)
         {
-            if(target.getType()=="std::string")
+            if(target.getType()=="std::string" || target.getType()==getTypeName(typeid(std::string)))
             {
                 target.set(pyAsString(value_py));
                 return true;
@@ -363,7 +363,7 @@ namespace detail {
 
         static void addPropertyToDict(PyObject* dict, const std::string& name, const Property& prop)
         {
-            if(prop.getType()=="std::string")
+            if(prop.getType()=="std::string" || prop.getType()==getTypeName(typeid(std::string)))
             {
                 PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<std::string>(prop.get())).ptr());
             }

--- a/pybind11_catkin/CMakeLists.txt
+++ b/pybind11_catkin/CMakeLists.txt
@@ -32,8 +32,9 @@ ExternalProject_Add_Step(
 
 
 file(MAKE_DIRECTORY include)
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include ${EIGEN3_INCLUDE_DIR}
   LIBRARIES ${PYTHON_LIBRARIES}
   CATKIN_DEPENDS
   CFG_EXTRAS pybind.cmake

--- a/pybind11_catkin/CMakeLists.txt
+++ b/pybind11_catkin/CMakeLists.txt
@@ -33,6 +33,9 @@ ExternalProject_Add_Step(
 
 file(MAKE_DIRECTORY include)
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
+
+set(pybind11_INCLUDE_DIRS include)
+
 catkin_package(
   INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include ${EIGEN3_INCLUDE_DIR}
   LIBRARIES ${PYTHON_LIBRARIES}


### PR DESCRIPTION
- Moved `fcl_catkin` to `ipab-slmc`.
- Moved and renamed all FCL files within `fcl_catkin` to avoid clashes with system installed FCL.
- Removed unused ```fcl2Eigen```
- Added ````ROS_KINETIC``` flag to `collision_scene_fcl` to deal with API incompatibility introduced in 0.5.0 (`boost::shared_ptr` was changed to `std::shared_ptr`).
- Fixed Kinetic detection in OMPL solver.
- Fixed exported include directories in packages where header files were generated directly into devel.
- Fixed Python string type detection when creating initializers.

`collision_cene_fcl_latest` segfaults on 16.04 when computing collision distance. The unit tests provided by FCL all succeed on the same system though. All other features work fine.
