### PR TITLE
Automatic reformatting using clang-format-3.8 and style=google

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# -*- yaml -*-
+BasedOnStyle: Google
+Language: Cpp
+IndentWidth: 4
+ColumnLimit: 0 # do not enforce a column limit, users are advised to make breaks as they see fit to ensure readability/logic
+BreakBeforeBraces: Allman
+AccessModifierOffset: -4

--- a/examples/exotica_examples/src/core.cpp
+++ b/examples/exotica_examples/src/core.cpp
@@ -36,6 +36,6 @@ using namespace exotica;
 
 int main(int argc, char **argv)
 {
-    ROS_INFO_STREAM("Exotica version: "<<exotica::Version);
+    ROS_INFO_STREAM("Exotica version: " << exotica::Version);
     Setup::printSupportedClasses();
 }

--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -39,36 +39,34 @@ void run()
     Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));
 
     // Scene using joint group 'arm'
-    Initializer scene("Scene",{
-                          {"Name",std::string("MyScene")},
-                          {"JointGroup",std::string("arm")},
-                          {"URDF",std::string("{exotica}/resources/robots/lwr_simplified.urdf")},
-                          {"SRDF",std::string("{exotica}/resources/robots/lwr_simplified.srdf")}});
+    Initializer scene("Scene", {{"Name", std::string("MyScene")},
+                                {"JointGroup", std::string("arm")},
+                                {"URDF", std::string("{exotica}/resources/robots/lwr_simplified.urdf")},
+                                {"SRDF", std::string("{exotica}/resources/robots/lwr_simplified.srdf")}});
     // End-effector task map with two position frames
-    Initializer map("exotica/EffFrame",{
-                        {"Name",std::string("Position")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("lwr_arm_6_link")}, {"LinkOffset", Eigen::VectorTransform(0 ,0 ,0 ,0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17)}}),
-                         })}});
+    Initializer map("exotica/EffFrame", {{"Name", std::string("Position")},
+                                         {"EndEffector", std::vector<Initializer>({
+                                                             Initializer("Frame", {{"Link", std::string("lwr_arm_6_link")}, {"LinkOffset", Eigen::VectorTransform(0, 0, 0, 0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17)}}),
+                                                         })}});
     Eigen::VectorXd W(7);
-    W << 7,6,5,4,3,2,1;
+    W << 7, 6, 5, 4, 3, 2, 1;
 
-    Initializer problem("exotica/UnconstrainedEndPoseProblem",{
-                            {"Name",std::string("MyProblem")},
-                            {"PlanningScene",scene},
-                            {"Maps",std::vector<Initializer>({map})},
-                            {"W",W},
-                            {"Tolerance",1e-5},
-                        });
+    Initializer problem("exotica/UnconstrainedEndPoseProblem", {
+                                                                   {"Name", std::string("MyProblem")},
+                                                                   {"PlanningScene", scene},
+                                                                   {"Maps", std::vector<Initializer>({map})},
+                                                                   {"W", W},
+                                                                   {"Tolerance", 1e-5},
+                                                               });
 
-    Initializer solver("exotica/IKsolver",{
-                           {"Name",std::string("MySolver")},
-                           {"MaxIt",1},
-                           {"MaxStep", 0.1},
-                           {"C",1e-3},
-                       });
+    Initializer solver("exotica/IKsolver", {
+                                               {"Name", std::string("MySolver")},
+                                               {"MaxIt", 1},
+                                               {"MaxStep", 0.1},
+                                               {"C", 1e-3},
+                                           });
 
-    HIGHLIGHT_NAMED("GenericLoader","Loaded from a hardcoded generic initializer.");
+    HIGHLIGHT_NAMED("GenericLoader", "Loaded from a hardcoded generic initializer.");
 
     // Initialize
 
@@ -82,7 +80,6 @@ void run()
     // Create the initial configuration
     Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->N);
     Eigen::MatrixXd solution;
-
 
     ROS_INFO_STREAM("Calling solve() in an infinite loop");
 
@@ -98,8 +95,8 @@ void run()
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
         my_problem->y = {0.6,
-                -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
+                         -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
+                         0.5 + sin(t * M_PI * 0.5) * 0.2, 0, 0, 0};
 
         // Solve the problem using the IK solver
         my_problem->setStartState(q);
@@ -107,7 +104,7 @@ void run()
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
         ROS_INFO_STREAM_THROTTLE(0.5,
-                                 "Finished solving in "<<time<<"s. Solution ["<<solution<<"]");
+                                 "Finished solving in " << time << "s. Solution [" << solution << "]");
         q = solution.row(solution.rows() - 1);
 
         my_problem->Update(q);

--- a/examples/exotica_examples/src/ik_minimal.cpp
+++ b/examples/exotica_examples/src/ik_minimal.cpp
@@ -42,5 +42,5 @@ int main(int argc, char **argv)
     Timer timer;
     solver->Solve(solution);
 
-    HIGHLIGHT("Finished solving in "<<timer.getDuration()<<"s. Solution ["<<solution<<"]");
+    HIGHLIGHT("Finished solving in " << timer.getDuration() << "s. Solution [" << solution << "]");
 }

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -45,19 +45,19 @@ void run()
     // Scene using joint group 'arm'
     SceneInitializer scene("MyScene", "arm", false, "", "{exotica}/resources/robots/lwr_simplified.urdf", "{exotica}/resources/robots/lwr_simplified.srdf");
     // End-effector task map with two position frames
-    EffFrameInitializer map("Position",false,
-    {FrameInitializer("lwr_arm_6_link", Eigen::VectorTransform(0 ,0 ,0 ,0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17))});
+    EffFrameInitializer map("Position", false,
+                            {FrameInitializer("lwr_arm_6_link", Eigen::VectorTransform(0, 0, 0, 0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17))});
     // Create a task using the map above (goal will be specified later)
     Eigen::VectorXd W(7);
-    W << 7,6,5,4,3,2,1;
+    W << 7, 6, 5, 4, 3, 2, 1;
 
-    UnconstrainedEndPoseProblemInitializer problem("MyProblem",scene,false,{map},W);
+    UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, W);
     IKsolverInitializer solver("MySolver");
     solver.C = 1e-3;
     solver.MaxIt = 1;
     solver.MaxStep = 0.1;
 
-    HIGHLIGHT_NAMED("ManualLoader","Loaded from a hardcoded specialized initializer.");
+    HIGHLIGHT_NAMED("ManualLoader", "Loaded from a hardcoded specialized initializer.");
 
     // Initialize
 
@@ -68,11 +68,9 @@ void run()
     any_solver->specifyProblem(any_problem);
     UnconstrainedEndPoseProblem_ptr my_problem = std::static_pointer_cast<UnconstrainedEndPoseProblem>(any_problem);
 
-
     // Create the initial configuration
     Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->N);
     Eigen::MatrixXd solution;
-
 
     ROS_INFO_STREAM("Calling solve() in an infinite loop");
 
@@ -88,15 +86,15 @@ void run()
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
         my_problem->y = {0.6,
-                -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
+                         -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
+                         0.5 + sin(t * M_PI * 0.5) * 0.2, 0, 0, 0};
 
         // Solve the problem using the IK solver
         my_problem->setStartState(q);
         any_solver->Solve(solution);
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
-        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in "<<time<<"s. Solution ["<<solution<<"]");
+        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in " << time << "s. Solution [" << solution << "]");
         q = solution.row(solution.rows() - 1);
 
         my_problem->Update(q);

--- a/examples/exotica_examples/src/planner.cpp
+++ b/examples/exotica_examples/src/planner.cpp
@@ -43,13 +43,13 @@ void run()
     Initializer solver, problem;
 
     std::string file_name, solver_name, problem_name;
-    Server::getParam("ConfigurationFile",file_name);
-    Server::getParam("Solver",solver_name);
-    Server::getParam("Problem",problem_name);
+    Server::getParam("ConfigurationFile", file_name);
+    Server::getParam("Solver", solver_name);
+    Server::getParam("Problem", problem_name);
 
-    XMLLoader::load(file_name,solver, problem, solver_name, problem_name);
+    XMLLoader::load(file_name, solver, problem, solver_name, problem_name);
 
-    HIGHLIGHT_NAMED("XMLnode","Loaded from XML");
+    HIGHLIGHT_NAMED("XMLnode", "Loaded from XML");
 
     // Initialize
 
@@ -62,17 +62,17 @@ void run()
     // If necessary, modify the problem after calling sol->specifyProblem()
     // e.g. set different rho:
 
-    if(any_problem->type()=="exotica::UnconstrainedTimeIndexedProblem")
+    if (any_problem->type() == "exotica::UnconstrainedTimeIndexedProblem")
     {
         UnconstrainedTimeIndexedProblem_ptr problem = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(any_problem);
-        for (int t = 0; t < problem->T-1; t++)
+        for (int t = 0; t < problem->T - 1; t++)
         {
             // This sets the precision of all time steps BUT the last one to zero
             // This means we only aim to minimize the task cost in the last time step
             // The rest of the trajectory minimizes the control cost
-            problem->setRho("Frame",0.0,t);
+            problem->setRho("Frame", 0.0, t);
         }
-        problem->setRho("Frame",1e3,99);
+        problem->setRho("Frame", 1e3, 99);
     }
 
     // Create the initial configuration
@@ -84,9 +84,10 @@ void run()
         // Solve the problem using the AICO solver
         any_solver->Solve(solution);
         double time = ros::Duration(
-                    (ros::WallTime::now() - start_time).toSec()).toSec();
-        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving ("<<time<<"s)");
-        ROS_INFO_STREAM_THROTTLE(0.5, "Solution "<<solution.row(solution.rows()-1));
+                          (ros::WallTime::now() - start_time).toSec())
+                          .toSec();
+        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving (" << time << "s)");
+        ROS_INFO_STREAM_THROTTLE(0.5, "Solution " << solution.row(solution.rows() - 1));
 
         ros::Rate loop_rate(50.0);
         int t = 0;
@@ -95,8 +96,8 @@ void run()
         while (ros::ok())
         {
             int i = 1;
-            if(t==0 || t==solution.rows()-1) i = PlaybackWaitInterval;
-            while(i-->0)
+            if (t == 0 || t == solution.rows() - 1) i = PlaybackWaitInterval;
+            while (i-- > 0)
             {
                 any_problem->getScene()->Update(solution.row(t).transpose());
                 any_problem->getScene()->getSolver().publishFrames();
@@ -107,7 +108,6 @@ void run()
             t = t + 1 >= solution.rows() ? 0 : t + 1;
         }
     }
-
 
     // All classes will be destroyed at this point.
 }

--- a/examples/exotica_examples/src/xml.cpp
+++ b/examples/exotica_examples/src/xml.cpp
@@ -42,11 +42,11 @@ void run()
     Initializer solver, problem;
 
     std::string file_name;
-    Server::getParam("ConfigurationFile",file_name);
+    Server::getParam("ConfigurationFile", file_name);
 
-    XMLLoader::load(file_name,solver, problem);
+    XMLLoader::load(file_name, solver, problem);
 
-    HIGHLIGHT_NAMED("XMLnode","Loaded from XML");
+    HIGHLIGHT_NAMED("XMLnode", "Loaded from XML");
 
     // Initialize
 
@@ -77,15 +77,15 @@ void run()
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
         my_problem->y = {0.6,
-                -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
+                         -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
+                         0.5 + sin(t * M_PI * 0.5) * 0.2, 0, 0, 0};
 
         // Solve the problem using the IK solver
         my_problem->setStartState(q);
         any_solver->Solve(solution);
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
-        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in "<<time<<"s. Solution ["<<solution<<"]");
+        ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in " << time << "s. Solution [" << solution << "]");
         q = solution.row(0);
 
         my_problem->Update(q);

--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -34,13 +34,13 @@
 #define COLLISIONSCENEFCL_H
 
 #include <exotica/CollisionScene.h>
+#include <fcl/BVH/BVH_model.h>
 #include <fcl/broadphase/broadphase.h>
-#include <fcl/narrowphase/narrowphase.h>
 #include <fcl/collision.h>
 #include <fcl/distance.h>
-#include <fcl/BVH/BVH_model.h>
-#include <fcl/shape/geometric_shapes.h>
+#include <fcl/narrowphase/narrowphase.h>
 #include <fcl/octree.h>
+#include <fcl/shape/geometric_shapes.h>
 #include <geometric_shapes/mesh_operations.h>
 #include <geometric_shapes/shape_operations.h>
 
@@ -49,11 +49,9 @@ namespace exotica
 class CollisionSceneFCL : public CollisionScene
 {
 public:
-
     struct CollisionData
     {
         CollisionData(CollisionSceneFCL* scene) : Scene(scene), Self(true) {}
-
         fcl::CollisionRequest Request;
         fcl::CollisionResult Result;
         CollisionSceneFCL* Scene;
@@ -93,7 +91,7 @@ public:
        */
     virtual std::vector<std::string> getCollisionRobotLinks();
 
-    virtual Eigen::Vector3d getTranslation(const std::string & name);
+    virtual Eigen::Vector3d getTranslation(const std::string& name);
 
     ///
     /// \brief Creates the collision scene from kinematic elements.
@@ -107,7 +105,6 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-
     static std::shared_ptr<fcl::CollisionObject> constructFclCollisionObject(std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObject* o1, fcl::CollisionObject* o2, CollisionData* data);
 
@@ -119,4 +116,4 @@ private:
 typedef std::shared_ptr<CollisionSceneFCL> CollisionSceneFCL_ptr;
 }
 
-#endif // COLLISIONSCENEFCL_H
+#endif  // COLLISIONSCENEFCL_H

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -56,13 +56,13 @@ CollisionSceneFCL::~CollisionSceneFCL()
 void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects)
 {
     fcl_objects_.resize(objects.size());
-    int i=0;
-    for(const auto& object : objects)
+    int i = 0;
+    for (const auto& object : objects)
     {
         std::shared_ptr<fcl::CollisionObject> new_object;
 
         const auto& cache_entry = fcl_cache_.find(object.first);
-        if(cache_entry == fcl_cache_.end())
+        if (cache_entry == fcl_cache_.end())
         {
             new_object = constructFclCollisionObject(object.second);
             fcl_cache_[object.first] = new_object;
@@ -77,7 +77,7 @@ void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::
 
 void CollisionSceneFCL::updateCollisionObjectTransforms()
 {
-    for(fcl::CollisionObject* collision_object : fcl_objects_)
+    for (fcl::CollisionObject* collision_object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(collision_object->getUserData());
         collision_object->setTransform(fcl_convert::KDL2fcl(element->Frame));
@@ -99,38 +99,38 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
 #endif
     switch (shape->type)
     {
-    case shapes::PLANE:
+        case shapes::PLANE:
         {
             const shapes::Plane* p = static_cast<const shapes::Plane*>(shape.get());
             geometry.reset(new fcl::Plane(p->a, p->b, p->c, p->d));
         }
         break;
-    case shapes::SPHERE:
+        case shapes::SPHERE:
         {
             const shapes::Sphere* s = static_cast<const shapes::Sphere*>(shape.get());
             geometry.reset(new fcl::Sphere(s->radius));
         }
         break;
-    case shapes::BOX:
+        case shapes::BOX:
         {
             const shapes::Box* s = static_cast<const shapes::Box*>(shape.get());
             const double* size = s->size;
             geometry.reset(new fcl::Box(size[0], size[1], size[2]));
         }
         break;
-    case shapes::CYLINDER:
+        case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
             geometry.reset(new fcl::Cylinder(s->radius, s->length));
         }
         break;
-    case shapes::CONE:
+        case shapes::CONE:
         {
             const shapes::Cone* s = static_cast<const shapes::Cone*>(shape.get());
             geometry.reset(new fcl::Cone(s->radius, s->length));
         }
         break;
-    case shapes::MESH:
+        case shapes::MESH:
         {
             fcl::BVHModel<fcl::OBBRSS>* g = new fcl::BVHModel<fcl::OBBRSS>();
             const shapes::Mesh* mesh = static_cast<const shapes::Mesh*>(shape.get());
@@ -139,7 +139,7 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
                 std::vector<fcl::Triangle> tri_indices(mesh->triangle_count);
                 for (unsigned int i = 0; i < mesh->triangle_count; ++i)
                     tri_indices[i] =
-                            fcl::Triangle(mesh->triangles[3 * i], mesh->triangles[3 * i + 1], mesh->triangles[3 * i + 2]);
+                        fcl::Triangle(mesh->triangles[3 * i], mesh->triangles[3 * i + 1], mesh->triangles[3 * i + 2]);
 
                 std::vector<fcl::Vec3f> points(mesh->vertex_count);
                 for (unsigned int i = 0; i < mesh->vertex_count; ++i)
@@ -152,14 +152,14 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
             geometry.reset(g);
         }
         break;
-    case shapes::OCTREE:
+        case shapes::OCTREE:
         {
             const shapes::OcTree* g = static_cast<const shapes::OcTree*>(shape.get());
             geometry.reset(new fcl::OcTree(g->octree));
         }
         break;
-    default:
-        throw_pretty("This shape type ("<<((int)shape->type)<<") is not supported using FCL yet");
+        default:
+            throw_pretty("This shape type (" << ((int)shape->type) << ") is not supported using FCL yet");
     }
     geometry->computeLocalAABB();
     geometry->setUserData(reinterpret_cast<void*>(element.get()));
@@ -177,18 +177,18 @@ bool CollisionSceneFCL::isAllowedToCollide(fcl::CollisionObject* o1, fcl::Collis
     bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink;
     bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink;
     // Don't check collisions between world objects
-    if(!isRobot1 && !isRobot2) return false;
+    if (!isRobot1 && !isRobot2) return false;
     // Skip self collisions if requested
-    if(isRobot1 && isRobot2 && !self) return false;
+    if (isRobot1 && isRobot2 && !self) return false;
     // Skip collisions between shapes within the same objects
-    if(e1->Parent==e2->Parent) return false;
+    if (e1->Parent == e2->Parent) return false;
     // Skip collisions between bodies attached to the same object
-    if(e1->ClosestRobotLink&&e2->ClosestRobotLink&&e1->ClosestRobotLink==e2->ClosestRobotLink) return false;
+    if (e1->ClosestRobotLink && e2->ClosestRobotLink && e1->ClosestRobotLink == e2->ClosestRobotLink) return false;
 
-    if(isRobot1 && isRobot2)
+    if (isRobot1 && isRobot2)
     {
-        const std::string& name1 = e1->ClosestRobotLink?e1->ClosestRobotLink->Segment.getName():e1->Parent->Segment.getName();
-        const std::string& name2 = e2->ClosestRobotLink?e2->ClosestRobotLink->Segment.getName():e2->Parent->Segment.getName();
+        const std::string& name1 = e1->ClosestRobotLink ? e1->ClosestRobotLink->Segment.getName() : e1->Parent->Segment.getName();
+        const std::string& name2 = e2->ClosestRobotLink ? e2->ClosestRobotLink->Segment.getName() : e2->Parent->Segment.getName();
         return scene->acm_.getAllowedCollision(name1, name2);
     }
     return true;
@@ -198,15 +198,15 @@ void CollisionSceneFCL::checkCollision(fcl::CollisionObject* o1, fcl::CollisionO
 {
     data->Request.num_max_contacts = 1000;
     data->Result.clear();
-    fcl::collide(o1,o2,data->Request, data->Result);
-    if(data->SafeDistance>0.0 && o1->getAABB().distance(o2->getAABB())<data->SafeDistance)
+    fcl::collide(o1, o2, data->Request, data->Result);
+    if (data->SafeDistance > 0.0 && o1->getAABB().distance(o2->getAABB()) < data->SafeDistance)
     {
         fcl::DistanceRequest req;
         fcl::DistanceResult res;
         req.enable_nearest_points = false;
         fcl::distance(o1, o2, req, res);
         // Add fake contact when distance is smaller than the safety distance.
-        if(res.min_distance<data->SafeDistance) data->Result.addContact(fcl::Contact());
+        if (res.min_distance < data->SafeDistance) data->Result.addContact(fcl::Contact());
     }
 }
 
@@ -214,7 +214,7 @@ bool CollisionSceneFCL::collisionCallback(fcl::CollisionObject* o1, fcl::Collisi
 {
     CollisionData* data_ = reinterpret_cast<CollisionData*>(data);
 
-    if(!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
+    if (!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
 
     checkCollision(o1, o2, data_);
     return data_->Result.isCollision();
@@ -235,38 +235,39 @@ bool CollisionSceneFCL::isCollisionFree(const std::string& o1, const std::string
 {
     std::vector<fcl::CollisionObject*> shapes1;
     std::vector<fcl::CollisionObject*> shapes2;
-    for(fcl::CollisionObject* o : fcl_objects_)
+    for (fcl::CollisionObject* o : fcl_objects_)
     {
         KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
-        if(e->Segment.getName()==o1 || e->Parent->Segment.getName()==o1) shapes1.push_back(o);
-        if(e->Segment.getName()==o2 || e->Parent->Segment.getName()==o2) shapes2.push_back(o);
+        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
+        if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
-    if(shapes1.size()==0) throw_pretty("Can't find object '"<<o1<<"'!");
-    if(shapes2.size()==0) throw_pretty("Can't find object '"<<o2<<"'!");
+    if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
+    if (shapes2.size() == 0) throw_pretty("Can't find object '" << o2 << "'!");
     CollisionData data(this);
     data.SafeDistance = safe_distance;
-    for(fcl::CollisionObject* s1 : shapes1)
+    for (fcl::CollisionObject* s1 : shapes1)
     {
-        for(fcl::CollisionObject* s2 : shapes2)
+        for (fcl::CollisionObject* s2 : shapes2)
         {
             checkCollision(s1, s2, &data);
-            if(data.Result.isCollision()) return false;
+            if (data.Result.isCollision()) return false;
         }
     }
     return true;
 }
 
-Eigen::Vector3d CollisionSceneFCL::getTranslation(const std::string & name)
+Eigen::Vector3d CollisionSceneFCL::getTranslation(const std::string& name)
 {
-    for(fcl::CollisionObject* object : fcl_objects_)
+    for (fcl::CollisionObject* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(element->Segment.getName()==name)
+        if (element->Segment.getName() == name)
         {
             return Eigen::Map<Eigen::Vector3d>(element->Frame.p.data);
         }
     }
-    throw_pretty("Robot not found!");;
+    throw_pretty("Robot not found!");
+    ;
 }
 
 std::vector<std::string> CollisionSceneFCL::getCollisionWorldLinks()
@@ -275,7 +276,7 @@ std::vector<std::string> CollisionSceneFCL::getCollisionWorldLinks()
     for (fcl::CollisionObject* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(!element->ClosestRobotLink)
+        if (!element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
         }
@@ -294,12 +295,11 @@ std::vector<std::string> CollisionSceneFCL::getCollisionRobotLinks()
     for (fcl::CollisionObject* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(element->ClosestRobotLink)
+        if (element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
         }
     }
     return tmp;
 }
-
 }

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -43,11 +43,9 @@ namespace exotica
 class CollisionSceneFCLLatest : public CollisionScene
 {
 public:
-
     struct CollisionData
     {
         CollisionData(CollisionSceneFCLLatest* scene) : Scene(scene), Self(true) {}
-
         fcl::CollisionRequestd Request;
         fcl::CollisionResultd Result;
         CollisionSceneFCLLatest* Scene;
@@ -58,7 +56,6 @@ public:
     struct DistanceData
     {
         DistanceData(CollisionSceneFCLLatest* scene) : Scene(scene), Self(true), Distance{1e300} {}
-
         fcl::DistanceRequestd Request;
         fcl::DistanceResultd Result;
         CollisionSceneFCLLatest* Scene;
@@ -109,7 +106,7 @@ public:
        */
     virtual std::vector<std::string> getCollisionRobotLinks();
 
-    virtual Eigen::Vector3d getTranslation(const std::string & name);
+    virtual Eigen::Vector3d getTranslation(const std::string& name);
 
     ///
     /// \brief Creates the collision scene from kinematic elements.
@@ -123,7 +120,6 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-
     static std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, CollisionData* data);
     static void computeDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, DistanceData* data);
@@ -136,4 +132,4 @@ private:
 typedef std::shared_ptr<CollisionSceneFCLLatest> CollisionSceneFCLLatest_ptr;
 }
 
-#endif // CollisionSceneFCLLatest_H
+#endif  // CollisionSceneFCLLatest_H

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -31,8 +31,8 @@
  */
 
 #include <collision_scene_fcl_latest/CollisionSceneFCLLatest.h>
-#include <exotica/Factory.h>
 #include <eigen_conversions/eigen_kdl.h>
+#include <exotica/Factory.h>
 
 REGISTER_COLLISION_SCENE_TYPE("CollisionSceneFCLLatest", exotica::CollisionSceneFCLLatest)
 
@@ -50,7 +50,7 @@ namespace exotica
 {
 CollisionSceneFCLLatest::CollisionSceneFCLLatest()
 {
-    HIGHLIGHT("FCL version: "<<FCL_VERSION);
+    HIGHLIGHT("FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCLLatest::~CollisionSceneFCLLatest()
@@ -60,13 +60,13 @@ CollisionSceneFCLLatest::~CollisionSceneFCLLatest()
 void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects)
 {
     fcl_objects_.resize(objects.size());
-    int i=0;
-    for(const auto& object : objects)
+    int i = 0;
+    for (const auto& object : objects)
     {
         std::shared_ptr<fcl::CollisionObjectd> new_object;
 
         const auto& cache_entry = fcl_cache_.find(object.first);
-        if(cache_entry == fcl_cache_.end())
+        if (cache_entry == fcl_cache_.end())
         {
             new_object = constructFclCollisionObject(object.second);
             fcl_cache_[object.first] = new_object;
@@ -81,7 +81,7 @@ void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string,
 
 void CollisionSceneFCLLatest::updateCollisionObjectTransforms()
 {
-    for(fcl::CollisionObjectd* collision_object : fcl_objects_)
+    for (fcl::CollisionObjectd* collision_object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(collision_object->getUserData());
         collision_object->setTransform(fcl_convert::KDL2fcl(element->Frame));
@@ -99,38 +99,38 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
     std::shared_ptr<fcl::CollisionGeometryd> geometry;
     switch (shape->type)
     {
-    case shapes::PLANE:
+        case shapes::PLANE:
         {
             const shapes::Plane* p = static_cast<const shapes::Plane*>(shape.get());
             geometry.reset(new fcl::Planed(p->a, p->b, p->c, p->d));
         }
         break;
-    case shapes::SPHERE:
+        case shapes::SPHERE:
         {
             const shapes::Sphere* s = static_cast<const shapes::Sphere*>(shape.get());
             geometry.reset(new fcl::Sphered(s->radius));
         }
         break;
-    case shapes::BOX:
+        case shapes::BOX:
         {
             const shapes::Box* s = static_cast<const shapes::Box*>(shape.get());
             const double* size = s->size;
             geometry.reset(new fcl::Boxd(size[0], size[1], size[2]));
         }
         break;
-    case shapes::CYLINDER:
+        case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
             geometry.reset(new fcl::Cylinderd(s->radius, s->length));
         }
         break;
-    case shapes::CONE:
+        case shapes::CONE:
         {
             const shapes::Cone* s = static_cast<const shapes::Cone*>(shape.get());
             geometry.reset(new fcl::Coned(s->radius, s->length));
         }
         break;
-    case shapes::MESH:
+        case shapes::MESH:
         {
             fcl::BVHModel<fcl::OBBRSSd>* g = new fcl::BVHModel<fcl::OBBRSSd>();
             const shapes::Mesh* mesh = static_cast<const shapes::Mesh*>(shape.get());
@@ -139,7 +139,7 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
                 std::vector<fcl::Triangle> tri_indices(mesh->triangle_count);
                 for (unsigned int i = 0; i < mesh->triangle_count; ++i)
                     tri_indices[i] =
-                            fcl::Triangle(mesh->triangles[3 * i], mesh->triangles[3 * i + 1], mesh->triangles[3 * i + 2]);
+                        fcl::Triangle(mesh->triangles[3 * i], mesh->triangles[3 * i + 1], mesh->triangles[3 * i + 2]);
 
                 std::vector<fcl::Vector3d> points(mesh->vertex_count);
                 for (unsigned int i = 0; i < mesh->vertex_count; ++i)
@@ -152,14 +152,14 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
             geometry.reset(g);
         }
         break;
-    case shapes::OCTREE:
+        case shapes::OCTREE:
         {
             const shapes::OcTree* g = static_cast<const shapes::OcTree*>(shape.get());
             geometry.reset(new fcl::OcTreed(to_std_ptr(g->octree)));
         }
         break;
-    default:
-        throw_pretty("This shape type ("<<((int)shape->type)<<") is not supported using FCL yet");
+        default:
+            throw_pretty("This shape type (" << ((int)shape->type) << ") is not supported using FCL yet");
     }
     geometry->computeLocalAABB();
     geometry->setUserData(reinterpret_cast<void*>(element.get()));
@@ -177,18 +177,18 @@ bool CollisionSceneFCLLatest::isAllowedToCollide(fcl::CollisionObjectd* o1, fcl:
     bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink;
     bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink;
     // Don't check collisions between world objects
-    if(!isRobot1 && !isRobot2) return false;
+    if (!isRobot1 && !isRobot2) return false;
     // Skip self collisions if requested
-    if(isRobot1 && isRobot2 && !self) return false;
+    if (isRobot1 && isRobot2 && !self) return false;
     // Skip collisions between shapes within the same objects
-    if(e1->Parent==e2->Parent) return false;
+    if (e1->Parent == e2->Parent) return false;
     // Skip collisions between bodies attached to the same object
-    if(e1->ClosestRobotLink&&e2->ClosestRobotLink&&e1->ClosestRobotLink==e2->ClosestRobotLink) return false;
+    if (e1->ClosestRobotLink && e2->ClosestRobotLink && e1->ClosestRobotLink == e2->ClosestRobotLink) return false;
 
-    if(isRobot1 && isRobot2)
+    if (isRobot1 && isRobot2)
     {
-        const std::string& name1 = e1->ClosestRobotLink?e1->ClosestRobotLink->Segment.getName():e1->Parent->Segment.getName();
-        const std::string& name2 = e2->ClosestRobotLink?e2->ClosestRobotLink->Segment.getName():e2->Parent->Segment.getName();
+        const std::string& name1 = e1->ClosestRobotLink ? e1->ClosestRobotLink->Segment.getName() : e1->Parent->Segment.getName();
+        const std::string& name2 = e2->ClosestRobotLink ? e2->ClosestRobotLink->Segment.getName() : e2->Parent->Segment.getName();
         return scene->acm_.getAllowedCollision(name1, name2);
     }
     return true;
@@ -198,15 +198,15 @@ void CollisionSceneFCLLatest::checkCollision(fcl::CollisionObjectd* o1, fcl::Col
 {
     data->Request.num_max_contacts = 1000;
     data->Result.clear();
-    fcl::collide(o1,o2,data->Request, data->Result);
-    if(data->SafeDistance>0.0 && o1->getAABB().distance(o2->getAABB())<data->SafeDistance)
+    fcl::collide(o1, o2, data->Request, data->Result);
+    if (data->SafeDistance > 0.0 && o1->getAABB().distance(o2->getAABB()) < data->SafeDistance)
     {
         fcl::DistanceRequestd req;
         fcl::DistanceResultd res;
         req.enable_nearest_points = false;
         fcl::distance(o1, o2, req, res);
         // Add fake contact when distance is smaller than the safety distance.
-        if(res.min_distance<data->SafeDistance) data->Result.addContact(fcl::Contactd());
+        if (res.min_distance < data->SafeDistance) data->Result.addContact(fcl::Contactd());
     }
 }
 
@@ -214,7 +214,7 @@ bool CollisionSceneFCLLatest::collisionCallback(fcl::CollisionObjectd* o1, fcl::
 {
     CollisionData* data_ = reinterpret_cast<CollisionData*>(data);
 
-    if(!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
+    if (!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
 
     checkCollision(o1, o2, data_);
     return data_->Result.isCollision();
@@ -223,7 +223,7 @@ bool CollisionSceneFCLLatest::collisionCallback(fcl::CollisionObjectd* o1, fcl::
 void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, DistanceData* data)
 {
     data->Request.enable_nearest_points = true;
-    data->Request.enable_signed_distance = true; // Added in FCL 0.6.0
+    data->Request.enable_signed_distance = true;  // Added in FCL 0.6.0
     // GST_LIBCCD produces incorrect contacts. Probably due to incompatible version of libccd.
     data->Request.gjk_solver_type = fcl::GST_INDEP;
     data->Result.clear();
@@ -234,12 +234,12 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     p.e2 = reinterpret_cast<KinematicElement*>(o2->getUserData());
 
     p.distance = data->Result.min_distance;
-    if(p.distance>0)
+    if (p.distance > 0)
     {
-        KDL::Vector c1 = p.e1->Frame*KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-        KDL::Vector c2 = p.e2->Frame*KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        KDL::Vector n1 = c2-c1;
-        KDL::Vector n2 = c1-c2;
+        KDL::Vector c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+        KDL::Vector c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        KDL::Vector n1 = c2 - c1;
+        KDL::Vector n2 = c1 - c2;
         n1.Normalize();
         n2.Normalize();
         tf::vectorKDLToEigen(c1, p.contact1);
@@ -252,8 +252,8 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
         // Contact points are not reliable (FCL bug), use shape centres instead.
         KDL::Vector c1 = p.e1->Frame.p;
         KDL::Vector c2 = p.e2->Frame.p;
-        KDL::Vector n1 = c2-c1;
-        KDL::Vector n2 = c1-c2;
+        KDL::Vector n1 = c2 - c1;
+        KDL::Vector n2 = c1 - c2;
         n1.Normalize();
         n2.Normalize();
         tf::vectorKDLToEigen(c1, p.contact1);
@@ -269,7 +269,7 @@ bool CollisionSceneFCLLatest::collisionCallbackDistance(fcl::CollisionObjectd* o
 {
     DistanceData* data_ = reinterpret_cast<DistanceData*>(data);
 
-    if(!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
+    if (!isAllowedToCollide(o1, o2, data_->Self, data_->Scene)) return false;
     computeDistance(o1, o2, data_);
     return false;
 }
@@ -289,22 +289,22 @@ bool CollisionSceneFCLLatest::isCollisionFree(const std::string& o1, const std::
 {
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
-    for(fcl::CollisionObjectd* o : fcl_objects_)
+    for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
-        if(e->Segment.getName()==o1 || e->Parent->Segment.getName()==o1) shapes1.push_back(o);
-        if(e->Segment.getName()==o2 || e->Parent->Segment.getName()==o2) shapes2.push_back(o);
+        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
+        if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
-    if(shapes1.size()==0) throw_pretty("Can't find object '"<<o1<<"'!");
-    if(shapes2.size()==0) throw_pretty("Can't find object '"<<o2<<"'!");
+    if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
+    if (shapes2.size() == 0) throw_pretty("Can't find object '" << o2 << "'!");
     CollisionData data(this);
     data.SafeDistance = safe_distance;
-    for(fcl::CollisionObjectd* s1 : shapes1)
+    for (fcl::CollisionObjectd* s1 : shapes1)
     {
-        for(fcl::CollisionObjectd* s2 : shapes2)
+        for (fcl::CollisionObjectd* s2 : shapes2)
         {
             checkCollision(s1, s2, &data);
-            if(data.Result.isCollision()) return false;
+            if (data.Result.isCollision()) return false;
         }
     }
     return true;
@@ -324,18 +324,18 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
 {
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
-    for(fcl::CollisionObjectd* o : fcl_objects_)
+    for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
-        if(e->Segment.getName()==o1 || e->Parent->Segment.getName()==o1) shapes1.push_back(o);
-        if(e->Segment.getName()==o2 || e->Parent->Segment.getName()==o2) shapes2.push_back(o);
+        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
+        if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
-    if(shapes1.size()==0) throw_pretty("Can't find object '"<<o1<<"'!");
-    if(shapes2.size()==0) throw_pretty("Can't find object '"<<o2<<"'!");
+    if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
+    if (shapes2.size() == 0) throw_pretty("Can't find object '" << o2 << "'!");
     DistanceData data(this);
-    for(fcl::CollisionObjectd* s1 : shapes1)
+    for (fcl::CollisionObjectd* s1 : shapes1)
     {
-        for(fcl::CollisionObjectd* s2 : shapes2)
+        for (fcl::CollisionObjectd* s2 : shapes2)
         {
             computeDistance(s1, s2, &data);
         }
@@ -343,17 +343,18 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
     return data.Proxies;
 }
 
-Eigen::Vector3d CollisionSceneFCLLatest::getTranslation(const std::string & name)
+Eigen::Vector3d CollisionSceneFCLLatest::getTranslation(const std::string& name)
 {
-    for(fcl::CollisionObjectd* object : fcl_objects_)
+    for (fcl::CollisionObjectd* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(element->Segment.getName()==name)
+        if (element->Segment.getName() == name)
         {
             return Eigen::Map<Eigen::Vector3d>(element->Frame.p.data);
         }
     }
-    throw_pretty("Robot not found!");;
+    throw_pretty("Robot not found!");
+    ;
 }
 
 std::vector<std::string> CollisionSceneFCLLatest::getCollisionWorldLinks()
@@ -362,7 +363,7 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionWorldLinks()
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(!element->ClosestRobotLink)
+        if (!element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
         }
@@ -381,12 +382,11 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionRobotLinks()
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
         KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
-        if(element->ClosestRobotLink)
+        if (element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
         }
     }
     return tmp;
 }
-
 }

--- a/exotations/solvers/aico/include/aico/incremental_gaussian.h
+++ b/exotations/solvers/aico/include/aico/incremental_gaussian.h
@@ -39,8 +39,8 @@ Chan, Tony F.; Golub, Gene H.; LeVeque, Randall J. (1979), “Updating Formulae 
 #ifndef SINGLE_PASS_MEAN_COVARIANCE_H
 #define SINGLE_PASS_MEAN_COVARIANCE_H
 
-#include <vector>
 #include <Eigen/Dense>
+#include <vector>
 
 class SinglePassMeanCoviariance
 {
@@ -50,128 +50,129 @@ class SinglePassMeanCoviariance
     Eigen::VectorXd T;
     Eigen::VectorXd dX;
     Eigen::MatrixXd S;
+
 public:
     SinglePassMeanCoviariance()
     {
-      D = 0;
-      D2 = 0;
-      T.resize(0);
-      dX.resize(0);
-      S.resize(0, 0);
+        D = 0;
+        D2 = 0;
+        T.resize(0);
+        dX.resize(0);
+        S.resize(0, 0);
     }
 
     SinglePassMeanCoviariance(int D_)
     {
-      resize(D_);
+        resize(D_);
     }
 
     void resize(int D_)
     {
-      D = D_;
-      D2 = (D_ * (D_ + 1) / 2);
+        D = D_;
+        D2 = (D_ * (D_ + 1) / 2);
 
-      T.resize(D_);
-      dX.resize(D_);
-      S.resize(D_, D_);
+        T.resize(D_);
+        dX.resize(D_);
+        S.resize(D_, D_);
 
-      clear();
+        clear();
     }
 
     void clear()
     {
-      T.setZero();
-      dX.setZero();
-      S.setZero();
-      W = 0.;
+        T.setZero();
+        dX.setZero();
+        S.setZero();
+        W = 0.;
     }
 
-    void add(const Eigen::Ref<const Eigen::VectorXd> & x)
+    void add(const Eigen::Ref<const Eigen::VectorXd>& x)
     {
-      if (W == 0.)
-      {
-        W = 1.;
-        T = x;
-        S.setZero();
-        return;
-      }
-      W += 1.;
-      T += x;
-      double f = 1. / W / (W - 1.);
-      dX = W * x - T;
-      for (int r = 0; r < D; r++)
-      {
-        for (int c = 0; c < D; c++)
+        if (W == 0.)
         {
-          S(r, c) += f * dX(r) * dX(c);
+            W = 1.;
+            T = x;
+            S.setZero();
+            return;
         }
-      }
+        W += 1.;
+        T += x;
+        double f = 1. / W / (W - 1.);
+        dX = W * x - T;
+        for (int r = 0; r < D; r++)
+        {
+            for (int c = 0; c < D; c++)
+            {
+                S(r, c) += f * dX(r) * dX(c);
+            }
+        }
     }
 
     inline void add(SinglePassMeanCoviariance& M)
     {
-      add(M.W, M.T, M.S);
+        add(M.W, M.T, M.S);
     }
 
-    void add(double& W_, const Eigen::Ref<const Eigen::VectorXd> & T_,
-        const Eigen::Ref<const Eigen::VectorXd> & S_)
+    void add(double& W_, const Eigen::Ref<const Eigen::VectorXd>& T_,
+             const Eigen::Ref<const Eigen::VectorXd>& S_)
     {
-      if (W == 0.)
-      {
-        W = W_;
-        T = T_;
-        S = S_;
-        return;
-      }
-      dX = T_ / W_ - T / W;
-
-      double f = W * W_ / (W + W_);
-      for (int r = 0; r < D; r++)
-      {
-        for (int c = 0; c < D; c++)
+        if (W == 0.)
         {
-          S(r, c) += S_(r, c) + f * dX(r) * dX(c);
+            W = W_;
+            T = T_;
+            S = S_;
+            return;
         }
-      }
-      T += T_;
-      W += W_;
+        dX = T_ / W_ - T / W;
+
+        double f = W * W_ / (W + W_);
+        for (int r = 0; r < D; r++)
+        {
+            for (int c = 0; c < D; c++)
+            {
+                S(r, c) += S_(r, c) + f * dX(r) * dX(c);
+            }
+        }
+        T += T_;
+        W += W_;
     }
 
-    inline void addw(double w, const Eigen::Ref<const Eigen::VectorXd> & x)
+    inline void addw(double w, const Eigen::Ref<const Eigen::VectorXd>& x)
     {
-      if (W == 0.)
-      {
-        W = w;
-        T = w * x;
-        S.setZero();
-        return;
-      }
-
-      dX = x - T / W;
-
-      double f = W * w / (W + w);
-      for (int r = 0; r < D; r++)
-      {
-        for (int c = 0; c < D; c++)
+        if (W == 0.)
         {
-          S(r, c) += f * dX(r) * dX(c);
+            W = w;
+            T = w * x;
+            S.setZero();
+            return;
         }
-      }
 
-      T += w * x;
-      W += w;
+        dX = x - T / W;
+
+        double f = W * w / (W + w);
+        for (int r = 0; r < D; r++)
+        {
+            for (int c = 0; c < D; c++)
+            {
+                S(r, c) += f * dX(r) * dX(c);
+            }
+        }
+
+        T += w * x;
+        W += w;
     }
 
     void mean(Eigen::VectorXd& mu)
     {
-      mu = T / W;
+        mu = T / W;
     }
     void cov(Eigen::MatrixXd& sig)
     {
-      sig = S / W;
+        sig = S / W;
     }
     void covp(Eigen::MatrixXd& sig)
     {
-      sig = S / (W - 1.);
+        sig = S / (W - 1.);
     }
 };
 

--- a/exotations/solvers/aico/include/lapack/cblas.h
+++ b/exotations/solvers/aico/include/lapack/cblas.h
@@ -13,27 +13,33 @@ ISBN = 0-89871-447-8 (paperback)
 #define CBLAS_H
 #include <cstddef>
 
-#define CBLAS_INDEX size_t 
+#define CBLAS_INDEX size_t
 
 enum CBLAS_ORDER
 {
-  CblasRowMajor = 101, CblasColMajor = 102
+    CblasRowMajor = 101,
+    CblasColMajor = 102
 };
 enum CBLAS_TRANSPOSE
 {
-  CblasNoTrans = 111, CblasTrans = 112, CblasConjTrans = 113
+    CblasNoTrans = 111,
+    CblasTrans = 112,
+    CblasConjTrans = 113
 };
 enum CBLAS_UPLO
 {
-  CblasUpper = 121, CblasLower = 122
+    CblasUpper = 121,
+    CblasLower = 122
 };
 enum CBLAS_DIAG
 {
-  CblasNonUnit = 131, CblasUnit = 132
+    CblasNonUnit = 131,
+    CblasUnit = 132
 };
 enum CBLAS_SIDE
 {
-  CblasLeft = 141, CblasRight = 142
+    CblasLeft = 141,
+    CblasRight = 142
 };
 
 int cblas_errprn(int ierr, int info, char *form, ...);
@@ -44,25 +50,25 @@ int cblas_errprn(int ierr, int info, char *form, ...);
  * ===========================================================================
  */
 float cblas_sdsdot(const int N, const float alpha, const float *X,
-    const int incX, const float *Y, const int incY);
+                   const int incX, const float *Y, const int incY);
 double cblas_dsdot(const int N, const float *X, const int incX, const float *Y,
-    const int incY);
+                   const int incY);
 float cblas_sdot(const int N, const float *X, const int incX, const float *Y,
-    const int incY);
+                 const int incY);
 double cblas_ddot(const int N, const double *X, const int incX, const double *Y,
-    const int incY);
+                  const int incY);
 /*
  * Functions having prefixes Z and C only
  */
 void cblas_cdotu_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotu);
+                     const int incY, void *dotu);
 void cblas_cdotc_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotc);
+                     const int incY, void *dotc);
 
 void cblas_zdotu_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotu);
+                     const int incY, void *dotu);
 void cblas_zdotc_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotc);
+                     const int incY, void *dotc);
 
 /*
  * Functions having prefixes S D SC DZ
@@ -97,30 +103,30 @@ CBLAS_INDEX cblas_izamax(const int N, const void *X, const int incX);
  * Routines with standard 4 prefixes (s, d, c, z)
  */
 void cblas_sswap(const int N, float *X, const int incX, float *Y,
-    const int incY);
+                 const int incY);
 void cblas_scopy(const int N, const float *X, const int incX, float *Y,
-    const int incY);
+                 const int incY);
 void cblas_saxpy(const int N, const float alpha, const float *X, const int incX,
-    float *Y, const int incY);
+                 float *Y, const int incY);
 
 void cblas_dswap(const int N, double *X, const int incX, double *Y,
-    const int incY);
+                 const int incY);
 void cblas_dcopy(const int N, const double *X, const int incX, double *Y,
-    const int incY);
+                 const int incY);
 void cblas_daxpy(const int N, const double alpha, const double *X,
-    const int incX, double *Y, const int incY);
+                 const int incX, double *Y, const int incY);
 
 void cblas_cswap(const int N, void *X, const int incX, void *Y, const int incY);
 void cblas_ccopy(const int N, const void *X, const int incX, void *Y,
-    const int incY);
+                 const int incY);
 void cblas_caxpy(const int N, const void *alpha, const void *X, const int incX,
-    void *Y, const int incY);
+                 void *Y, const int incY);
 
 void cblas_zswap(const int N, void *X, const int incX, void *Y, const int incY);
 void cblas_zcopy(const int N, const void *X, const int incX, void *Y,
-    const int incY);
+                 const int incY);
 void cblas_zaxpy(const int N, const void *alpha, const void *X, const int incX,
-    void *Y, const int incY);
+                 void *Y, const int incY);
 
 /*
  * Routines with S and D prefix only
@@ -128,17 +134,17 @@ void cblas_zaxpy(const int N, const void *alpha, const void *X, const int incX,
 void cblas_srotg(float *a, float *b, float *c, float *s);
 void cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
 void cblas_srot(const int N, float *X, const int incX, float *Y, const int incY,
-    const float c, const float s);
+                const float c, const float s);
 void cblas_srotm(const int N, float *X, const int incX, float *Y,
-    const int incY, const float *P);
+                 const int incY, const float *P);
 
 void cblas_drotg(double *a, double *b, double *c, double *s);
 void cblas_drotmg(double *d1, double *d2, double *b1, const double b2,
-    double *P);
+                  double *P);
 void cblas_drot(const int N, double *X, const int incX, double *Y,
-    const int incY, const double c, const double s);
+                const int incY, const double c, const double s);
 void cblas_drotm(const int N, double *X, const int incX, double *Y,
-    const int incY, const double *P);
+                 const int incY, const double *P);
 
 /*
  * Routines with S D C Z CS and ZD prefixes
@@ -160,224 +166,224 @@ void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const float alpha, const float *A, const int lda, const float *X,
-    const int incX, const float beta, float *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const float alpha, const float *A, const int lda, const float *X,
+                 const int incX, const float beta, float *Y, const int incY);
 void cblas_sgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_strmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *A, const int lda, float *X, const int incX);
 void cblas_stbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const float *A, const int lda, float *X, const int incX);
 void cblas_stpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *Ap, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *Ap, float *X, const int incX);
 void cblas_strsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *A, const int lda, float *X, const int incX);
 void cblas_stbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const float *A, const int lda, float *X, const int incX);
 void cblas_stpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *Ap, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *Ap, float *X, const int incX);
 
 void cblas_dgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const double alpha, const double *A, const int lda, const double *X,
-    const int incX, const double beta, double *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const double alpha, const double *A, const int lda, const double *X,
+                 const int incX, const double beta, double *Y, const int incY);
 void cblas_dgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const double alpha, const double *A, const int lda,
-    const double *X, const int incX, const double beta, double *Y,
-    const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const double alpha, const double *A, const int lda,
+                 const double *X, const int incX, const double beta, double *Y,
+                 const int incY);
 void cblas_dtrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *A, const int lda, double *X, const int incX);
 void cblas_dtbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const double *A, const int lda, double *X, const int incX);
 void cblas_dtpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *Ap, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *Ap, double *X, const int incX);
 void cblas_dtrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *A, const int lda, double *X, const int incX);
 void cblas_dtbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const double *A, const int lda, double *X, const int incX);
 void cblas_dtpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *Ap, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *Ap, double *X, const int incX);
 
 void cblas_cgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_cgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_ctrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ctbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ctpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 void cblas_ctrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ctbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ctpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 
 void cblas_zgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_ztrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ztbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ztpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 void cblas_ztrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ztbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ztpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 
 /*
  * Routines with S and D prefixes only
  */
 void cblas_ssymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const int N, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_ssbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const int N, const int K, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_sspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *Ap, const float *X,
-    const int incX, const float beta, float *Y, const int incY);
+                 const int N, const float alpha, const float *Ap, const float *X,
+                 const int incX, const float beta, float *Y, const int incY);
 void cblas_sger(const enum CBLAS_ORDER Order, const int M, const int N,
-    const float alpha, const float *X, const int incX, const float *Y,
-    const int incY, float *A, const int lda);
+                const float alpha, const float *X, const int incX, const float *Y,
+                const int incY, float *A, const int lda);
 void cblas_ssyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX, float *A,
-    const int lda);
+                const int N, const float alpha, const float *X, const int incX, float *A,
+                const int lda);
 void cblas_sspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX, float *Ap);
+                const int N, const float alpha, const float *X, const int incX, float *Ap);
 void cblas_ssyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX,
-    const float *Y, const int incY, float *A, const int lda);
+                 const int N, const float alpha, const float *X, const int incX,
+                 const float *Y, const int incY, float *A, const int lda);
 void cblas_sspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX,
-    const float *Y, const int incY, float *A);
+                 const int N, const float alpha, const float *X, const int incX,
+                 const float *Y, const int incY, float *A);
 
 void cblas_dsymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *A, const int lda,
-    const double *X, const int incX, const double beta, double *Y,
-    const int incY);
+                 const int N, const double alpha, const double *A, const int lda,
+                 const double *X, const int incX, const double beta, double *Y,
+                 const int incY);
 void cblas_dsbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const double alpha, const double *A,
-    const int lda, const double *X, const int incX, const double beta,
-    double *Y, const int incY);
+                 const int N, const int K, const double alpha, const double *A,
+                 const int lda, const double *X, const int incX, const double beta,
+                 double *Y, const int incY);
 void cblas_dspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *Ap, const double *X,
-    const int incX, const double beta, double *Y, const int incY);
+                 const int N, const double alpha, const double *Ap, const double *X,
+                 const int incX, const double beta, double *Y, const int incY);
 void cblas_dger(const enum CBLAS_ORDER Order, const int M, const int N,
-    const double alpha, const double *X, const int incX, const double *Y,
-    const int incY, double *A, const int lda);
+                const double alpha, const double *X, const int incX, const double *Y,
+                const int incY, double *A, const int lda);
 void cblas_dsyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX, double *A,
-    const int lda);
+                const int N, const double alpha, const double *X, const int incX, double *A,
+                const int lda);
 void cblas_dspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    double *Ap);
+                const int N, const double alpha, const double *X, const int incX,
+                double *Ap);
 void cblas_dsyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    const double *Y, const int incY, double *A, const int lda);
+                 const int N, const double alpha, const double *X, const int incX,
+                 const double *Y, const int incY, double *A, const int lda);
 void cblas_dspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    const double *Y, const int incY, double *A);
+                 const int N, const double alpha, const double *X, const int incX,
+                 const double *Y, const int incY, double *A);
 
 /*
  * Routines with C and Z prefixes only
  */
 void cblas_chemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_chbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const int K, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_chpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *Ap, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *Ap, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_cgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_cgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_cher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const void *X, const int incX, void *A,
-    const int lda);
+                const int N, const float alpha, const void *X, const int incX, void *A,
+                const int lda);
 void cblas_chpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const void *X, const int incX, void *A);
+                const int N, const float alpha, const void *X, const int incX, void *A);
 void cblas_cher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *A, const int lda);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
 void cblas_chpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *Ap);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *Ap);
 
 void cblas_zhemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zhbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const int K, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_zhpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *Ap, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *Ap, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_zgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_zher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const void *X, const int incX, void *A,
-    const int lda);
+                const int N, const double alpha, const void *X, const int incX, void *A,
+                const int lda);
 void cblas_zhpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const void *X, const int incX, void *A);
+                const int N, const double alpha, const void *X, const int incX, void *A);
 void cblas_zher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *A, const int lda);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
 void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *Ap);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *Ap);
 
 /*
  * ===========================================================================
@@ -389,136 +395,136 @@ void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const float alpha, const float *A,
-    const int lda, const float *B, const int ldb, const float beta, float *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const float alpha, const float *A,
+                 const int lda, const float *B, const int ldb, const float beta, float *C,
+                 const int ldc);
 void cblas_ssymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const float alpha,
-    const float *A, const int lda, const float *B, const int ldb,
-    const float beta, float *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const float alpha,
+                 const float *A, const int lda, const float *B, const int ldb,
+                 const float beta, float *C, const int ldc);
 void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const float *A, const int lda, const float beta,
-    float *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const float *A, const int lda, const float beta,
+                 float *C, const int ldc);
 void cblas_ssyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const float *A, const int lda, const float *B,
-    const int ldb, const float beta, float *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const float alpha, const float *A, const int lda, const float *B,
+                  const int ldb, const float beta, float *C, const int ldc);
 void cblas_strmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
-    const float *A, const int lda, float *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
+                 const float *A, const int lda, float *B, const int ldb);
 void cblas_strsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
-    const float *A, const int lda, float *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
+                 const float *A, const int lda, float *B, const int ldb);
 
 void cblas_dgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const double alpha, const double *A,
-    const int lda, const double *B, const int ldb, const double beta, double *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const double alpha, const double *A,
+                 const int lda, const double *B, const int ldb, const double beta, double *C,
+                 const int ldc);
 void cblas_dsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const double alpha,
-    const double *A, const int lda, const double *B, const int ldb,
-    const double beta, double *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const double alpha,
+                 const double *A, const int lda, const double *B, const int ldb,
+                 const double beta, double *C, const int ldc);
 void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const double *A, const int lda, const double beta,
-    double *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const double *A, const int lda, const double beta,
+                 double *C, const int ldc);
 void cblas_dsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const double *A, const int lda, const double *B,
-    const int ldb, const double beta, double *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const double alpha, const double *A, const int lda, const double *B,
+                  const int ldb, const double beta, double *C, const int ldc);
 void cblas_dtrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
-    const double *A, const int lda, double *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
+                 const double *A, const int lda, double *B, const int ldb);
 void cblas_dtrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
-    const double *A, const int lda, double *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
+                 const double *A, const int lda, double *B, const int ldb);
 
 void cblas_cgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const void *alpha, const void *A,
-    const int lda, const void *B, const int ldb, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb, const void *beta, void *C,
+                 const int ldc);
 void cblas_csymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_csyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda, const void *beta, void *C,
+                 const int ldc);
 void cblas_csyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const void *beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const void *beta, void *C, const int ldc);
 void cblas_ctrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 void cblas_ctrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 
 void cblas_zgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const void *alpha, const void *A,
-    const int lda, const void *B, const int ldb, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb, const void *beta, void *C,
+                 const int ldc);
 void cblas_zsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_zsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda, const void *beta, void *C,
+                 const int ldc);
 void cblas_zsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const void *beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const void *beta, void *C, const int ldc);
 void cblas_ztrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 
 /*
  * Routines with prefixes C and Z only
  */
 void cblas_chemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_cherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const void *A, const int lda, const float beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const void *A, const int lda, const float beta, void *C,
+                 const int ldc);
 void cblas_cher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const float beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const float beta, void *C, const int ldc);
 void cblas_zhemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_zherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const void *A, const int lda, const double beta,
-    void *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const void *A, const int lda, const double beta,
+                 void *C, const int ldc);
 void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const double beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const double beta, void *C, const int ldc);
 
 int cblas_errprn(int ierr, int info, char *form, ...);
 

--- a/exotations/solvers/aico/include/lapack/clapack.h
+++ b/exotations/solvers/aico/include/lapack/clapack.h
@@ -14,7292 +14,7291 @@ ISBN = 0-89871-447-8 (paperback)
 #ifndef __CLAPACK_H
 #define __CLAPACK_H
 
-#ifdef __cplusplus 	
-extern "C"
-{
-#endif		
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-  /* Subroutine */int caxpy_(integer *n, complex *ca, complex *cx,
-      integer * incx, complex *cy, integer *incy);
+/* Subroutine */ int caxpy_(integer *n, complex *ca, complex *cx,
+                            integer *incx, complex *cy, integer *incy);
 
-  /* Subroutine */int ccopy_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy);
+/* Subroutine */ int ccopy_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy);
 
-  /* Complex */VOID cdotc_(complex * ret_val, integer *n, complex *cx,
-      integer *incx, complex *cy, integer *incy);
+/* Complex */ VOID cdotc_(complex *ret_val, integer *n, complex *cx,
+                          integer *incx, complex *cy, integer *incy);
 
-  /* Complex */VOID cdotu_(complex * ret_val, integer *n, complex *cx,
-      integer *incx, complex *cy, integer *incy);
+/* Complex */ VOID cdotu_(complex *ret_val, integer *n, complex *cx,
+                          integer *incx, complex *cy, integer *incy);
 
-  /* Subroutine */int cgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, complex *alpha, complex *a, integer *lda, complex *x,
-      integer *incx, complex *beta, complex *y, integer *incy);
+/* Subroutine */ int cgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, complex *alpha, complex *a, integer *lda, complex *x,
+                            integer *incx, complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int cgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb, complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int cgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb, complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int cgemv_(char *trans, integer *m, integer *n,
-      complex * alpha, complex *a, integer *lda, complex *x, integer *incx,
-      complex * beta, complex *y, integer *incy);
+/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                            complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int cgerc_(integer *m, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cgerc_(integer *m, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int cgeru_(integer *m, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cgeru_(integer *m, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int chbmv_(char *uplo, integer *n, integer *k,
-      complex * alpha, complex *a, integer *lda, complex *x, integer *incx,
-      complex * beta, complex *y, integer *incy);
+/* Subroutine */ int chbmv_(char *uplo, integer *n, integer *k,
+                            complex *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                            complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int chemm_(char *side, char *uplo, integer *m, integer *n,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int chemm_(char *side, char *uplo, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int chemv_(char *uplo, integer *n, complex *alpha,
-      complex * a, integer *lda, complex *x, integer *incx, complex *beta,
-      complex *y, integer *incy);
+/* Subroutine */ int chemv_(char *uplo, integer *n, complex *alpha,
+                            complex *a, integer *lda, complex *x, integer *incx, complex *beta,
+                            complex *y, integer *incy);
 
-  /* Subroutine */int cher_(char *uplo, integer *n, real *alpha, complex *x,
-      integer *incx, complex *a, integer *lda);
+/* Subroutine */ int cher_(char *uplo, integer *n, real *alpha, complex *x,
+                           integer *incx, complex *a, integer *lda);
 
-  /* Subroutine */int cher2_(char *uplo, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cher2_(char *uplo, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int cher2k_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      real *beta, complex *c__, integer *ldc);
+/* Subroutine */ int cher2k_(char *uplo, char *trans, integer *n, integer *k,
+                             complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                             real *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int cherk_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, complex *a, integer *lda, real *beta, complex *c__,
-      integer *ldc);
+/* Subroutine */ int cherk_(char *uplo, char *trans, integer *n, integer *k,
+                            real *alpha, complex *a, integer *lda, real *beta, complex *c__,
+                            integer *ldc);
 
-  /* Subroutine */int chpmv_(char *uplo, integer *n, complex *alpha,
-      complex * ap, complex *x, integer *incx, complex *beta, complex *y,
-      integer * incy);
+/* Subroutine */ int chpmv_(char *uplo, integer *n, complex *alpha,
+                            complex *ap, complex *x, integer *incx, complex *beta, complex *y,
+                            integer *incy);
 
-  /* Subroutine */int chpr_(char *uplo, integer *n, real *alpha, complex *x,
-      integer *incx, complex *ap);
+/* Subroutine */ int chpr_(char *uplo, integer *n, real *alpha, complex *x,
+                           integer *incx, complex *ap);
 
-  /* Subroutine */int chpr2_(char *uplo, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *ap);
+/* Subroutine */ int chpr2_(char *uplo, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *ap);
 
-  /* Subroutine */int crotg_(complex *ca, complex *cb, real *c__, complex *s);
+/* Subroutine */ int crotg_(complex *ca, complex *cb, real *c__, complex *s);
 
-  /* Subroutine */int cscal_(integer *n, complex *ca, complex *cx,
-      integer * incx);
+/* Subroutine */ int cscal_(integer *n, complex *ca, complex *cx,
+                            integer *incx);
 
-  /* Subroutine */int csrot_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, real *c__, real *s);
+/* Subroutine */ int csrot_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy, real *c__, real *s);
 
-  /* Subroutine */int csscal_(integer *n, real *sa, complex *cx, integer *incx);
+/* Subroutine */ int csscal_(integer *n, real *sa, complex *cx, integer *incx);
 
-  /* Subroutine */int cswap_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy);
+/* Subroutine */ int cswap_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy);
 
-  /* Subroutine */int csymm_(char *side, char *uplo, integer *m, integer *n,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int csymm_(char *side, char *uplo, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int csyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int csyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int csyrk_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *beta, complex *c__,
-      integer *ldc);
+/* Subroutine */ int csyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            complex *alpha, complex *a, integer *lda, complex *beta, complex *c__,
+                            integer *ldc);
 
-  /* Subroutine */int ctbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctpmv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *ap, complex *x, integer *incx);
+/* Subroutine */ int ctpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *ap, complex *x, integer *incx);
 
-  /* Subroutine */int ctpsv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *ap, complex *x, integer *incx);
+/* Subroutine */ int ctpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *ap, complex *x, integer *incx);
 
-  /* Subroutine */int ctrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctrmv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctrsv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *a, integer *lda, complex *x, integer *incx);
 
-  doublereal dasum_(integer *n, doublereal *dx, integer *incx);
+doublereal dasum_(integer *n, doublereal *dx, integer *incx);
 
-  /* Subroutine */int daxpy_(integer *n, doublereal *da, doublereal *dx,
-      integer *incx, doublereal *dy, integer *incy);
+/* Subroutine */ int daxpy_(integer *n, doublereal *da, doublereal *dx,
+                            integer *incx, doublereal *dy, integer *incy);
 
-  doublereal dcabs1_(doublecomplex *z__);
+doublereal dcabs1_(doublecomplex *z__);
 
-  /* Subroutine */int dcopy_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy);
+/* Subroutine */ int dcopy_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy);
 
-  doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
-      integer *incy);
+doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
+                 integer *incy);
 
-  /* Subroutine */int dgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *x, integer *incx, doublereal *beta, doublereal *y,
-      integer *incy);
+/* Subroutine */ int dgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *x, integer *incx, doublereal *beta, doublereal *y,
+                            integer *incy);
 
-  /* Subroutine */int dgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *b, integer *ldb, doublereal *beta, doublereal *c__,
-      integer *ldc);
+/* Subroutine */ int dgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb, doublereal *beta, doublereal *c__,
+                            integer *ldc);
 
-  /* Subroutine */int dgemv_(char *trans, integer *m, integer *n,
-      doublereal * alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dgemv_(char *trans, integer *m, integer *n,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                            integer *incx, doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dger_(integer *m, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
-      integer *lda);
+/* Subroutine */ int dger_(integer *m, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
+                           integer *lda);
 
-  doublereal dnrm2_(integer *n, doublereal *x, integer *incx);
+doublereal dnrm2_(integer *n, doublereal *x, integer *incx);
 
-  /* Subroutine */int drot_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy, doublereal *c__, doublereal *s);
+/* Subroutine */ int drot_(integer *n, doublereal *dx, integer *incx,
+                           doublereal *dy, integer *incy, doublereal *c__, doublereal *s);
 
-  /* Subroutine */int drotg_(doublereal *da, doublereal *db, doublereal *c__,
-      doublereal *s);
+/* Subroutine */ int drotg_(doublereal *da, doublereal *db, doublereal *c__,
+                            doublereal *s);
 
-  /* Subroutine */int drotm_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy, doublereal *dparam);
+/* Subroutine */ int drotm_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy, doublereal *dparam);
 
-  /* Subroutine */int drotmg_(doublereal *dd1, doublereal *dd2,
-      doublereal * dx1, doublereal *dy1, doublereal *dparam);
+/* Subroutine */ int drotmg_(doublereal *dd1, doublereal *dd2,
+                             doublereal *dx1, doublereal *dy1, doublereal *dparam);
 
-  /* Subroutine */int dsbmv_(char *uplo, integer *n, integer *k,
-      doublereal * alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dsbmv_(char *uplo, integer *n, integer *k,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                            integer *incx, doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dscal_(integer *n, doublereal *da, doublereal *dx,
-      integer *incx);
+/* Subroutine */ int dscal_(integer *n, doublereal *da, doublereal *dx,
+                            integer *incx);
 
-  doublereal dsdot_(integer *n, real *sx, integer *incx, real *sy,
-      integer * incy);
+doublereal dsdot_(integer *n, real *sx, integer *incx, real *sy,
+                  integer *incy);
 
-  /* Subroutine */int dspmv_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *ap, doublereal *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
+/* Subroutine */ int dspmv_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *ap, doublereal *x, integer *incx, doublereal *beta,
+                            doublereal *y, integer *incy);
 
-  /* Subroutine */int dspr_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *ap);
+/* Subroutine */ int dspr_(char *uplo, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *ap);
 
-  /* Subroutine */int dspr2_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy,
-      doublereal *ap);
+/* Subroutine */ int dspr2_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *x, integer *incx, doublereal *y, integer *incy,
+                            doublereal *ap);
 
-  /* Subroutine */int dswap_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy);
+/* Subroutine */ int dswap_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy);
 
-  /* Subroutine */int dsymm_(char *side, char *uplo, integer *m, integer *n,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
+/* Subroutine */ int dsymm_(char *side, char *uplo, integer *m, integer *n,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dsymv_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *a, integer *lda, doublereal *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dsymv_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx,
+                            doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dsyr_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *a, integer *lda);
+/* Subroutine */ int dsyr_(char *uplo, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *a, integer *lda);
 
-  /* Subroutine */int dsyr2_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
-      integer *lda);
+/* Subroutine */ int dsyr2_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
+                            integer *lda);
 
-  /* Subroutine */int dsyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
+/* Subroutine */ int dsyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dsyrk_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *beta,
-      doublereal *c__, integer *ldc);
+/* Subroutine */ int dsyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *beta,
+                            doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dtbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtpmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *ap, doublereal *x, integer *incx);
+/* Subroutine */ int dtpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *ap, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtpsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *ap, doublereal *x, integer *incx);
+/* Subroutine */ int dtpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *ap, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublereal *alpha, doublereal *a, integer * lda,
-      doublereal *b, integer *ldb);
+/* Subroutine */ int dtrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb);
 
-  /* Subroutine */int dtrmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublereal *alpha, doublereal *a, integer * lda,
-      doublereal *b, integer *ldb);
+/* Subroutine */ int dtrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb);
 
-  /* Subroutine */int dtrsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx);
+doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx);
 
-  doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx);
+doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx);
 
-  integer icamax_(integer *n, complex *cx, integer *incx);
+integer icamax_(integer *n, complex *cx, integer *incx);
 
-  integer idamax_(integer *n, doublereal *dx, integer *incx);
+integer idamax_(integer *n, doublereal *dx, integer *incx);
 
-  integer isamax_(integer *n, real *sx, integer *incx);
+integer isamax_(integer *n, real *sx, integer *incx);
 
-  integer izamax_(integer *n, doublecomplex *zx, integer *incx);
+integer izamax_(integer *n, doublecomplex *zx, integer *incx);
 
-  logical lsame_(char *ca, char *cb);
+logical lsame_(char *ca, char *cb);
 
-  doublereal sasum_(integer *n, real *sx, integer *incx);
+doublereal sasum_(integer *n, real *sx, integer *incx);
 
-  /* Subroutine */int saxpy_(integer *n, real *sa, real *sx, integer *incx,
-      real *sy, integer *incy);
+/* Subroutine */ int saxpy_(integer *n, real *sa, real *sx, integer *incx,
+                            real *sy, integer *incy);
 
-  doublereal scabs1_(complex *z__);
+doublereal scabs1_(complex *z__);
 
-  doublereal scasum_(integer *n, complex *cx, integer *incx);
+doublereal scasum_(integer *n, complex *cx, integer *incx);
 
-  doublereal scnrm2_(integer *n, complex *x, integer *incx);
+doublereal scnrm2_(integer *n, complex *x, integer *incx);
 
-  /* Subroutine */int scopy_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+/* Subroutine */ int scopy_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy);
 
-  doublereal sdot_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+doublereal sdot_(integer *n, real *sx, integer *incx, real *sy,
+                 integer *incy);
 
-  doublereal sdsdot_(integer *n, real *sb, real *sx, integer *incx, real *sy,
-      integer *incy);
+doublereal sdsdot_(integer *n, real *sb, real *sx, integer *incx, real *sy,
+                   integer *incy);
 
-  /* Subroutine */int sgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, real *alpha, real *a, integer *lda, real *x, integer * incx,
-      real *beta, real *y, integer *incy);
+/* Subroutine */ int sgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, real *alpha, real *a, integer *lda, real *x, integer *incx,
+                            real *beta, real *y, integer *incy);
 
-  /* Subroutine */int sgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, real *alpha, real *a, integer *lda, real *b,
-      integer * ldb, real *beta, real *c__, integer *ldc);
+/* Subroutine */ int sgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb, real *beta, real *c__, integer *ldc);
 
-  /* Subroutine */int sgemv_(char *trans, integer *m, integer *n, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int sgemv_(char *trans, integer *m, integer *n, real *alpha,
+                            real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int sger_(integer *m, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *a, integer *lda);
+/* Subroutine */ int sger_(integer *m, integer *n, real *alpha, real *x,
+                           integer *incx, real *y, integer *incy, real *a, integer *lda);
 
-  doublereal snrm2_(integer *n, real *x, integer *incx);
+doublereal snrm2_(integer *n, real *x, integer *incx);
 
-  /* Subroutine */int srot_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy, real *c__, real *s);
+/* Subroutine */ int srot_(integer *n, real *sx, integer *incx, real *sy,
+                           integer *incy, real *c__, real *s);
 
-  /* Subroutine */int srotg_(real *sa, real *sb, real *c__, real *s);
+/* Subroutine */ int srotg_(real *sa, real *sb, real *c__, real *s);
 
-  /* Subroutine */int srotm_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy, real *sparam);
+/* Subroutine */ int srotm_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy, real *sparam);
 
-  /* Subroutine */int srotmg_(real *sd1, real *sd2, real *sx1, real *sy1,
-      real *sparam);
+/* Subroutine */ int srotmg_(real *sd1, real *sd2, real *sx1, real *sy1,
+                             real *sparam);
 
-  /* Subroutine */int ssbmv_(char *uplo, integer *n, integer *k, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int ssbmv_(char *uplo, integer *n, integer *k, real *alpha,
+                            real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int sscal_(integer *n, real *sa, real *sx, integer *incx);
+/* Subroutine */ int sscal_(integer *n, real *sa, real *sx, integer *incx);
 
-  /* Subroutine */int sspmv_(char *uplo, integer *n, real *alpha, real *ap,
-      real *x, integer *incx, real *beta, real *y, integer *incy);
+/* Subroutine */ int sspmv_(char *uplo, integer *n, real *alpha, real *ap,
+                            real *x, integer *incx, real *beta, real *y, integer *incy);
 
-  /* Subroutine */int sspr_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *ap);
+/* Subroutine */ int sspr_(char *uplo, integer *n, real *alpha, real *x,
+                           integer *incx, real *ap);
 
-  /* Subroutine */int sspr2_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *ap);
+/* Subroutine */ int sspr2_(char *uplo, integer *n, real *alpha, real *x,
+                            integer *incx, real *y, integer *incy, real *ap);
 
-  /* Subroutine */int sswap_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+/* Subroutine */ int sswap_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy);
 
-  /* Subroutine */int ssymm_(char *side, char *uplo, integer *m, integer *n,
-      real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
-      real *c__, integer *ldc);
+/* Subroutine */ int ssymm_(char *side, char *uplo, integer *m, integer *n,
+                            real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
+                            real *c__, integer *ldc);
 
-  /* Subroutine */int ssymv_(char *uplo, integer *n, real *alpha, real *a,
-      integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer * incy);
+/* Subroutine */ int ssymv_(char *uplo, integer *n, real *alpha, real *a,
+                            integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int ssyr_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *a, integer *lda);
+/* Subroutine */ int ssyr_(char *uplo, integer *n, real *alpha, real *x,
+                           integer *incx, real *a, integer *lda);
 
-  /* Subroutine */int ssyr2_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *a, integer *lda);
+/* Subroutine */ int ssyr2_(char *uplo, integer *n, real *alpha, real *x,
+                            integer *incx, real *y, integer *incy, real *a, integer *lda);
 
-  /* Subroutine */int ssyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
-      real *c__, integer *ldc);
+/* Subroutine */ int ssyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
+                             real *c__, integer *ldc);
 
-  /* Subroutine */int ssyrk_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, real *a, integer *lda, real *beta, real *c__, integer * ldc);
+/* Subroutine */ int ssyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            real *alpha, real *a, integer *lda, real *beta, real *c__, integer *ldc);
 
-  /* Subroutine */int stbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int stbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int stbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int stbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int stpmv_(char *uplo, char *trans, char *diag, integer *n,
-      real *ap, real *x, integer *incx);
+/* Subroutine */ int stpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *ap, real *x, integer *incx);
 
-  /* Subroutine */int stpsv_(char *uplo, char *trans, char *diag, integer *n,
-      real *ap, real *x, integer *incx);
+/* Subroutine */ int stpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *ap, real *x, integer *incx);
 
-  /* Subroutine */int strmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
-      integer *ldb);
+/* Subroutine */ int strmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb);
 
-  /* Subroutine */int strmv_(char *uplo, char *trans, char *diag, integer *n,
-      real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int strmv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int strsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
-      integer *ldb);
+/* Subroutine */ int strsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb);
 
-  /* Subroutine */int strsv_(char *uplo, char *trans, char *diag, integer *n,
-      real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int strsv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int xerbla_(char *srname, integer *info);
+/* Subroutine */ int xerbla_(char *srname, integer *info);
 
-  /* Subroutine */int xerbla_array__(char *srname_array__,
-      integer * srname_len__, integer *info, ftnlen srname_array_len);
+/* Subroutine */ int xerbla_array__(char *srname_array__,
+                                    integer *srname_len__, integer *info, ftnlen srname_array_len);
 
-  /* Subroutine */int zaxpy_(integer *n, doublecomplex *za, doublecomplex *zx,
-      integer *incx, doublecomplex *zy, integer *incy);
+/* Subroutine */ int zaxpy_(integer *n, doublecomplex *za, doublecomplex *zx,
+                            integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zcopy_(integer *n, doublecomplex *zx, integer *incx,
-      doublecomplex *zy, integer *incy);
+/* Subroutine */ int zcopy_(integer *n, doublecomplex *zx, integer *incx,
+                            doublecomplex *zy, integer *incy);
 
-  /* Double Complex */VOID zdotc_(doublecomplex * ret_val, integer *n,
-      doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
+/* Double Complex */ VOID zdotc_(doublecomplex *ret_val, integer *n,
+                                 doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Double Complex */VOID zdotu_(doublecomplex * ret_val, integer *n,
-      doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
+/* Double Complex */ VOID zdotu_(doublecomplex *ret_val, integer *n,
+                                 doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zdrot_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublereal *c__, doublereal *s);
+/* Subroutine */ int zdrot_(integer *n, doublecomplex *cx, integer *incx,
+                            doublecomplex *cy, integer *incy, doublereal *c__, doublereal *s);
 
-  /* Subroutine */int zdscal_(integer *n, doublereal *da, doublecomplex *zx,
-      integer *incx);
+/* Subroutine */ int zdscal_(integer *n, doublereal *da, doublecomplex *zx,
+                             integer *incx);
 
-  /* Subroutine */int zgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda,
-      doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex * y,
-      integer *incy);
+/* Subroutine */ int zgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda,
+                            doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex *y,
+                            integer *incy);
 
-  /* Subroutine */int zgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublecomplex *beta,
-      doublecomplex * c__, integer *ldc);
+/* Subroutine */ int zgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb, doublecomplex *beta,
+                            doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zgemv_(char *trans, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * x,
-      integer *incx, doublecomplex *beta, doublecomplex *y, integer * incy);
+/* Subroutine */ int zgemv_(char *trans, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zgerc_(integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zgerc_(integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zgeru_(integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zgeru_(integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zhbmv_(char *uplo, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer * incx, doublecomplex *beta, doublecomplex *y, integer *incy);
+/* Subroutine */ int zhbmv_(char *uplo, integer *n, integer *k,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zhemm_(char *side, char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zhemm_(char *side, char *uplo, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zhemv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublecomplex *beta, doublecomplex *y, integer *incy);
+/* Subroutine */ int zhemv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                            doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zher_(char *uplo, integer *n, doublereal *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
+/* Subroutine */ int zher_(char *uplo, integer *n, doublereal *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zher2_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zher2_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zher2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublereal *beta, doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zher2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zherk_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublecomplex *a, integer *lda, doublereal *beta,
-      doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zherk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublereal *alpha, doublecomplex *a, integer *lda, doublereal *beta,
+                            doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zhpmv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex * beta,
-      doublecomplex *y, integer *incy);
+/* Subroutine */ int zhpmv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta,
+                            doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zhpr_(char *uplo, integer *n, doublereal *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *ap);
+/* Subroutine */ int zhpr_(char *uplo, integer *n, doublereal *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *ap);
 
-  /* Subroutine */int zhpr2_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *ap);
+/* Subroutine */ int zhpr2_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *ap);
 
-  /* Subroutine */int zrotg_(doublecomplex *ca, doublecomplex *cb,
-      doublereal * c__, doublecomplex *s);
+/* Subroutine */ int zrotg_(doublecomplex *ca, doublecomplex *cb,
+                            doublereal *c__, doublecomplex *s);
 
-  /* Subroutine */int zscal_(integer *n, doublecomplex *za, doublecomplex *zx,
-      integer *incx);
+/* Subroutine */ int zscal_(integer *n, doublecomplex *za, doublecomplex *zx,
+                            integer *incx);
 
-  /* Subroutine */int zswap_(integer *n, doublecomplex *zx, integer *incx,
-      doublecomplex *zy, integer *incy);
+/* Subroutine */ int zswap_(integer *n, doublecomplex *zx, integer *incx,
+                            doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zsymm_(char *side, char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zsymm_(char *side, char *uplo, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zsyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zsyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zsyrk_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda,
-      doublecomplex * beta, doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zsyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda,
+                            doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int ztbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx);
+/* Subroutine */ int ztbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx);
 
-  /* Subroutine */int ztbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx);
+/* Subroutine */ int ztbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx);
 
-  /* Subroutine */int ztpmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *ap, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *ap, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztpsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *ap, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *ap, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb);
+/* Subroutine */ int ztrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb);
 
-  /* Subroutine */int ztrmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb);
+/* Subroutine */ int ztrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb);
 
-  /* Subroutine */int ztrsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int cbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, real *d__, real *e, complex *vt,
-      integer *ldvt, complex *u, integer *ldu, complex *c__, integer *ldc,
-      real *rwork, integer *info);
+/* Subroutine */ int cbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, real *d__, real *e, complex *vt,
+                             integer *ldvt, complex *u, integer *ldu, complex *c__, integer *ldc,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, complex *ab, integer *ldab, real *d__, real *e,
-      complex *q, integer *ldq, complex *pt, integer *ldpt, complex *c__,
-      integer *ldc, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, complex *ab, integer *ldab, real *d__, real *e,
+                             complex *q, integer *ldq, complex *pt, integer *ldpt, complex *c__,
+                             integer *ldc, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, integer *info);
+/* Subroutine */ int cgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, integer *info);
 
-  /* Subroutine */int cgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, complex *ab, integer *ldab, real *r__, real *c__,
-      real *rowcnd, real *colcnd, real *amax, integer *info);
+/* Subroutine */ int cgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, complex *ab, integer *ldab, real *r__, real *c__,
+                              real *rowcnd, real *colcnd, real *amax, integer *info);
 
-  /* Subroutine */int cgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
-      integer * ldafb, integer *ipiv, complex *b, integer *ldb, complex *x,
-      integer * ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer * info);
+/* Subroutine */ int cgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
+                             integer *ldafb, integer *ipiv, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
-      complex * afb, integer *ldafb, integer *ipiv, real *r__, real *c__,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real *rwork, integer * info);
+/* Subroutine */ int cgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
+                              complex *afb, integer *ldafb, integer *ipiv, real *r__, real *c__,
+                              complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, complex *ab, integer *ldab, integer *ipiv, complex *b,
-      integer * ldb, integer *info);
+/* Subroutine */ int cgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, complex *ab, integer *ldab, integer *ipiv, complex *b,
+                            integer *ldb, integer *info);
 
-  /* Subroutine */int cgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
-      integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
+                             integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
-      complex * afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
-      real *c__, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
+                              complex *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
+                              real *c__, complex *b, integer *ldb, complex *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int cgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int cgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, complex *ab, integer *ldab, integer *ipiv,
-      complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, integer *ipiv,
+                             complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *scale, integer *m, complex *v, integer *ldv,
-      integer *info);
+/* Subroutine */ int cgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *scale, integer *m, complex *v, integer *ldv,
+                             integer *info);
 
-  /* Subroutine */int cgebal_(char *job, integer *n, complex *a, integer *lda,
-      integer *ilo, integer *ihi, real *scale, integer *info);
+/* Subroutine */ int cgebal_(char *job, integer *n, complex *a, integer *lda,
+                             integer *ilo, integer *ihi, real *scale, integer *info);
 
-  /* Subroutine */int cgebd2_(integer *m, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tauq, complex *taup, complex *work,
-      integer *info);
+/* Subroutine */ int cgebd2_(integer *m, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tauq, complex *taup, complex *work,
+                             integer *info);
 
-  /* Subroutine */int cgebrd_(integer *m, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tauq, complex *taup, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int cgebrd_(integer *m, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tauq, complex *taup, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int cgecon_(char *norm, integer *n, complex *a, integer *lda,
-      real *anorm, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgecon_(char *norm, integer *n, complex *a, integer *lda,
+                             real *anorm, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgeequ_(integer *m, integer *n, complex *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
+/* Subroutine */ int cgeequ_(integer *m, integer *n, complex *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             integer *info);
 
-  /* Subroutine */int cgeequb_(integer *m, integer *n, complex *a,
-      integer * lda, real *r__, real *c__, real *rowcnd, real *colcnd,
-      real *amax, integer *info);
+/* Subroutine */ int cgeequb_(integer *m, integer *n, complex *a,
+                              integer *lda, real *r__, real *c__, real *rowcnd, real *colcnd,
+                              real *amax, integer *info);
 
-  /* Subroutine */int cgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      complex *a, integer *lda, integer *sdim, complex *w, complex *vs,
-      integer *ldvs, complex *work, integer *lwork, real *rwork,
-      logical * bwork, integer *info);
+/* Subroutine */ int cgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            complex *a, integer *lda, integer *sdim, complex *w, complex *vs,
+                            integer *ldvs, complex *work, integer *lwork, real *rwork,
+                            logical *bwork, integer *info);
 
-  /* Subroutine */int cgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, complex *a, integer *lda, integer *sdim,
-      complex * w, complex *vs, integer *ldvs, real *rconde, real *rcondv,
-      complex * work, integer *lwork, real *rwork, logical *bwork,
-      integer *info);
+/* Subroutine */ int cgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, complex *a, integer *lda, integer *sdim,
+                             complex *w, complex *vs, integer *ldvs, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, logical *bwork,
+                             integer *info);
 
-  /* Subroutine */int cgeev_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *w, complex *vl, integer *ldvl, complex *vr,
-      integer *ldvr, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgeev_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *w, complex *vl, integer *ldvl, complex *vr,
+                            integer *ldvr, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, complex *a, integer *lda, complex *w,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *ilo,
-      integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
-      complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, complex *a, integer *lda, complex *w,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *ilo,
+                             integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgegs_(char *jobvsl, char *jobvsr, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, complex *alpha,
-      complex * beta, complex *vsl, integer *ldvsl, complex *vsr,
-      integer *ldvsr, complex *work, integer *lwork, real *rwork,
-      integer *info);
+/* Subroutine */ int cgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            complex *a, integer *lda, complex *b, integer *ldb, complex *alpha,
+                            complex *beta, complex *vsl, integer *ldvsl, complex *vsr,
+                            integer *ldvsr, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cgegv_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex * work,
-      integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgegv_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
+                            complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex *work,
+                            integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgehd2_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgehd2_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgehrd_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cgehrd_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cgelq2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgelq2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgelqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgelqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      complex * work, integer *lwork, integer *info);
+/* Subroutine */ int cgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgelsd_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
-      integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * iwork, integer *info);
+/* Subroutine */ int cgelsd_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
+                             integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int cgelss_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
-      integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgelss_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
+                             integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgelsx_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *jpvt,
-      real *rcond, integer *rank, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgelsx_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *jpvt,
+                             real *rcond, integer *rank, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgelsy_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *jpvt,
-      real *rcond, integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgelsy_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *jpvt,
+                             real *rcond, integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgeql2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgeql2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgeqlf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgeqlf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgeqp3_(integer *m, integer *n, complex *a, integer *lda,
-      integer *jpvt, complex *tau, complex *work, integer *lwork, real * rwork,
-      integer *info);
+/* Subroutine */ int cgeqp3_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *jpvt, complex *tau, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgeqpf_(integer *m, integer *n, complex *a, integer *lda,
-      integer *jpvt, complex *tau, complex *work, real *rwork, integer * info);
+/* Subroutine */ int cgeqpf_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *jpvt, complex *tau, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgeqr2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgeqr2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgeqrf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgeqrf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgerfs_(char *trans, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgerfs_(char *trans, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *r__, real *c__, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *r__, real *c__, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgerq2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgerq2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgerqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgerqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgesc2_(integer *n, complex *a, integer *lda,
-      complex * rhs, integer *ipiv, integer *jpiv, real *scale);
+/* Subroutine */ int cgesc2_(integer *n, complex *a, integer *lda,
+                             complex *rhs, integer *ipiv, integer *jpiv, real *scale);
 
-  /* Subroutine */int cgesdd_(char *jobz, integer *m, integer *n, complex *a,
-      integer *lda, real *s, complex *u, integer *ldu, complex *vt,
-      integer *ldvt, complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer *info);
+/* Subroutine */ int cgesdd_(char *jobz, integer *m, integer *n, complex *a,
+                             integer *lda, real *s, complex *u, integer *ldu, complex *vt,
+                             integer *ldvt, complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int cgesv_(integer *n, integer *nrhs, complex *a,
-      integer * lda, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgesv_(integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      complex *a, integer *lda, real *s, complex *u, integer *ldu, complex * vt,
-      integer *ldvt, complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             complex *a, integer *lda, real *s, complex *u, integer *ldu, complex *vt,
+                             integer *ldvt, complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *r__, real *c__, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, char *equed, real *r__, real *c__, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *r__, real *c__, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *rcond, real *rpvgrw,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real *rwork, integer * info);
+/* Subroutine */ int cgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *r__, real *c__, complex *b,
+                              integer *ldb, complex *x, integer *ldx, real *rcond, real *rpvgrw,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cgetc2_(integer *n, complex *a, integer *lda,
-      integer * ipiv, integer *jpiv, integer *info);
+/* Subroutine */ int cgetc2_(integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
 
-  /* Subroutine */int cgetf2_(integer *m, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int cgetf2_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int cgetrf_(integer *m, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int cgetrf_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int cgetri_(integer *n, complex *a, integer *lda,
-      integer * ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgetri_(integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgetrs_(char *trans, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cgetrs_(char *trans, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int cggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *lscale, real *rscale, integer *m, complex *v,
-      integer *ldv, integer *info);
+/* Subroutine */ int cggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *lscale, real *rscale, integer *m, complex *v,
+                             integer *ldv, integer *info);
 
-  /* Subroutine */int cggbal_(char *job, integer *n, complex *a, integer *lda,
-      complex *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
-      real *rscale, real *work, integer *info);
+/* Subroutine */ int cggbal_(char *job, integer *n, complex *a, integer *lda,
+                             complex *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *work, integer *info);
 
-  /* Subroutine */int cgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, complex *a, integer *lda, complex *b,
-      integer * ldb, integer *sdim, complex *alpha, complex *beta, complex *vsl,
-      integer *ldvsl, complex *vsr, integer *ldvsr, complex *work,
-      integer * lwork, real *rwork, logical *bwork, integer *info);
+/* Subroutine */ int cgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, complex *a, integer *lda, complex *b,
+                            integer *ldb, integer *sdim, complex *alpha, complex *beta, complex *vsl,
+                            integer *ldvsl, complex *vsr, integer *ldvsr, complex *work,
+                            integer *lwork, real *rwork, logical *bwork, integer *info);
 
-  /* Subroutine */int cggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, complex *a, integer *lda,
-      complex *b, integer *ldb, integer *sdim, complex *alpha, complex *beta,
-      complex * vsl, integer *ldvsl, complex *vsr, integer *ldvsr, real *rconde,
-      real *rcondv, complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer *liwork, logical *bwork, integer *info);
+/* Subroutine */ int cggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, complex *a, integer *lda,
+                             complex *b, integer *ldb, integer *sdim, complex *alpha, complex *beta,
+                             complex *vsl, integer *ldvsl, complex *vsr, integer *ldvsr, real *rconde,
+                             real *rcondv, complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *liwork, logical *bwork, integer *info);
 
-  /* Subroutine */int cggev_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex * work,
-      integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cggev_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
+                            complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex *work,
+                            integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *alpha, complex *beta, complex *vl, integer *ldvl,
-      complex * vr, integer *ldvr, integer *ilo, integer *ihi, real *lscale,
-      real * rscale, real *abnrm, real *bbnrm, real *rconde, real *rcondv,
-      complex *work, integer *lwork, real *rwork, integer *iwork,
-      logical *bwork, integer *info);
+/* Subroutine */ int cggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *alpha, complex *beta, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *abnrm, real *bbnrm, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, integer *iwork,
+                             logical *bwork, integer *info);
 
-  /* Subroutine */int cggglm_(integer *n, integer *m, integer *p, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *d__, complex *x,
-      complex *y, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggglm_(integer *n, integer *m, integer *p, complex *a,
+                             integer *lda, complex *b, integer *ldb, complex *d__, complex *x,
+                             complex *y, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *q, integer *ldq, complex *z__, integer *ldz,
-      integer *info);
+/* Subroutine */ int cgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *q, integer *ldq, complex *z__, integer *ldz,
+                             integer *info);
 
-  /* Subroutine */int cgglse_(integer *m, integer *n, integer *p, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *c__, complex *d__,
-      complex *x, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgglse_(integer *m, integer *n, integer *p, complex *a,
+                             integer *lda, complex *b, integer *ldb, complex *c__, complex *d__,
+                             complex *x, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggqrf_(integer *n, integer *m, integer *p, complex *a,
-      integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
-      complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggqrf_(integer *n, integer *m, integer *p, complex *a,
+                             integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
+                             complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggrqf_(integer *m, integer *p, integer *n, complex *a,
-      integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
-      complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggrqf_(integer *m, integer *p, integer *n, complex *a,
+                             integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
+                             complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, complex *a, integer * lda,
-      complex *b, integer *ldb, real *alpha, real *beta, complex *u,
-      integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
-      complex *work, real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int cggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, complex *a, integer *lda,
+                             complex *b, integer *ldb, real *alpha, real *beta, complex *u,
+                             integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
+                             complex *work, real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int cggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, real *tola, real *tolb, integer *k, integer *l, complex *u,
-      integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
-      integer *iwork, real *rwork, complex *tau, complex *work, integer * info);
+/* Subroutine */ int cggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, real *tola, real *tolb, integer *k, integer *l, complex *u,
+                             integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
+                             integer *iwork, real *rwork, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgtcon_(char *norm, integer *n, complex *dl,
-      complex * d__, complex *du, complex *du2, integer *ipiv, real *anorm,
-      real * rcond, complex *work, integer *info);
+/* Subroutine */ int cgtcon_(char *norm, integer *n, complex *dl,
+                             complex *d__, complex *du, complex *du2, integer *ipiv, real *anorm,
+                             real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cgtrfs_(char *trans, integer *n, integer *nrhs,
-      complex * dl, complex *d__, complex *du, complex *dlf, complex *df,
-      complex * duf, complex *du2, integer *ipiv, complex *b, integer *ldb,
-      complex * x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int cgtrfs_(char *trans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *dlf, complex *df,
+                             complex *duf, complex *du2, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cgtsv_(integer *n, integer *nrhs, complex *dl,
-      complex * d__, complex *du, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgtsv_(integer *n, integer *nrhs, complex *dl,
+                            complex *d__, complex *du, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *dl, complex *d__, complex *du, complex *dlf,
-      complex * df, complex *duf, complex *du2, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, complex *dl, complex *d__, complex *du, complex *dlf,
+                             complex *df, complex *duf, complex *du2, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgttrf_(integer *n, complex *dl, complex *d__,
-      complex * du, complex *du2, integer *ipiv, integer *info);
+/* Subroutine */ int cgttrf_(integer *n, complex *dl, complex *d__,
+                             complex *du, complex *du2, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgttrs_(char *trans, integer *n, integer *nrhs,
-      complex * dl, complex *d__, complex *du, complex *du2, integer *ipiv,
-      complex * b, integer *ldb, integer *info);
+/* Subroutine */ int cgttrs_(char *trans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
+                             complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgtts2_(integer *itrans, integer *n, integer *nrhs,
-      complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
-      complex *b, integer *ldb);
+/* Subroutine */ int cgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
+                             complex *b, integer *ldb);
 
-  /* Subroutine */int chbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int chbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
+                            complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
-      complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
+                             complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, complex *ab, integer *ldab, complex *q, integer *ldq,
-      real *vl, real *vu, integer *il, integer *iu, real *abstol, integer * m,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int chbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, complex *ab, integer *ldab, complex *q, integer *ldq,
+                             real *vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
+                             real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                             integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int chbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      complex *x, integer *ldx, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                             complex *x, integer *ldx, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                            real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int chbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
-      real *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int chbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                             real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
+                             real *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int chbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, complex *ab, integer *ldab, complex *bb,
-      integer *ldbb, complex *q, integer *ldq, real *vl, real *vu, integer * il,
-      integer *iu, real *abstol, integer *m, real *w, complex *z__,
-      integer *ldz, complex *work, real *rwork, integer *iwork, integer * ifail,
-      integer *info);
+/* Subroutine */ int chbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, complex *ab, integer *ldab, complex *bb,
+                             integer *ldbb, complex *q, integer *ldq, real *vl, real *vu, integer *il,
+                             integer *iu, real *abstol, integer *m, real *w, complex *z__,
+                             integer *ldz, complex *work, real *rwork, integer *iwork, integer *ifail,
+                             integer *info);
 
-  /* Subroutine */int chbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *d__, real *e, complex *q, integer * ldq,
-      complex *work, integer *info);
+/* Subroutine */ int chbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             complex *ab, integer *ldab, real *d__, real *e, complex *q, integer *ldq,
+                             complex *work, integer *info);
 
-  /* Subroutine */int checon_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, complex *work, integer * info);
+/* Subroutine */ int checon_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cheequb_(char *uplo, integer *n, complex *a,
-      integer * lda, real *s, real *scond, real *amax, complex *work,
-      integer *info);
+/* Subroutine */ int cheequb_(char *uplo, integer *n, complex *a,
+                              integer *lda, real *s, real *scond, real *amax, complex *work,
+                              integer *info);
 
-  /* Subroutine */int cheev_(char *jobz, char *uplo, integer *n, complex *a,
-      integer *lda, real *w, complex *work, integer *lwork, real *rwork,
-      integer *info);
+/* Subroutine */ int cheev_(char *jobz, char *uplo, integer *n, complex *a,
+                            integer *lda, real *w, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cheevd_(char *jobz, char *uplo, integer *n, complex *a,
-      integer *lda, real *w, complex *work, integer *lwork, real *rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer *info);
+/* Subroutine */ int cheevd_(char *jobz, char *uplo, integer *n, complex *a,
+                             integer *lda, real *w, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cheevr_(char *jobz, char *range, char *uplo, integer *n,
-      complex *a, integer *lda, real *vl, real *vu, integer *il, integer * iu,
-      real *abstol, integer *m, real *w, complex *z__, integer *ldz,
-      integer *isuppz, complex *work, integer *lwork, real *rwork,
-      integer * lrwork, integer *iwork, integer *liwork, integer *info);
+/* Subroutine */ int cheevr_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, complex *z__, integer *ldz,
+                             integer *isuppz, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cheevx_(char *jobz, char *range, char *uplo, integer *n,
-      complex *a, integer *lda, real *vl, real *vu, integer *il, integer * iu,
-      real *abstol, integer *m, real *w, complex *z__, integer *ldz,
-      complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer * ifail, integer *info);
+/* Subroutine */ int cheevx_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, complex *z__, integer *ldz,
+                             complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *ifail, integer *info);
 
-  /* Subroutine */int chegs2_(integer *itype, char *uplo, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chegs2_(integer *itype, char *uplo, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chegst_(integer *itype, char *uplo, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chegst_(integer *itype, char *uplo, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chegv_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
-      complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int chegv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
+                            complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int chegvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
-      complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chegvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
+                             complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chegvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer * m, real *w, complex *z__, integer *ldz, complex *work,
-      integer *lwork, real *rwork, integer *iwork, integer *ifail,
-      integer *info);
+/* Subroutine */ int chegvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, real *rwork, integer *iwork, integer *ifail,
+                             integer *info);
 
-  /* Subroutine */int cherfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cherfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cherfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *s, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cherfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *s, complex *b, integer *ldb, complex *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chesv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int chesv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int chesvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
-      real *rwork, integer *info);
+/* Subroutine */ int chesvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int chesvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *s, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chesvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, complex *work, real *rwork,
+                              integer *info);
 
-  /* Subroutine */int chetd2_(char *uplo, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tau, integer *info);
+/* Subroutine */ int chetd2_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tau, integer *info);
 
-  /* Subroutine */int chetf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int chetf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int chetrd_(char *uplo, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int chetrd_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int chetrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int chetrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int chetri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *info);
+/* Subroutine */ int chetri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int chetrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int chetrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int chfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, real *alpha, complex *a, integer *lda, real *beta,
-      complex *c__);
+/* Subroutine */ int chfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, real *alpha, complex *a, integer *lda, real *beta,
+                            complex *c__);
 
-  /* Subroutine */int chgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *t,
-      integer *ldt, complex *alpha, complex *beta, complex *q, integer *ldq,
-      complex *z__, integer *ldz, complex *work, integer *lwork, real * rwork,
-      integer *info);
+/* Subroutine */ int chgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *t,
+                             integer *ldt, complex *alpha, complex *beta, complex *q, integer *ldq,
+                             complex *z__, integer *ldz, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Character */VOID chla_transtype__(char *ret_val, ftnlen ret_val_len,
-      integer *trans);
+/* Character */ VOID chla_transtype__(char *ret_val, ftnlen ret_val_len,
+                                      integer *trans);
 
-  /* Subroutine */int chpcon_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, real *anorm, real *rcond, complex *work, integer *info);
+/* Subroutine */ int chpcon_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int chpev_(char *jobz, char *uplo, integer *n, complex *ap,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chpev_(char *jobz, char *uplo, integer *n, complex *ap,
+                            real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int chpevd_(char *jobz, char *uplo, integer *n, complex *ap,
-      real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
-      real *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int chpevd_(char *jobz, char *uplo, integer *n, complex *ap,
+                             real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
+                             real *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int chpevx_(char *jobz, char *range, char *uplo, integer *n,
-      complex *ap, real *vl, real *vu, integer *il, integer *iu, real * abstol,
-      integer *m, real *w, complex *z__, integer *ldz, complex * work,
-      real *rwork, integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int chpevx_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, complex *work,
+                             real *rwork, integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int chpgst_(integer *itype, char *uplo, integer *n,
-      complex * ap, complex *bp, integer *info);
+/* Subroutine */ int chpgst_(integer *itype, char *uplo, integer *n,
+                             complex *ap, complex *bp, integer *info);
 
-  /* Subroutine */int chpgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *ap, complex *bp, real *w, complex *z__,
-      integer *ldz, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chpgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, complex *ap, complex *bp, real *w, complex *z__,
+                            integer *ldz, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chpgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *ap, complex *bp, real *w, complex *z__,
-      integer *ldz, complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chpgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, complex *ap, complex *bp, real *w, complex *z__,
+                             integer *ldz, complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chpgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, complex *ap, complex *bp, real *vl, real *vu,
-      integer *il, integer *iu, real *abstol, integer *m, real *w,
-      complex * z__, integer *ldz, complex *work, real *rwork, integer *iwork,
-      integer *ifail, integer *info);
+/* Subroutine */ int chpgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, complex *ap, complex *bp, real *vl, real *vu,
+                             integer *il, integer *iu, real *abstol, integer *m, real *w,
+                             complex *z__, integer *ldz, complex *work, real *rwork, integer *iwork,
+                             integer *ifail, integer *info);
 
-  /* Subroutine */int chprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int chprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int chpsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chpsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chpsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chpsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chptrd_(char *uplo, integer *n, complex *ap, real *d__,
-      real *e, complex *tau, integer *info);
+/* Subroutine */ int chptrd_(char *uplo, integer *n, complex *ap, real *d__,
+                             real *e, complex *tau, integer *info);
 
-  /* Subroutine */int chptrf_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, integer *info);
+/* Subroutine */ int chptrf_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int chptri_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, complex *work, integer *info);
+/* Subroutine */ int chptri_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int chptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, complex *h__, integer *ldh, complex *w,
-      complex * vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
-      integer * m, complex *work, real *rwork, integer *ifaill, integer *ifailr,
-      integer *info);
+/* Subroutine */ int chsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, complex *h__, integer *ldh, complex *w,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
+                             integer *m, complex *work, real *rwork, integer *ifaill, integer *ifailr,
+                             integer *info);
 
-  /* Subroutine */int chseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, complex *h__, integer *ldh, complex *w, complex *z__,
-      integer *ldz, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int chseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, complex *h__, integer *ldh, complex *w, complex *z__,
+                             integer *ldz, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, real *alpha, complex *ab, integer *ldab,
-      complex *x, integer *incx, real *beta, real *y, integer *incy);
+/* Subroutine */ int cla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, real *alpha, complex *ab, integer *ldab,
+                                 complex *x, integer *incx, real *beta, real *y, integer *incy);
 
-  doublereal cla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, complex *afb, integer *ldafb, integer * ipiv,
-      real *c__, logical *capply, integer *info, complex *work, real * rwork,
-      ftnlen trans_len);
+doublereal cla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
+                           complex *ab, integer *ldab, complex *afb, integer *ldafb, integer *ipiv,
+                           real *c__, logical *capply, integer *info, complex *work, real *rwork,
+                           ftnlen trans_len);
 
-  doublereal cla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, complex *afb, integer *ldafb, integer * ipiv,
-      complex *x, integer *info, complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
+                           complex *ab, integer *ldab, complex *afb, integer *ldafb, integer *ipiv,
+                           complex *x, integer *info, complex *work, real *rwork, ftnlen trans_len);
 
-  /* Subroutine */int cla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
-      integer * ipiv, logical *colequ, real *c__, complex *b, integer *ldb,
-      complex * y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
-      complex * y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info);
+/* Subroutine */ int cla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                                           integer *ipiv, logical *colequ, real *c__, complex *b, integer *ldb,
+                                           complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
+                                           complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info);
 
-  doublereal cla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, complex *ab, integer *ldab, complex *afb,
-      integer *ldafb);
+doublereal cla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, complex *ab, integer *ldab, complex *afb,
+                          integer *ldafb);
 
-  /* Subroutine */int cla_geamv__(integer *trans, integer *m, integer *n,
-      real *alpha, complex *a, integer *lda, complex *x, integer *incx,
-      real * beta, real *y, integer *incy);
+/* Subroutine */ int cla_geamv__(integer *trans, integer *m, integer *n,
+                                 real *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                                 real *beta, real *y, integer *incy);
 
-  doublereal cla_gercond_c__(char *trans, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gercond_c__(char *trans, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen trans_len);
 
-  doublereal cla_gercond_x__(char *trans, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gercond_x__(char *trans, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen trans_len);
 
-  /* Subroutine */int cla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      real *c__, complex *b, integer *ldb, complex *y, integer *ldy,
-      real *berr_out__, integer *n_norms__, real *errs_n__, real *errs_c__,
-      complex *res, real *ayb, complex *dy, complex *y_tail__, real *rcond,
-      integer * ithresh, real *rthresh, real *dz_ub__, logical *ignore_cwise__,
-      integer *info);
+/* Subroutine */ int cla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, complex *a,
+                                           integer *lda, complex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           real *c__, complex *b, integer *ldb, complex *y, integer *ldy,
+                                           real *berr_out__, integer *n_norms__, real *errs_n__, real *errs_c__,
+                                           complex *res, real *ayb, complex *dy, complex *y_tail__, real *rcond,
+                                           integer *ithresh, real *rthresh, real *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
 
-  /* Subroutine */int cla_heamv__(integer *uplo, integer *n, real *alpha,
-      complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int cla_heamv__(integer *uplo, integer *n, real *alpha,
+                                 complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
 
-  doublereal cla_hercond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_hercond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_hercond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_hercond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_herfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
-      integer *ldb, complex *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, complex *res,
-      real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
-      real * rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
+/* Subroutine */ int cla_herfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
+                                           integer *ldb, complex *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, complex *res,
+                                           real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
+                                           real *rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
 
-  doublereal cla_herpvgrw__(char *uplo, integer *n, integer *info, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
+doublereal cla_herpvgrw__(char *uplo, integer *n, integer *info, complex *a,
+                          integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
 
-  /* Subroutine */int cla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      complex *res, real *ayb, real *berr);
+/* Subroutine */ int cla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    complex *res, real *ayb, real *berr);
 
-  doublereal cla_porcond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, real *c__, logical *capply, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_porcond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, real *c__, logical *capply, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_porcond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, complex *x, integer *info, complex *work,
-      real *rwork, ftnlen uplo_len);
+doublereal cla_porcond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, complex *x, integer *info, complex *work,
+                           real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, logical *colequ, real *c__, complex *b, integer *ldb,
-      complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real * errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
-      complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+/* Subroutine */ int cla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, logical *colequ, real *c__, complex *b, integer *ldb,
+                                           complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
+                                           complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
 
-  doublereal cla_porpvgrw__(char *uplo, integer *ncols, complex *a,
-      integer * lda, complex *af, integer *ldaf, real *work, ftnlen uplo_len);
+doublereal cla_porpvgrw__(char *uplo, integer *ncols, complex *a,
+                          integer *lda, complex *af, integer *ldaf, real *work, ftnlen uplo_len);
 
-  doublereal cla_rpvgrw__(integer *n, integer *ncols, complex *a, integer *lda,
-      complex *af, integer *ldaf);
+doublereal cla_rpvgrw__(integer *n, integer *ncols, complex *a, integer *lda,
+                        complex *af, integer *ldaf);
 
-  /* Subroutine */int cla_syamv__(integer *uplo, integer *n, real *alpha,
-      complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int cla_syamv__(integer *uplo, integer *n, real *alpha,
+                                 complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
 
-  doublereal cla_syrcond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_syrcond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_syrcond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_syrcond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
-      integer *ldb, complex *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, complex *res,
-      real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
-      real * rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
+/* Subroutine */ int cla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
+                                           integer *ldb, complex *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, complex *res,
+                                           real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
+                                           real *rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
 
-  doublereal cla_syrpvgrw__(char *uplo, integer *n, integer *info, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
+doublereal cla_syrpvgrw__(char *uplo, integer *n, integer *info, complex *a,
+                          integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
 
-  /* Subroutine */int cla_wwaddw__(integer *n, complex *x, complex *y,
-      complex *w);
+/* Subroutine */ int cla_wwaddw__(integer *n, complex *x, complex *y,
+                                  complex *w);
 
-  /* Subroutine */int clabrd_(integer *m, integer *n, integer *nb, complex *a,
-      integer *lda, real *d__, real *e, complex *tauq, complex *taup,
-      complex *x, integer *ldx, complex *y, integer *ldy);
+/* Subroutine */ int clabrd_(integer *m, integer *n, integer *nb, complex *a,
+                             integer *lda, real *d__, real *e, complex *tauq, complex *taup,
+                             complex *x, integer *ldx, complex *y, integer *ldy);
 
-  /* Subroutine */int clacgv_(integer *n, complex *x, integer *incx);
+/* Subroutine */ int clacgv_(integer *n, complex *x, integer *incx);
 
-  /* Subroutine */int clacn2_(integer *n, complex *v, complex *x, real *est,
-      integer *kase, integer *isave);
+/* Subroutine */ int clacn2_(integer *n, complex *v, complex *x, real *est,
+                             integer *kase, integer *isave);
 
-  /* Subroutine */int clacon_(integer *n, complex *v, complex *x, real *est,
-      integer *kase);
+/* Subroutine */ int clacon_(integer *n, complex *v, complex *x, real *est,
+                             integer *kase);
 
-  /* Subroutine */int clacp2_(char *uplo, integer *m, integer *n, real *a,
-      integer *lda, complex *b, integer *ldb);
+/* Subroutine */ int clacp2_(char *uplo, integer *m, integer *n, real *a,
+                             integer *lda, complex *b, integer *ldb);
 
-  /* Subroutine */int clacpy_(char *uplo, integer *m, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb);
+/* Subroutine */ int clacpy_(char *uplo, integer *m, integer *n, complex *a,
+                             integer *lda, complex *b, integer *ldb);
 
-  /* Subroutine */int clacrm_(integer *m, integer *n, complex *a, integer *lda,
-      real *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
+/* Subroutine */ int clacrm_(integer *m, integer *n, complex *a, integer *lda,
+                             real *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
 
-  /* Subroutine */int clacrt_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, complex *c__, complex *s);
+/* Subroutine */ int clacrt_(integer *n, complex *cx, integer *incx,
+                             complex *cy, integer *incy, complex *c__, complex *s);
 
-  /* Complex */VOID cladiv_(complex * ret_val, complex *x, complex *y);
+/* Complex */ VOID cladiv_(complex *ret_val, complex *x, complex *y);
 
-  /* Subroutine */int claed0_(integer *qsiz, integer *n, real *d__, real *e,
-      complex *q, integer *ldq, complex *qstore, integer *ldqs, real *rwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int claed0_(integer *qsiz, integer *n, real *d__, real *e,
+                             complex *q, integer *ldq, complex *qstore, integer *ldqs, real *rwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int claed7_(integer *n, integer *cutpnt, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, real *d__, complex * q,
-      integer *ldq, real *rho, integer *indxq, real *qstore, integer * qptr,
-      integer *prmptr, integer *perm, integer *givptr, integer * givcol,
-      real *givnum, complex *work, real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int claed7_(integer *n, integer *cutpnt, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, real *d__, complex *q,
+                             integer *ldq, real *rho, integer *indxq, real *qstore, integer *qptr,
+                             integer *prmptr, integer *perm, integer *givptr, integer *givcol,
+                             real *givnum, complex *work, real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int claed8_(integer *k, integer *n, integer *qsiz,
-      complex * q, integer *ldq, real *d__, real *rho, integer *cutpnt,
-      real *z__, real *dlamda, complex *q2, integer *ldq2, real *w,
-      integer *indxp, integer *indx, integer *indxq, integer *perm,
-      integer *givptr, integer *givcol, real *givnum, integer *info);
+/* Subroutine */ int claed8_(integer *k, integer *n, integer *qsiz,
+                             complex *q, integer *ldq, real *d__, real *rho, integer *cutpnt,
+                             real *z__, real *dlamda, complex *q2, integer *ldq2, real *w,
+                             integer *indxp, integer *indx, integer *indxq, integer *perm,
+                             integer *givptr, integer *givcol, real *givnum, integer *info);
 
-  /* Subroutine */int claein_(logical *rightv, logical *noinit, integer *n,
-      complex *h__, integer *ldh, complex *w, complex *v, complex *b,
-      integer *ldb, real *rwork, real *eps3, real *smlnum, integer *info);
+/* Subroutine */ int claein_(logical *rightv, logical *noinit, integer *n,
+                             complex *h__, integer *ldh, complex *w, complex *v, complex *b,
+                             integer *ldb, real *rwork, real *eps3, real *smlnum, integer *info);
 
-  /* Subroutine */int claesy_(complex *a, complex *b, complex *c__,
-      complex * rt1, complex *rt2, complex *evscal, complex *cs1, complex *sn1);
+/* Subroutine */ int claesy_(complex *a, complex *b, complex *c__,
+                             complex *rt1, complex *rt2, complex *evscal, complex *cs1, complex *sn1);
 
-  /* Subroutine */int claev2_(complex *a, complex *b, complex *c__, real *rt1,
-      real *rt2, real *cs1, complex *sn1);
+/* Subroutine */ int claev2_(complex *a, complex *b, complex *c__, real *rt1,
+                             real *rt2, real *cs1, complex *sn1);
 
-  /* Subroutine */int clag2z_(integer *m, integer *n, complex *sa,
-      integer * ldsa, doublecomplex *a, integer *lda, integer *info);
+/* Subroutine */ int clag2z_(integer *m, integer *n, complex *sa,
+                             integer *ldsa, doublecomplex *a, integer *lda, integer *info);
 
-  /* Subroutine */int clags2_(logical *upper, real *a1, complex *a2, real *a3,
-      real *b1, complex *b2, real *b3, real *csu, complex *snu, real *csv,
-      complex *snv, real *csq, complex *snq);
+/* Subroutine */ int clags2_(logical *upper, real *a1, complex *a2, real *a3,
+                             real *b1, complex *b2, real *b3, real *csu, complex *snu, real *csv,
+                             complex *snv, real *csq, complex *snq);
 
-  /* Subroutine */int clagtm_(char *trans, integer *n, integer *nrhs,
-      real * alpha, complex *dl, complex *d__, complex *du, complex *x,
-      integer * ldx, real *beta, complex *b, integer *ldb);
+/* Subroutine */ int clagtm_(char *trans, integer *n, integer *nrhs,
+                             real *alpha, complex *dl, complex *d__, complex *du, complex *x,
+                             integer *ldx, real *beta, complex *b, integer *ldb);
 
-  /* Subroutine */int clahef_(char *uplo, integer *n, integer *nb, integer *kb,
-      complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
-      integer *info);
+/* Subroutine */ int clahef_(char *uplo, integer *n, integer *nb, integer *kb,
+                             complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
+                             integer *info);
 
-  /* Subroutine */int clahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * info);
+/* Subroutine */ int clahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *info);
 
-  /* Subroutine */int clahr2_(integer *n, integer *k, integer *nb, complex *a,
-      integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
-      integer *ldy);
+/* Subroutine */ int clahr2_(integer *n, integer *k, integer *nb, complex *a,
+                             integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
+                             integer *ldy);
 
-  /* Subroutine */int clahrd_(integer *n, integer *k, integer *nb, complex *a,
-      integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
-      integer *ldy);
+/* Subroutine */ int clahrd_(integer *n, integer *k, integer *nb, complex *a,
+                             integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
+                             integer *ldy);
 
-  /* Subroutine */int claic1_(integer *job, integer *j, complex *x, real *sest,
-      complex *w, complex *gamma, real *sestpr, complex *s, complex *c__);
+/* Subroutine */ int claic1_(integer *job, integer *j, complex *x, real *sest,
+                             complex *w, complex *gamma, real *sestpr, complex *s, complex *c__);
 
-  /* Subroutine */int clals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, complex *b, integer *ldb, complex *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * rwork,
-      integer *info);
+/* Subroutine */ int clals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, complex *b, integer *ldb, complex *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int clalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, complex *b, integer *ldb, complex *bx, integer *ldbx,
-      real *u, integer *ldu, real *vt, integer *k, real *difl, real *difr,
-      real *z__, real *poles, integer *givptr, integer *givcol,
-      integer * ldgcol, integer *perm, real *givnum, real *c__, real *s,
-      real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int clalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, complex *b, integer *ldb, complex *bx, integer *ldbx,
+                             real *u, integer *ldu, real *vt, integer *k, real *difl, real *difr,
+                             real *z__, real *poles, integer *givptr, integer *givcol,
+                             integer *ldgcol, integer *perm, real *givnum, real *c__, real *s,
+                             real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int clalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, real *d__, real *e, complex *b, integer *ldb, real *rcond,
-      integer *rank, complex *work, real *rwork, integer *iwork,
-      integer * info);
+/* Subroutine */ int clalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, real *d__, real *e, complex *b, integer *ldb, real *rcond,
+                             integer *rank, complex *work, real *rwork, integer *iwork,
+                             integer *info);
 
-  doublereal clangb_(char *norm, integer *n, integer *kl, integer *ku,
-      complex * ab, integer *ldab, real *work);
+doublereal clangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clange_(char *norm, integer *m, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clange_(char *norm, integer *m, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clangt_(char *norm, integer *n, complex *dl, complex *d__,
-      complex *du);
+doublereal clangt_(char *norm, integer *n, complex *dl, complex *d__,
+                   complex *du);
 
-  doublereal clanhb_(char *norm, char *uplo, integer *n, integer *k,
-      complex * ab, integer *ldab, real *work);
+doublereal clanhb_(char *norm, char *uplo, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clanhf_(char *norm, char *transr, char *uplo, integer *n,
-      complex * a, real *work);
+doublereal clanhf_(char *norm, char *transr, char *uplo, integer *n,
+                   complex *a, real *work);
 
-  doublereal clanhp_(char *norm, char *uplo, integer *n, complex *ap,
-      real * work);
+doublereal clanhp_(char *norm, char *uplo, integer *n, complex *ap,
+                   real *work);
 
-  doublereal clanhs_(char *norm, integer *n, complex *a, integer *lda,
-      real * work);
+doublereal clanhs_(char *norm, integer *n, complex *a, integer *lda,
+                   real *work);
 
-  doublereal clanht_(char *norm, integer *n, real *d__, complex *e);
+doublereal clanht_(char *norm, integer *n, real *d__, complex *e);
 
-  doublereal clansb_(char *norm, char *uplo, integer *n, integer *k,
-      complex * ab, integer *ldab, real *work);
+doublereal clansb_(char *norm, char *uplo, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clansp_(char *norm, char *uplo, integer *n, complex *ap,
-      real * work);
+doublereal clansp_(char *norm, char *uplo, integer *n, complex *ap,
+                   real *work);
 
-  doublereal clansy_(char *norm, char *uplo, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clansy_(char *norm, char *uplo, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      complex *ab, integer *ldab, real *work);
+doublereal clantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clantp_(char *norm, char *uplo, char *diag, integer *n,
-      complex * ap, real *work);
+doublereal clantp_(char *norm, char *uplo, char *diag, integer *n,
+                   complex *ap, real *work);
 
-  doublereal clantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      complex *a, integer *lda, real *work);
+doublereal clantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   complex *a, integer *lda, real *work);
 
-  /* Subroutine */int clapll_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *ssmin);
+/* Subroutine */ int clapll_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *ssmin);
 
-  /* Subroutine */int clapmt_(logical *forwrd, integer *m, integer *n,
-      complex *x, integer *ldx, integer *k);
+/* Subroutine */ int clapmt_(logical *forwrd, integer *m, integer *n,
+                             complex *x, integer *ldx, integer *k);
 
-  /* Subroutine */int claqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, char *equed);
+/* Subroutine */ int claqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, char *equed);
 
-  /* Subroutine */int claqge_(integer *m, integer *n, complex *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      char * equed);
+/* Subroutine */ int claqge_(integer *m, integer *n, complex *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             char *equed);
 
-  /* Subroutine */int claqhb_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhb_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqhe_(char *uplo, integer *n, complex *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhe_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqhp_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhp_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqp2_(integer *m, integer *n, integer *offset,
-      complex *a, integer *lda, integer *jpvt, complex *tau, real *vn1,
-      real *vn2, complex *work);
+/* Subroutine */ int claqp2_(integer *m, integer *n, integer *offset,
+                             complex *a, integer *lda, integer *jpvt, complex *tau, real *vn1,
+                             real *vn2, complex *work);
 
-  /* Subroutine */int claqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, complex *a, integer *lda, integer *jpvt,
-      complex * tau, real *vn1, real *vn2, complex *auxv, complex *f,
-      integer *ldf);
+/* Subroutine */ int claqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, complex *a, integer *lda, integer *jpvt,
+                             complex *tau, real *vn1, real *vn2, complex *auxv, complex *f,
+                             integer *ldf);
 
-  /* Subroutine */int claqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex * work,
-      integer *lwork, integer *info);
+/* Subroutine */ int claqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int claqr1_(integer *n, complex *h__, integer *ldh,
-      complex * s1, complex *s2, complex *v);
+/* Subroutine */ int claqr1_(integer *n, complex *h__, integer *ldh,
+                             complex *s1, complex *s2, complex *v);
 
-  /* Subroutine */int claqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * ns,
-      integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
-      complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
-      complex *work, integer *lwork);
+/* Subroutine */ int claqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *ns,
+                             integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
+                             complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
+                             complex *work, integer *lwork);
 
-  /* Subroutine */int claqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * ns,
-      integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
-      complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
-      complex *work, integer *lwork);
+/* Subroutine */ int claqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *ns,
+                             integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
+                             complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
+                             complex *work, integer *lwork);
 
-  /* Subroutine */int claqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex * work,
-      integer *lwork, integer *info);
+/* Subroutine */ int claqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int claqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, complex *s,
-      complex *h__, integer *ldh, integer *iloz, integer *ihiz, complex * z__,
-      integer *ldz, complex *v, integer *ldv, complex *u, integer *ldu,
-      integer *nv, complex *wv, integer *ldwv, integer *nh, complex *wh,
-      integer *ldwh);
+/* Subroutine */ int claqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, complex *s,
+                             complex *h__, integer *ldh, integer *iloz, integer *ihiz, complex *z__,
+                             integer *ldz, complex *v, integer *ldv, complex *u, integer *ldu,
+                             integer *nv, complex *wv, integer *ldwv, integer *nh, complex *wh,
+                             integer *ldwh);
 
-  /* Subroutine */int claqsb_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsb_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqsp_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsp_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqsy_(char *uplo, integer *n, complex *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsy_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int clar1v_(integer *n, integer *b1, integer *bn,
-      real * lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
-      real * gaptol, complex *z__, logical *wantnc, integer *negcnt, real *ztz,
-      real *mingma, integer *r__, integer *isuppz, real *nrminv, real * resid,
-      real *rqcorr, real *work);
+/* Subroutine */ int clar1v_(integer *n, integer *b1, integer *bn,
+                             real *lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
+                             real *gaptol, complex *z__, logical *wantnc, integer *negcnt, real *ztz,
+                             real *mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
+                             real *rqcorr, real *work);
 
-  /* Subroutine */int clar2v_(integer *n, complex *x, complex *y, complex *z__,
-      integer *incx, real *c__, complex *s, integer *incc);
+/* Subroutine */ int clar2v_(integer *n, complex *x, complex *y, complex *z__,
+                             integer *incx, real *c__, complex *s, integer *incc);
 
-  /* Subroutine */int clarcm_(integer *m, integer *n, real *a, integer *lda,
-      complex *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
+/* Subroutine */ int clarcm_(integer *m, integer *n, real *a, integer *lda,
+                             complex *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
 
-  /* Subroutine */int clarf_(char *side, integer *m, integer *n, complex *v,
-      integer *incv, complex *tau, complex *c__, integer *ldc, complex * work);
+/* Subroutine */ int clarf_(char *side, integer *m, integer *n, complex *v,
+                            integer *incv, complex *tau, complex *c__, integer *ldc, complex *work);
 
-  /* Subroutine */int clarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, complex *v,
-      integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
-      complex *work, integer *ldwork);
+/* Subroutine */ int clarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, complex *v,
+                             integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
+                             complex *work, integer *ldwork);
 
-  /* Subroutine */int clarfg_(integer *n, complex *alpha, complex *x,
-      integer * incx, complex *tau);
+/* Subroutine */ int clarfg_(integer *n, complex *alpha, complex *x,
+                             integer *incx, complex *tau);
 
-  /* Subroutine */int clarfp_(integer *n, complex *alpha, complex *x,
-      integer * incx, complex *tau);
+/* Subroutine */ int clarfp_(integer *n, complex *alpha, complex *x,
+                             integer *incx, complex *tau);
 
-  /* Subroutine */int clarft_(char *direct, char *storev, integer *n,
-      integer * k, complex *v, integer *ldv, complex *tau, complex *t,
-      integer *ldt);
+/* Subroutine */ int clarft_(char *direct, char *storev, integer *n,
+                             integer *k, complex *v, integer *ldv, complex *tau, complex *t,
+                             integer *ldt);
 
-  /* Subroutine */int clarfx_(char *side, integer *m, integer *n, complex *v,
-      complex *tau, complex *c__, integer *ldc, complex *work);
+/* Subroutine */ int clarfx_(char *side, integer *m, integer *n, complex *v,
+                             complex *tau, complex *c__, integer *ldc, complex *work);
 
-  /* Subroutine */int clargv_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *c__, integer *incc);
+/* Subroutine */ int clargv_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *c__, integer *incc);
 
-  /* Subroutine */int clarnv_(integer *idist, integer *iseed, integer *n,
-      complex *x);
+/* Subroutine */ int clarnv_(integer *idist, integer *iseed, integer *n,
+                             complex *x);
 
-  /* Subroutine */int clarrv_(integer *n, real *vl, real *vu, real *d__,
-      real * l, real *pivmin, integer *isplit, integer *m, integer *dol,
-      integer * dou, real *minrgp, real *rtol1, real *rtol2, real *w,
-      real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
-      complex * z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int clarrv_(integer *n, real *vl, real *vu, real *d__,
+                             real *l, real *pivmin, integer *isplit, integer *m, integer *dol,
+                             integer *dou, real *minrgp, real *rtol1, real *rtol2, real *w,
+                             real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
+                             complex *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int clarscl2_(integer *m, integer *n, real *d__, complex *x,
-      integer *ldx);
+/* Subroutine */ int clarscl2_(integer *m, integer *n, real *d__, complex *x,
+                               integer *ldx);
 
-  /* Subroutine */int clartg_(complex *f, complex *g, real *cs, complex *sn,
-      complex *r__);
+/* Subroutine */ int clartg_(complex *f, complex *g, real *cs, complex *sn,
+                             complex *r__);
 
-  /* Subroutine */int clartv_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *c__, complex *s, integer *incc);
+/* Subroutine */ int clartv_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *c__, complex *s, integer *incc);
 
-  /* Subroutine */int clarz_(char *side, integer *m, integer *n, integer *l,
-      complex *v, integer *incv, complex *tau, complex *c__, integer *ldc,
-      complex *work);
+/* Subroutine */ int clarz_(char *side, integer *m, integer *n, integer *l,
+                            complex *v, integer *incv, complex *tau, complex *c__, integer *ldc,
+                            complex *work);
 
-  /* Subroutine */int clarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l, complex *v,
-      integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
-      complex *work, integer *ldwork);
+/* Subroutine */ int clarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l, complex *v,
+                             integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
+                             complex *work, integer *ldwork);
 
-  /* Subroutine */int clarzt_(char *direct, char *storev, integer *n,
-      integer * k, complex *v, integer *ldv, complex *tau, complex *t,
-      integer *ldt);
+/* Subroutine */ int clarzt_(char *direct, char *storev, integer *n,
+                             integer *k, complex *v, integer *ldv, complex *tau, complex *t,
+                             integer *ldt);
 
-  /* Subroutine */int clascl_(char *type__, integer *kl, integer *ku,
-      real * cfrom, real *cto, integer *m, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clascl_(char *type__, integer *kl, integer *ku,
+                             real *cfrom, real *cto, integer *m, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int clascl2_(integer *m, integer *n, real *d__, complex *x,
-      integer *ldx);
+/* Subroutine */ int clascl2_(integer *m, integer *n, real *d__, complex *x,
+                              integer *ldx);
 
-  /* Subroutine */int claset_(char *uplo, integer *m, integer *n,
-      complex * alpha, complex *beta, complex *a, integer *lda);
+/* Subroutine */ int claset_(char *uplo, integer *m, integer *n,
+                             complex *alpha, complex *beta, complex *a, integer *lda);
 
-  /* Subroutine */int clasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, real *c__, real *s, complex *a, integer *lda);
+/* Subroutine */ int clasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, real *c__, real *s, complex *a, integer *lda);
 
-  /* Subroutine */int classq_(integer *n, complex *x, integer *incx,
-      real * scale, real *sumsq);
+/* Subroutine */ int classq_(integer *n, complex *x, integer *incx,
+                             real *scale, real *sumsq);
 
-  /* Subroutine */int claswp_(integer *n, complex *a, integer *lda,
-      integer * k1, integer *k2, integer *ipiv, integer *incx);
+/* Subroutine */ int claswp_(integer *n, complex *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
 
-  /* Subroutine */int clasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
-      integer *info);
+/* Subroutine */ int clasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
+                             integer *info);
 
-  /* Subroutine */int clatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, complex *ab, integer *ldab,
-      complex * x, real *scale, real *cnorm, integer *info);
+/* Subroutine */ int clatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, complex *ab, integer *ldab,
+                             complex *x, real *scale, real *cnorm, integer *info);
 
-  /* Subroutine */int clatdf_(integer *ijob, integer *n, complex *z__,
-      integer *ldz, complex *rhs, real *rdsum, real *rdscal, integer *ipiv,
-      integer *jpiv);
+/* Subroutine */ int clatdf_(integer *ijob, integer *n, complex *z__,
+                             integer *ldz, complex *rhs, real *rdsum, real *rdscal, integer *ipiv,
+                             integer *jpiv);
 
-  /* Subroutine */int clatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, complex *ap, complex *x, real *scale,
-      real *cnorm, integer *info);
+/* Subroutine */ int clatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, complex *ap, complex *x, real *scale,
+                             real *cnorm, integer *info);
 
-  /* Subroutine */int clatrd_(char *uplo, integer *n, integer *nb, complex *a,
-      integer *lda, real *e, complex *tau, complex *w, integer *ldw);
+/* Subroutine */ int clatrd_(char *uplo, integer *n, integer *nb, complex *a,
+                             integer *lda, real *e, complex *tau, complex *w, integer *ldw);
 
-  /* Subroutine */int clatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, complex *a, integer *lda, complex *x,
-      real *scale, real *cnorm, integer *info);
+/* Subroutine */ int clatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, complex *a, integer *lda, complex *x,
+                             real *scale, real *cnorm, integer *info);
 
-  /* Subroutine */int clatrz_(integer *m, integer *n, integer *l, complex *a,
-      integer *lda, complex *tau, complex *work);
+/* Subroutine */ int clatrz_(integer *m, integer *n, integer *l, complex *a,
+                             integer *lda, complex *tau, complex *work);
 
-  /* Subroutine */int clatzm_(char *side, integer *m, integer *n, complex *v,
-      integer *incv, complex *tau, complex *c1, complex *c2, integer *ldc,
-      complex *work);
+/* Subroutine */ int clatzm_(char *side, integer *m, integer *n, complex *v,
+                             integer *incv, complex *tau, complex *c1, complex *c2, integer *ldc,
+                             complex *work);
 
-  /* Subroutine */int clauu2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clauu2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int clauum_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clauum_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpbcon_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *anorm, real *rcond, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpbcon_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *anorm, real *rcond, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cpbequ_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, integer *info);
+/* Subroutine */ int cpbequ_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real * berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpbstf_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbstf_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
+                            integer *info);
 
-  /* Subroutine */int cpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, complex *ab, integer *ldab, complex *afb, integer * ldafb,
-      char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                             char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cpbtf2_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbtf2_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbtrf_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbtrf_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int cpftrf_(char *transr, char *uplo, integer *n, complex *a,
-      integer *info);
+/* Subroutine */ int cpftrf_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *info);
 
-  /* Subroutine */int cpftri_(char *transr, char *uplo, integer *n, complex *a,
-      integer *info);
+/* Subroutine */ int cpftri_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *info);
 
-  /* Subroutine */int cpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, complex *a, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, complex *a, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cpocon_(char *uplo, integer *n, complex *a, integer *lda,
-      real *anorm, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cpocon_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *anorm, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpoequ_(integer *n, complex *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cpoequ_(integer *n, complex *a, integer *lda, real *s,
+                             real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpoequb_(integer *n, complex *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cpoequb_(integer *n, complex *a, integer *lda, real *s,
+                              real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cporfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int cporfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      real *s, complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real * err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real * rwork, integer *info);
+/* Subroutine */ int cporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              real *s, complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cposv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cposv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      char * equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      char * equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpotf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpotrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cppcon_(char *uplo, integer *n, complex *ap, real *anorm,
-      real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cppcon_(char *uplo, integer *n, complex *ap, real *anorm,
+                             real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cppequ_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cppequ_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cppsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cppsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, char *equed, real *s,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, char *equed, real *s,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpptrf_(char *uplo, integer *n, complex *ap,
-      integer * info);
+/* Subroutine */ int cpptrf_(char *uplo, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int cpptri_(char *uplo, integer *n, complex *ap,
-      integer * info);
+/* Subroutine */ int cpptri_(char *uplo, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int cpptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cpstf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
+/* Subroutine */ int cpstf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
 
-  /* Subroutine */int cpstrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
+/* Subroutine */ int cpstrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
 
-  /* Subroutine */int cptcon_(integer *n, real *d__, complex *e, real *anorm,
-      real *rcond, real *rwork, integer *info);
+/* Subroutine */ int cptcon_(integer *n, real *d__, complex *e, real *anorm,
+                             real *rcond, real *rwork, integer *info);
 
-  /* Subroutine */int cpteqr_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, real *work, integer *info);
+/* Subroutine */ int cpteqr_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, real *work, integer *info);
 
-  /* Subroutine */int cptrfs_(char *uplo, integer *n, integer *nrhs, real *d__,
-      complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cptrfs_(char *uplo, integer *n, integer *nrhs, real *d__,
+                             complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cptsv_(integer *n, integer *nrhs, real *d__, complex *e,
-      complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cptsv_(integer *n, integer *nrhs, real *d__, complex *e,
+                            complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
-      complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int cptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
+                             complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *rcond, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cpttrf_(integer *n, real *d__, complex *e, integer *info);
+/* Subroutine */ int cpttrf_(integer *n, real *d__, complex *e, integer *info);
 
-  /* Subroutine */int cpttrs_(char *uplo, integer *n, integer *nrhs, real *d__,
-      complex *e, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpttrs_(char *uplo, integer *n, integer *nrhs, real *d__,
+                             complex *e, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cptts2_(integer *iuplo, integer *n, integer *nrhs,
-      real * d__, complex *e, complex *b, integer *ldb);
+/* Subroutine */ int cptts2_(integer *iuplo, integer *n, integer *nrhs,
+                             real *d__, complex *e, complex *b, integer *ldb);
 
-  /* Subroutine */int crot_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, real *c__, complex *s);
+/* Subroutine */ int crot_(integer *n, complex *cx, integer *incx,
+                           complex *cy, integer *incy, real *c__, complex *s);
 
-  /* Subroutine */int cspcon_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, real *anorm, real *rcond, complex *work, integer *info);
+/* Subroutine */ int cspcon_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cspmv_(char *uplo, integer *n, complex *alpha,
-      complex * ap, complex *x, integer *incx, complex *beta, complex *y,
-      integer * incy);
+/* Subroutine */ int cspmv_(char *uplo, integer *n, complex *alpha,
+                            complex *ap, complex *x, integer *incx, complex *beta, complex *y,
+                            integer *incy);
 
-  /* Subroutine */int cspr_(char *uplo, integer *n, complex *alpha, complex *x,
-      integer *incx, complex *ap);
+/* Subroutine */ int cspr_(char *uplo, integer *n, complex *alpha, complex *x,
+                           integer *incx, complex *ap);
 
-  /* Subroutine */int csprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int csprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cspsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cspsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csptrf_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, integer *info);
+/* Subroutine */ int csptrf_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int csptri_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, complex *work, integer *info);
+/* Subroutine */ int csptri_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int csptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int csptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int csrscl_(integer *n, real *sa, complex *sx, integer *incx);
+/* Subroutine */ int csrscl_(integer *n, real *sa, complex *sx, integer *incx);
 
-  /* Subroutine */int cstedc_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, complex *work, integer *lwork, real * rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer * info);
+/* Subroutine */ int cstedc_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cstegr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, complex *z__, integer *ldz, integer *isuppz,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer * info);
+/* Subroutine */ int cstegr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int cstein_(integer *n, real *d__, real *e, integer *m,
-      real *w, integer *iblock, integer *isplit, complex *z__, integer *ldz,
-      real *work, integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int cstein_(integer *n, real *d__, real *e, integer *m,
+                             real *w, integer *iblock, integer *isplit, complex *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int cstemr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
-      real *w, complex *z__, integer *ldz, integer *nzc, integer *isuppz,
-      logical *tryrac, real *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
+/* Subroutine */ int cstemr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
+                             real *w, complex *z__, integer *ldz, integer *nzc, integer *isuppz,
+                             logical *tryrac, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
 
-  /* Subroutine */int csteqr_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, real *work, integer *info);
+/* Subroutine */ int csteqr_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, real *work, integer *info);
 
-  /* Subroutine */int csycon_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, complex *work, integer * info);
+/* Subroutine */ int csycon_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int csyequb_(char *uplo, integer *n, complex *a,
-      integer * lda, real *s, real *scond, real *amax, complex *work,
-      integer *info);
+/* Subroutine */ int csyequb_(char *uplo, integer *n, complex *a,
+                              integer *lda, real *s, real *scond, real *amax, complex *work,
+                              integer *info);
 
-  /* Subroutine */int csymv_(char *uplo, integer *n, complex *alpha,
-      complex * a, integer *lda, complex *x, integer *incx, complex *beta,
-      complex *y, integer *incy);
+/* Subroutine */ int csymv_(char *uplo, integer *n, complex *alpha,
+                            complex *a, integer *lda, complex *x, integer *incx, complex *beta,
+                            complex *y, integer *incy);
 
-  /* Subroutine */int csyr_(char *uplo, integer *n, complex *alpha, complex *x,
-      integer *incx, complex *a, integer *lda);
+/* Subroutine */ int csyr_(char *uplo, integer *n, complex *alpha, complex *x,
+                           integer *incx, complex *a, integer *lda);
 
-  /* Subroutine */int csyrfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int csyrfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *s, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int csyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *s, complex *b, integer *ldb, complex *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csysv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int csysv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int csysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
-      real *rwork, integer *info);
+/* Subroutine */ int csysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int csysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *s, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int csysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, complex *work, real *rwork,
+                              integer *info);
 
-  /* Subroutine */int csytf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int csytf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int csytrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int csytrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int csytri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *info);
+/* Subroutine */ int csytri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int csytrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int csytrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int ctbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, complex *ab, integer *ldab, real *rcond, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, complex *ab, integer *ldab, real *rcond, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
-      integer *ldb, integer *info);
+/* Subroutine */ int ctbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
+                             integer *ldb, integer *info);
 
-  /* Subroutine */int ctfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, complex *alpha, complex *a,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, complex *alpha, complex *a,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctftri_(char *transr, char *uplo, char *diag, integer *n,
-      complex *a, integer *info);
+/* Subroutine */ int ctftri_(char *transr, char *uplo, char *diag, integer *n,
+                             complex *a, integer *info);
 
-  /* Subroutine */int ctfttp_(char *transr, char *uplo, integer *n,
-      complex * arf, complex *ap, integer *info);
+/* Subroutine */ int ctfttp_(char *transr, char *uplo, integer *n,
+                             complex *arf, complex *ap, integer *info);
 
-  /* Subroutine */int ctfttr_(char *transr, char *uplo, integer *n,
-      complex * arf, complex *a, integer *lda, integer *info);
+/* Subroutine */ int ctfttr_(char *transr, char *uplo, integer *n,
+                             complex *arf, complex *a, integer *lda, integer *info);
 
-  /* Subroutine */int ctgevc_(char *side, char *howmny, logical *select,
-      integer *n, complex *s, integer *lds, complex *p, integer *ldp,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
-      integer *m, complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctgevc_(char *side, char *howmny, logical *select,
+                             integer *n, complex *s, integer *lds, complex *p, integer *ldp,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
+                             integer *m, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctgex2_(logical *wantq, logical *wantz, integer *n,
-      complex *a, integer *lda, complex *b, integer *ldb, complex *q,
-      integer *ldq, complex *z__, integer *ldz, integer *j1, integer *info);
+/* Subroutine */ int ctgex2_(logical *wantq, logical *wantz, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, complex *q,
+                             integer *ldq, complex *z__, integer *ldz, integer *j1, integer *info);
 
-  /* Subroutine */int ctgexc_(logical *wantq, logical *wantz, integer *n,
-      complex *a, integer *lda, complex *b, integer *ldb, complex *q,
-      integer *ldq, complex *z__, integer *ldz, integer *ifst, integer * ilst,
-      integer *info);
+/* Subroutine */ int ctgexc_(logical *wantq, logical *wantz, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, complex *q,
+                             integer *ldq, complex *z__, integer *ldz, integer *ifst, integer *ilst,
+                             integer *info);
 
-  /* Subroutine */int ctgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *alpha, complex *beta, complex *q, integer *ldq,
-      complex *z__, integer *ldz, integer *m, real *pl, real *pr, real * dif,
-      complex *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int ctgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *alpha, complex *beta, complex *q, integer *ldq,
+                             complex *z__, integer *ldz, integer *m, real *pl, real *pr, real *dif,
+                             complex *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int ctgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, complex *a, integer * lda,
-      complex *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
-      complex *u, integer *ldu, complex *v, integer *ldv, complex *q,
-      integer *ldq, complex *work, integer *ncycle, integer * info);
+/* Subroutine */ int ctgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, complex *a, integer *lda,
+                             complex *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
+                             complex *u, integer *ldu, complex *v, integer *ldv, complex *q,
+                             integer *ldq, complex *work, integer *ncycle, integer *info);
 
-  /* Subroutine */int ctgsna_(char *job, char *howmny, logical *select,
-      integer *n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, real *s,
-      real *dif, integer *mm, integer *m, complex *work, integer *lwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int ctgsna_(char *job, char *howmny, logical *select,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, real *s,
+                             real *dif, integer *mm, integer *m, complex *work, integer *lwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int ctgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
-      integer *lde, complex *f, integer *ldf, real *scale, real *rdsum,
-      real *rdscal, integer *info);
+/* Subroutine */ int ctgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
+                             integer *lde, complex *f, integer *ldf, real *scale, real *rdsum,
+                             real *rdscal, integer *info);
 
-  /* Subroutine */int ctgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
-      integer *lde, complex *f, integer *ldf, real *scale, real *dif,
-      complex *work, integer *lwork, integer *iwork, integer *info);
+/* Subroutine */ int ctgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
+                             integer *lde, complex *f, integer *ldf, real *scale, real *dif,
+                             complex *work, integer *lwork, integer *iwork, integer *info);
 
-  /* Subroutine */int ctpcon_(char *norm, char *uplo, char *diag, integer *n,
-      complex *ap, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             complex *ap, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *ap, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int ctprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *ap, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int ctptri_(char *uplo, char *diag, integer *n, complex *ap,
-      integer *info);
+/* Subroutine */ int ctptri_(char *uplo, char *diag, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int ctptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int ctptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int ctpttf_(char *transr, char *uplo, integer *n,
-      complex * ap, complex *arf, integer *info);
+/* Subroutine */ int ctpttf_(char *transr, char *uplo, integer *n,
+                             complex *ap, complex *arf, integer *info);
 
-  /* Subroutine */int ctpttr_(char *uplo, integer *n, complex *ap, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctpttr_(char *uplo, integer *n, complex *ap, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrcon_(char *norm, char *uplo, char *diag, integer *n,
-      complex *a, integer *lda, real *rcond, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int ctrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             complex *a, integer *lda, real *rcond, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int ctrevc_(char *side, char *howmny, logical *select,
-      integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
-      complex *vr, integer *ldvr, integer *mm, integer *m, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctrevc_(char *side, char *howmny, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, integer *mm, integer *m, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctrexc_(char *compq, integer *n, complex *t,
-      integer * ldt, complex *q, integer *ldq, integer *ifst, integer *ilst,
-      integer * info);
+/* Subroutine */ int ctrexc_(char *compq, integer *n, complex *t,
+                             integer *ldt, complex *q, integer *ldq, integer *ifst, integer *ilst,
+                             integer *info);
 
-  /* Subroutine */int ctrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctrsen_(char *job, char *compq, logical *select,
-      integer *n, complex *t, integer *ldt, complex *q, integer *ldq,
-      complex *w, integer *m, real *s, real *sep, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int ctrsen_(char *job, char *compq, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *q, integer *ldq,
+                             complex *w, integer *m, real *s, real *sep, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int ctrsna_(char *job, char *howmny, logical *select,
-      integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
-      complex *vr, integer *ldvr, real *s, real *sep, integer *mm, integer * m,
-      complex *work, integer *ldwork, real *rwork, integer *info);
+/* Subroutine */ int ctrsna_(char *job, char *howmny, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, real *s, real *sep, integer *mm, integer *m,
+                             complex *work, integer *ldwork, real *rwork, integer *info);
 
-  /* Subroutine */int ctrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *c__, integer *ldc, real *scale, integer *info);
+/* Subroutine */ int ctrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *c__, integer *ldc, real *scale, integer *info);
 
-  /* Subroutine */int ctrti2_(char *uplo, char *diag, integer *n, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctrti2_(char *uplo, char *diag, integer *n, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrtri_(char *uplo, char *diag, integer *n, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctrtri_(char *uplo, char *diag, integer *n, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      integer *info);
+/* Subroutine */ int ctrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int ctrttf_(char *transr, char *uplo, integer *n, complex *a,
-      integer *lda, complex *arf, integer *info);
+/* Subroutine */ int ctrttf_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *lda, complex *arf, integer *info);
 
-  /* Subroutine */int ctrttp_(char *uplo, integer *n, complex *a, integer *lda,
-      complex *ap, integer *info);
+/* Subroutine */ int ctrttp_(char *uplo, integer *n, complex *a, integer *lda,
+                             complex *ap, integer *info);
 
-  /* Subroutine */int ctzrqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, integer *info);
+/* Subroutine */ int ctzrqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, integer *info);
 
-  /* Subroutine */int ctzrzf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int ctzrzf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cung2l_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cung2l_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cung2r_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cung2r_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cungbr_(char *vect, integer *m, integer *n, integer *k,
-      complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cungbr_(char *vect, integer *m, integer *n, integer *k,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunghr_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cunghr_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungl2_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cungl2_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cunglq_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunglq_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungql_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungql_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungqr_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungqr_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungr2_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cungr2_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cungrq_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungrq_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungtr_(char *uplo, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cungtr_(char *uplo, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunmhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunmr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunmr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cupgtr_(char *uplo, integer *n, complex *ap,
-      complex * tau, complex *q, integer *ldq, complex *work, integer *info);
+/* Subroutine */ int cupgtr_(char *uplo, integer *n, complex *ap,
+                             complex *tau, complex *q, integer *ldq, complex *work, integer *info);
 
-  /* Subroutine */int cupmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, complex *ap, complex *tau, complex *c__, integer *ldc,
-      complex *work, integer *info);
+/* Subroutine */ int cupmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, complex *ap, complex *tau, complex *c__, integer *ldc,
+                             complex *work, integer *info);
 
-  /* Subroutine */int dbdsdc_(char *uplo, char *compq, integer *n,
-      doublereal * d__, doublereal *e, doublereal *u, integer *ldu,
-      doublereal *vt, integer *ldvt, doublereal *q, integer *iq,
-      doublereal *work, integer * iwork, integer *info);
+/* Subroutine */ int dbdsdc_(char *uplo, char *compq, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *q, integer *iq,
+                             doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, doublereal *d__, doublereal *e,
-      doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
-      doublereal *c__, integer * ldc, doublereal *work, integer *info);
+/* Subroutine */ int dbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, doublereal *d__, doublereal *e,
+                             doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
 
-  /* Subroutine */int ddisna_(char *job, integer *m, integer *n,
-      doublereal * d__, doublereal *sep, integer *info);
+/* Subroutine */ int ddisna_(char *job, integer *m, integer *n,
+                             doublereal *d__, doublereal *sep, integer *info);
 
-  /* Subroutine */int dgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, doublereal *ab, integer *ldab, doublereal * d__,
-      doublereal *e, doublereal *q, integer *ldq, doublereal *pt, integer *ldpt,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
+/* Subroutine */ int dgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, doublereal *ab, integer *ldab, doublereal *d__,
+                             doublereal *e, doublereal *q, integer *ldq, doublereal *pt, integer *ldpt,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
 
-  /* Subroutine */int dgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, doublereal *anorm,
-      doublereal *rcond, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, doublereal *anorm,
+                             doublereal *rcond, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer * info);
+/* Subroutine */ int dgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, doublereal *ab, integer *ldab, doublereal *r__,
-      doublereal *c__, doublereal *rowcnd, doublereal *colcnd, doublereal *amax,
-      integer * info);
+/* Subroutine */ int dgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, doublereal *ab, integer *ldab, doublereal *r__,
+                              doublereal *c__, doublereal *rowcnd, doublereal *colcnd, doublereal *amax,
+                              integer *info);
 
-  /* Subroutine */int dgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                             doublereal *afb, integer *ldafb, integer *ipiv, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer * nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                              doublereal *afb, integer *ldafb, integer *ipiv, doublereal *r__,
+                              doublereal *c__, doublereal *b, integer *ldb, doublereal *x,
+                              integer *ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
 
-  /* Subroutine */int dgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, doublereal *ab, integer *ldab, integer *ipiv,
-      doublereal *b, integer *ldb, integer *info);
+/* Subroutine */ int dgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
+                            doublereal *b, integer *ldb, integer *info);
 
-  /* Subroutine */int dgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                             doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
+                             doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                              doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
+                              doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int dgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int dgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int dgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int dgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
-      doublereal *b, integer *ldb, integer *info);
+/* Subroutine */ int dgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
+                             doublereal *b, integer *ldb, integer *info);
 
-  /* Subroutine */int dgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *scale, integer *m, doublereal *v, integer * ldv,
-      integer *info);
+/* Subroutine */ int dgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *scale, integer *m, doublereal *v, integer *ldv,
+                             integer *info);
 
-  /* Subroutine */int dgebal_(char *job, integer *n, doublereal *a,
-      integer * lda, integer *ilo, integer *ihi, doublereal *scale,
-      integer *info);
+/* Subroutine */ int dgebal_(char *job, integer *n, doublereal *a,
+                             integer *lda, integer *ilo, integer *ihi, doublereal *scale,
+                             integer *info);
 
-  /* Subroutine */int dgebd2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tauq,
-      doublereal * taup, doublereal *work, integer *info);
+/* Subroutine */ int dgebd2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tauq,
+                             doublereal *taup, doublereal *work, integer *info);
 
-  /* Subroutine */int dgebrd_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tauq,
-      doublereal * taup, doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgebrd_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tauq,
+                             doublereal *taup, doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgecon_(char *norm, integer *n, doublereal *a,
-      integer * lda, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer * iwork, integer *info);
+/* Subroutine */ int dgecon_(char *norm, integer *n, doublereal *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int dgeequ_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
+/* Subroutine */ int dgeequ_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgeequb_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
+/* Subroutine */ int dgeequb_(integer *m, integer *n, doublereal *a,
+                              integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                              doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      doublereal *a, integer *lda, integer *sdim, doublereal *wr,
-      doublereal *wi, doublereal *vs, integer *ldvs, doublereal *work,
-      integer *lwork, logical *bwork, integer *info);
+/* Subroutine */ int dgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            doublereal *a, integer *lda, integer *sdim, doublereal *wr,
+                            doublereal *wi, doublereal *vs, integer *ldvs, doublereal *work,
+                            integer *lwork, logical *bwork, integer *info);
 
-  /* Subroutine */int dgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, doublereal *a, integer *lda, integer *sdim,
-      doublereal *wr, doublereal *wi, doublereal *vs, integer *ldvs,
-      doublereal *rconde, doublereal *rcondv, doublereal *work, integer * lwork,
-      integer *iwork, integer *liwork, logical *bwork, integer *info);
+/* Subroutine */ int dgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, doublereal *a, integer *lda, integer *sdim,
+                             doublereal *wr, doublereal *wi, doublereal *vs, integer *ldvs,
+                             doublereal *rconde, doublereal *rcondv, doublereal *work, integer *lwork,
+                             integer *iwork, integer *liwork, logical *bwork, integer *info);
 
-  /* Subroutine */int dgeev_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *wr, doublereal *wi,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgeev_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *wr, doublereal *wi,
+                            doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublereal *a, integer *lda, doublereal *wr,
-      doublereal *wi, doublereal *vl, integer *ldvl, doublereal *vr,
-      integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
-      doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
-      doublereal *work, integer *lwork, integer *iwork, integer *info);
+/* Subroutine */ int dgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublereal *a, integer *lda, doublereal *wr,
+                             doublereal *wi, doublereal *vl, integer *ldvl, doublereal *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
+                             doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
 
-  /* Subroutine */int dgegs_(char *jobvsl, char *jobvsr, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal * alphar, doublereal *alphai, doublereal *beta,
-      doublereal *vsl, integer *ldvsl, doublereal *vsr, integer *ldvsr,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta,
+                            doublereal *vsl, integer *ldvsl, doublereal *vsr, integer *ldvsr,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgegv_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
-      integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgegv_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
+                            integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int dgehd2_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
+/* Subroutine */ int dgehd2_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
 
-  /* Subroutine */int dgehrd_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgehrd_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int dgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
-      char *jobt, char *jobp, integer *m, integer *n, doublereal *a,
-      integer *lda, doublereal *sva, doublereal *u, integer *ldu, doublereal *v,
-      integer *ldv, doublereal *work, integer *lwork, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
+                             char *jobt, char *jobp, integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *sva, doublereal *u, integer *ldu, doublereal *v,
+                             integer *ldv, doublereal *work, integer *lwork, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int dgelq2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgelq2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgelqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgelqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgelsd_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * s,
-      doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int dgelsd_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *s,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int dgelss_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * s,
-      doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgelss_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *s,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgelsx_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * jpvt,
-      doublereal *rcond, integer *rank, doublereal *work, integer * info);
+/* Subroutine */ int dgelsx_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *jpvt,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *info);
 
-  /* Subroutine */int dgelsy_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * jpvt,
-      doublereal *rcond, integer *rank, doublereal *work, integer * lwork,
-      integer *info);
+/* Subroutine */ int dgelsy_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *jpvt,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgeql2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgeql2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgeqlf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgeqlf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgeqp3_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *jpvt, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgeqp3_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *jpvt, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int dgeqpf_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *jpvt, doublereal *tau, doublereal *work,
-      integer *info);
+/* Subroutine */ int dgeqpf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *jpvt, doublereal *tau, doublereal *work,
+                             integer *info);
 
-  /* Subroutine */int dgeqr2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgeqr2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgeqrf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgeqrf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgerfs_(char *trans, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf,
-      integer * ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgerfs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int dgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
+                              doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                              doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
 
-  /* Subroutine */int dgerq2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
-
-  /* Subroutine */int dgerqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesc2_(integer *n, doublereal *a, integer *lda,
-      doublereal *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
-
-  /* Subroutine */int dgesdd_(char *jobz, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
-      doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dgesv_(integer *n, integer *nrhs, doublereal *a,
-      integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      doublereal *a, integer *lda, doublereal *s, doublereal *u, integer * ldu,
-      doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesvj_(char *joba, char *jobu, char *jobv, integer *m,
-      integer *n, doublereal *a, integer *lda, doublereal *sva, integer *mv,
-      doublereal *v, integer *ldv, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dgetc2_(integer *n, doublereal *a, integer *lda,
-      integer *ipiv, integer *jpiv, integer *info);
-
-  /* Subroutine */int dgetf2_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgetrf_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgetri_(integer *n, doublereal *a, integer *lda,
-      integer *ipiv, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dgetrs_(char *trans, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
-      doublereal *v, integer *ldv, integer *info);
-
-  /* Subroutine */int dggbal_(char *job, integer *n, doublereal *a,
-      integer * lda, doublereal *b, integer *ldb, integer *ilo, integer *ihi,
-      doublereal *lscale, doublereal *rscale, doublereal *work, integer * info);
-
-  /* Subroutine */int dgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, integer *sdim, doublereal *alphar, doublereal *alphai,
-      doublereal *beta, doublereal *vsl, integer *ldvsl, doublereal *vsr,
-      integer *ldvsr, doublereal *work, integer *lwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int dggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, doublereal *a, integer *lda,
-      doublereal *b, integer *ldb, integer *sdim, doublereal *alphar,
-      doublereal *alphai, doublereal *beta, doublereal *vsl, integer *ldvsl,
-      doublereal *vsr, integer *ldvsr, doublereal *rconde, doublereal * rcondv,
-      doublereal *work, integer *lwork, integer *iwork, integer * liwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int dggev_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
-      integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
-      doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
-      doublereal * rcondv, doublereal *work, integer *lwork, integer *iwork,
-      logical * bwork, integer *info);
-
-  /* Subroutine */int dggglm_(integer *n, integer *m, integer *p,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *d__, doublereal *x, doublereal *y, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *q, integer *ldq, doublereal *z__, integer * ldz,
-      integer *info);
-
-  /* Subroutine */int dgglse_(integer *m, integer *n, integer *p,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, doublereal *d__, doublereal *x, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dggqrf_(integer *n, integer *m, integer *p,
-      doublereal * a, integer *lda, doublereal *taua, doublereal *b,
-      integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dggrqf_(integer *m, integer *p, integer *n,
-      doublereal * a, integer *lda, doublereal *taua, doublereal *b,
-      integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, doublereal *a,
-      integer *lda, doublereal *b, integer *ldb, doublereal *alpha,
-      doublereal *beta, doublereal *u, integer *ldu, doublereal *v,
-      integer *ldv, doublereal *q, integer *ldq, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
-      doublereal *u, integer *ldu, doublereal *v, integer *ldv, doublereal *q,
-      integer *ldq, integer *iwork, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dgsvj0_(char *jobv, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *d__, doublereal *sva,
-      integer *mv, doublereal *v, integer *ldv, doublereal *eps,
-      doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
-      doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
-      integer *mv, doublereal *v, integer *ldv, doublereal *eps,
-      doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int dgtcon_(char *norm, integer *n, doublereal *dl,
-      doublereal *d__, doublereal *du, doublereal *du2, integer *ipiv,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dgtrfs_(char *trans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *dlf,
-      doublereal *df, doublereal *duf, doublereal *du2, integer *ipiv,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int dgtsv_(integer *n, integer *nrhs, doublereal *dl,
-      doublereal *d__, doublereal *du, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *dl, doublereal *d__, doublereal *du,
-      doublereal * dlf, doublereal *df, doublereal *duf, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dgttrf_(integer *n, doublereal *dl, doublereal *d__,
-      doublereal *du, doublereal *du2, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgttrs_(char *trans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dgtts2_(integer *itrans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb);
-
-  /* Subroutine */int dhgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *t,
-      integer *ldt, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dhsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, doublereal *h__, integer *ldh,
-      doublereal *wr, doublereal *wi, doublereal *vl, integer *ldvl,
-      doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
-      integer * ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int dhseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *info);
-
-  logical disnan_(doublereal *din);
-
-  /* Subroutine */int dla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, doublereal *alpha, doublereal *ab,
-      integer * ldab, doublereal *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
-
-  doublereal dla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *afb, integer *ldafb,
-      integer *ipiv, integer *cmode, doublereal *c__, integer *info,
-      doublereal *work, integer *iwork, ftnlen trans_len);
-
-  /* Subroutine */int dla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
-      doublereal * y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
-      integer *info);
-
-  doublereal dla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb);
-
-  /* Subroutine */int dla_geamv__(integer *trans, integer *m, integer *n,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal dla_gercond__(char *trans, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
-      doublereal *c__, integer *info, doublereal *work, integer *iwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int dla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, doublereal *a,
-      integer *lda, doublereal *af, integer *ldaf, integer *ipiv,
-      logical *colequ, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *y, integer * ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal *errs_n__, doublereal *errs_c__, doublereal *res,
-      doublereal *ayb, doublereal * dy, doublereal *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical *ignore_cwise__, integer *info);
-
-  /* Subroutine */int dla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      doublereal *res, doublereal *ayb, doublereal *berr);
-
-  doublereal dla_porcond__(char *uplo, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *cmode, doublereal *c__,
-      integer *info, doublereal *work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int dla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal * af,
-      integer *ldaf, logical *colequ, doublereal *c__, doublereal *b,
-      integer *ldb, doublereal *y, integer *ldy, doublereal *berr_out__,
-      integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
-      doublereal *res, doublereal *ayb, doublereal *dy, doublereal * y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal dla_porpvgrw__(char *uplo, integer *ncols, doublereal *a,
-      integer * lda, doublereal *af, integer *ldaf, doublereal *work,
-      ftnlen uplo_len);
-
-  doublereal dla_rpvgrw__(integer *n, integer *ncols, doublereal *a,
-      integer * lda, doublereal *af, integer *ldaf);
-
-  /* Subroutine */int dla_syamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublereal *a, integer *lda, doublereal *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal dla_syrcond__(char *uplo, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
-      doublereal *c__, integer *info, doublereal *work, integer *iwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int dla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal * af,
-      integer *ldaf, integer *ipiv, logical *colequ, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *y, integer *ldy,
-      doublereal * berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal * errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
-      doublereal *y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
-      integer *info, ftnlen uplo_len);
-
-  doublereal dla_syrpvgrw__(char *uplo, integer *n, integer *info,
-      doublereal * a, integer *lda, doublereal *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int dla_wwaddw__(integer *n, doublereal *x, doublereal *y,
-      doublereal *w);
-
-  /* Subroutine */int dlabad_(doublereal *small, doublereal *large);
-
-  /* Subroutine */int dlabrd_(integer *m, integer *n, integer *nb,
-      doublereal * a, integer *lda, doublereal *d__, doublereal *e,
-      doublereal *tauq, doublereal *taup, doublereal *x, integer *ldx,
-      doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlacn2_(integer *n, doublereal *v, doublereal *x,
-      integer *isgn, doublereal *est, integer *kase, integer *isave);
-
-  /* Subroutine */int dlacon_(integer *n, doublereal *v, doublereal *x,
-      integer *isgn, doublereal *est, integer *kase);
-
-  /* Subroutine */int dlacpy_(char *uplo, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb);
-
-  /* Subroutine */int dladiv_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *d__, doublereal *p, doublereal *q);
-
-  /* Subroutine */int dlae2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *rt1, doublereal *rt2);
-
-  /* Subroutine */int dlaebz_(integer *ijob, integer *nitmax, integer *n,
-      integer *mmax, integer *minp, integer *nbmin, doublereal *abstol,
-      doublereal *reltol, doublereal *pivmin, doublereal *d__, doublereal * e,
-      doublereal *e2, integer *nval, doublereal *ab, doublereal *c__,
-      integer *mout, integer *nab, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlaed0_(integer *icompq, integer *qsiz, integer *n,
-      doublereal *d__, doublereal *e, doublereal *q, integer *ldq,
-      doublereal *qstore, integer *ldqs, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlaed1_(integer *n, doublereal *d__, doublereal *q,
-      integer *ldq, integer *indxq, doublereal *rho, integer *cutpnt,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlaed2_(integer *k, integer *n, integer *n1,
-      doublereal * d__, doublereal *q, integer *ldq, integer *indxq,
-      doublereal *rho, doublereal *z__, doublereal *dlamda, doublereal *w,
-      doublereal *q2, integer *indx, integer *indxc, integer *indxp,
-      integer *coltyp, integer *info);
-
-  /* Subroutine */int dlaed3_(integer *k, integer *n, integer *n1,
-      doublereal * d__, doublereal *q, integer *ldq, doublereal *rho,
-      doublereal *dlamda, doublereal *q2, integer *indx, integer *ctot,
-      doublereal *w, doublereal *s, integer *info);
-
-  /* Subroutine */int dlaed4_(integer *n, integer *i__, doublereal *d__,
-      doublereal *z__, doublereal *delta, doublereal *rho, doublereal *dlam,
-      integer *info);
-
-  /* Subroutine */int dlaed5_(integer *i__, doublereal *d__, doublereal *z__,
-      doublereal *delta, doublereal *rho, doublereal *dlam);
-
-  /* Subroutine */int dlaed6_(integer *kniter, logical *orgati,
-      doublereal * rho, doublereal *d__, doublereal *z__, doublereal *finit,
-      doublereal * tau, integer *info);
-
-  /* Subroutine */int dlaed7_(integer *icompq, integer *n, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
-      doublereal *q, integer *ldq, integer *indxq, doublereal *rho,
-      integer *cutpnt, doublereal *qstore, integer *qptr, integer *prmptr,
-      integer * perm, integer *givptr, integer *givcol, doublereal *givnum,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlaed8_(integer *icompq, integer *k, integer *n,
-      integer *qsiz, doublereal *d__, doublereal *q, integer *ldq,
-      integer *indxq, doublereal *rho, integer *cutpnt, doublereal *z__,
-      doublereal *dlamda, doublereal *q2, integer *ldq2, doublereal *w,
-      integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
-      integer *indxp, integer *indx, integer *info);
-
-  /* Subroutine */int dlaed9_(integer *k, integer *kstart, integer *kstop,
-      integer *n, doublereal *d__, doublereal *q, integer *ldq,
-      doublereal * rho, doublereal *dlamda, doublereal *w, doublereal *s,
-      integer *lds, integer *info);
-
-  /* Subroutine */int dlaeda_(integer *n, integer *tlvls, integer *curlvl,
-      integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
-      integer *givcol, doublereal *givnum, doublereal *q, integer *qptr,
-      doublereal *z__, doublereal *ztemp, integer *info);
-
-  /* Subroutine */int dlaein_(logical *rightv, logical *noinit, integer *n,
-      doublereal *h__, integer *ldh, doublereal *wr, doublereal *wi,
-      doublereal *vr, doublereal *vi, doublereal *b, integer *ldb,
-      doublereal *work, doublereal *eps3, doublereal *smlnum,
-      doublereal * bignum, integer *info);
-
-  /* Subroutine */int dlaev2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *rt1, doublereal *rt2, doublereal *cs1, doublereal *sn1);
-
-  /* Subroutine */int dlaexc_(logical *wantq, integer *n, doublereal *t,
-      integer *ldt, doublereal *q, integer *ldq, integer *j1, integer *n1,
-      integer *n2, doublereal *work, integer *info);
-
-  /* Subroutine */int dlag2_(doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *safmin, doublereal *scale1, doublereal * scale2,
-      doublereal *wr1, doublereal *wr2, doublereal *wi);
-
-  /* Subroutine */int dlag2s_(integer *m, integer *n, doublereal *a,
-      integer * lda, real *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int dlags2_(logical *upper, doublereal *a1, doublereal *a2,
-      doublereal *a3, doublereal *b1, doublereal *b2, doublereal *b3,
-      doublereal *csu, doublereal *snu, doublereal *csv, doublereal *snv,
-      doublereal *csq, doublereal *snq);
-
-  /* Subroutine */int dlagtf_(integer *n, doublereal *a, doublereal *lambda,
-      doublereal *b, doublereal *c__, doublereal *tol, doublereal *d__,
-      integer *in, integer *info);
-
-  /* Subroutine */int dlagtm_(char *trans, integer *n, integer *nrhs,
-      doublereal *alpha, doublereal *dl, doublereal *d__, doublereal *du,
-      doublereal *x, integer *ldx, doublereal *beta, doublereal *b,
-      integer *ldb);
-
-  /* Subroutine */int dlagts_(integer *job, integer *n, doublereal *a,
-      doublereal *b, doublereal *c__, doublereal *d__, integer *in,
-      doublereal *y, doublereal *tol, integer *info);
-
-  /* Subroutine */int dlagv2_(doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *csl, doublereal *snl, doublereal *csr, doublereal * snr);
-
-  /* Subroutine */int dlahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, integer *info);
-
-  /* Subroutine */int dlahr2_(integer *n, integer *k, integer *nb,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *t,
-      integer *ldt, doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlahrd_(integer *n, integer *k, integer *nb,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *t,
-      integer *ldt, doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlaic1_(integer *job, integer *j, doublereal *x,
-      doublereal *sest, doublereal *w, doublereal *gamma, doublereal * sestpr,
-      doublereal *s, doublereal *c__);
-
-  logical dlaisnan_(doublereal *din1, doublereal *din2);
-
-  /* Subroutine */int dlaln2_(logical *ltrans, integer *na, integer *nw,
-      doublereal *smin, doublereal *ca, doublereal *a, integer *lda,
-      doublereal *d1, doublereal *d2, doublereal *b, integer *ldb,
-      doublereal *wr, doublereal *wi, doublereal *x, integer *ldx,
-      doublereal *scale, doublereal *xnorm, integer *info);
-
-  /* Subroutine */int dlals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, doublereal *givnum, integer *ldgnum, doublereal * poles,
-      doublereal *difl, doublereal *difr, doublereal *z__, integer * k,
-      doublereal *c__, doublereal *s, doublereal *work, integer *info);
-
-  /* Subroutine */int dlalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
-      integer * ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
-      doublereal *difl, doublereal *difr, doublereal *z__, doublereal * poles,
-      integer *givptr, integer *givcol, integer *ldgcol, integer * perm,
-      doublereal *givnum, doublereal *c__, doublereal *s, doublereal * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *d__, doublereal *e, doublereal *b,
-      integer *ldb, doublereal *rcond, integer *rank, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlamrg_(integer *n1, integer *n2, doublereal *a,
-      integer *dtrd1, integer *dtrd2, integer *index);
-
-  integer dlaneg_(integer *n, doublereal *d__, doublereal *lld,
-      doublereal * sigma, doublereal *pivmin, integer *r__);
-
-  doublereal dlangb_(char *norm, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlange_(char *norm, integer *m, integer *n, doublereal *a,
-      integer *lda, doublereal *work);
-
-  doublereal dlangt_(char *norm, integer *n, doublereal *dl, doublereal *d__,
-      doublereal *du);
-
-  doublereal dlanhs_(char *norm, integer *n, doublereal *a, integer *lda,
-      doublereal *work);
-
-  doublereal dlansb_(char *norm, char *uplo, integer *n, integer *k,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlansf_(char *norm, char *transr, char *uplo, integer *n,
-      doublereal *a, doublereal *work);
-
-  doublereal dlansp_(char *norm, char *uplo, integer *n, doublereal *ap,
-      doublereal *work);
-
-  doublereal dlanst_(char *norm, integer *n, doublereal *d__, doublereal *e);
-
-  doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a,
-      integer *lda, doublereal *work);
-
-  doublereal dlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlantp_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *ap, doublereal *work);
-
-  doublereal dlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      doublereal *a, integer *lda, doublereal *work);
-
-  /* Subroutine */int dlanv2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *d__, doublereal *rt1r, doublereal *rt1i, doublereal *rt2r,
-      doublereal *rt2i, doublereal *cs, doublereal *sn);
-
-  /* Subroutine */int dlapll_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *ssmin);
-
-  /* Subroutine */int dlapmt_(logical *forwrd, integer *m, integer *n,
-      doublereal *x, integer *ldx, integer *k);
-
-  doublereal dlapy2_(doublereal *x, doublereal *y);
-
-  doublereal dlapy3_(doublereal *x, doublereal *y, doublereal *z__);
-
-  /* Subroutine */int dlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqge_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqp2_(integer *m, integer *n, integer *offset,
-      doublereal *a, integer *lda, integer *jpvt, doublereal *tau,
-      doublereal *vn1, doublereal *vn2, doublereal *work);
-
-  /* Subroutine */int dlaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, doublereal *a, integer *lda, integer *jpvt,
-      doublereal *tau, doublereal *vn1, doublereal *vn2, doublereal *auxv,
-      doublereal *f, integer *ldf);
-
-  /* Subroutine */int dlaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dlaqr1_(integer *n, doublereal *h__, integer *ldh,
-      doublereal *sr1, doublereal *si1, doublereal *sr2, doublereal *si2,
-      doublereal *v);
-
-  /* Subroutine */int dlaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer * ldh,
-      integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
-      integer *nd, doublereal *sr, doublereal *si, doublereal * v, integer *ldv,
-      integer *nh, doublereal *t, integer *ldt, integer * nv, doublereal *wv,
-      integer *ldwv, doublereal *work, integer *lwork);
-
-  /* Subroutine */int dlaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer * ldh,
-      integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
-      integer *nd, doublereal *sr, doublereal *si, doublereal * v, integer *ldv,
-      integer *nh, doublereal *t, integer *ldt, integer * nv, doublereal *wv,
-      integer *ldwv, doublereal *work, integer *lwork);
-
-  /* Subroutine */int dlaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, doublereal *sr,
-      doublereal *si, doublereal *h__, integer *ldh, integer *iloz,
-      integer *ihiz, doublereal *z__, integer *ldz, doublereal *v,
-      integer * ldv, doublereal *u, integer *ldu, integer *nv, doublereal *wv,
-      integer *ldwv, integer *nh, doublereal *wh, integer *ldwh);
-
-  /* Subroutine */int dlaqsb_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqsp_(char *uplo, integer *n, doublereal *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqsy_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int dlaqtr_(logical *ltran, logical *lreal, integer *n,
-      doublereal *t, integer *ldt, doublereal *b, doublereal *w,
-      doublereal *scale, doublereal *x, doublereal *work, integer *info);
-
-  /* Subroutine */int dlar1v_(integer *n, integer *b1, integer *bn,
-      doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
-      doublereal * lld, doublereal *pivmin, doublereal *gaptol, doublereal *z__,
-      logical *wantnc, integer *negcnt, doublereal *ztz, doublereal *mingma,
-      integer *r__, integer *isuppz, doublereal *nrminv, doublereal *resid,
-      doublereal *rqcorr, doublereal *work);
-
-  /* Subroutine */int dlar2v_(integer *n, doublereal *x, doublereal *y,
-      doublereal *z__, integer *incx, doublereal *c__, doublereal *s,
-      integer *incc);
-
-  /* Subroutine */int dlarf_(char *side, integer *m, integer *n, doublereal *v,
-      integer *incv, doublereal *tau, doublereal *c__, integer *ldc,
-      doublereal *work);
-
-  /* Subroutine */int dlarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, doublereal *v,
-      integer * ldv, doublereal *t, integer *ldt, doublereal *c__, integer *ldc,
-      doublereal *work, integer *ldwork);
-
-  /* Subroutine */int dlarfg_(integer *n, doublereal *alpha, doublereal *x,
-      integer *incx, doublereal *tau);
-
-  /* Subroutine */int dlarfp_(integer *n, doublereal *alpha, doublereal *x,
-      integer *incx, doublereal *tau);
-
-  /* Subroutine */int dlarft_(char *direct, char *storev, integer *n,
-      integer * k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
-      integer *ldt);
-
-  /* Subroutine */int dlarfx_(char *side, integer *m, integer *n,
-      doublereal * v, doublereal *tau, doublereal *c__, integer *ldc,
-      doublereal *work);
-
-  /* Subroutine */int dlargv_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *c__, integer *incc);
-
-  /* Subroutine */int dlarnv_(integer *idist, integer *iseed, integer *n,
-      doublereal *x);
-
-  /* Subroutine */int dlarra_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *spltol, doublereal *tnrm, integer *nsplit,
-      integer *isplit, integer *info);
-
-  /* Subroutine */int dlarrb_(integer *n, doublereal *d__, doublereal *lld,
-      integer *ifirst, integer *ilast, doublereal *rtol1, doublereal *rtol2,
-      integer *offset, doublereal *w, doublereal *wgap, doublereal *werr,
-      doublereal *work, integer *iwork, doublereal *pivmin, doublereal * spdiam,
-      integer *twist, integer *info);
-
-  /* Subroutine */int dlarrc_(char *jobt, integer *n, doublereal *vl,
-      doublereal *vu, doublereal *d__, doublereal *e, doublereal *pivmin,
-      integer *eigcnt, integer *lcnt, integer *rcnt, integer *info);
-
-  /* Subroutine */int dlarrd_(char *range, char *order, integer *n,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *gers, doublereal *reltol, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *pivmin, integer *nsplit, integer *isplit,
-      integer *m, doublereal *w, doublereal *werr, doublereal *wl,
-      doublereal *wu, integer *iblock, integer *indexw, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlarre_(char *range, integer *n, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *rtol1, doublereal *rtol2, doublereal * spltol,
-      integer *nsplit, integer *isplit, integer *m, doublereal *w,
-      doublereal *werr, doublereal *wgap, integer *iblock, integer *indexw,
-      doublereal *gers, doublereal *pivmin, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dlarrf_(integer *n, doublereal *d__, doublereal *l,
-      doublereal *ld, integer *clstrt, integer *clend, doublereal *w,
-      doublereal *wgap, doublereal *werr, doublereal *spdiam,
-      doublereal * clgapl, doublereal *clgapr, doublereal *pivmin,
-      doublereal *sigma, doublereal *dplus, doublereal *lplus, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dlarrj_(integer *n, doublereal *d__, doublereal *e2,
-      integer *ifirst, integer *ilast, doublereal *rtol, integer *offset,
-      doublereal *w, doublereal *werr, doublereal *work, integer *iwork,
-      doublereal *pivmin, doublereal *spdiam, integer *info);
-
-  /* Subroutine */int dlarrk_(integer *n, integer *iw, doublereal *gl,
-      doublereal *gu, doublereal *d__, doublereal *e2, doublereal *pivmin,
-      doublereal *reltol, doublereal *w, doublereal *werr, integer *info);
-
-  /* Subroutine */int dlarrr_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dlarrv_(integer *n, doublereal *vl, doublereal *vu,
-      doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
-      integer *m, integer *dol, integer *dou, doublereal *minrgp,
-      doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
-      doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlarscl2_(integer *m, integer *n, doublereal *d__,
-      doublereal *x, integer *ldx);
-
-  /* Subroutine */int dlartg_(doublereal *f, doublereal *g, doublereal *cs,
-      doublereal *sn, doublereal *r__);
-
-  /* Subroutine */int dlartv_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *c__, doublereal *s,
-      integer *incc);
-
-  /* Subroutine */int dlaruv_(integer *iseed, integer *n, doublereal *x);
-
-  /* Subroutine */int dlarz_(char *side, integer *m, integer *n, integer *l,
-      doublereal *v, integer *incv, doublereal *tau, doublereal *c__,
-      integer *ldc, doublereal *work);
-
-  /* Subroutine */int dlarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l,
-      doublereal *v, integer *ldv, doublereal *t, integer *ldt, doublereal *c__,
-      integer * ldc, doublereal *work, integer *ldwork);
-
-  /* Subroutine */int dlarzt_(char *direct, char *storev, integer *n,
-      integer * k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
-      integer *ldt);
-
-  /* Subroutine */int dlas2_(doublereal *f, doublereal *g, doublereal *h__,
-      doublereal *ssmin, doublereal *ssmax);
-
-  /* Subroutine */int dlascl_(char *type__, integer *kl, integer *ku,
-      doublereal *cfrom, doublereal *cto, integer *m, integer *n, doublereal *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int dlascl2_(integer *m, integer *n, doublereal *d__,
-      doublereal *x, integer *ldx);
-
-  /* Subroutine */int dlasd0_(integer *n, integer *sqre, doublereal *d__,
-      doublereal *e, doublereal *u, integer *ldu, doublereal *vt,
-      integer * ldvt, integer *smlsiz, integer *iwork, doublereal *work,
-      integer * info);
-
-  /* Subroutine */int dlasd1_(integer *nl, integer *nr, integer *sqre,
-      doublereal *d__, doublereal *alpha, doublereal *beta, doublereal *u,
-      integer *ldu, doublereal *vt, integer *ldvt, integer *idxq,
-      integer * iwork, doublereal *work, integer *info);
-
-  /* Subroutine */int dlasd2_(integer *nl, integer *nr, integer *sqre,
-      integer *k, doublereal *d__, doublereal *z__, doublereal *alpha,
-      doublereal * beta, doublereal *u, integer *ldu, doublereal *vt,
-      integer *ldvt, doublereal *dsigma, doublereal *u2, integer *ldu2,
-      doublereal *vt2, integer *ldvt2, integer *idxp, integer *idx,
-      integer *idxc, integer * idxq, integer *coltyp, integer *info);
-
-  /* Subroutine */int dlasd3_(integer *nl, integer *nr, integer *sqre,
-      integer *k, doublereal *d__, doublereal *q, integer *ldq,
-      doublereal *dsigma, doublereal *u, integer *ldu, doublereal *u2,
-      integer *ldu2, doublereal *vt, integer *ldvt, doublereal *vt2,
-      integer *ldvt2, integer *idxc, integer *ctot, doublereal *z__,
-      integer *info);
-
-  /* Subroutine */int dlasd4_(integer *n, integer *i__, doublereal *d__,
-      doublereal *z__, doublereal *delta, doublereal *rho, doublereal * sigma,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dlasd5_(integer *i__, doublereal *d__, doublereal *z__,
-      doublereal *delta, doublereal *rho, doublereal *dsigma,
-      doublereal * work);
-
-  /* Subroutine */int dlasd6_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, doublereal *d__, doublereal *vf, doublereal *vl,
-      doublereal *alpha, doublereal *beta, integer *idxq, integer *perm,
-      integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
-      integer *ldgnum, doublereal *poles, doublereal *difl, doublereal * difr,
-      doublereal *z__, integer *k, doublereal *c__, doublereal *s,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlasd7_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *k, doublereal *d__, doublereal *z__,
-      doublereal *zw, doublereal *vf, doublereal *vfw, doublereal *vl,
-      doublereal *vlw, doublereal *alpha, doublereal *beta, doublereal * dsigma,
-      integer *idx, integer *idxp, integer *idxq, integer *perm,
-      integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
-      integer *ldgnum, doublereal *c__, doublereal *s, integer *info);
-
-  /* Subroutine */int dlasd8_(integer *icompq, integer *k, doublereal *d__,
-      doublereal *z__, doublereal *vf, doublereal *vl, doublereal *difl,
-      doublereal *difr, integer *lddifr, doublereal *dsigma, doublereal * work,
-      integer *info);
-
-  /* Subroutine */int dlasda_(integer *icompq, integer *smlsiz, integer *n,
-      integer *sqre, doublereal *d__, doublereal *e, doublereal *u,
-      integer *ldu, doublereal *vt, integer *k, doublereal *difl,
-      doublereal *difr, doublereal *z__, doublereal *poles, integer *givptr,
-      integer *givcol, integer *ldgcol, integer *perm, doublereal *givnum,
-      doublereal *c__, doublereal *s, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlasdq_(char *uplo, integer *sqre, integer *n,
-      integer * ncvt, integer *nru, integer *ncc, doublereal *d__,
-      doublereal *e, doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dlasdt_(integer *n, integer *lvl, integer *nd,
-      integer * inode, integer *ndiml, integer *ndimr, integer *msub);
-
-  /* Subroutine */int dlaset_(char *uplo, integer *m, integer *n,
-      doublereal * alpha, doublereal *beta, doublereal *a, integer *lda);
-
-  /* Subroutine */int dlasq1_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dlasq2_(integer *n, doublereal *z__, integer *info);
-
-  /* Subroutine */int dlasq3_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *dmin__, doublereal *sigma, doublereal *desig,
-      doublereal *qmax, integer *nfail, integer *iter, integer *ndiv,
-      logical *ieee, integer *ttype, doublereal *dmin1, doublereal *dmin2,
-      doublereal *dn, doublereal *dn1, doublereal *dn2, doublereal *g,
-      doublereal *tau);
-
-  /* Subroutine */int dlasq4_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, integer *n0in, doublereal *dmin__, doublereal *dmin1,
-      doublereal *dmin2, doublereal *dn, doublereal *dn1, doublereal *dn2,
-      doublereal *tau, integer *ttype, doublereal *g);
-
-  /* Subroutine */int dlasq5_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *tau, doublereal *dmin__, doublereal *dmin1,
-      doublereal *dmin2, doublereal *dn, doublereal *dnm1, doublereal *dnm2,
-      logical *ieee);
-
-  /* Subroutine */int dlasq6_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *dmin__, doublereal *dmin1, doublereal *dmin2,
-      doublereal *dn, doublereal *dnm1, doublereal *dnm2);
-
-  /* Subroutine */int dlasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, doublereal *c__, doublereal *s, doublereal *a, integer * lda);
-
-  /* Subroutine */int dlasrt_(char *id, integer *n, doublereal *d__,
-      integer * info);
-
-  /* Subroutine */int dlassq_(integer *n, doublereal *x, integer *incx,
-      doublereal *scale, doublereal *sumsq);
-
-  /* Subroutine */int dlasv2_(doublereal *f, doublereal *g, doublereal *h__,
-      doublereal *ssmin, doublereal *ssmax, doublereal *snr, doublereal * csr,
-      doublereal *snl, doublereal *csl);
-
-  /* Subroutine */int dlaswp_(integer *n, doublereal *a, integer *lda,
-      integer *k1, integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int dlasy2_(logical *ltranl, logical *ltranr, integer *isgn,
-      integer *n1, integer *n2, doublereal *tl, integer *ldtl, doublereal * tr,
-      integer *ldtr, doublereal *b, integer *ldb, doublereal *scale,
-      doublereal *x, integer *ldx, doublereal *xnorm, integer *info);
-
-  /* Subroutine */int dlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *w, integer * ldw,
-      integer *info);
-
-  /* Subroutine */int dlat2s_(char *uplo, integer *n, doublereal *a,
-      integer * lda, real *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int dlatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, doublereal *ab, integer *ldab,
-      doublereal *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatdf_(integer *ijob, integer *n, doublereal *z__,
-      integer *ldz, doublereal *rhs, doublereal *rdsum, doublereal *rdscal,
-      integer *ipiv, integer *jpiv);
-
-  /* Subroutine */int dlatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublereal *ap, doublereal *x,
-      doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatrd_(char *uplo, integer *n, integer *nb,
-      doublereal * a, integer *lda, doublereal *e, doublereal *tau,
-      doublereal *w, integer *ldw);
-
-  /* Subroutine */int dlatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublereal *a, integer *lda, doublereal *x,
-      doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatrz_(integer *m, integer *n, integer *l,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work);
-
-  /* Subroutine */int dlatzm_(char *side, integer *m, integer *n,
-      doublereal * v, integer *incv, doublereal *tau, doublereal *c1,
-      doublereal *c2, integer *ldc, doublereal *work);
-
-  /* Subroutine */int dlauu2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dlauum_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dopgtr_(char *uplo, integer *n, doublereal *ap,
-      doublereal *tau, doublereal *q, integer *ldq, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dopmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublereal *ap, doublereal *tau, doublereal *c__,
-      integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dorg2l_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorg2r_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorgbr_(char *vect, integer *m, integer *n, integer *k,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorghr_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgl2_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorglq_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgql_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgqr_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgr2_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorgrq_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgtr_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dorm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dorm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal * tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dorml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dpbcon_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *anorm, doublereal *rcond,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpbequ_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int dpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int dpbstf_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, char *equed, doublereal *s, doublereal *b, integer * ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpbtf2_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbtrf_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dpftrf_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dpftri_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dpocon_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dpoequ_(integer *n, doublereal *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dpoequb_(integer *n, doublereal *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dporfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal * ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer * info);
-
-  /* Subroutine */int dporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, doublereal *s, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer * nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dposv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
-      doublereal * x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal * berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
-      doublereal * x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
-      doublereal * berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpotf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotri_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dppcon_(char *uplo, integer *n, doublereal *ap,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dppequ_(char *uplo, integer *n, doublereal *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dpprfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *afp, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dppsv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *ap, doublereal *afp, char *equed,
-      doublereal *s, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dpptrf_(char *uplo, integer *n, doublereal *ap,
-      integer * info);
-
-  /* Subroutine */int dpptri_(char *uplo, integer *n, doublereal *ap,
-      integer * info);
-
-  /* Subroutine */int dpptrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dpstf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dpstrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dptcon_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer *info);
-
-  /* Subroutine */int dpteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dptrfs_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *df, doublereal *ef, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *info);
-
-  /* Subroutine */int dptsv_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dptsvx_(char *fact, integer *n, integer *nrhs,
-      doublereal *d__, doublereal *e, doublereal *df, doublereal *ef,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * info);
-
-  /* Subroutine */int dpttrf_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dpttrs_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dptts2_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb);
-
-  /* Subroutine */int drscl_(integer *n, doublereal *sa, doublereal *sx,
-      integer *incx);
-
-  /* Subroutine */int dsbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *info);
-
-  /* Subroutine */int dsbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int dsbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, doublereal *ab, integer *ldab, doublereal *q, integer * ldq,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *iwork, integer *ifail,
-      integer *info);
-
-  /* Subroutine */int dsbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *x, integer *ldx, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dsbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dsbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dsbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, doublereal *ab, integer *ldab, doublereal * bb,
-      integer *ldbb, doublereal *q, integer *ldq, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
-      doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *d__, doublereal *e,
-      doublereal *q, integer *ldq, doublereal *work, integer *info);
-
-  /* Subroutine */int dsfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *beta, doublereal *c__);
-
-  /* Subroutine */int dsgesv_(integer *n, integer *nrhs, doublereal *a,
-      integer *lda, integer *ipiv, doublereal *b, integer *ldb, doublereal * x,
-      integer *ldx, doublereal *work, real *swork, integer *iter,
-      integer *info);
-
-  /* Subroutine */int dspcon_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dspev_(char *jobz, char *uplo, integer *n,
-      doublereal * ap, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dspevd_(char *jobz, char *uplo, integer *n,
-      doublereal * ap, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dspevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *ap, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *iwork, integer *ifail,
-      integer *info);
-
-  /* Subroutine */int dspgst_(integer *itype, char *uplo, integer *n,
-      doublereal *ap, doublereal *bp, integer *info);
-
-  /* Subroutine */int dspgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *ap, doublereal *bp, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *info);
-
-  /* Subroutine */int dspgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *ap, doublereal *bp, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dspgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublereal *ap, doublereal *bp, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
-      doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsposv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * x,
-      integer *ldx, doublereal *work, real *swork, integer *iter,
-      integer *info);
-
-  /* Subroutine */int dsprfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *afp, integer *ipiv, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dspsv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *ap, doublereal *afp, integer *ipiv,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dsptrd_(char *uplo, integer *n, doublereal *ap,
-      doublereal *d__, doublereal *e, doublereal *tau, integer *info);
-
-  /* Subroutine */int dsptrf_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, integer *info);
-
-  /* Subroutine */int dsptri_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, doublereal *work, integer *info);
-
-  /* Subroutine */int dsptrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int dstebz_(char *range, char *order, integer *n,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, doublereal *d__, doublereal *e, integer *m,
-      integer *nsplit, doublereal *w, integer *iblock, integer *isplit,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dstedc_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstegr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstein_(integer *n, doublereal *d__, doublereal *e,
-      integer *m, doublereal *w, integer *iblock, integer *isplit,
-      doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dstemr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dsteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dsterf_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dstev_(char *jobz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dstevd_(char *jobz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstevr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstevx_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dsycon_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dsyequb_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublereal * work, integer *info);
-
-  /* Subroutine */int dsyev_(char *jobz, char *uplo, integer *n, doublereal *a,
-      integer *lda, doublereal *w, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dsyevd_(char *jobz, char *uplo, integer *n,
-      doublereal * a, integer *lda, doublereal *w, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dsyevr_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer * il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dsyevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer * il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsygs2_(integer *itype, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dsygst_(integer *itype, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dsygv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *w, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsygvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *w, doublereal *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int dsygvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dsyrfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf,
-      integer * ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dsyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *s, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dsysv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int dsysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *s, doublereal *b,
-      integer * ldb, doublereal *x, integer *ldx, doublereal *rcond,
-      doublereal * rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal * err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dsytd2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tau,
-      integer *info);
-
-  /* Subroutine */int dsytf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dsytrd_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tau,
-      doublereal * work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsytrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dsytri_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *work, integer *info);
-
-  /* Subroutine */int dsytrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dtbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, doublereal *ab, integer *ldab, doublereal *rcond,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dtfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, doublereal *alpha, doublereal *a,
-      doublereal *b, integer *ldb);
-
-  /* Subroutine */int dtftri_(char *transr, char *uplo, char *diag, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dtfttp_(char *transr, char *uplo, integer *n,
-      doublereal *arf, doublereal *ap, integer *info);
-
-  /* Subroutine */int dtfttr_(char *transr, char *uplo, integer *n,
-      doublereal *arf, doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int dtgevc_(char *side, char *howmny, logical *select,
-      integer *n, doublereal *s, integer *lds, doublereal *p, integer *ldp,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr, integer *mm,
-      integer *m, doublereal *work, integer *info);
-
-  /* Subroutine */int dtgex2_(logical *wantq, logical *wantz, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * q,
-      integer *ldq, doublereal *z__, integer *ldz, integer *j1, integer * n1,
-      integer *n2, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dtgexc_(logical *wantq, logical *wantz, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * q,
-      integer *ldq, doublereal *z__, integer *ldz, integer *ifst, integer *ilst,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dtgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, doublereal *a, integer *lda, doublereal * b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *q, integer *ldq, doublereal *z__, integer *ldz, integer *m,
-      doublereal *pl, doublereal *pr, doublereal *dif, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dtgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, doublereal *a,
-      integer *lda, doublereal *b, integer *ldb, doublereal *tola,
-      doublereal *tolb, doublereal *alpha, doublereal *beta, doublereal *u,
-      integer *ldu, doublereal *v, integer *ldv, doublereal *q, integer * ldq,
-      doublereal *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int dtgsna_(char *job, char *howmny, logical *select,
-      integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      doublereal *s, doublereal *dif, integer *mm, integer *m,
-      doublereal * work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int dtgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
-      doublereal *e, integer *lde, doublereal *f, integer *ldf,
-      doublereal * scale, doublereal *rdsum, doublereal *rdscal, integer *iwork,
-      integer *pq, integer *info);
-
-  /* Subroutine */int dtgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
-      doublereal *e, integer *lde, doublereal *f, integer *ldf,
-      doublereal * scale, doublereal *dif, doublereal *work, integer *lwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dtpcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *ap, doublereal *rcond, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dtprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *ap, doublereal *b, integer *ldb, doublereal *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dtptri_(char *uplo, char *diag, integer *n,
-      doublereal * ap, integer *info);
-
-  /* Subroutine */int dtptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *ap, doublereal *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int dtpttf_(char *transr, char *uplo, integer *n,
-      doublereal *ap, doublereal *arf, integer *info);
-
-  /* Subroutine */int dtpttr_(char *uplo, integer *n, doublereal *ap,
-      doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *rcond, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dtrevc_(char *side, char *howmny, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *vl, integer * ldvl,
-      doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dtrexc_(char *compq, integer *n, doublereal *t,
-      integer * ldt, doublereal *q, integer *ldq, integer *ifst, integer *ilst,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dtrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer * ldb,
-      doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtrsen_(char *job, char *compq, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *q, integer *ldq,
-      doublereal *wr, doublereal *wi, integer *m, doublereal *s,
-      doublereal *sep, doublereal *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
-
-  /* Subroutine */int dtrsna_(char *job, char *howmny, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *vl, integer * ldvl,
-      doublereal *vr, integer *ldvr, doublereal *s, doublereal *sep,
-      integer *mm, integer *m, doublereal *work, integer *ldwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dtrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer * ldb, doublereal *c__, integer *ldc, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int dtrti2_(char *uplo, char *diag, integer *n,
-      doublereal * a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrtri_(char *uplo, char *diag, integer *n,
-      doublereal * a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dtrttf_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *arf, integer *info);
-
-  /* Subroutine */int dtrttp_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *ap, integer *info);
-
-  /* Subroutine */int dtzrqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, integer *info);
-
-  /* Subroutine */int dtzrzf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  doublereal dzsum1_(integer *n, doublecomplex *cx, integer *incx);
-
-  integer icmax1_(integer *n, complex *cx, integer *incx);
-
-  integer ieeeck_(integer *ispec, real *zero, real *one);
-
-  integer ilaclc_(integer *m, integer *n, complex *a, integer *lda);
-
-  integer ilaclr_(integer *m, integer *n, complex *a, integer *lda);
-
-  integer iladiag_(char *diag);
-
-  integer iladlc_(integer *m, integer *n, doublereal *a, integer *lda);
-
-  integer iladlr_(integer *m, integer *n, doublereal *a, integer *lda);
-
-  integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
-      integer *n2, integer *n3, integer *n4);
-
-  integer ilaprec_(char *prec);
-
-  integer ilaslc_(integer *m, integer *n, real *a, integer *lda);
-
-  integer ilaslr_(integer *m, integer *n, real *a, integer *lda);
-
-  integer ilatrans_(char *trans);
-
-  integer ilauplo_(char *uplo);
-
-  /* Subroutine */int ilaver_(integer *vers_major__, integer *vers_minor__,
-      integer *vers_patch__);
-
-  integer ilazlc_(integer *m, integer *n, doublecomplex *a, integer *lda);
-
-  integer ilazlr_(integer *m, integer *n, doublecomplex *a, integer *lda);
-
-  integer iparmq_(integer *ispec, char *name__, char *opts, integer *n,
-      integer *ilo, integer *ihi, integer *lwork);
-
-  integer izmax1_(integer *n, doublecomplex *cx, integer *incx);
-
-  logical lsamen_(integer *n, char *ca, char *cb);
-
-  integer smaxloc_(real *a, integer *dimm);
-
-  /* Subroutine */int sbdsdc_(char *uplo, char *compq, integer *n, real *d__,
-      real *e, real *u, integer *ldu, real *vt, integer *ldvt, real *q,
-      integer *iq, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, real *d__, real *e, real *vt, integer *ldvt,
-      real * u, integer *ldu, real *c__, integer *ldc, real *work,
-      integer *info);
-
-  doublereal scsum1_(integer *n, complex *cx, integer *incx);
-
-  /* Subroutine */int sdisna_(char *job, integer *m, integer *n, real *d__,
-      real *sep, integer *info);
-
-  /* Subroutine */int sgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, real *ab, integer *ldab, real *d__, real * e,
-      real *q, integer *ldq, real *pt, integer *ldpt, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real * colcnd, real *amax, integer *info);
-
-  /* Subroutine */int sgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, integer *info);
-
-  /* Subroutine */int sgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, real *ab, integer *ldab, real *afb,
-      integer *ldafb, integer *ipiv, real *b, integer *ldb, real *x,
-      integer *ldx, real * ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
-      real *afb, integer *ldafb, integer *ipiv, real *r__, real *c__, real *b,
-      integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, real *ab, integer *ldab, integer *ipiv, real *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int sgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
-      integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__, real *b,
-      integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
-      real *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
-      real *c__, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
-      real * rpvgrw, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, real *ab, integer *ldab, integer *ipiv,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *scale, integer *m, real *v, integer *ldv,
-      integer *info);
-
-  /* Subroutine */int sgebal_(char *job, integer *n, real *a, integer *lda,
-      integer *ilo, integer *ihi, real *scale, integer *info);
-
-  /* Subroutine */int sgebd2_(integer *m, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tauq, real *taup, real *work, integer *info);
-
-  /* Subroutine */int sgebrd_(integer *m, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tauq, real *taup, real *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int sgecon_(char *norm, integer *n, real *a, integer *lda,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgeequ_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
-
-  /* Subroutine */int sgeequb_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
-
-  /* Subroutine */int sgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      real *a, integer *lda, integer *sdim, real *wr, real *wi, real *vs,
-      integer *ldvs, real *work, integer *lwork, logical *bwork,
-      integer * info);
-
-  /* Subroutine */int sgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, real *a, integer *lda, integer *sdim, real *wr,
-      real *wi, real *vs, integer *ldvs, real *rconde, real *rcondv,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int sgeev_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *wr, real *wi, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, real *a, integer *lda, real *wr, real *wi,
-      real * vl, integer *ldvl, real *vr, integer *ldvr, integer *ilo,
-      integer * ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgegs_(char *jobvsl, char *jobvsr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vsl, integer *ldvsl, real *vsr, integer *ldvsr,
-      real * work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgegv_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgehd2_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgehrd_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
-      char *jobt, char *jobp, integer *m, integer *n, real *a, integer *lda,
-      real *sva, real *u, integer *ldu, real *v, integer *ldv, real *work,
-      integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgelq2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgelqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, real *a, integer *lda, real *b, integer *ldb, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgelsd_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, real *s, real *rcond, integer * rank,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgelss_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, real *s, real *rcond, integer * rank,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgelsx_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
-      integer *rank, real *work, integer *info);
-
-  /* Subroutine */int sgelsy_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
-      integer *rank, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeql2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqlf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeqp3_(integer *m, integer *n, real *a, integer *lda,
-      integer *jpvt, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeqpf_(integer *m, integer *n, real *a, integer *lda,
-      integer *jpvt, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqr2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqrf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgerfs_(char *trans, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *r__, real *c__, real *b, integer *ldb, real *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgerq2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgerqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesc2_(integer *n, real *a, integer *lda, real *rhs,
-      integer *ipiv, integer *jpiv, real *scale);
-
-  /* Subroutine */int sgesdd_(char *jobz, integer *m, integer *n, real *a,
-      integer *lda, real *s, real *u, integer *ldu, real *vt, integer *ldvt,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgesv_(integer *n, integer *nrhs, real *a, integer *lda,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      real *a, integer *lda, real *s, real *u, integer *ldu, real *vt,
-      integer *ldvt, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesvj_(char *joba, char *jobu, char *jobv, integer *m,
-      integer *n, real *a, integer *lda, real *sva, integer *mv, real *v,
-      integer *ldv, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgetc2_(integer *n, real *a, integer *lda, integer *ipiv,
-      integer *jpiv, integer *info);
-
-  /* Subroutine */int sgetf2_(integer *m, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int sgetrf_(integer *m, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int sgetri_(integer *n, real *a, integer *lda, integer *ipiv,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgetrs_(char *trans, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *lscale, real *rscale, integer *m, real *v,
-      integer *ldv, integer *info);
-
-  /* Subroutine */int sggbal_(char *job, integer *n, real *a, integer *lda,
-      real *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
-      real *rscale, real *work, integer *info);
-
-  /* Subroutine */int sgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      integer *sdim, real *alphar, real *alphai, real *beta, real *vsl,
-      integer *ldvsl, real *vsr, integer *ldvsr, real *work, integer *lwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int sggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, real *a, integer *lda, real *b,
-      integer *ldb, integer *sdim, real *alphar, real *alphai, real *beta,
-      real *vsl, integer *ldvsl, real *vsr, integer *ldvsr, real *rconde,
-      real *rcondv, real *work, integer *lwork, integer *iwork,
-      integer * liwork, logical *bwork, integer *info);
-
-  /* Subroutine */int sggev_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real *alphar, real *alphai, real *beta, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, integer *ilo, integer *ihi, real *lscale, real *rscale,
-      real *abnrm, real *bbnrm, real *rconde, real *rcondv, real *work,
-      integer *lwork, integer *iwork, logical *bwork, integer *info);
-
-  /* Subroutine */int sggglm_(integer *n, integer *m, integer *p, real *a,
-      integer *lda, real *b, integer *ldb, real *d__, real *x, real *y,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, real *a, integer *lda, real *b, integer *ldb,
-      real *q, integer *ldq, real *z__, integer *ldz, integer *info);
-
-  /* Subroutine */int sgglse_(integer *m, integer *n, integer *p, real *a,
-      integer *lda, real *b, integer *ldb, real *c__, real *d__, real *x,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sggqrf_(integer *n, integer *m, integer *p, real *a,
-      integer *lda, real *taua, real *b, integer *ldb, real *taub, real * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggrqf_(integer *m, integer *p, integer *n, real *a,
-      integer *lda, real *taua, real *b, integer *ldb, real *taub, real * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, real *a, integer *lda,
-      real *b, integer *ldb, real *alpha, real *beta, real *u, integer * ldu,
-      real *v, integer *ldv, real *q, integer *ldq, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real *tola, real *tolb, integer *k, integer *l, real *u, integer *ldu,
-      real *v, integer *ldv, real *q, integer *ldq, integer *iwork, real * tau,
-      real *work, integer *info);
-
-  /* Subroutine */int sgsvj0_(char *jobv, integer *m, integer *n, real *a,
-      integer *lda, real *d__, real *sva, integer *mv, real *v, integer * ldv,
-      real *eps, real *sfmin, real *tol, integer *nsweep, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
-      real *a, integer *lda, real *d__, real *sva, integer *mv, real *v,
-      integer *ldv, real *eps, real *sfmin, real *tol, integer *nsweep,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgtcon_(char *norm, integer *n, real *dl, real *d__,
-      real *du, real *du2, integer *ipiv, real *anorm, real *rcond, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgtrfs_(char *trans, integer *n, integer *nrhs, real *dl,
-      real *d__, real *du, real *dlf, real *df, real *duf, real *du2,
-      integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real * ferr,
-      real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgtsv_(integer *n, integer *nrhs, real *dl, real *d__,
-      real *du, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *dl, real *d__, real *du, real *dlf, real *df,
-      real *duf, real *du2, integer *ipiv, real *b, integer *ldb, real *x,
-      integer * ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgttrf_(integer *n, real *dl, real *d__, real *du,
-      real * du2, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgttrs_(char *trans, integer *n, integer *nrhs, real *dl,
-      real *d__, real *du, real *du2, integer *ipiv, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int sgtts2_(integer *itrans, integer *n, integer *nrhs,
-      real *dl, real *d__, real *du, real *du2, integer *ipiv, real *b,
-      integer * ldb);
-
-  /* Subroutine */int shgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *t,
-      integer *ldt, real *alphar, real *alphai, real *beta, real *q,
-      integer *ldq, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int shsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, real *h__, integer *ldh, real *wr, real *wi,
-      real *vl, integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
-      real *work, integer *ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int shseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, real *h__, integer *ldh, real *wr, real *wi, real *z__,
-      integer *ldz, real *work, integer *lwork, integer *info);
-
-  logical sisnan_(real *sin__);
-
-  /* Subroutine */int sla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, real *alpha, real *ab, integer *ldab, real * x,
-      integer *incx, real *beta, real *y, integer *incy);
-
-  doublereal sla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *afb, integer *ldafb, integer *ipiv,
-      integer *cmode, real *c__, integer *info, real *work, integer *iwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int sla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      integer *ipiv, logical *colequ, real *c__, real *b, integer *ldb, real *y,
-      integer * ldy, real *berr_out__, integer *n_norms__, real *errs_n__,
-      real * errs_c__, real *res, real *ayb, real *dy, real *y_tail__,
-      real *rcond, integer *ithresh, real *rthresh, real *dz_ub__,
-      logical * ignore_cwise__, integer *info);
-
-  doublereal sla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, real *ab, integer *ldab, real *afb, integer *ldafb);
-
-  /* Subroutine */int sla_geamv__(integer *trans, integer *m, integer *n,
-      real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta,
-      real *y, integer *incy);
-
-  doublereal sla_gercond__(char *trans, integer *n, real *a, integer *lda,
-      real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
-      integer *info, real *work, integer *iwork, ftnlen trans_len);
-
-  /* Subroutine */int sla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, real *a, integer *lda,
-      real * af, integer *ldaf, integer *ipiv, logical *colequ, real *c__,
-      real *b, integer *ldb, real *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
-      real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info);
-
-  /* Subroutine */int sla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      real *res, real *ayb, real *berr);
-
-  doublereal sla_porcond__(char *uplo, integer *n, real *a, integer *lda,
-      real * af, integer *ldaf, integer *cmode, real *c__, integer *info,
-      real * work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int sla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, real *a, integer *lda, real *af,
-      integer * ldaf, logical *colequ, real *c__, real *b, integer *ldb,
-      real *y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real *errs_n__, real *errs_c__, real *res, real *ayb, real *dy,
-      real *y_tail__, real * rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical * ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal sla_porpvgrw__(char *uplo, integer *ncols, real *a, integer *lda,
-      real *af, integer *ldaf, real *work, ftnlen uplo_len);
-
-  doublereal sla_rpvgrw__(integer *n, integer *ncols, real *a, integer *lda,
-      real *af, integer *ldaf);
-
-  /* Subroutine */int sla_syamv__(integer *uplo, integer *n, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
-
-  doublereal sla_syrcond__(char *uplo, integer *n, real *a, integer *lda,
-      real * af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
-      integer * info, real *work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int sla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, real *a, integer *lda, real *af,
-      integer * ldaf, integer *ipiv, logical *colequ, real *c__, real *b,
-      integer * ldb, real *y, integer *ldy, real *berr_out__,
-      integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
-      real *dy, real * y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal sla_syrpvgrw__(char *uplo, integer *n, integer *info, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
-
-  /* Subroutine */int sla_wwaddw__(integer *n, real *x, real *y, real *w);
-
-  /* Subroutine */int slabad_(real *small, real *large);
-
-  /* Subroutine */int slabrd_(integer *m, integer *n, integer *nb, real *a,
-      integer *lda, real *d__, real *e, real *tauq, real *taup, real *x,
-      integer *ldx, real *y, integer *ldy);
-
-  /* Subroutine */int slacn2_(integer *n, real *v, real *x, integer *isgn,
-      real *est, integer *kase, integer *isave);
-
-  /* Subroutine */int slacon_(integer *n, real *v, real *x, integer *isgn,
-      real *est, integer *kase);
-
-  /* Subroutine */int slacpy_(char *uplo, integer *m, integer *n, real *a,
-      integer *lda, real *b, integer *ldb);
-
-  /* Subroutine */int sladiv_(real *a, real *b, real *c__, real *d__, real *p,
-      real *q);
-
-  /* Subroutine */int slae2_(real *a, real *b, real *c__, real *rt1, real *rt2);
-
-  /* Subroutine */int slaebz_(integer *ijob, integer *nitmax, integer *n,
-      integer *mmax, integer *minp, integer *nbmin, real *abstol, real * reltol,
-      real *pivmin, real *d__, real *e, real *e2, integer *nval, real *ab,
-      real *c__, integer *mout, integer *nab, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int slaed0_(integer *icompq, integer *qsiz, integer *n,
-      real *d__, real *e, real *q, integer *ldq, real *qstore, integer *ldqs,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slaed1_(integer *n, real *d__, real *q, integer *ldq,
-      integer *indxq, real *rho, integer *cutpnt, real *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int slaed2_(integer *k, integer *n, integer *n1, real *d__,
-      real *q, integer *ldq, integer *indxq, real *rho, real *z__,
-      real * dlamda, real *w, real *q2, integer *indx, integer *indxc,
-      integer * indxp, integer *coltyp, integer *info);
-
-  /* Subroutine */int slaed3_(integer *k, integer *n, integer *n1, real *d__,
-      real *q, integer *ldq, real *rho, real *dlamda, real *q2, integer * indx,
-      integer *ctot, real *w, real *s, integer *info);
-
-  /* Subroutine */int slaed4_(integer *n, integer *i__, real *d__, real *z__,
-      real *delta, real *rho, real *dlam, integer *info);
-
-  /* Subroutine */int slaed5_(integer *i__, real *d__, real *z__, real *delta,
-      real *rho, real *dlam);
-
-  /* Subroutine */int slaed6_(integer *kniter, logical *orgati, real *rho,
-      real *d__, real *z__, real *finit, real *tau, integer *info);
-
-  /* Subroutine */int slaed7_(integer *icompq, integer *n, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, real *d__, real *q,
-      integer *ldq, integer *indxq, real *rho, integer *cutpnt, real * qstore,
-      integer *qptr, integer *prmptr, integer *perm, integer * givptr,
-      integer *givcol, real *givnum, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slaed8_(integer *icompq, integer *k, integer *n,
-      integer *qsiz, real *d__, real *q, integer *ldq, integer *indxq,
-      real *rho, integer *cutpnt, real *z__, real *dlamda, real *q2,
-      integer *ldq2, real *w, integer *perm, integer *givptr, integer *givcol,
-      real * givnum, integer *indxp, integer *indx, integer *info);
-
-  /* Subroutine */int slaed9_(integer *k, integer *kstart, integer *kstop,
-      integer *n, real *d__, real *q, integer *ldq, real *rho, real *dlamda,
-      real *w, real *s, integer *lds, integer *info);
-
-  /* Subroutine */int slaeda_(integer *n, integer *tlvls, integer *curlvl,
-      integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
-      integer *givcol, real *givnum, real *q, integer *qptr, real *z__,
-      real *ztemp, integer *info);
-
-  /* Subroutine */int slaein_(logical *rightv, logical *noinit, integer *n,
-      real *h__, integer *ldh, real *wr, real *wi, real *vr, real *vi, real *b,
-      integer *ldb, real *work, real *eps3, real *smlnum, real *bignum,
-      integer *info);
-
-  /* Subroutine */int slaev2_(real *a, real *b, real *c__, real *rt1,
-      real * rt2, real *cs1, real *sn1);
-
-  /* Subroutine */int slaexc_(logical *wantq, integer *n, real *t,
-      integer * ldt, real *q, integer *ldq, integer *j1, integer *n1,
-      integer *n2, real *work, integer *info);
-
-  /* Subroutine */int slag2_(real *a, integer *lda, real *b, integer *ldb,
-      real *safmin, real *scale1, real *scale2, real *wr1, real *wr2,
-      real * wi);
-
-  /* Subroutine */int slag2d_(integer *m, integer *n, real *sa, integer *ldsa,
-      doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int slags2_(logical *upper, real *a1, real *a2, real *a3,
-      real *b1, real *b2, real *b3, real *csu, real *snu, real *csv, real * snv,
-      real *csq, real *snq);
-
-  /* Subroutine */int slagtf_(integer *n, real *a, real *lambda, real *b,
-      real *c__, real *tol, real *d__, integer *in, integer *info);
-
-  /* Subroutine */int slagtm_(char *trans, integer *n, integer *nrhs,
-      real * alpha, real *dl, real *d__, real *du, real *x, integer *ldx,
-      real * beta, real *b, integer *ldb);
-
-  /* Subroutine */int slagts_(integer *job, integer *n, real *a, real *b,
-      real *c__, real *d__, integer *in, real *y, real *tol, integer *info);
-
-  /* Subroutine */int slagv2_(real *a, integer *lda, real *b, integer *ldb,
-      real *alphar, real *alphai, real *beta, real *csl, real *snl, real * csr,
-      real *snr);
-
-  /* Subroutine */int slahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer * info);
-
-  /* Subroutine */int slahr2_(integer *n, integer *k, integer *nb, real *a,
-      integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
-
-  /* Subroutine */int slahrd_(integer *n, integer *k, integer *nb, real *a,
-      integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
-
-  /* Subroutine */int slaic1_(integer *job, integer *j, real *x, real *sest,
-      real *w, real *gamma, real *sestpr, real *s, real *c__);
-
-  logical slaisnan_(real *sin1, real *sin2);
-
-  /* Subroutine */int slaln2_(logical *ltrans, integer *na, integer *nw,
-      real * smin, real *ca, real *a, integer *lda, real *d1, real *d2, real *b,
-      integer *ldb, real *wr, real *wi, real *x, integer *ldx, real *scale,
-      real *xnorm, integer *info);
-
-  /* Subroutine */int slals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, real *b, integer *ldb, real *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * work,
-      integer *info);
-
-  /* Subroutine */int slalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, real *b, integer *ldb, real *bx, integer *ldbx, real * u,
-      integer *ldu, real *vt, integer *k, real *difl, real *difr, real * z__,
-      real *poles, integer *givptr, integer *givcol, integer *ldgcol,
-      integer *perm, real *givnum, real *c__, real *s, real *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int slalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, real *d__, real *e, real *b, integer *ldb, real *rcond,
-      integer *rank, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slamrg_(integer *n1, integer *n2, real *a,
-      integer * strd1, integer *strd2, integer *index);
-
-  integer slaneg_(integer *n, real *d__, real *lld, real *sigma, real *pivmin,
-      integer *r__);
-
-  doublereal slangb_(char *norm, integer *n, integer *kl, integer *ku, real *ab,
-      integer *ldab, real *work);
-
-  doublereal slange_(char *norm, integer *m, integer *n, real *a, integer *lda,
-      real *work);
-
-  doublereal slangt_(char *norm, integer *n, real *dl, real *d__, real *du);
-
-  doublereal slanhs_(char *norm, integer *n, real *a, integer *lda, real *work);
-
-  doublereal slansb_(char *norm, char *uplo, integer *n, integer *k, real *ab,
-      integer *ldab, real *work);
-
-  doublereal slansf_(char *norm, char *transr, char *uplo, integer *n, real *a,
-      real *work);
-
-  doublereal slansp_(char *norm, char *uplo, integer *n, real *ap, real *work);
-
-  doublereal slanst_(char *norm, integer *n, real *d__, real *e);
-
-  doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
-      real *work);
-
-  doublereal slantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      real *ab, integer *ldab, real *work);
-
-  doublereal slantp_(char *norm, char *uplo, char *diag, integer *n, real *ap,
-      real *work);
-
-  doublereal slantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      real *a, integer *lda, real *work);
-
-  /* Subroutine */int slanv2_(real *a, real *b, real *c__, real *d__,
-      real * rt1r, real *rt1i, real *rt2r, real *rt2i, real *cs, real *sn);
-
-  /* Subroutine */int slapll_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *ssmin);
-
-  /* Subroutine */int slapmt_(logical *forwrd, integer *m, integer *n, real *x,
-      integer *ldx, integer *k);
-
-  doublereal slapy2_(real *x, real *y);
-
-  doublereal slapy3_(real *x, real *y, real *z__);
-
-  /* Subroutine */int slaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real * colcnd, real *amax, char *equed);
-
-  /* Subroutine */int slaqge_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      char * equed);
-
-  /* Subroutine */int slaqp2_(integer *m, integer *n, integer *offset, real *a,
-      integer *lda, integer *jpvt, real *tau, real *vn1, real *vn2,
-      real * work);
-
-  /* Subroutine */int slaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, real *a, integer *lda, integer *jpvt, real *tau,
-      real *vn1, real *vn2, real *auxv, real *f, integer *ldf);
-
-  /* Subroutine */int slaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int slaqr1_(integer *n, real *h__, integer *ldh, real *sr1,
-      real *si1, real *sr2, real *si2, real *v);
-
-  /* Subroutine */int slaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
-      integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
-      real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real * work,
-      integer *lwork);
-
-  /* Subroutine */int slaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
-      integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
-      real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real * work,
-      integer *lwork);
-
-  /* Subroutine */int slaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int slaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, real *sr,
-      real *si, real *h__, integer *ldh, integer *iloz, integer *ihiz,
-      real *z__, integer *ldz, real *v, integer *ldv, real *u, integer *ldu,
-      integer *nv, real *wv, integer *ldwv, integer *nh, real *wh,
-      integer * ldwh);
-
-  /* Subroutine */int slaqsb_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqsp_(char *uplo, integer *n, real *ap, real *s,
-      real * scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqsy_(char *uplo, integer *n, real *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqtr_(logical *ltran, logical *lreal, integer *n,
-      real *t, integer *ldt, real *b, real *w, real *scale, real *x, real *work,
-      integer *info);
-
-  /* Subroutine */int slar1v_(integer *n, integer *b1, integer *bn,
-      real * lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
-      real * gaptol, real *z__, logical *wantnc, integer *negcnt, real *ztz,
-      real * mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
-      real *rqcorr, real *work);
-
-  /* Subroutine */int slar2v_(integer *n, real *x, real *y, real *z__,
-      integer *incx, real *c__, real *s, integer *incc);
-
-  /* Subroutine */int slarf_(char *side, integer *m, integer *n, real *v,
-      integer *incv, real *tau, real *c__, integer *ldc, real *work);
-
-  /* Subroutine */int slarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, real *v, integer *ldv,
-      real *t, integer *ldt, real *c__, integer *ldc, real *work,
-      integer * ldwork);
-
-  /* Subroutine */int slarfg_(integer *n, real *alpha, real *x, integer *incx,
-      real *tau);
-
-  /* Subroutine */int slarfp_(integer *n, real *alpha, real *x, integer *incx,
-      real *tau);
-
-  /* Subroutine */int slarft_(char *direct, char *storev, integer *n,
-      integer * k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
-
-  /* Subroutine */int slarfx_(char *side, integer *m, integer *n, real *v,
-      real *tau, real *c__, integer *ldc, real *work);
-
-  /* Subroutine */int slargv_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *c__, integer *incc);
-
-  /* Subroutine */int slarnv_(integer *idist, integer *iseed, integer *n,
-      real *x);
-
-  /* Subroutine */int slarra_(integer *n, real *d__, real *e, real *e2,
-      real * spltol, real *tnrm, integer *nsplit, integer *isplit,
-      integer *info);
-
-  /* Subroutine */int slarrb_(integer *n, real *d__, real *lld,
-      integer * ifirst, integer *ilast, real *rtol1, real *rtol2,
-      integer *offset, real *w, real *wgap, real *werr, real *work,
-      integer *iwork, real * pivmin, real *spdiam, integer *twist,
-      integer *info);
-
-  /* Subroutine */int slarrc_(char *jobt, integer *n, real *vl, real *vu,
-      real *d__, real *e, real *pivmin, integer *eigcnt, integer *lcnt,
-      integer * rcnt, integer *info);
-
-  /* Subroutine */int slarrd_(char *range, char *order, integer *n, real *vl,
-      real *vu, integer *il, integer *iu, real *gers, real *reltol, real * d__,
-      real *e, real *e2, real *pivmin, integer *nsplit, integer * isplit,
-      integer *m, real *w, real *werr, real *wl, real *wu, integer * iblock,
-      integer *indexw, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slarre_(char *range, integer *n, real *vl, real *vu,
-      integer *il, integer *iu, real *d__, real *e, real *e2, real *rtol1,
-      real *rtol2, real *spltol, integer *nsplit, integer *isplit, integer * m,
-      real *w, real *werr, real *wgap, integer *iblock, integer *indexw,
-      real *gers, real *pivmin, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slarrf_(integer *n, real *d__, real *l, real *ld,
-      integer *clstrt, integer *clend, real *w, real *wgap, real *werr,
-      real *spdiam, real *clgapl, real *clgapr, real *pivmin, real *sigma,
-      real *dplus, real *lplus, real *work, integer *info);
-
-  /* Subroutine */int slarrj_(integer *n, real *d__, real *e2, integer *ifirst,
-      integer *ilast, real *rtol, integer *offset, real *w, real *werr,
-      real *work, integer *iwork, real *pivmin, real *spdiam, integer *info);
-
-  /* Subroutine */int slarrk_(integer *n, integer *iw, real *gl, real *gu,
-      real *d__, real *e2, real *pivmin, real *reltol, real *w, real *werr,
-      integer *info);
-
-  /* Subroutine */int slarrr_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int slarrv_(integer *n, real *vl, real *vu, real *d__,
-      real * l, real *pivmin, integer *isplit, integer *m, integer *dol,
-      integer * dou, real *minrgp, real *rtol1, real *rtol2, real *w,
-      real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
-      real *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int slarscl2_(integer *m, integer *n, real *d__, real *x,
-      integer *ldx);
-
-  /* Subroutine */int slartg_(real *f, real *g, real *cs, real *sn, real *r__);
-
-  /* Subroutine */int slartv_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *c__, real *s, integer *incc);
-
-  /* Subroutine */int slaruv_(integer *iseed, integer *n, real *x);
-
-  /* Subroutine */int slarz_(char *side, integer *m, integer *n, integer *l,
-      real *v, integer *incv, real *tau, real *c__, integer *ldc, real * work);
-
-  /* Subroutine */int slarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l, real *v,
-      integer *ldv, real *t, integer *ldt, real *c__, integer *ldc, real * work,
-      integer *ldwork);
-
-  /* Subroutine */int slarzt_(char *direct, char *storev, integer *n,
-      integer * k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
-
-  /* Subroutine */int slas2_(real *f, real *g, real *h__, real *ssmin,
-      real * ssmax);
-
-  /* Subroutine */int slascl_(char *type__, integer *kl, integer *ku,
-      real * cfrom, real *cto, integer *m, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int slascl2_(integer *m, integer *n, real *d__, real *x,
-      integer *ldx);
-
-  /* Subroutine */int slasd0_(integer *n, integer *sqre, real *d__, real *e,
-      real *u, integer *ldu, real *vt, integer *ldvt, integer *smlsiz,
-      integer *iwork, real *work, integer *info);
-
-  /* Subroutine */int slasd1_(integer *nl, integer *nr, integer *sqre,
-      real * d__, real *alpha, real *beta, real *u, integer *ldu, real *vt,
-      integer *ldvt, integer *idxq, integer *iwork, real *work, integer * info);
-
-  /* Subroutine */int slasd2_(integer *nl, integer *nr, integer *sqre,
-      integer *k, real *d__, real *z__, real *alpha, real *beta, real *u,
-      integer * ldu, real *vt, integer *ldvt, real *dsigma, real *u2,
-      integer *ldu2, real *vt2, integer *ldvt2, integer *idxp, integer *idx,
-      integer *idxc, integer *idxq, integer *coltyp, integer *info);
-
-  /* Subroutine */int slasd3_(integer *nl, integer *nr, integer *sqre,
-      integer *k, real *d__, real *q, integer *ldq, real *dsigma, real *u,
-      integer * ldu, real *u2, integer *ldu2, real *vt, integer *ldvt,
-      real *vt2, integer *ldvt2, integer *idxc, integer *ctot, real *z__,
-      integer * info);
-
-  /* Subroutine */int slasd4_(integer *n, integer *i__, real *d__, real *z__,
-      real *delta, real *rho, real *sigma, real *work, integer *info);
-
-  /* Subroutine */int slasd5_(integer *i__, real *d__, real *z__, real *delta,
-      real *rho, real *dsigma, real *work);
-
-  /* Subroutine */int slasd6_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, real *d__, real *vf, real *vl, real *alpha, real *beta,
-      integer *idxq, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int slasd7_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *k, real *d__, real *z__, real *zw, real *vf,
-      real *vfw, real *vl, real *vlw, real *alpha, real *beta, real *dsigma,
-      integer *idx, integer *idxp, integer *idxq, integer *perm,
-      integer * givptr, integer *givcol, integer *ldgcol, real *givnum,
-      integer * ldgnum, real *c__, real *s, integer *info);
-
-  /* Subroutine */int slasd8_(integer *icompq, integer *k, real *d__,
-      real * z__, real *vf, real *vl, real *difl, real *difr, integer *lddifr,
-      real *dsigma, real *work, integer *info);
-
-  /* Subroutine */int slasda_(integer *icompq, integer *smlsiz, integer *n,
-      integer *sqre, real *d__, real *e, real *u, integer *ldu, real *vt,
-      integer *k, real *difl, real *difr, real *z__, real *poles,
-      integer * givptr, integer *givcol, integer *ldgcol, integer *perm,
-      real *givnum, real *c__, real *s, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int slasdq_(char *uplo, integer *sqre, integer *n,
-      integer * ncvt, integer *nru, integer *ncc, real *d__, real *e, real *vt,
-      integer *ldvt, real *u, integer *ldu, real *c__, integer *ldc,
-      real * work, integer *info);
-
-  /* Subroutine */int slasdt_(integer *n, integer *lvl, integer *nd,
-      integer * inode, integer *ndiml, integer *ndimr, integer *msub);
-
-  /* Subroutine */int slaset_(char *uplo, integer *m, integer *n, real *alpha,
-      real *beta, real *a, integer *lda);
-
-  /* Subroutine */int slasq1_(integer *n, real *d__, real *e, real *work,
-      integer *info);
-
-  /* Subroutine */int slasq2_(integer *n, real *z__, integer *info);
-
-  /* Subroutine */int slasq3_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *dmin__, real *sigma, real *desig, real *qmax, integer *nfail,
-      integer *iter, integer *ndiv, logical *ieee, integer *ttype, real * dmin1,
-      real *dmin2, real *dn, real *dn1, real *dn2, real *g, real * tau);
-
-  /* Subroutine */int slasq4_(integer *i0, integer *n0, real *z__, integer *pp,
-      integer *n0in, real *dmin__, real *dmin1, real *dmin2, real *dn,
-      real *dn1, real *dn2, real *tau, integer *ttype, real *g);
-
-  /* Subroutine */int slasq5_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *tau, real *dmin__, real *dmin1, real *dmin2, real *dn, real * dnm1,
-      real *dnm2, logical *ieee);
-
-  /* Subroutine */int slasq6_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
-      real * dnm2);
-
-  /* Subroutine */int slasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, real *c__, real *s, real *a, integer *lda);
-
-  /* Subroutine */int slasrt_(char *id, integer *n, real *d__, integer *info);
-
-  /* Subroutine */int slassq_(integer *n, real *x, integer *incx, real *scale,
-      real *sumsq);
-
-  /* Subroutine */int slasv2_(real *f, real *g, real *h__, real *ssmin,
-      real * ssmax, real *snr, real *csr, real *snl, real *csl);
-
-  /* Subroutine */int slaswp_(integer *n, real *a, integer *lda, integer *k1,
-      integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int slasy2_(logical *ltranl, logical *ltranr, integer *isgn,
-      integer *n1, integer *n2, real *tl, integer *ldtl, real *tr,
-      integer * ldtr, real *b, integer *ldb, real *scale, real *x, integer *ldx,
-      real *xnorm, integer *info);
-
-  /* Subroutine */int slasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      real *a, integer *lda, integer *ipiv, real *w, integer *ldw,
-      integer *info);
-
-  /* Subroutine */int slatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, real *ab, integer *ldab, real *x,
-      real *scale, real *cnorm, integer *info);
-
-  /* Subroutine */int slatdf_(integer *ijob, integer *n, real *z__,
-      integer * ldz, real *rhs, real *rdsum, real *rdscal, integer *ipiv,
-      integer * jpiv);
-
-  /* Subroutine */int slatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, real *ap, real *x, real *scale, real *cnorm,
-      integer *info);
-
-  /* Subroutine */int slatrd_(char *uplo, integer *n, integer *nb, real *a,
-      integer *lda, real *e, real *tau, real *w, integer *ldw);
-
-  /* Subroutine */int slatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, real *a, integer *lda, real *x, real *scale,
-      real *cnorm, integer *info);
-
-  /* Subroutine */int slatrz_(integer *m, integer *n, integer *l, real *a,
-      integer *lda, real *tau, real *work);
-
-  /* Subroutine */int slatzm_(char *side, integer *m, integer *n, real *v,
-      integer *incv, real *tau, real *c1, real *c2, integer *ldc, real * work);
-
-  /* Subroutine */int slauu2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int slauum_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int sopgtr_(char *uplo, integer *n, real *ap, real *tau,
-      real *q, integer *ldq, real *work, integer *info);
-
-  /* Subroutine */int sopmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, real *ap, real *tau, real *c__, integer *ldc, real *work,
-      integer *info);
-
-  /* Subroutine */int sorg2l_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorg2r_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorgbr_(char *vect, integer *m, integer *n, integer *k,
-      real *a, integer *lda, real *tau, real *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int sorghr_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgl2_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorglq_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgql_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgqr_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgr2_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorgrq_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgtr_(char *uplo, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sorm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, real *a, integer *lda, real *tau, real * c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *info);
-
-  /* Subroutine */int sormrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int spbcon_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *anorm, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int spbequ_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *s, real *scond, real *amax, integer *info);
-
-  /* Subroutine */int spbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      real *b, integer *ldb, real *x, integer *ldx, real *ferr, real *berr,
-      real * work, integer *iwork, integer *info);
-
-  /* Subroutine */int spbstf_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int spbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int spbtf2_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbtrf_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int spftrf_(char *transr, char *uplo, integer *n, real *a,
-      integer *info);
-
-  /* Subroutine */int spftri_(char *transr, char *uplo, integer *n, real *a,
-      integer *info);
-
-  /* Subroutine */int spftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, real *a, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int spocon_(char *uplo, integer *n, real *a, integer *lda,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spoequ_(integer *n, real *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
-
-  /* Subroutine */int spoequb_(integer *n, real *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
-
-  /* Subroutine */int sporfs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, real *b, integer *ldb, real *x,
-      integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf, real *s,
-      real * b, integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
-      integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer *nparams, real *params, real *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int sposv_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spotf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotri_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotrs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sppcon_(char *uplo, integer *n, real *ap, real *anorm,
-      real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sppequ_(char *uplo, integer *n, real *ap, real *s,
-      real * scond, real *amax, integer *info);
-
-  /* Subroutine */int spprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *afp, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
-      real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sppsv_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *ap, real *afp, char *equed, real *s, real *b,
-      integer * ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spptrf_(char *uplo, integer *n, real *ap, integer *info);
-
-  /* Subroutine */int spptri_(char *uplo, integer *n, real *ap, integer *info);
-
-  /* Subroutine */int spptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int spstf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
-
-  /* Subroutine */int spstrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
-
-  /* Subroutine */int sptcon_(integer *n, real *d__, real *e, real *anorm,
-      real *rcond, real *work, integer *info);
-
-  /* Subroutine */int spteqr_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sptrfs_(integer *n, integer *nrhs, real *d__, real *e,
-      real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
-      real *ferr, real *berr, real *work, integer *info);
-
-  /* Subroutine */int sptsv_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
-      real *e, real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *info);
-
-  /* Subroutine */int spttrf_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int spttrs_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sptts2_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb);
-
-  /* Subroutine */int srscl_(integer *n, real *sa, real *sx, integer *incx);
-
-  /* Subroutine */int ssbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
-      integer *info);
-
-  /* Subroutine */int ssbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int ssbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, real *ab, integer *ldab, real *q, integer *ldq, real *vl,
-      real *vu, integer *il, integer *iu, real *abstol, integer *m, real * w,
-      real *z__, integer *ldz, real *work, integer *iwork, integer * ifail,
-      integer *info);
-
-  /* Subroutine */int ssbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * x,
-      integer *ldx, real *work, integer *info);
-
-  /* Subroutine */int ssbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * w,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int ssbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * w,
-      real *z__, integer *ldz, real *work, integer *lwork, integer * iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, real *ab, integer *ldab, real *bb,
-      integer * ldbb, real *q, integer *ldq, real *vl, real *vu, integer *il,
-      integer *iu, real *abstol, integer *m, real *w, real *z__, integer *ldz,
-      real *work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *d__, real *e, real *q, integer *ldq,
-      real *work, integer *info);
-
-  /* Subroutine */int ssfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, real *alpha, real *a, integer *lda, real *beta, real * c__);
-
-  /* Subroutine */int sspcon_(char *uplo, integer *n, real *ap, integer *ipiv,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sspev_(char *jobz, char *uplo, integer *n, real *ap,
-      real *w, real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sspevd_(char *jobz, char *uplo, integer *n, real *ap,
-      real *w, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int sspevx_(char *jobz, char *range, char *uplo, integer *n,
-      real *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, real *work, integer * iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int sspgst_(integer *itype, char *uplo, integer *n, real *ap,
-      real *bp, integer *info);
-
-  /* Subroutine */int sspgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *ap, real *bp, real *w, real *z__, integer *ldz,
-      real *work, integer *info);
-
-  /* Subroutine */int sspgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *ap, real *bp, real *w, real *z__, integer *ldz,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sspgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, real *ap, real *bp, real *vl, real *vu,
-      integer *il, integer *iu, real *abstol, integer *m, real *w, real *z__,
-      integer * ldz, real *work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *afp, integer *ipiv, real *b, integer *ldb, real *x, integer * ldx,
-      real *ferr, real *berr, real *work, integer *iwork, integer * info);
-
-  /* Subroutine */int sspsv_(char *uplo, integer *n, integer *nrhs, real *ap,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *ap, real *afp, integer *ipiv, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int ssptrd_(char *uplo, integer *n, real *ap, real *d__,
-      real *e, real *tau, integer *info);
-
-  /* Subroutine */int ssptrf_(char *uplo, integer *n, real *ap, integer *ipiv,
-      integer *info);
-
-  /* Subroutine */int ssptri_(char *uplo, integer *n, real *ap, integer *ipiv,
-      real *work, integer *info);
-
-  /* Subroutine */int ssptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sstebz_(char *range, char *order, integer *n, real *vl,
-      real *vu, integer *il, integer *iu, real *abstol, real *d__, real *e,
-      integer *m, integer *nsplit, real *w, integer *iblock, integer * isplit,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sstedc_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int sstegr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sstein_(integer *n, real *d__, real *e, integer *m,
-      real *w, integer *iblock, integer *isplit, real *z__, integer *ldz,
-      real * work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int sstemr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
-      real *w, real *z__, integer *ldz, integer *nzc, integer *isuppz,
-      logical *tryrac, real *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
-
-  /* Subroutine */int ssteqr_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int ssterf_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int sstev_(char *jobz, integer *n, real *d__, real *e,
-      real * z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sstevd_(char *jobz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int sstevr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sstevx_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, real *work, integer * iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int ssycon_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int ssyequb_(char *uplo, integer *n, real *a, integer *lda,
-      real *s, real *scond, real *amax, real *work, integer *info);
-
-  /* Subroutine */int ssyev_(char *jobz, char *uplo, integer *n, real *a,
-      integer *lda, real *w, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssyevd_(char *jobz, char *uplo, integer *n, real *a,
-      integer *lda, real *w, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssyevr_(char *jobz, char *range, char *uplo, integer *n,
-      real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
-      real *abstol, integer *m, real *w, real *z__, integer *ldz,
-      integer * isuppz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssyevx_(char *jobz, char *range, char *uplo, integer *n,
-      real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
-      real *abstol, integer *m, real *w, real *z__, integer *ldz, real * work,
-      integer *lwork, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssygs2_(integer *itype, char *uplo, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ssygst_(integer *itype, char *uplo, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ssygv_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *w,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssygvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *w,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int ssygvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real * vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
-      real *w, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssyrfs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int ssyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real * err_bnds_comp__, integer *nparams, real *params, real *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int ssysv_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int ssysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, real *work, integer *lwork, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int ssysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *s, real *b, integer *ldb, real *x,
-      integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer *n_err_bnds__, real * err_bnds_norm__, real *err_bnds_comp__,
-      integer *nparams, real * params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int ssytd2_(char *uplo, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tau, integer *info);
-
-  /* Subroutine */int ssytf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int ssytrd_(char *uplo, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tau, real *work, integer *lwork,
-      integer * info);
-
-  /* Subroutine */int ssytrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssytri_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *work, integer *info);
-
-  /* Subroutine */int ssytrs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int stbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, real *ab, integer *ldab, real *rcond, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int stbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int stbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int stfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, real *alpha, real *a, real *b,
-      integer *ldb);
-
-  /* Subroutine */int stftri_(char *transr, char *uplo, char *diag, integer *n,
-      real *a, integer *info);
-
-  /* Subroutine */int stfttp_(char *transr, char *uplo, integer *n, real *arf,
-      real *ap, integer *info);
-
-  /* Subroutine */int stfttr_(char *transr, char *uplo, integer *n, real *arf,
-      real *a, integer *lda, integer *info);
-
-  /* Subroutine */int stgevc_(char *side, char *howmny, logical *select,
-      integer *n, real *s, integer *lds, real *p, integer *ldp, real *vl,
-      integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
-      real *work, integer *info);
-
-  /* Subroutine */int stgex2_(logical *wantq, logical *wantz, integer *n,
-      real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
-      real * z__, integer *ldz, integer *j1, integer *n1, integer *n2,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int stgexc_(logical *wantq, logical *wantz, integer *n,
-      real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
-      real * z__, integer *ldz, integer *ifst, integer *ilst, real *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int stgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, real *a, integer *lda, real *b,
-      integer * ldb, real *alphar, real *alphai, real *beta, real *q,
-      integer *ldq, real *z__, integer *ldz, integer *m, real *pl, real *pr,
-      real *dif, real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer * info);
-
-  /* Subroutine */int stgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, real *a, integer *lda,
-      real *b, integer *ldb, real *tola, real *tolb, real *alpha, real * beta,
-      real *u, integer *ldu, real *v, integer *ldv, real *q, integer * ldq,
-      real *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int stgsna_(char *job, char *howmny, logical *select,
-      integer *n, real *a, integer *lda, real *b, integer *ldb, real *vl,
-      integer *ldvl, real *vr, integer *ldvr, real *s, real *dif, integer * mm,
-      integer *m, real *work, integer *lwork, integer *iwork, integer * info);
-
-  /* Subroutine */int stgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *c__,
-      integer * ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
-      integer *ldf, real *scale, real *rdsum, real *rdscal, integer *iwork,
-      integer *pq, integer *info);
-
-  /* Subroutine */int stgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *c__,
-      integer * ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
-      integer *ldf, real *scale, real *dif, real *work, integer *lwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int stpcon_(char *norm, char *uplo, char *diag, integer *n,
-      real *ap, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int stprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *ap, real *b, integer *ldb, real *x, integer *ldx,
-      real *ferr, real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int stptri_(char *uplo, char *diag, integer *n, real *ap,
-      integer *info);
-
-  /* Subroutine */int stptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *ap, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int stpttf_(char *transr, char *uplo, integer *n, real *ap,
-      real *arf, integer *info);
-
-  /* Subroutine */int stpttr_(char *uplo, integer *n, real *ap, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strcon_(char *norm, char *uplo, char *diag, integer *n,
-      real *a, integer *lda, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int strevc_(char *side, char *howmny, logical *select,
-      integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, integer *mm, integer *m, real *work, integer *info);
-
-  /* Subroutine */int strexc_(char *compq, integer *n, real *t, integer *ldt,
-      real *q, integer *ldq, integer *ifst, integer *ilst, real *work,
-      integer *info);
-
-  /* Subroutine */int strrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *x,
-      integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int strsen_(char *job, char *compq, logical *select,
-      integer *n, real *t, integer *ldt, real *q, integer *ldq, real *wr,
-      real *wi, integer *m, real *s, real *sep, real *work, integer *lwork,
-      integer * iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int strsna_(char *job, char *howmny, logical *select,
-      integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, real *s, real *sep, integer *mm, integer *m, real * work,
-      integer *ldwork, integer *iwork, integer *info);
-
-  /* Subroutine */int strsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real * c__, integer *ldc, real *scale, integer *info);
-
-  /* Subroutine */int strti2_(char *uplo, char *diag, integer *n, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strtri_(char *uplo, char *diag, integer *n, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *a, integer *lda, real *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int strttf_(char *transr, char *uplo, integer *n, real *a,
-      integer *lda, real *arf, integer *info);
-
-  /* Subroutine */int strttp_(char *uplo, integer *n, real *a, integer *lda,
-      real *ap, integer *info);
-
-  /* Subroutine */int stzrqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, integer *info);
-
-  /* Subroutine */int stzrzf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int xerbla_(char *srname, integer *info);
-
-  /* Subroutine */int xerbla_array__(char *srname_array__,
-      integer * srname_len__, integer *info, ftnlen srname_array_len);
-
-  /* Subroutine */int zbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, doublereal *d__, doublereal *e,
-      doublecomplex *vt, integer *ldvt, doublecomplex *u, integer *ldu,
-      doublecomplex *c__, integer *ldc, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zcgesv_(integer *n, integer *nrhs, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
-      doublereal *rwork, integer *iter, integer *info);
-
-  /* Subroutine */int zcposv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
-      doublereal *rwork, integer *iter, integer *info);
-
-  /* Subroutine */int zdrscl_(integer *n, doublereal *sa, doublecomplex *sx,
-      integer *incx);
-
-  /* Subroutine */int zgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, doublecomplex *ab, integer *ldab,
-      doublereal *d__, doublereal *e, doublecomplex *q, integer *ldq,
-      doublecomplex *pt, integer *ldpt, doublecomplex *c__, integer *ldc,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, doublereal *anorm,
-      doublereal *rcond, doublecomplex *work, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer * info);
-
-  /* Subroutine */int zgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, doublecomplex *ab, integer *ldab, doublereal *r__,
-      doublereal * c__, doublereal *rowcnd, doublereal *colcnd,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int zgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex * afb, integer *ldafb, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublecomplex *ab,
-      integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
-      doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, doublecomplex *ab, integer *ldab, integer *ipiv,
-      doublecomplex * b, integer *ldb, integer *info);
-
-  /* Subroutine */int zgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublecomplex *ab,
-      integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
-      char *equed, doublereal *r__, doublereal *c__, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      integer *ipiv, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *scale, integer *m, doublecomplex *v,
-      integer *ldv, integer *info);
-
-  /* Subroutine */int zgebal_(char *job, integer *n, doublecomplex *a,
-      integer *lda, integer *ilo, integer *ihi, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int zgebd2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
-      doublecomplex *taup, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgebrd_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
-      doublecomplex *taup, doublecomplex *work, integer *lwork, integer * info);
-
-  /* Subroutine */int zgecon_(char *norm, integer *n, doublecomplex *a,
-      integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeequ_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
-
-  /* Subroutine */int zgeequb_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
-
-  /* Subroutine */int zgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      doublecomplex *a, integer *lda, integer *sdim, doublecomplex *w,
-      doublecomplex *vs, integer *ldvs, doublecomplex *work, integer *lwork,
-      doublereal *rwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, doublecomplex *a, integer *lda, integer *sdim,
-      doublecomplex *w, doublecomplex *vs, integer *ldvs, doublereal * rconde,
-      doublereal *rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zgeev_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *w, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
-      doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
-      doublecomplex *work, integer * lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgegs_(char *jobvsl, char *jobvsr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vsl,
-      integer *ldvsl, doublecomplex *vsr, integer *ldvsr, doublecomplex * work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgegv_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgehd2_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zgehrd_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zgelq2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgelqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgelsd_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zgelss_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgelsx_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgelsy_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeql2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgeqlf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgeqp3_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeqpf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeqr2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgeqrf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgerfs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
-      doublecomplex * b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgerq2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgerqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgesc2_(integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
-
-  /* Subroutine */int zgesdd_(char *jobz, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
-      integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zgesv_(integer *n, integer *nrhs, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int zgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
-      integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgetc2_(integer *n, doublecomplex *a, integer *lda,
-      integer *ipiv, integer *jpiv, integer *info);
-
-  /* Subroutine */int zgetf2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgetrf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgetri_(integer *n, doublecomplex *a, integer *lda,
-      integer *ipiv, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgetrs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int zggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
-      doublecomplex *v, integer *ldv, integer *info);
-
-  /* Subroutine */int zggbal_(char *job, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, integer *ilo, integer *ihi,
-      doublereal *lscale, doublereal *rscale, doublereal *work, integer * info);
-
-  /* Subroutine */int zgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, integer *sdim, doublecomplex *alpha, doublecomplex * beta,
-      doublecomplex *vsl, integer *ldvsl, doublecomplex *vsr, integer *ldvsr,
-      doublecomplex *work, integer *lwork, doublereal *rwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int zggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, integer *sdim, doublecomplex *alpha,
-      doublecomplex *beta, doublecomplex *vsl, integer *ldvsl,
-      doublecomplex *vsr, integer *ldvsr, doublereal *rconde,
-      doublereal * rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *iwork, integer *liwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int zggev_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *alpha, doublecomplex *beta,
-      doublecomplex *vl, integer *ldvl, doublecomplex *vr, integer *ldvr,
-      integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
-      doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
-      doublereal * rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *iwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zggglm_(integer *n, integer *m, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *d__, doublecomplex *x, doublecomplex *y,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *q, integer *ldq,
-      doublecomplex *z__, integer *ldz, integer *info);
-
-  /* Subroutine */int zgglse_(integer *m, integer *n, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *c__, doublecomplex *d__, doublecomplex *x,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zggqrf_(integer *n, integer *m, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
-      integer *ldb, doublecomplex *taub, doublecomplex *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int zggrqf_(integer *m, integer *p, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
-      integer *ldb, doublecomplex *taub, doublecomplex *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int zggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublereal *alpha,
-      doublereal *beta, doublecomplex *u, integer *ldu, doublecomplex *v,
-      integer *ldv, doublecomplex *q, integer *ldq, doublecomplex *work,
-      doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
-      doublecomplex *u, integer *ldu, doublecomplex *v, integer *ldv,
-      doublecomplex *q, integer *ldq, integer *iwork, doublereal * rwork,
-      doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgtcon_(char *norm, integer *n, doublecomplex *dl,
-      doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer * ipiv,
-      doublereal *anorm, doublereal *rcond, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgtrfs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgtsv_(integer *n, integer *nrhs, doublecomplex *dl,
-      doublecomplex *d__, doublecomplex *du, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zgttrf_(integer *n, doublecomplex *dl,
-      doublecomplex * d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
-      integer * info);
-
-  /* Subroutine */int zgttrs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zgtts2_(integer *itrans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zhbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, doublecomplex *ab, integer *ldab, doublecomplex *q,
-      integer *ldq, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int zhbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublecomplex *x, integer *ldx, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, integer *lwork, doublereal *rwork, integer * lrwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, doublecomplex *ab, integer *ldab,
-      doublecomplex *bb, integer *ldbb, doublecomplex *q, integer *ldq,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal * abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer * ifail, integer *info);
-
-  /* Subroutine */int zhbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *d__, doublereal *e,
-      doublecomplex *q, integer *ldq, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhecon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zheequb_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zheev_(char *jobz, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zheevd_(char *jobz, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zheevr_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal * w,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublecomplex * work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer * iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zheevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal * w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer * lwork,
-      doublereal *rwork, integer *iwork, integer *ifail, integer * info);
-
-  /* Subroutine */int zhegs2_(integer *itype, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhegst_(integer *itype, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhegv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhegvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int zhegvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int zherfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zherfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhesv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zhesvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zhesvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *s,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhetd2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
-      integer *info);
-
-  /* Subroutine */int zhetf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zhetrd_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zhetrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zhetri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhetrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int zhfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, doublereal *alpha, doublecomplex *a, integer *lda,
-      doublereal *beta, doublecomplex *c__);
-
-  /* Subroutine */int zhgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *t, integer *ldt, doublecomplex *alpha,
-      doublecomplex * beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
-      integer * ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zhpcon_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zhpev_(char *jobz, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhpevd_(char *jobz, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, integer *lwork, doublereal *rwork, integer * lrwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhpevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *vl, doublereal *vu, integer *il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal * rwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int zhpgst_(integer *itype, char *uplo, integer *n,
-      doublecomplex *ap, doublecomplex *bp, integer *info);
-
-  /* Subroutine */int zhpgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zhpgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
-      doublereal * rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer * info);
-
-  /* Subroutine */int zhpgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublecomplex *ap, doublecomplex *bp,
-      doublereal * vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer * ifail, integer *info);
-
-  /* Subroutine */int zhprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex * b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zhpsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhpsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhptrd_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *d__, doublereal *e, doublecomplex *tau, integer *info);
-
-  /* Subroutine */int zhptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int zhptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, doublecomplex *h__, integer *ldh,
-      doublecomplex * w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer *ldvr, integer *mm, integer *m, doublecomplex *work,
-      doublereal *rwork, integer *ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int zhseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, doublecomplex *h__, integer *ldh, doublecomplex *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, doublereal *alpha, doublecomplex *ab,
-      integer *ldab, doublecomplex *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
-
-  doublereal zla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
-      integer *ipiv, doublereal *c__, logical *capply, integer *info,
-      doublecomplex *work, doublereal *rwork, ftnlen trans_len);
-
-  doublereal zla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
-      integer *ipiv, doublecomplex *x, integer *info, doublecomplex *work,
-      doublereal *rwork, ftnlen trans_len);
-
-  /* Subroutine */int zla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
-      doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
-      doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical *ignore_cwise__, integer *info);
-
-  doublereal zla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer * ldafb);
-
-  /* Subroutine */int zla_geamv__(integer *trans, integer *m, integer *n,
-      doublereal *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_gercond_c__(char *trans, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal * c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen trans_len);
-
-  doublereal zla_gercond_x__(char *trans, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int zla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      logical *colequ, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *y, integer *ldy, doublereal *berr_out__,
-      integer *n_norms__, doublereal * errs_n__, doublereal *errs_c__,
-      doublecomplex *res, doublereal *ayb, doublecomplex *dy,
-      doublecomplex *y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical * ignore_cwise__,
-      integer *info);
-
-  /* Subroutine */int zla_heamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_hercond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal *c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen uplo_len);
-
-  doublereal zla_hercond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int zla_herfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
-      integer *ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal * errs_n__, doublereal *errs_c__, doublecomplex *res,
-      doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical * ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal zla_herpvgrw__(char *uplo, integer *n, integer *info,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int zla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      doublecomplex *res, doublereal *ayb, doublereal *berr);
-
-  doublereal zla_porcond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, doublereal *c__,
-      logical * capply, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  doublereal zla_porcond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, doublecomplex *x,
-      integer * info, doublecomplex *work, doublereal *rwork, ftnlen uplo_len);
-
-  /* Subroutine */int zla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, logical *colequ, doublereal *c__,
-      doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
-      doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical * ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal zla_porpvgrw__(char *uplo, integer *ncols, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, doublereal *work,
-      ftnlen uplo_len);
-
-  doublereal zla_rpvgrw__(integer *n, integer *ncols, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf);
-
-  /* Subroutine */int zla_syamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_syrcond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal *c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen uplo_len);
-
-  doublereal zla_syrcond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int zla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
-      integer *ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal * errs_n__, doublereal *errs_c__, doublecomplex *res,
-      doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical * ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal zla_syrpvgrw__(char *uplo, integer *n, integer *info,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int zla_wwaddw__(integer *n, doublecomplex *x,
-      doublecomplex *y, doublecomplex *w);
-
-  /* Subroutine */int zlabrd_(integer *m, integer *n, integer *nb,
-      doublecomplex *a, integer *lda, doublereal *d__, doublereal *e,
-      doublecomplex *tauq, doublecomplex *taup, doublecomplex *x, integer * ldx,
-      doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlacgv_(integer *n, doublecomplex *x, integer *incx);
-
-  /* Subroutine */int zlacn2_(integer *n, doublecomplex *v, doublecomplex *x,
-      doublereal *est, integer *kase, integer *isave);
-
-  /* Subroutine */int zlacon_(integer *n, doublecomplex *v, doublecomplex *x,
-      doublereal *est, integer *kase);
-
-  /* Subroutine */int zlacp2_(char *uplo, integer *m, integer *n,
-      doublereal * a, integer *lda, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlacpy_(char *uplo, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlacrm_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *b, integer *ldb, doublecomplex *c__,
-      integer *ldc, doublereal *rwork);
-
-  /* Subroutine */int zlacrt_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublecomplex *c__, doublecomplex * s);
-
-  /* Double Complex */VOID zladiv_(doublecomplex * ret_val, doublecomplex *x,
-      doublecomplex *y);
-
-  /* Subroutine */int zlaed0_(integer *qsiz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *q, integer *ldq, doublecomplex *qstore,
-      integer *ldqs, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zlaed7_(integer *n, integer *cutpnt, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
-      doublecomplex *q, integer *ldq, doublereal *rho, integer *indxq,
-      doublereal *qstore, integer *qptr, integer *prmptr, integer *perm,
-      integer *givptr, integer *givcol, doublereal *givnum,
-      doublecomplex * work, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zlaed8_(integer *k, integer *n, integer *qsiz,
-      doublecomplex *q, integer *ldq, doublereal *d__, doublereal *rho,
-      integer *cutpnt, doublereal *z__, doublereal *dlamda, doublecomplex * q2,
-      integer *ldq2, doublereal *w, integer *indxp, integer *indx,
-      integer *indxq, integer *perm, integer *givptr, integer *givcol,
-      doublereal *givnum, integer *info);
-
-  /* Subroutine */int zlaein_(logical *rightv, logical *noinit, integer *n,
-      doublecomplex *h__, integer *ldh, doublecomplex *w, doublecomplex *v,
-      doublecomplex *b, integer *ldb, doublereal *rwork, doublereal *eps3,
-      doublereal *smlnum, integer *info);
-
-  /* Subroutine */int zlaesy_(doublecomplex *a, doublecomplex *b,
-      doublecomplex *c__, doublecomplex *rt1, doublecomplex *rt2,
-      doublecomplex *evscal, doublecomplex *cs1, doublecomplex *sn1);
-
-  /* Subroutine */int zlaev2_(doublecomplex *a, doublecomplex *b,
-      doublecomplex *c__, doublereal *rt1, doublereal *rt2, doublereal *cs1,
-      doublecomplex *sn1);
-
-  /* Subroutine */int zlag2c_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, complex *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int zlags2_(logical *upper, doublereal *a1,
-      doublecomplex * a2, doublereal *a3, doublereal *b1, doublecomplex *b2,
-      doublereal *b3, doublereal *csu, doublecomplex *snu, doublereal *csv,
-      doublecomplex * snv, doublereal *csq, doublecomplex *snq);
-
-  /* Subroutine */int zlagtm_(char *trans, integer *n, integer *nrhs,
-      doublereal *alpha, doublecomplex *dl, doublecomplex *d__,
-      doublecomplex *du, doublecomplex *x, integer *ldx, doublereal *beta,
-      doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlahef_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
-      integer *ldw, integer *info);
-
-  /* Subroutine */int zlahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *info);
-
-  /* Subroutine */int zlahr2_(integer *n, integer *k, integer *nb,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
-      integer *ldt, doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlahrd_(integer *n, integer *k, integer *nb,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
-      integer *ldt, doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlaic1_(integer *job, integer *j, doublecomplex *x,
-      doublereal *sest, doublecomplex *w, doublecomplex *gamma,
-      doublereal * sestpr, doublecomplex *s, doublecomplex *c__);
-
-  /* Subroutine */int zlals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, doublecomplex *b, integer *ldb,
-      doublecomplex *bx, integer *ldbx, integer *perm, integer *givptr,
-      integer *givcol, integer *ldgcol, doublereal *givnum, integer *ldgnum,
-      doublereal *poles, doublereal *difl, doublereal *difr, doublereal * z__,
-      integer *k, doublereal *c__, doublereal *s, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zlalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, doublecomplex *b, integer *ldb, doublecomplex *bx,
-      integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer * k,
-      doublereal *difl, doublereal *difr, doublereal *z__, doublereal * poles,
-      integer *givptr, integer *givcol, integer *ldgcol, integer * perm,
-      doublereal *givnum, doublereal *c__, doublereal *s, doublereal * rwork,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int zlalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *d__, doublereal *e, doublecomplex *b,
-      integer *ldb, doublereal *rcond, integer *rank, doublecomplex *work,
-      doublereal * rwork, integer *iwork, integer *info);
-
-  doublereal zlangb_(char *norm, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlange_(char *norm, integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlangt_(char *norm, integer *n, doublecomplex *dl,
-      doublecomplex * d__, doublecomplex *du);
-
-  doublereal zlanhb_(char *norm, char *uplo, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlanhf_(char *norm, char *transr, char *uplo, integer *n,
-      doublecomplex *a, doublereal *work);
-
-  doublereal zlanhp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
-      doublereal *work);
-
-  doublereal zlanhs_(char *norm, integer *n, doublecomplex *a, integer *lda,
-      doublereal *work);
-
-  doublereal zlanht_(char *norm, integer *n, doublereal *d__, doublecomplex *e);
-
-  doublereal zlansb_(char *norm, char *uplo, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlansp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
-      doublereal *work);
-
-  doublereal zlansy_(char *norm, char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlantp_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *ap, doublereal *work);
-
-  doublereal zlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *work);
-
-  /* Subroutine */int zlapll_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *ssmin);
-
-  /* Subroutine */int zlapmt_(logical *forwrd, integer *m, integer *n,
-      doublecomplex *x, integer *ldx, integer *k);
-
-  /* Subroutine */int zlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqge_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqhb_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqhe_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int zlaqhp_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqp2_(integer *m, integer *n, integer *offset,
-      doublecomplex *a, integer *lda, integer *jpvt, doublecomplex *tau,
-      doublereal *vn1, doublereal *vn2, doublecomplex *work);
-
-  /* Subroutine */int zlaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, doublecomplex *a, integer *lda, integer *jpvt,
-      doublecomplex *tau, doublereal *vn1, doublereal *vn2,
-      doublecomplex * auxv, doublecomplex *f, integer *ldf);
-
-  /* Subroutine */int zlaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zlaqr1_(integer *n, doublecomplex *h__, integer *ldh,
-      doublecomplex *s1, doublecomplex *s2, doublecomplex *v);
-
-  /* Subroutine */int zlaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
-      integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
-      doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
-      integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
-      doublecomplex *work, integer *lwork);
-
-  /* Subroutine */int zlaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
-      integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
-      doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
-      integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
-      doublecomplex *work, integer *lwork);
-
-  /* Subroutine */int zlaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts,
-      doublecomplex *s, doublecomplex *h__, integer *ldh, integer *iloz,
-      integer *ihiz, doublecomplex *z__, integer *ldz, doublecomplex *v,
-      integer *ldv, doublecomplex *u, integer *ldu, integer *nv,
-      doublecomplex *wv, integer *ldwv, integer *nh, doublecomplex *wh,
-      integer *ldwh);
-
-  /* Subroutine */int zlaqsb_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqsp_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqsy_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int zlar1v_(integer *n, integer *b1, integer *bn,
-      doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
-      doublereal * lld, doublereal *pivmin, doublereal *gaptol,
-      doublecomplex *z__, logical *wantnc, integer *negcnt, doublereal *ztz,
-      doublereal *mingma, integer *r__, integer *isuppz, doublereal *nrminv,
-      doublereal *resid, doublereal *rqcorr, doublereal *work);
-
-  /* Subroutine */int zlar2v_(integer *n, doublecomplex *x, doublecomplex *y,
-      doublecomplex *z__, integer *incx, doublereal *c__, doublecomplex *s,
-      integer *incc);
-
-  /* Subroutine */int zlarcm_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublecomplex *b, integer *ldb, doublecomplex *c__,
-      integer *ldc, doublereal *rwork);
-
-  /* Subroutine */int zlarf_(char *side, integer *m, integer *n,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
-      integer * ldc, doublecomplex *work);
-
-  /* Subroutine */int zlarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, doublecomplex *v,
-      integer *ldv, doublecomplex *t, integer *ldt, doublecomplex *c__,
-      integer * ldc, doublecomplex *work, integer *ldwork);
-
-  /* Subroutine */int zlarfg_(integer *n, doublecomplex *alpha,
-      doublecomplex * x, integer *incx, doublecomplex *tau);
-
-  /* Subroutine */int zlarfp_(integer *n, doublecomplex *alpha,
-      doublecomplex * x, integer *incx, doublecomplex *tau);
-
-  /* Subroutine */int zlarft_(char *direct, char *storev, integer *n,
-      integer * k, doublecomplex *v, integer *ldv, doublecomplex *tau,
-      doublecomplex * t, integer *ldt);
-
-  /* Subroutine */int zlarfx_(char *side, integer *m, integer *n,
-      doublecomplex *v, doublecomplex *tau, doublecomplex *c__, integer * ldc,
-      doublecomplex *work);
-
-  /* Subroutine */int zlargv_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *c__, integer *incc);
-
-  /* Subroutine */int zlarnv_(integer *idist, integer *iseed, integer *n,
-      doublecomplex *x);
-
-  /* Subroutine */int zlarrv_(integer *n, doublereal *vl, doublereal *vu,
-      doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
-      integer *m, integer *dol, integer *dou, doublereal *minrgp,
-      doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
-      doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int zlarscl2_(integer *m, integer *n, doublereal *d__,
-      doublecomplex *x, integer *ldx);
-
-  /* Subroutine */int zlartg_(doublecomplex *f, doublecomplex *g,
-      doublereal * cs, doublecomplex *sn, doublecomplex *r__);
-
-  /* Subroutine */int zlartv_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *c__, doublecomplex *s,
-      integer *incc);
-
-  /* Subroutine */int zlarz_(char *side, integer *m, integer *n, integer *l,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex * c__,
-      integer *ldc, doublecomplex *work);
-
-  /* Subroutine */int zlarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l,
-      doublecomplex *v, integer *ldv, doublecomplex *t, integer *ldt,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *ldwork);
-
-  /* Subroutine */int zlarzt_(char *direct, char *storev, integer *n,
-      integer * k, doublecomplex *v, integer *ldv, doublecomplex *tau,
-      doublecomplex * t, integer *ldt);
-
-  /* Subroutine */int zlascl_(char *type__, integer *kl, integer *ku,
-      doublereal *cfrom, doublereal *cto, integer *m, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int zlascl2_(integer *m, integer *n, doublereal *d__,
-      doublecomplex *x, integer *ldx);
-
-  /* Subroutine */int zlaset_(char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *a,
-      integer * lda);
-
-  /* Subroutine */int zlasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, doublereal *c__, doublereal *s, doublecomplex *a,
-      integer *lda);
-
-  /* Subroutine */int zlassq_(integer *n, doublecomplex *x, integer *incx,
-      doublereal *scale, doublereal *sumsq);
-
-  /* Subroutine */int zlaswp_(integer *n, doublecomplex *a, integer *lda,
-      integer *k1, integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int zlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
-      integer *ldw, integer *info);
-
-  /* Subroutine */int zlat2c_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, complex *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int zlatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, doublecomplex *ab, integer *ldab,
-      doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatdf_(integer *ijob, integer *n, doublecomplex *z__,
-      integer *ldz, doublecomplex *rhs, doublereal *rdsum, doublereal * rdscal,
-      integer *ipiv, integer *jpiv);
-
-  /* Subroutine */int zlatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublecomplex *ap, doublecomplex *x,
-      doublereal * scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatrd_(char *uplo, integer *n, integer *nb,
-      doublecomplex *a, integer *lda, doublereal *e, doublecomplex *tau,
-      doublecomplex *w, integer *ldw);
-
-  /* Subroutine */int zlatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatrz_(integer *m, integer *n, integer *l,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work);
-
-  /* Subroutine */int zlatzm_(char *side, integer *m, integer *n,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex * c1,
-      doublecomplex *c2, integer *ldc, doublecomplex *work);
-
-  /* Subroutine */int zlauu2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zlauum_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpbcon_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *anorm, doublereal * rcond,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpbequ_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int zpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer * ldafb, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zpbstf_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
-      integer * ldb, integer *info);
-
-  /* Subroutine */int zpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer *ldafb, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal * ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpbtf2_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbtrf_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
-      integer * ldb, integer *info);
-
-  /* Subroutine */int zpftrf_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int zpftri_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int zpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zpocon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpoequ_(integer *n, doublecomplex *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zpoequb_(integer *n, doublecomplex *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zporfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, doublereal *s, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zposv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer * info);
-
-  /* Subroutine */int zposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpotf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zppcon_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *anorm, doublereal *rcond, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zppequ_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zpprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zppsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, char *equed,
-      doublereal * s, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *info);
-
-  /* Subroutine */int zpptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *info);
-
-  /* Subroutine */int zpptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zpstf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int zpstrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int zptcon_(integer *n, doublereal *d__, doublecomplex *e,
-      doublereal *anorm, doublereal *rcond, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zpteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int zptrfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zptsv_(integer *n, integer *nrhs, doublereal *d__,
-      doublecomplex *e, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zptsvx_(char *fact, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpttrf_(integer *n, doublereal *d__, doublecomplex *e,
-      integer *info);
-
-  /* Subroutine */int zpttrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zptts2_(integer *iuplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zrot_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublereal *c__, doublecomplex *s);
-
-  /* Subroutine */int zspcon_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zspmv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex * beta,
-      doublecomplex *y, integer *incy);
-
-  /* Subroutine */int zspr_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *ap);
-
-  /* Subroutine */int zsprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex * b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zspsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int zsptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zstedc_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zstegr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zstein_(integer *n, doublereal *d__, doublereal *e,
-      integer *m, doublereal *w, integer *iblock, integer *isplit,
-      doublecomplex *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int zstemr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, integer *m, doublereal *w, doublecomplex *z__,
-      integer * ldz, integer *nzc, integer *isuppz, logical *tryrac,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int zsteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int zsycon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsyequb_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsymv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublecomplex *beta, doublecomplex *y, integer *incy);
-
-  /* Subroutine */int zsyr_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
-
-  /* Subroutine */int zsyrfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsysv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zsysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zsysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *s,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsytf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zsytrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zsytri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsytrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int ztbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, doublecomplex *ab, integer *ldab, doublereal *rcond,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int ztbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ztfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *a, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int ztftri_(char *transr, char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int ztfttp_(char *transr, char *uplo, integer *n,
-      doublecomplex *arf, doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztfttr_(char *transr, char *uplo, integer *n,
-      doublecomplex *arf, doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztgevc_(char *side, char *howmny, logical *select,
-      integer *n, doublecomplex *s, integer *lds, doublecomplex *p,
-      integer *ldp, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer * ldvr, integer *mm, integer *m, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztgex2_(logical *wantq, logical *wantz, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
-      integer *j1, integer *info);
-
-  /* Subroutine */int ztgexc_(logical *wantq, logical *wantz, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
-      integer *ifst, integer *ilst, integer *info);
-
-  /* Subroutine */int ztgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *alpha,
-      doublecomplex * beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
-      integer * ldz, integer *m, doublereal *pl, doublereal *pr,
-      doublereal *dif, doublecomplex *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ztgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublereal *tola,
-      doublereal *tolb, doublereal *alpha, doublereal *beta, doublecomplex * u,
-      integer *ldu, doublecomplex *v, integer *ldv, doublecomplex *q,
-      integer *ldq, doublecomplex *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int ztgsna_(char *job, char *howmny, logical *select,
-      integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer * ldvr, doublereal *s, doublereal *dif, integer *mm, integer *m,
-      doublecomplex *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int ztgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
-      integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
-      integer *ldf, doublereal *scale, doublereal *rdsum, doublereal *rdscal,
-      integer * info);
-
-  /* Subroutine */int ztgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
-      integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
-      integer *ldf, doublereal *scale, doublereal *dif, doublecomplex *work,
-      integer * lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int ztpcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *ap, doublereal *rcond, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztptri_(char *uplo, char *diag, integer *n,
-      doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int ztpttf_(char *transr, char *uplo, integer *n,
-      doublecomplex *ap, doublecomplex *arf, integer *info);
-
-  /* Subroutine */int ztpttr_(char *uplo, integer *n, doublecomplex *ap,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrevc_(char *side, char *howmny, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, integer *mm, integer *m,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrexc_(char *compq, integer *n, doublecomplex *t,
-      integer *ldt, doublecomplex *q, integer *ldq, integer *ifst,
-      integer * ilst, integer *info);
-
-  /* Subroutine */int ztrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int ztrsen_(char *job, char *compq, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *q,
-      integer *ldq, doublecomplex *w, integer *m, doublereal *s,
-      doublereal *sep, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ztrsna_(char *job, char *howmny, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublereal *s,
-      doublereal *sep, integer *mm, integer *m, doublecomplex *work,
-      integer *ldwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int ztrti2_(char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrtri_(char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int ztrttf_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *arf, integer *info);
-
-  /* Subroutine */int ztrttp_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztzrqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, integer *info);
-
-  /* Subroutine */int ztzrzf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zung2l_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zung2r_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zungbr_(char *vect, integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zunghr_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungl2_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zunglq_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungql_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungqr_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungr2_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zungrq_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungtr_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int zunmhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc,
-      doublecomplex * work, integer *lwork, integer *info);
-
-  /* Subroutine */int zunml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * info);
-
-  /* Subroutine */int zunmrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int zunmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zupgtr_(char *uplo, integer *n, doublecomplex *ap,
-      doublecomplex *tau, doublecomplex *q, integer *ldq, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zupmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublecomplex *ap, doublecomplex *tau, doublecomplex *c__,
-      integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int dlamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  doublereal dsecnd_();
-
-  /* Subroutine */int ilaver_(integer *vers_major__, integer *vers_minor__,
-      integer *vers_patch__);
-
-  logical lsame_(char *ca, char *cb);
-
-  doublereal second_();
-
-  doublereal slamch_(char *cmach);
-
-  /* Subroutine */int slamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  /* Subroutine */int slamc2_(integer *beta, integer *t, logical *rnd,
-      real * eps, integer *emin, real *rmin, integer *emax, real *rmax);
-
-  doublereal slamc3_(real *a, real *b);
-
-  /* Subroutine */int slamc4_(integer *emin, real *start, integer *base);
-
-  /* Subroutine */int slamc5_(integer *beta, integer *p, integer *emin,
-      logical *ieee, integer *emax, real *rmax);
-
-  doublereal dlamch_(char *cmach);
-
-  /* Subroutine */int dlamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  /* Subroutine */int dlamc2_(integer *beta, integer *t, logical *rnd,
-      doublereal *eps, integer *emin, doublereal *rmin, integer *emax,
-      doublereal *rmax);
-
-  doublereal dlamc3_(doublereal *a, doublereal *b);
-
-  /* Subroutine */int dlamc4_(integer *emin, doublereal *start, integer *base);
-
-  /* Subroutine */int dlamc5_(integer *beta, integer *p, integer *emin,
-      logical *ieee, integer *emax, doublereal *rmax);
-
-  integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
-      integer *n2, integer *n3, integer *n4);
+/* Subroutine */ int dgerq2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
+
+/* Subroutine */ int dgerqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesc2_(integer *n, doublereal *a, integer *lda,
+                             doublereal *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
+
+/* Subroutine */ int dgesdd_(char *jobz, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgesv_(integer *n, integer *nrhs, doublereal *a,
+                            integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesvj_(char *joba, char *jobu, char *jobv, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *sva, integer *mv,
+                             doublereal *v, integer *ldv, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                             doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                              doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dgetc2_(integer *n, doublereal *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
+
+/* Subroutine */ int dgetf2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgetrf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgetri_(integer *n, doublereal *a, integer *lda,
+                             integer *ipiv, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dgetrs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
+                             doublereal *v, integer *ldv, integer *info);
+
+/* Subroutine */ int dggbal_(char *job, integer *n, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, integer *ilo, integer *ihi,
+                             doublereal *lscale, doublereal *rscale, doublereal *work, integer *info);
+
+/* Subroutine */ int dgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, integer *sdim, doublereal *alphar, doublereal *alphai,
+                            doublereal *beta, doublereal *vsl, integer *ldvsl, doublereal *vsr,
+                            integer *ldvsr, doublereal *work, integer *lwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int dggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, doublereal *a, integer *lda,
+                             doublereal *b, integer *ldb, integer *sdim, doublereal *alphar,
+                             doublereal *alphai, doublereal *beta, doublereal *vsl, integer *ldvsl,
+                             doublereal *vsr, integer *ldvsr, doublereal *rconde, doublereal *rcondv,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int dggev_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
+                            integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int dggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                             integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
+                             doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
+                             doublereal *rcondv, doublereal *work, integer *lwork, integer *iwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int dggglm_(integer *n, integer *m, integer *p,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *d__, doublereal *x, doublereal *y, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
+                             integer *info);
+
+/* Subroutine */ int dgglse_(integer *m, integer *n, integer *p,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, doublereal *d__, doublereal *x, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dggqrf_(integer *n, integer *m, integer *p,
+                             doublereal *a, integer *lda, doublereal *taua, doublereal *b,
+                             integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dggrqf_(integer *m, integer *p, integer *n,
+                             doublereal *a, integer *lda, doublereal *taua, doublereal *b,
+                             integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, doublereal *alpha,
+                             doublereal *beta, doublereal *u, integer *ldu, doublereal *v,
+                             integer *ldv, doublereal *q, integer *ldq, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
+                             doublereal *u, integer *ldu, doublereal *v, integer *ldv, doublereal *q,
+                             integer *ldq, integer *iwork, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dgsvj0_(char *jobv, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
+                             integer *mv, doublereal *v, integer *ldv, doublereal *eps,
+                             doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
+                             integer *mv, doublereal *v, integer *ldv, doublereal *eps,
+                             doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgtcon_(char *norm, integer *n, doublereal *dl,
+                             doublereal *d__, doublereal *du, doublereal *du2, integer *ipiv,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dgtrfs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *dlf,
+                             doublereal *df, doublereal *duf, doublereal *du2, integer *ipiv,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dgtsv_(integer *n, integer *nrhs, doublereal *dl,
+                            doublereal *d__, doublereal *du, doublereal *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int dgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublereal *dl, doublereal *d__, doublereal *du,
+                             doublereal *dlf, doublereal *df, doublereal *duf, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgttrf_(integer *n, doublereal *dl, doublereal *d__,
+                             doublereal *du, doublereal *du2, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgttrs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb);
+
+/* Subroutine */ int dhgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *t,
+                             integer *ldt, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dhsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, doublereal *h__, integer *ldh,
+                             doublereal *wr, doublereal *wi, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
+                             integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int dhseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *info);
+
+logical disnan_(doublereal *din);
+
+/* Subroutine */ int dla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, doublereal *alpha, doublereal *ab,
+                                 integer *ldab, doublereal *x, integer *incx, doublereal *beta,
+                                 doublereal *y, integer *incy);
+
+doublereal dla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
+                         doublereal *ab, integer *ldab, doublereal *afb, integer *ldafb,
+                         integer *ipiv, integer *cmode, doublereal *c__, integer *info,
+                         doublereal *work, integer *iwork, ftnlen trans_len);
+
+/* Subroutine */ int dla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                                           integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublereal *b, integer *ldb, doublereal *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
+                                           doublereal *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
+
+doublereal dla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, doublereal *ab, integer *ldab, doublereal *afb,
+                          integer *ldafb);
+
+/* Subroutine */ int dla_geamv__(integer *trans, integer *m, integer *n,
+                                 doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                                 integer *incx, doublereal *beta, doublereal *y, integer *incy);
+
+doublereal dla_gercond__(char *trans, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
+                         doublereal *c__, integer *info, doublereal *work, integer *iwork,
+                         ftnlen trans_len);
+
+/* Subroutine */ int dla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, doublereal *a,
+                                           integer *lda, doublereal *af, integer *ldaf, integer *ipiv,
+                                           logical *colequ, doublereal *c__, doublereal *b, integer *ldb,
+                                           doublereal *y, integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublereal *res,
+                                           doublereal *ayb, doublereal *dy, doublereal *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+/* Subroutine */ int dla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    doublereal *res, doublereal *ayb, doublereal *berr);
+
+doublereal dla_porcond__(char *uplo, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *cmode, doublereal *c__,
+                         integer *info, doublereal *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int dla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                                           integer *ldaf, logical *colequ, doublereal *c__, doublereal *b,
+                                           integer *ldb, doublereal *y, integer *ldy, doublereal *berr_out__,
+                                           integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
+                                           doublereal *res, doublereal *ayb, doublereal *dy, doublereal *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal dla_porpvgrw__(char *uplo, integer *ncols, doublereal *a,
+                          integer *lda, doublereal *af, integer *ldaf, doublereal *work,
+                          ftnlen uplo_len);
+
+doublereal dla_rpvgrw__(integer *n, integer *ncols, doublereal *a,
+                        integer *lda, doublereal *af, integer *ldaf);
+
+/* Subroutine */ int dla_syamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublereal *a, integer *lda, doublereal *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal dla_syrcond__(char *uplo, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
+                         doublereal *c__, integer *info, doublereal *work, integer *iwork,
+                         ftnlen uplo_len);
+
+/* Subroutine */ int dla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublereal *b, integer *ldb, doublereal *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
+                                           doublereal *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info, ftnlen uplo_len);
+
+doublereal dla_syrpvgrw__(char *uplo, integer *n, integer *info,
+                          doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int dla_wwaddw__(integer *n, doublereal *x, doublereal *y,
+                                  doublereal *w);
+
+/* Subroutine */ int dlabad_(doublereal *small, doublereal *large);
+
+/* Subroutine */ int dlabrd_(integer *m, integer *n, integer *nb,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *e,
+                             doublereal *tauq, doublereal *taup, doublereal *x, integer *ldx,
+                             doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlacn2_(integer *n, doublereal *v, doublereal *x,
+                             integer *isgn, doublereal *est, integer *kase, integer *isave);
+
+/* Subroutine */ int dlacon_(integer *n, doublereal *v, doublereal *x,
+                             integer *isgn, doublereal *est, integer *kase);
+
+/* Subroutine */ int dlacpy_(char *uplo, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb);
+
+/* Subroutine */ int dladiv_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *d__, doublereal *p, doublereal *q);
+
+/* Subroutine */ int dlae2_(doublereal *a, doublereal *b, doublereal *c__,
+                            doublereal *rt1, doublereal *rt2);
+
+/* Subroutine */ int dlaebz_(integer *ijob, integer *nitmax, integer *n,
+                             integer *mmax, integer *minp, integer *nbmin, doublereal *abstol,
+                             doublereal *reltol, doublereal *pivmin, doublereal *d__, doublereal *e,
+                             doublereal *e2, integer *nval, doublereal *ab, doublereal *c__,
+                             integer *mout, integer *nab, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlaed0_(integer *icompq, integer *qsiz, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *q, integer *ldq,
+                             doublereal *qstore, integer *ldqs, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlaed1_(integer *n, doublereal *d__, doublereal *q,
+                             integer *ldq, integer *indxq, doublereal *rho, integer *cutpnt,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlaed2_(integer *k, integer *n, integer *n1,
+                             doublereal *d__, doublereal *q, integer *ldq, integer *indxq,
+                             doublereal *rho, doublereal *z__, doublereal *dlamda, doublereal *w,
+                             doublereal *q2, integer *indx, integer *indxc, integer *indxp,
+                             integer *coltyp, integer *info);
+
+/* Subroutine */ int dlaed3_(integer *k, integer *n, integer *n1,
+                             doublereal *d__, doublereal *q, integer *ldq, doublereal *rho,
+                             doublereal *dlamda, doublereal *q2, integer *indx, integer *ctot,
+                             doublereal *w, doublereal *s, integer *info);
+
+/* Subroutine */ int dlaed4_(integer *n, integer *i__, doublereal *d__,
+                             doublereal *z__, doublereal *delta, doublereal *rho, doublereal *dlam,
+                             integer *info);
+
+/* Subroutine */ int dlaed5_(integer *i__, doublereal *d__, doublereal *z__,
+                             doublereal *delta, doublereal *rho, doublereal *dlam);
+
+/* Subroutine */ int dlaed6_(integer *kniter, logical *orgati,
+                             doublereal *rho, doublereal *d__, doublereal *z__, doublereal *finit,
+                             doublereal *tau, integer *info);
+
+/* Subroutine */ int dlaed7_(integer *icompq, integer *n, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
+                             doublereal *q, integer *ldq, integer *indxq, doublereal *rho,
+                             integer *cutpnt, doublereal *qstore, integer *qptr, integer *prmptr,
+                             integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlaed8_(integer *icompq, integer *k, integer *n,
+                             integer *qsiz, doublereal *d__, doublereal *q, integer *ldq,
+                             integer *indxq, doublereal *rho, integer *cutpnt, doublereal *z__,
+                             doublereal *dlamda, doublereal *q2, integer *ldq2, doublereal *w,
+                             integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
+                             integer *indxp, integer *indx, integer *info);
+
+/* Subroutine */ int dlaed9_(integer *k, integer *kstart, integer *kstop,
+                             integer *n, doublereal *d__, doublereal *q, integer *ldq,
+                             doublereal *rho, doublereal *dlamda, doublereal *w, doublereal *s,
+                             integer *lds, integer *info);
+
+/* Subroutine */ int dlaeda_(integer *n, integer *tlvls, integer *curlvl,
+                             integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, doublereal *givnum, doublereal *q, integer *qptr,
+                             doublereal *z__, doublereal *ztemp, integer *info);
+
+/* Subroutine */ int dlaein_(logical *rightv, logical *noinit, integer *n,
+                             doublereal *h__, integer *ldh, doublereal *wr, doublereal *wi,
+                             doublereal *vr, doublereal *vi, doublereal *b, integer *ldb,
+                             doublereal *work, doublereal *eps3, doublereal *smlnum,
+                             doublereal *bignum, integer *info);
+
+/* Subroutine */ int dlaev2_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *rt1, doublereal *rt2, doublereal *cs1, doublereal *sn1);
+
+/* Subroutine */ int dlaexc_(logical *wantq, integer *n, doublereal *t,
+                             integer *ldt, doublereal *q, integer *ldq, integer *j1, integer *n1,
+                             integer *n2, doublereal *work, integer *info);
+
+/* Subroutine */ int dlag2_(doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, doublereal *safmin, doublereal *scale1, doublereal *scale2,
+                            doublereal *wr1, doublereal *wr2, doublereal *wi);
+
+/* Subroutine */ int dlag2s_(integer *m, integer *n, doublereal *a,
+                             integer *lda, real *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int dlags2_(logical *upper, doublereal *a1, doublereal *a2,
+                             doublereal *a3, doublereal *b1, doublereal *b2, doublereal *b3,
+                             doublereal *csu, doublereal *snu, doublereal *csv, doublereal *snv,
+                             doublereal *csq, doublereal *snq);
+
+/* Subroutine */ int dlagtf_(integer *n, doublereal *a, doublereal *lambda,
+                             doublereal *b, doublereal *c__, doublereal *tol, doublereal *d__,
+                             integer *in, integer *info);
+
+/* Subroutine */ int dlagtm_(char *trans, integer *n, integer *nrhs,
+                             doublereal *alpha, doublereal *dl, doublereal *d__, doublereal *du,
+                             doublereal *x, integer *ldx, doublereal *beta, doublereal *b,
+                             integer *ldb);
+
+/* Subroutine */ int dlagts_(integer *job, integer *n, doublereal *a,
+                             doublereal *b, doublereal *c__, doublereal *d__, integer *in,
+                             doublereal *y, doublereal *tol, integer *info);
+
+/* Subroutine */ int dlagv2_(doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *csl, doublereal *snl, doublereal *csr, doublereal *snr);
+
+/* Subroutine */ int dlahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, integer *info);
+
+/* Subroutine */ int dlahr2_(integer *n, integer *k, integer *nb,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *t,
+                             integer *ldt, doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlahrd_(integer *n, integer *k, integer *nb,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *t,
+                             integer *ldt, doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlaic1_(integer *job, integer *j, doublereal *x,
+                             doublereal *sest, doublereal *w, doublereal *gamma, doublereal *sestpr,
+                             doublereal *s, doublereal *c__);
+
+logical dlaisnan_(doublereal *din1, doublereal *din2);
+
+/* Subroutine */ int dlaln2_(logical *ltrans, integer *na, integer *nw,
+                             doublereal *smin, doublereal *ca, doublereal *a, integer *lda,
+                             doublereal *d1, doublereal *d2, doublereal *b, integer *ldb,
+                             doublereal *wr, doublereal *wi, doublereal *x, integer *ldx,
+                             doublereal *scale, doublereal *xnorm, integer *info);
+
+/* Subroutine */ int dlals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, doublereal *givnum, integer *ldgnum, doublereal *poles,
+                             doublereal *difl, doublereal *difr, doublereal *z__, integer *k,
+                             doublereal *c__, doublereal *s, doublereal *work, integer *info);
+
+/* Subroutine */ int dlalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
+                             integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
+                             doublereal *difl, doublereal *difr, doublereal *z__, doublereal *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             doublereal *givnum, doublereal *c__, doublereal *s, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *d__, doublereal *e, doublereal *b,
+                             integer *ldb, doublereal *rcond, integer *rank, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlamrg_(integer *n1, integer *n2, doublereal *a,
+                             integer *dtrd1, integer *dtrd2, integer *index);
+
+integer dlaneg_(integer *n, doublereal *d__, doublereal *lld,
+                doublereal *sigma, doublereal *pivmin, integer *r__);
+
+doublereal dlangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlange_(char *norm, integer *m, integer *n, doublereal *a,
+                   integer *lda, doublereal *work);
+
+doublereal dlangt_(char *norm, integer *n, doublereal *dl, doublereal *d__,
+                   doublereal *du);
+
+doublereal dlanhs_(char *norm, integer *n, doublereal *a, integer *lda,
+                   doublereal *work);
+
+doublereal dlansb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlansf_(char *norm, char *transr, char *uplo, integer *n,
+                   doublereal *a, doublereal *work);
+
+doublereal dlansp_(char *norm, char *uplo, integer *n, doublereal *ap,
+                   doublereal *work);
+
+doublereal dlanst_(char *norm, integer *n, doublereal *d__, doublereal *e);
+
+doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a,
+                   integer *lda, doublereal *work);
+
+doublereal dlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlantp_(char *norm, char *uplo, char *diag, integer *n,
+                   doublereal *ap, doublereal *work);
+
+doublereal dlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   doublereal *a, integer *lda, doublereal *work);
+
+/* Subroutine */ int dlanv2_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *d__, doublereal *rt1r, doublereal *rt1i, doublereal *rt2r,
+                             doublereal *rt2i, doublereal *cs, doublereal *sn);
+
+/* Subroutine */ int dlapll_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *ssmin);
+
+/* Subroutine */ int dlapmt_(logical *forwrd, integer *m, integer *n,
+                             doublereal *x, integer *ldx, integer *k);
+
+doublereal dlapy2_(doublereal *x, doublereal *y);
+
+doublereal dlapy3_(doublereal *x, doublereal *y, doublereal *z__);
+
+/* Subroutine */ int dlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqge_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqp2_(integer *m, integer *n, integer *offset,
+                             doublereal *a, integer *lda, integer *jpvt, doublereal *tau,
+                             doublereal *vn1, doublereal *vn2, doublereal *work);
+
+/* Subroutine */ int dlaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, doublereal *a, integer *lda, integer *jpvt,
+                             doublereal *tau, doublereal *vn1, doublereal *vn2, doublereal *auxv,
+                             doublereal *f, integer *ldf);
+
+/* Subroutine */ int dlaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dlaqr1_(integer *n, doublereal *h__, integer *ldh,
+                             doublereal *sr1, doublereal *si1, doublereal *sr2, doublereal *si2,
+                             doublereal *v);
+
+/* Subroutine */ int dlaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
+                             integer *nd, doublereal *sr, doublereal *si, doublereal *v, integer *ldv,
+                             integer *nh, doublereal *t, integer *ldt, integer *nv, doublereal *wv,
+                             integer *ldwv, doublereal *work, integer *lwork);
+
+/* Subroutine */ int dlaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
+                             integer *nd, doublereal *sr, doublereal *si, doublereal *v, integer *ldv,
+                             integer *nh, doublereal *t, integer *ldt, integer *nv, doublereal *wv,
+                             integer *ldwv, doublereal *work, integer *lwork);
+
+/* Subroutine */ int dlaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, doublereal *sr,
+                             doublereal *si, doublereal *h__, integer *ldh, integer *iloz,
+                             integer *ihiz, doublereal *z__, integer *ldz, doublereal *v,
+                             integer *ldv, doublereal *u, integer *ldu, integer *nv, doublereal *wv,
+                             integer *ldwv, integer *nh, doublereal *wh, integer *ldwh);
+
+/* Subroutine */ int dlaqsb_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqsp_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqsy_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int dlaqtr_(logical *ltran, logical *lreal, integer *n,
+                             doublereal *t, integer *ldt, doublereal *b, doublereal *w,
+                             doublereal *scale, doublereal *x, doublereal *work, integer *info);
+
+/* Subroutine */ int dlar1v_(integer *n, integer *b1, integer *bn,
+                             doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
+                             doublereal *lld, doublereal *pivmin, doublereal *gaptol, doublereal *z__,
+                             logical *wantnc, integer *negcnt, doublereal *ztz, doublereal *mingma,
+                             integer *r__, integer *isuppz, doublereal *nrminv, doublereal *resid,
+                             doublereal *rqcorr, doublereal *work);
+
+/* Subroutine */ int dlar2v_(integer *n, doublereal *x, doublereal *y,
+                             doublereal *z__, integer *incx, doublereal *c__, doublereal *s,
+                             integer *incc);
+
+/* Subroutine */ int dlarf_(char *side, integer *m, integer *n, doublereal *v,
+                            integer *incv, doublereal *tau, doublereal *c__, integer *ldc,
+                            doublereal *work);
+
+/* Subroutine */ int dlarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, doublereal *v,
+                             integer *ldv, doublereal *t, integer *ldt, doublereal *c__, integer *ldc,
+                             doublereal *work, integer *ldwork);
+
+/* Subroutine */ int dlarfg_(integer *n, doublereal *alpha, doublereal *x,
+                             integer *incx, doublereal *tau);
+
+/* Subroutine */ int dlarfp_(integer *n, doublereal *alpha, doublereal *x,
+                             integer *incx, doublereal *tau);
+
+/* Subroutine */ int dlarft_(char *direct, char *storev, integer *n,
+                             integer *k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
+                             integer *ldt);
+
+/* Subroutine */ int dlarfx_(char *side, integer *m, integer *n,
+                             doublereal *v, doublereal *tau, doublereal *c__, integer *ldc,
+                             doublereal *work);
+
+/* Subroutine */ int dlargv_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *c__, integer *incc);
+
+/* Subroutine */ int dlarnv_(integer *idist, integer *iseed, integer *n,
+                             doublereal *x);
+
+/* Subroutine */ int dlarra_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *spltol, doublereal *tnrm, integer *nsplit,
+                             integer *isplit, integer *info);
+
+/* Subroutine */ int dlarrb_(integer *n, doublereal *d__, doublereal *lld,
+                             integer *ifirst, integer *ilast, doublereal *rtol1, doublereal *rtol2,
+                             integer *offset, doublereal *w, doublereal *wgap, doublereal *werr,
+                             doublereal *work, integer *iwork, doublereal *pivmin, doublereal *spdiam,
+                             integer *twist, integer *info);
+
+/* Subroutine */ int dlarrc_(char *jobt, integer *n, doublereal *vl,
+                             doublereal *vu, doublereal *d__, doublereal *e, doublereal *pivmin,
+                             integer *eigcnt, integer *lcnt, integer *rcnt, integer *info);
+
+/* Subroutine */ int dlarrd_(char *range, char *order, integer *n,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *gers, doublereal *reltol, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *pivmin, integer *nsplit, integer *isplit,
+                             integer *m, doublereal *w, doublereal *werr, doublereal *wl,
+                             doublereal *wu, integer *iblock, integer *indexw, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlarre_(char *range, integer *n, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *rtol1, doublereal *rtol2, doublereal *spltol,
+                             integer *nsplit, integer *isplit, integer *m, doublereal *w,
+                             doublereal *werr, doublereal *wgap, integer *iblock, integer *indexw,
+                             doublereal *gers, doublereal *pivmin, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlarrf_(integer *n, doublereal *d__, doublereal *l,
+                             doublereal *ld, integer *clstrt, integer *clend, doublereal *w,
+                             doublereal *wgap, doublereal *werr, doublereal *spdiam,
+                             doublereal *clgapl, doublereal *clgapr, doublereal *pivmin,
+                             doublereal *sigma, doublereal *dplus, doublereal *lplus, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlarrj_(integer *n, doublereal *d__, doublereal *e2,
+                             integer *ifirst, integer *ilast, doublereal *rtol, integer *offset,
+                             doublereal *w, doublereal *werr, doublereal *work, integer *iwork,
+                             doublereal *pivmin, doublereal *spdiam, integer *info);
+
+/* Subroutine */ int dlarrk_(integer *n, integer *iw, doublereal *gl,
+                             doublereal *gu, doublereal *d__, doublereal *e2, doublereal *pivmin,
+                             doublereal *reltol, doublereal *w, doublereal *werr, integer *info);
+
+/* Subroutine */ int dlarrr_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dlarrv_(integer *n, doublereal *vl, doublereal *vu,
+                             doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
+                             integer *m, integer *dol, integer *dou, doublereal *minrgp,
+                             doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
+                             doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlarscl2_(integer *m, integer *n, doublereal *d__,
+                               doublereal *x, integer *ldx);
+
+/* Subroutine */ int dlartg_(doublereal *f, doublereal *g, doublereal *cs,
+                             doublereal *sn, doublereal *r__);
+
+/* Subroutine */ int dlartv_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *c__, doublereal *s,
+                             integer *incc);
+
+/* Subroutine */ int dlaruv_(integer *iseed, integer *n, doublereal *x);
+
+/* Subroutine */ int dlarz_(char *side, integer *m, integer *n, integer *l,
+                            doublereal *v, integer *incv, doublereal *tau, doublereal *c__,
+                            integer *ldc, doublereal *work);
+
+/* Subroutine */ int dlarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l,
+                             doublereal *v, integer *ldv, doublereal *t, integer *ldt, doublereal *c__,
+                             integer *ldc, doublereal *work, integer *ldwork);
+
+/* Subroutine */ int dlarzt_(char *direct, char *storev, integer *n,
+                             integer *k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
+                             integer *ldt);
+
+/* Subroutine */ int dlas2_(doublereal *f, doublereal *g, doublereal *h__,
+                            doublereal *ssmin, doublereal *ssmax);
+
+/* Subroutine */ int dlascl_(char *type__, integer *kl, integer *ku,
+                             doublereal *cfrom, doublereal *cto, integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dlascl2_(integer *m, integer *n, doublereal *d__,
+                              doublereal *x, integer *ldx);
+
+/* Subroutine */ int dlasd0_(integer *n, integer *sqre, doublereal *d__,
+                             doublereal *e, doublereal *u, integer *ldu, doublereal *vt,
+                             integer *ldvt, integer *smlsiz, integer *iwork, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlasd1_(integer *nl, integer *nr, integer *sqre,
+                             doublereal *d__, doublereal *alpha, doublereal *beta, doublereal *u,
+                             integer *ldu, doublereal *vt, integer *ldvt, integer *idxq,
+                             integer *iwork, doublereal *work, integer *info);
+
+/* Subroutine */ int dlasd2_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, doublereal *d__, doublereal *z__, doublereal *alpha,
+                             doublereal *beta, doublereal *u, integer *ldu, doublereal *vt,
+                             integer *ldvt, doublereal *dsigma, doublereal *u2, integer *ldu2,
+                             doublereal *vt2, integer *ldvt2, integer *idxp, integer *idx,
+                             integer *idxc, integer *idxq, integer *coltyp, integer *info);
+
+/* Subroutine */ int dlasd3_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, doublereal *d__, doublereal *q, integer *ldq,
+                             doublereal *dsigma, doublereal *u, integer *ldu, doublereal *u2,
+                             integer *ldu2, doublereal *vt, integer *ldvt, doublereal *vt2,
+                             integer *ldvt2, integer *idxc, integer *ctot, doublereal *z__,
+                             integer *info);
+
+/* Subroutine */ int dlasd4_(integer *n, integer *i__, doublereal *d__,
+                             doublereal *z__, doublereal *delta, doublereal *rho, doublereal *sigma,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dlasd5_(integer *i__, doublereal *d__, doublereal *z__,
+                             doublereal *delta, doublereal *rho, doublereal *dsigma,
+                             doublereal *work);
+
+/* Subroutine */ int dlasd6_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, doublereal *d__, doublereal *vf, doublereal *vl,
+                             doublereal *alpha, doublereal *beta, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
+                             integer *ldgnum, doublereal *poles, doublereal *difl, doublereal *difr,
+                             doublereal *z__, integer *k, doublereal *c__, doublereal *s,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlasd7_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *k, doublereal *d__, doublereal *z__,
+                             doublereal *zw, doublereal *vf, doublereal *vfw, doublereal *vl,
+                             doublereal *vlw, doublereal *alpha, doublereal *beta, doublereal *dsigma,
+                             integer *idx, integer *idxp, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
+                             integer *ldgnum, doublereal *c__, doublereal *s, integer *info);
+
+/* Subroutine */ int dlasd8_(integer *icompq, integer *k, doublereal *d__,
+                             doublereal *z__, doublereal *vf, doublereal *vl, doublereal *difl,
+                             doublereal *difr, integer *lddifr, doublereal *dsigma, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlasda_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *sqre, doublereal *d__, doublereal *e, doublereal *u,
+                             integer *ldu, doublereal *vt, integer *k, doublereal *difl,
+                             doublereal *difr, doublereal *z__, doublereal *poles, integer *givptr,
+                             integer *givcol, integer *ldgcol, integer *perm, doublereal *givnum,
+                             doublereal *c__, doublereal *s, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlasdq_(char *uplo, integer *sqre, integer *n,
+                             integer *ncvt, integer *nru, integer *ncc, doublereal *d__,
+                             doublereal *e, doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dlasdt_(integer *n, integer *lvl, integer *nd,
+                             integer *inode, integer *ndiml, integer *ndimr, integer *msub);
+
+/* Subroutine */ int dlaset_(char *uplo, integer *m, integer *n,
+                             doublereal *alpha, doublereal *beta, doublereal *a, integer *lda);
+
+/* Subroutine */ int dlasq1_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dlasq2_(integer *n, doublereal *z__, integer *info);
+
+/* Subroutine */ int dlasq3_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *dmin__, doublereal *sigma, doublereal *desig,
+                             doublereal *qmax, integer *nfail, integer *iter, integer *ndiv,
+                             logical *ieee, integer *ttype, doublereal *dmin1, doublereal *dmin2,
+                             doublereal *dn, doublereal *dn1, doublereal *dn2, doublereal *g,
+                             doublereal *tau);
+
+/* Subroutine */ int dlasq4_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, integer *n0in, doublereal *dmin__, doublereal *dmin1,
+                             doublereal *dmin2, doublereal *dn, doublereal *dn1, doublereal *dn2,
+                             doublereal *tau, integer *ttype, doublereal *g);
+
+/* Subroutine */ int dlasq5_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *tau, doublereal *dmin__, doublereal *dmin1,
+                             doublereal *dmin2, doublereal *dn, doublereal *dnm1, doublereal *dnm2,
+                             logical *ieee);
+
+/* Subroutine */ int dlasq6_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *dmin__, doublereal *dmin1, doublereal *dmin2,
+                             doublereal *dn, doublereal *dnm1, doublereal *dnm2);
+
+/* Subroutine */ int dlasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, doublereal *c__, doublereal *s, doublereal *a, integer *lda);
+
+/* Subroutine */ int dlasrt_(char *id, integer *n, doublereal *d__,
+                             integer *info);
+
+/* Subroutine */ int dlassq_(integer *n, doublereal *x, integer *incx,
+                             doublereal *scale, doublereal *sumsq);
+
+/* Subroutine */ int dlasv2_(doublereal *f, doublereal *g, doublereal *h__,
+                             doublereal *ssmin, doublereal *ssmax, doublereal *snr, doublereal *csr,
+                             doublereal *snl, doublereal *csl);
+
+/* Subroutine */ int dlaswp_(integer *n, doublereal *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int dlasy2_(logical *ltranl, logical *ltranr, integer *isgn,
+                             integer *n1, integer *n2, doublereal *tl, integer *ldtl, doublereal *tr,
+                             integer *ldtr, doublereal *b, integer *ldb, doublereal *scale,
+                             doublereal *x, integer *ldx, doublereal *xnorm, integer *info);
+
+/* Subroutine */ int dlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *w, integer *ldw,
+                             integer *info);
+
+/* Subroutine */ int dlat2s_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, real *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int dlatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, doublereal *ab, integer *ldab,
+                             doublereal *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatdf_(integer *ijob, integer *n, doublereal *z__,
+                             integer *ldz, doublereal *rhs, doublereal *rdsum, doublereal *rdscal,
+                             integer *ipiv, integer *jpiv);
+
+/* Subroutine */ int dlatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublereal *ap, doublereal *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatrd_(char *uplo, integer *n, integer *nb,
+                             doublereal *a, integer *lda, doublereal *e, doublereal *tau,
+                             doublereal *w, integer *ldw);
+
+/* Subroutine */ int dlatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublereal *a, integer *lda, doublereal *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatrz_(integer *m, integer *n, integer *l,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work);
+
+/* Subroutine */ int dlatzm_(char *side, integer *m, integer *n,
+                             doublereal *v, integer *incv, doublereal *tau, doublereal *c1,
+                             doublereal *c2, integer *ldc, doublereal *work);
+
+/* Subroutine */ int dlauu2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dlauum_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dopgtr_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *tau, doublereal *q, integer *ldq, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dopmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublereal *ap, doublereal *tau, doublereal *c__,
+                             integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dorg2l_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorg2r_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorgbr_(char *vect, integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorghr_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgl2_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorglq_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgql_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgqr_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgr2_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorgrq_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgtr_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dorm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dorm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dorml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dpbcon_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *anorm, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpbequ_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, integer *info);
+
+/* Subroutine */ int dpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                             integer *ldafb, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dpbstf_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int dpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                             integer *ldafb, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpbtf2_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbtrf_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int dpftrf_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dpftri_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dpocon_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dpoequ_(integer *n, doublereal *a, integer *lda,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dpoequb_(integer *n, doublereal *a, integer *lda,
+                              doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dporfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, doublereal *s, doublereal *b, integer *ldb, doublereal *x,
+                              integer *ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int dposv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpotf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotri_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dppcon_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dppequ_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dpprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *afp, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dppsv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *ap, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *afp, char *equed,
+                             doublereal *s, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dpptrf_(char *uplo, integer *n, doublereal *ap,
+                             integer *info);
+
+/* Subroutine */ int dpptri_(char *uplo, integer *n, doublereal *ap,
+                             integer *info);
+
+/* Subroutine */ int dpptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dpstf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dpstrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dptcon_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *info);
+
+/* Subroutine */ int dpteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dptrfs_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *df, doublereal *ef, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *info);
+
+/* Subroutine */ int dptsv_(integer *n, integer *nrhs, doublereal *d__,
+                            doublereal *e, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dptsvx_(char *fact, integer *n, integer *nrhs,
+                             doublereal *d__, doublereal *e, doublereal *df, doublereal *ef,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dpttrf_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dpttrs_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dptts2_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *b, integer *ldb);
+
+/* Subroutine */ int drscl_(integer *n, doublereal *sa, doublereal *sx,
+                            integer *incx);
+
+/* Subroutine */ int dsbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
+                            integer *ldz, doublereal *work, integer *info);
+
+/* Subroutine */ int dsbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dsbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, doublereal *ab, integer *ldab, doublereal *q, integer *ldq,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int dsbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *x, integer *ldx, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dsbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                            integer *ldbb, doublereal *w, doublereal *z__, integer *ldz,
+                            doublereal *work, integer *info);
+
+/* Subroutine */ int dsbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *w, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dsbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *q, integer *ldq, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
+                             doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *d__, doublereal *e,
+                             doublereal *q, integer *ldq, doublereal *work, integer *info);
+
+/* Subroutine */ int dsfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *beta, doublereal *c__);
+
+/* Subroutine */ int dsgesv_(integer *n, integer *nrhs, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *work, real *swork, integer *iter,
+                             integer *info);
+
+/* Subroutine */ int dspcon_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dspev_(char *jobz, char *uplo, integer *n,
+                            doublereal *ap, doublereal *w, doublereal *z__, integer *ldz,
+                            doublereal *work, integer *info);
+
+/* Subroutine */ int dspevd_(char *jobz, char *uplo, integer *n,
+                             doublereal *ap, doublereal *w, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dspevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *ap, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int dspgst_(integer *itype, char *uplo, integer *n,
+                             doublereal *ap, doublereal *bp, integer *info);
+
+/* Subroutine */ int dspgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublereal *ap, doublereal *bp, doublereal *w,
+                            doublereal *z__, integer *ldz, doublereal *work, integer *info);
+
+/* Subroutine */ int dspgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublereal *ap, doublereal *bp, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dspgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublereal *ap, doublereal *bp, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
+                             doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsposv_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *work, real *swork, integer *iter,
+                             integer *info);
+
+/* Subroutine */ int dsprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *afp, integer *ipiv, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dspsv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int dspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *afp, integer *ipiv,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dsptrd_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *d__, doublereal *e, doublereal *tau, integer *info);
+
+/* Subroutine */ int dsptrf_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int dsptri_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, doublereal *work, integer *info);
+
+/* Subroutine */ int dsptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dstebz_(char *range, char *order, integer *n,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, doublereal *d__, doublereal *e, integer *m,
+                             integer *nsplit, doublereal *w, integer *iblock, integer *isplit,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dstedc_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstegr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstein_(integer *n, doublereal *d__, doublereal *e,
+                             integer *m, doublereal *w, integer *iblock, integer *isplit,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dstemr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dsteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dsterf_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dstev_(char *jobz, integer *n, doublereal *d__,
+                            doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                            integer *info);
+
+/* Subroutine */ int dstevd_(char *jobz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstevr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstevx_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dsycon_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dsyequb_(char *uplo, integer *n, doublereal *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublereal *work, integer *info);
+
+/* Subroutine */ int dsyev_(char *jobz, char *uplo, integer *n, doublereal *a,
+                            integer *lda, doublereal *w, doublereal *work, integer *lwork,
+                            integer *info);
+
+/* Subroutine */ int dsyevd_(char *jobz, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *w, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dsyevr_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dsyevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsygs2_(integer *itype, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dsygst_(integer *itype, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dsygv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *w, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsygvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *w, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dsygvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dsyrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dsyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dsysv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                            doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int dsysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s, doublereal *b,
+                              integer *ldb, doublereal *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int dsytd2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tau,
+                             integer *info);
+
+/* Subroutine */ int dsytf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dsytrd_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tau,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsytrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dsytri_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *work, integer *info);
+
+/* Subroutine */ int dsytrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, doublereal *ab, integer *ldab, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int dtfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, doublereal *alpha, doublereal *a,
+                            doublereal *b, integer *ldb);
+
+/* Subroutine */ int dtftri_(char *transr, char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dtfttp_(char *transr, char *uplo, integer *n,
+                             doublereal *arf, doublereal *ap, integer *info);
+
+/* Subroutine */ int dtfttr_(char *transr, char *uplo, integer *n,
+                             doublereal *arf, doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtgevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublereal *s, integer *lds, doublereal *p, integer *ldp,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr, integer *mm,
+                             integer *m, doublereal *work, integer *info);
+
+/* Subroutine */ int dtgex2_(logical *wantq, logical *wantz, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *q,
+                             integer *ldq, doublereal *z__, integer *ldz, integer *j1, integer *n1,
+                             integer *n2, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dtgexc_(logical *wantq, logical *wantz, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *q,
+                             integer *ldq, doublereal *z__, integer *ldz, integer *ifst, integer *ilst,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dtgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *q, integer *ldq, doublereal *z__, integer *ldz, integer *m,
+                             doublereal *pl, doublereal *pr, doublereal *dif, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dtgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, doublereal *tola,
+                             doublereal *tolb, doublereal *alpha, doublereal *beta, doublereal *u,
+                             integer *ldu, doublereal *v, integer *ldv, doublereal *q, integer *ldq,
+                             doublereal *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int dtgsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                             doublereal *s, doublereal *dif, integer *mm, integer *m,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int dtgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
+                             doublereal *e, integer *lde, doublereal *f, integer *ldf,
+                             doublereal *scale, doublereal *rdsum, doublereal *rdscal, integer *iwork,
+                             integer *pq, integer *info);
+
+/* Subroutine */ int dtgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
+                             doublereal *e, integer *lde, doublereal *f, integer *ldf,
+                             doublereal *scale, doublereal *dif, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublereal *ap, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dtprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtptri_(char *uplo, char *diag, integer *n,
+                             doublereal *ap, integer *info);
+
+/* Subroutine */ int dtptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtpttf_(char *transr, char *uplo, integer *n,
+                             doublereal *ap, doublereal *arf, integer *info);
+
+/* Subroutine */ int dtpttr_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtrevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dtrexc_(char *compq, integer *n, doublereal *t,
+                             integer *ldt, doublereal *q, integer *ldq, integer *ifst, integer *ilst,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dtrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtrsen_(char *job, char *compq, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *q, integer *ldq,
+                             doublereal *wr, doublereal *wi, integer *m, doublereal *s,
+                             doublereal *sep, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dtrsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, doublereal *s, doublereal *sep,
+                             integer *mm, integer *m, doublereal *work, integer *ldwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *c__, integer *ldc, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int dtrti2_(char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrtri_(char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtrttf_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *arf, integer *info);
+
+/* Subroutine */ int dtrttp_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *ap, integer *info);
+
+/* Subroutine */ int dtzrqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, integer *info);
+
+/* Subroutine */ int dtzrzf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+doublereal dzsum1_(integer *n, doublecomplex *cx, integer *incx);
+
+integer icmax1_(integer *n, complex *cx, integer *incx);
+
+integer ieeeck_(integer *ispec, real *zero, real *one);
+
+integer ilaclc_(integer *m, integer *n, complex *a, integer *lda);
+
+integer ilaclr_(integer *m, integer *n, complex *a, integer *lda);
+
+integer iladiag_(char *diag);
+
+integer iladlc_(integer *m, integer *n, doublereal *a, integer *lda);
+
+integer iladlr_(integer *m, integer *n, doublereal *a, integer *lda);
+
+integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
+                integer *n2, integer *n3, integer *n4);
+
+integer ilaprec_(char *prec);
+
+integer ilaslc_(integer *m, integer *n, real *a, integer *lda);
+
+integer ilaslr_(integer *m, integer *n, real *a, integer *lda);
+
+integer ilatrans_(char *trans);
+
+integer ilauplo_(char *uplo);
+
+/* Subroutine */ int ilaver_(integer *vers_major__, integer *vers_minor__,
+                             integer *vers_patch__);
+
+integer ilazlc_(integer *m, integer *n, doublecomplex *a, integer *lda);
+
+integer ilazlr_(integer *m, integer *n, doublecomplex *a, integer *lda);
+
+integer iparmq_(integer *ispec, char *name__, char *opts, integer *n,
+                integer *ilo, integer *ihi, integer *lwork);
+
+integer izmax1_(integer *n, doublecomplex *cx, integer *incx);
+
+logical lsamen_(integer *n, char *ca, char *cb);
+
+integer smaxloc_(real *a, integer *dimm);
+
+/* Subroutine */ int sbdsdc_(char *uplo, char *compq, integer *n, real *d__,
+                             real *e, real *u, integer *ldu, real *vt, integer *ldvt, real *q,
+                             integer *iq, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, real *d__, real *e, real *vt, integer *ldvt,
+                             real *u, integer *ldu, real *c__, integer *ldc, real *work,
+                             integer *info);
+
+doublereal scsum1_(integer *n, complex *cx, integer *incx);
+
+/* Subroutine */ int sdisna_(char *job, integer *m, integer *n, real *d__,
+                             real *sep, integer *info);
+
+/* Subroutine */ int sgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, real *ab, integer *ldab, real *d__, real *e,
+                             real *q, integer *ldq, real *pt, integer *ldpt, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, integer *info);
+
+/* Subroutine */ int sgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                              real *colcnd, real *amax, integer *info);
+
+/* Subroutine */ int sgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
+                             integer *ldafb, integer *ipiv, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
+                              real *afb, integer *ldafb, integer *ipiv, real *r__, real *c__, real *b,
+                              integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, real *ab, integer *ldab, integer *ipiv, real *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int sgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
+                             integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__, real *b,
+                             integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
+                              real *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
+                              real *c__, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
+                              real *rpvgrw, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, real *work,
+                              integer *iwork, integer *info);
+
+/* Subroutine */ int sgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, integer *ipiv,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *scale, integer *m, real *v, integer *ldv,
+                             integer *info);
+
+/* Subroutine */ int sgebal_(char *job, integer *n, real *a, integer *lda,
+                             integer *ilo, integer *ihi, real *scale, integer *info);
+
+/* Subroutine */ int sgebd2_(integer *m, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tauq, real *taup, real *work, integer *info);
+
+/* Subroutine */ int sgebrd_(integer *m, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tauq, real *taup, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int sgecon_(char *norm, integer *n, real *a, integer *lda,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgeequ_(integer *m, integer *n, real *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             integer *info);
+
+/* Subroutine */ int sgeequb_(integer *m, integer *n, real *a, integer *lda,
+                              real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                              integer *info);
+
+/* Subroutine */ int sgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            real *a, integer *lda, integer *sdim, real *wr, real *wi, real *vs,
+                            integer *ldvs, real *work, integer *lwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int sgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, real *a, integer *lda, integer *sdim, real *wr,
+                             real *wi, real *vs, integer *ldvs, real *rconde, real *rcondv,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int sgeev_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *wr, real *wi, real *vl, integer *ldvl, real *vr,
+                            integer *ldvr, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, real *a, integer *lda, real *wr, real *wi,
+                             real *vl, integer *ldvl, real *vr, integer *ldvr, integer *ilo,
+                             integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgegs_(char *jobvsl, char *jobvsr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vsl, integer *ldvsl, real *vsr, integer *ldvsr,
+                            real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgegv_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sgehd2_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgehrd_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
+                             char *jobt, char *jobp, integer *m, integer *n, real *a, integer *lda,
+                             real *sva, real *u, integer *ldu, real *v, integer *ldv, real *work,
+                             integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgelq2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgelqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sgelsd_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, real *s, real *rcond, integer *rank,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgelss_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, real *s, real *rcond, integer *rank,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgelsx_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
+                             integer *rank, real *work, integer *info);
+
+/* Subroutine */ int sgelsy_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
+                             integer *rank, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeql2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqlf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeqp3_(integer *m, integer *n, real *a, integer *lda,
+                             integer *jpvt, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeqpf_(integer *m, integer *n, real *a, integer *lda,
+                             integer *jpvt, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqr2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqrf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgerfs_(char *trans, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, real *r__, real *c__, real *b, integer *ldb, real *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgerq2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgerqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesc2_(integer *n, real *a, integer *lda, real *rhs,
+                             integer *ipiv, integer *jpiv, real *scale);
+
+/* Subroutine */ int sgesdd_(char *jobz, integer *m, integer *n, real *a,
+                             integer *lda, real *s, real *u, integer *ldu, real *vt, integer *ldvt,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgesv_(integer *n, integer *nrhs, real *a, integer *lda,
+                            integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             real *a, integer *lda, real *s, real *u, integer *ldu, real *vt,
+                             integer *ldvt, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesvj_(char *joba, char *jobu, char *jobv, integer *m,
+                             integer *n, real *a, integer *lda, real *sva, integer *mv, real *v,
+                             integer *ldv, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
+                             real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
+                              real *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sgetc2_(integer *n, real *a, integer *lda, integer *ipiv,
+                             integer *jpiv, integer *info);
+
+/* Subroutine */ int sgetf2_(integer *m, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int sgetrf_(integer *m, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int sgetri_(integer *n, real *a, integer *lda, integer *ipiv,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgetrs_(char *trans, integer *n, integer *nrhs, real *a,
+                             integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *lscale, real *rscale, integer *m, real *v,
+                             integer *ldv, integer *info);
+
+/* Subroutine */ int sggbal_(char *job, integer *n, real *a, integer *lda,
+                             real *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *work, integer *info);
+
+/* Subroutine */ int sgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                            integer *sdim, real *alphar, real *alphai, real *beta, real *vsl,
+                            integer *ldvsl, real *vsr, integer *ldvsr, real *work, integer *lwork,
+                            logical *bwork, integer *info);
+
+/* Subroutine */ int sggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, real *a, integer *lda, real *b,
+                             integer *ldb, integer *sdim, real *alphar, real *alphai, real *beta,
+                             real *vsl, integer *ldvsl, real *vsr, integer *ldvsr, real *rconde,
+                             real *rcondv, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, logical *bwork, integer *info);
+
+/* Subroutine */ int sggev_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *alphar, real *alphai, real *beta, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, real *lscale, real *rscale,
+                             real *abnrm, real *bbnrm, real *rconde, real *rcondv, real *work,
+                             integer *lwork, integer *iwork, logical *bwork, integer *info);
+
+/* Subroutine */ int sggglm_(integer *n, integer *m, integer *p, real *a,
+                             integer *lda, real *b, integer *ldb, real *d__, real *x, real *y,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, real *a, integer *lda, real *b, integer *ldb,
+                             real *q, integer *ldq, real *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int sgglse_(integer *m, integer *n, integer *p, real *a,
+                             integer *lda, real *b, integer *ldb, real *c__, real *d__, real *x,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sggqrf_(integer *n, integer *m, integer *p, real *a,
+                             integer *lda, real *taua, real *b, integer *ldb, real *taub, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sggrqf_(integer *m, integer *p, integer *n, real *a,
+                             integer *lda, real *taua, real *b, integer *ldb, real *taub, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, real *a, integer *lda,
+                             real *b, integer *ldb, real *alpha, real *beta, real *u, integer *ldu,
+                             real *v, integer *ldv, real *q, integer *ldq, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *tola, real *tolb, integer *k, integer *l, real *u, integer *ldu,
+                             real *v, integer *ldv, real *q, integer *ldq, integer *iwork, real *tau,
+                             real *work, integer *info);
+
+/* Subroutine */ int sgsvj0_(char *jobv, integer *m, integer *n, real *a,
+                             integer *lda, real *d__, real *sva, integer *mv, real *v, integer *ldv,
+                             real *eps, real *sfmin, real *tol, integer *nsweep, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
+                             real *a, integer *lda, real *d__, real *sva, integer *mv, real *v,
+                             integer *ldv, real *eps, real *sfmin, real *tol, integer *nsweep,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgtcon_(char *norm, integer *n, real *dl, real *d__,
+                             real *du, real *du2, integer *ipiv, real *anorm, real *rcond, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgtrfs_(char *trans, integer *n, integer *nrhs, real *dl,
+                             real *d__, real *du, real *dlf, real *df, real *duf, real *du2,
+                             integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
+                             real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgtsv_(integer *n, integer *nrhs, real *dl, real *d__,
+                            real *du, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, real *dl, real *d__, real *du, real *dlf, real *df,
+                             real *duf, real *du2, integer *ipiv, real *b, integer *ldb, real *x,
+                             integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgttrf_(integer *n, real *dl, real *d__, real *du,
+                             real *du2, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgttrs_(char *trans, integer *n, integer *nrhs, real *dl,
+                             real *d__, real *du, real *du2, integer *ipiv, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int sgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             real *dl, real *d__, real *du, real *du2, integer *ipiv, real *b,
+                             integer *ldb);
+
+/* Subroutine */ int shgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *t,
+                             integer *ldt, real *alphar, real *alphai, real *beta, real *q,
+                             integer *ldq, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int shsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, real *h__, integer *ldh, real *wr, real *wi,
+                             real *vl, integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
+                             real *work, integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int shseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, real *h__, integer *ldh, real *wr, real *wi, real *z__,
+                             integer *ldz, real *work, integer *lwork, integer *info);
+
+logical sisnan_(real *sin__);
+
+/* Subroutine */ int sla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, real *alpha, real *ab, integer *ldab, real *x,
+                                 integer *incx, real *beta, real *y, integer *incy);
+
+doublereal sla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
+                         real *ab, integer *ldab, real *afb, integer *ldafb, integer *ipiv,
+                         integer *cmode, real *c__, integer *info, real *work, integer *iwork,
+                         ftnlen trans_len);
+
+/* Subroutine */ int sla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                                           integer *ipiv, logical *colequ, real *c__, real *b, integer *ldb, real *y,
+                                           integer *ldy, real *berr_out__, integer *n_norms__, real *errs_n__,
+                                           real *errs_c__, real *res, real *ayb, real *dy, real *y_tail__,
+                                           real *rcond, integer *ithresh, real *rthresh, real *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+doublereal sla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, real *ab, integer *ldab, real *afb, integer *ldafb);
+
+/* Subroutine */ int sla_geamv__(integer *trans, integer *m, integer *n,
+                                 real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta,
+                                 real *y, integer *incy);
+
+doublereal sla_gercond__(char *trans, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
+                         integer *info, real *work, integer *iwork, ftnlen trans_len);
+
+/* Subroutine */ int sla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, real *a, integer *lda,
+                                           real *af, integer *ldaf, integer *ipiv, logical *colequ, real *c__,
+                                           real *b, integer *ldb, real *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
+                                           real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info);
+
+/* Subroutine */ int sla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    real *res, real *ayb, real *berr);
+
+doublereal sla_porcond__(char *uplo, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *cmode, real *c__, integer *info,
+                         real *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int sla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, real *a, integer *lda, real *af,
+                                           integer *ldaf, logical *colequ, real *c__, real *b, integer *ldb,
+                                           real *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, real *res, real *ayb, real *dy,
+                                           real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal sla_porpvgrw__(char *uplo, integer *ncols, real *a, integer *lda,
+                          real *af, integer *ldaf, real *work, ftnlen uplo_len);
+
+doublereal sla_rpvgrw__(integer *n, integer *ncols, real *a, integer *lda,
+                        real *af, integer *ldaf);
+
+/* Subroutine */ int sla_syamv__(integer *uplo, integer *n, real *alpha,
+                                 real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
+
+doublereal sla_syrcond__(char *uplo, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
+                         integer *info, real *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int sla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, real *a, integer *lda, real *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, real *b,
+                                           integer *ldb, real *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
+                                           real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal sla_syrpvgrw__(char *uplo, integer *n, integer *info, real *a,
+                          integer *lda, real *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
+
+/* Subroutine */ int sla_wwaddw__(integer *n, real *x, real *y, real *w);
+
+/* Subroutine */ int slabad_(real *small, real *large);
+
+/* Subroutine */ int slabrd_(integer *m, integer *n, integer *nb, real *a,
+                             integer *lda, real *d__, real *e, real *tauq, real *taup, real *x,
+                             integer *ldx, real *y, integer *ldy);
+
+/* Subroutine */ int slacn2_(integer *n, real *v, real *x, integer *isgn,
+                             real *est, integer *kase, integer *isave);
+
+/* Subroutine */ int slacon_(integer *n, real *v, real *x, integer *isgn,
+                             real *est, integer *kase);
+
+/* Subroutine */ int slacpy_(char *uplo, integer *m, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb);
+
+/* Subroutine */ int sladiv_(real *a, real *b, real *c__, real *d__, real *p,
+                             real *q);
+
+/* Subroutine */ int slae2_(real *a, real *b, real *c__, real *rt1, real *rt2);
+
+/* Subroutine */ int slaebz_(integer *ijob, integer *nitmax, integer *n,
+                             integer *mmax, integer *minp, integer *nbmin, real *abstol, real *reltol,
+                             real *pivmin, real *d__, real *e, real *e2, integer *nval, real *ab,
+                             real *c__, integer *mout, integer *nab, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slaed0_(integer *icompq, integer *qsiz, integer *n,
+                             real *d__, real *e, real *q, integer *ldq, real *qstore, integer *ldqs,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slaed1_(integer *n, real *d__, real *q, integer *ldq,
+                             integer *indxq, real *rho, integer *cutpnt, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slaed2_(integer *k, integer *n, integer *n1, real *d__,
+                             real *q, integer *ldq, integer *indxq, real *rho, real *z__,
+                             real *dlamda, real *w, real *q2, integer *indx, integer *indxc,
+                             integer *indxp, integer *coltyp, integer *info);
+
+/* Subroutine */ int slaed3_(integer *k, integer *n, integer *n1, real *d__,
+                             real *q, integer *ldq, real *rho, real *dlamda, real *q2, integer *indx,
+                             integer *ctot, real *w, real *s, integer *info);
+
+/* Subroutine */ int slaed4_(integer *n, integer *i__, real *d__, real *z__,
+                             real *delta, real *rho, real *dlam, integer *info);
+
+/* Subroutine */ int slaed5_(integer *i__, real *d__, real *z__, real *delta,
+                             real *rho, real *dlam);
+
+/* Subroutine */ int slaed6_(integer *kniter, logical *orgati, real *rho,
+                             real *d__, real *z__, real *finit, real *tau, integer *info);
+
+/* Subroutine */ int slaed7_(integer *icompq, integer *n, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, real *d__, real *q,
+                             integer *ldq, integer *indxq, real *rho, integer *cutpnt, real *qstore,
+                             integer *qptr, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, real *givnum, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slaed8_(integer *icompq, integer *k, integer *n,
+                             integer *qsiz, real *d__, real *q, integer *ldq, integer *indxq,
+                             real *rho, integer *cutpnt, real *z__, real *dlamda, real *q2,
+                             integer *ldq2, real *w, integer *perm, integer *givptr, integer *givcol,
+                             real *givnum, integer *indxp, integer *indx, integer *info);
+
+/* Subroutine */ int slaed9_(integer *k, integer *kstart, integer *kstop,
+                             integer *n, real *d__, real *q, integer *ldq, real *rho, real *dlamda,
+                             real *w, real *s, integer *lds, integer *info);
+
+/* Subroutine */ int slaeda_(integer *n, integer *tlvls, integer *curlvl,
+                             integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, real *givnum, real *q, integer *qptr, real *z__,
+                             real *ztemp, integer *info);
+
+/* Subroutine */ int slaein_(logical *rightv, logical *noinit, integer *n,
+                             real *h__, integer *ldh, real *wr, real *wi, real *vr, real *vi, real *b,
+                             integer *ldb, real *work, real *eps3, real *smlnum, real *bignum,
+                             integer *info);
+
+/* Subroutine */ int slaev2_(real *a, real *b, real *c__, real *rt1,
+                             real *rt2, real *cs1, real *sn1);
+
+/* Subroutine */ int slaexc_(logical *wantq, integer *n, real *t,
+                             integer *ldt, real *q, integer *ldq, integer *j1, integer *n1,
+                             integer *n2, real *work, integer *info);
+
+/* Subroutine */ int slag2_(real *a, integer *lda, real *b, integer *ldb,
+                            real *safmin, real *scale1, real *scale2, real *wr1, real *wr2,
+                            real *wi);
+
+/* Subroutine */ int slag2d_(integer *m, integer *n, real *sa, integer *ldsa,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int slags2_(logical *upper, real *a1, real *a2, real *a3,
+                             real *b1, real *b2, real *b3, real *csu, real *snu, real *csv, real *snv,
+                             real *csq, real *snq);
+
+/* Subroutine */ int slagtf_(integer *n, real *a, real *lambda, real *b,
+                             real *c__, real *tol, real *d__, integer *in, integer *info);
+
+/* Subroutine */ int slagtm_(char *trans, integer *n, integer *nrhs,
+                             real *alpha, real *dl, real *d__, real *du, real *x, integer *ldx,
+                             real *beta, real *b, integer *ldb);
+
+/* Subroutine */ int slagts_(integer *job, integer *n, real *a, real *b,
+                             real *c__, real *d__, integer *in, real *y, real *tol, integer *info);
+
+/* Subroutine */ int slagv2_(real *a, integer *lda, real *b, integer *ldb,
+                             real *alphar, real *alphai, real *beta, real *csl, real *snl, real *csr,
+                             real *snr);
+
+/* Subroutine */ int slahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int slahr2_(integer *n, integer *k, integer *nb, real *a,
+                             integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
+
+/* Subroutine */ int slahrd_(integer *n, integer *k, integer *nb, real *a,
+                             integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
+
+/* Subroutine */ int slaic1_(integer *job, integer *j, real *x, real *sest,
+                             real *w, real *gamma, real *sestpr, real *s, real *c__);
+
+logical slaisnan_(real *sin1, real *sin2);
+
+/* Subroutine */ int slaln2_(logical *ltrans, integer *na, integer *nw,
+                             real *smin, real *ca, real *a, integer *lda, real *d1, real *d2, real *b,
+                             integer *ldb, real *wr, real *wi, real *x, integer *ldx, real *scale,
+                             real *xnorm, integer *info);
+
+/* Subroutine */ int slals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, real *b, integer *ldb, real *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *work,
+                             integer *info);
+
+/* Subroutine */ int slalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, real *b, integer *ldb, real *bx, integer *ldbx, real *u,
+                             integer *ldu, real *vt, integer *k, real *difl, real *difr, real *z__,
+                             real *poles, integer *givptr, integer *givcol, integer *ldgcol,
+                             integer *perm, real *givnum, real *c__, real *s, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int slalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, real *d__, real *e, real *b, integer *ldb, real *rcond,
+                             integer *rank, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slamrg_(integer *n1, integer *n2, real *a,
+                             integer *strd1, integer *strd2, integer *index);
+
+integer slaneg_(integer *n, real *d__, real *lld, real *sigma, real *pivmin,
+                integer *r__);
+
+doublereal slangb_(char *norm, integer *n, integer *kl, integer *ku, real *ab,
+                   integer *ldab, real *work);
+
+doublereal slange_(char *norm, integer *m, integer *n, real *a, integer *lda,
+                   real *work);
+
+doublereal slangt_(char *norm, integer *n, real *dl, real *d__, real *du);
+
+doublereal slanhs_(char *norm, integer *n, real *a, integer *lda, real *work);
+
+doublereal slansb_(char *norm, char *uplo, integer *n, integer *k, real *ab,
+                   integer *ldab, real *work);
+
+doublereal slansf_(char *norm, char *transr, char *uplo, integer *n, real *a,
+                   real *work);
+
+doublereal slansp_(char *norm, char *uplo, integer *n, real *ap, real *work);
+
+doublereal slanst_(char *norm, integer *n, real *d__, real *e);
+
+doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
+                   real *work);
+
+doublereal slantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   real *ab, integer *ldab, real *work);
+
+doublereal slantp_(char *norm, char *uplo, char *diag, integer *n, real *ap,
+                   real *work);
+
+doublereal slantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   real *a, integer *lda, real *work);
+
+/* Subroutine */ int slanv2_(real *a, real *b, real *c__, real *d__,
+                             real *rt1r, real *rt1i, real *rt2r, real *rt2i, real *cs, real *sn);
+
+/* Subroutine */ int slapll_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *ssmin);
+
+/* Subroutine */ int slapmt_(logical *forwrd, integer *m, integer *n, real *x,
+                             integer *ldx, integer *k);
+
+doublereal slapy2_(real *x, real *y);
+
+doublereal slapy3_(real *x, real *y, real *z__);
+
+/* Subroutine */ int slaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, char *equed);
+
+/* Subroutine */ int slaqge_(integer *m, integer *n, real *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             char *equed);
+
+/* Subroutine */ int slaqp2_(integer *m, integer *n, integer *offset, real *a,
+                             integer *lda, integer *jpvt, real *tau, real *vn1, real *vn2,
+                             real *work);
+
+/* Subroutine */ int slaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, real *a, integer *lda, integer *jpvt, real *tau,
+                             real *vn1, real *vn2, real *auxv, real *f, integer *ldf);
+
+/* Subroutine */ int slaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int slaqr1_(integer *n, real *h__, integer *ldh, real *sr1,
+                             real *si1, real *sr2, real *si2, real *v);
+
+/* Subroutine */ int slaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
+                             integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
+                             real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real *work,
+                             integer *lwork);
+
+/* Subroutine */ int slaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
+                             integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
+                             real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real *work,
+                             integer *lwork);
+
+/* Subroutine */ int slaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int slaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, real *sr,
+                             real *si, real *h__, integer *ldh, integer *iloz, integer *ihiz,
+                             real *z__, integer *ldz, real *v, integer *ldv, real *u, integer *ldu,
+                             integer *nv, real *wv, integer *ldwv, integer *nh, real *wh,
+                             integer *ldwh);
+
+/* Subroutine */ int slaqsb_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqsp_(char *uplo, integer *n, real *ap, real *s,
+                             real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqsy_(char *uplo, integer *n, real *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqtr_(logical *ltran, logical *lreal, integer *n,
+                             real *t, integer *ldt, real *b, real *w, real *scale, real *x, real *work,
+                             integer *info);
+
+/* Subroutine */ int slar1v_(integer *n, integer *b1, integer *bn,
+                             real *lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
+                             real *gaptol, real *z__, logical *wantnc, integer *negcnt, real *ztz,
+                             real *mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
+                             real *rqcorr, real *work);
+
+/* Subroutine */ int slar2v_(integer *n, real *x, real *y, real *z__,
+                             integer *incx, real *c__, real *s, integer *incc);
+
+/* Subroutine */ int slarf_(char *side, integer *m, integer *n, real *v,
+                            integer *incv, real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, real *v, integer *ldv,
+                             real *t, integer *ldt, real *c__, integer *ldc, real *work,
+                             integer *ldwork);
+
+/* Subroutine */ int slarfg_(integer *n, real *alpha, real *x, integer *incx,
+                             real *tau);
+
+/* Subroutine */ int slarfp_(integer *n, real *alpha, real *x, integer *incx,
+                             real *tau);
+
+/* Subroutine */ int slarft_(char *direct, char *storev, integer *n,
+                             integer *k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
+
+/* Subroutine */ int slarfx_(char *side, integer *m, integer *n, real *v,
+                             real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slargv_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *c__, integer *incc);
+
+/* Subroutine */ int slarnv_(integer *idist, integer *iseed, integer *n,
+                             real *x);
+
+/* Subroutine */ int slarra_(integer *n, real *d__, real *e, real *e2,
+                             real *spltol, real *tnrm, integer *nsplit, integer *isplit,
+                             integer *info);
+
+/* Subroutine */ int slarrb_(integer *n, real *d__, real *lld,
+                             integer *ifirst, integer *ilast, real *rtol1, real *rtol2,
+                             integer *offset, real *w, real *wgap, real *werr, real *work,
+                             integer *iwork, real *pivmin, real *spdiam, integer *twist,
+                             integer *info);
+
+/* Subroutine */ int slarrc_(char *jobt, integer *n, real *vl, real *vu,
+                             real *d__, real *e, real *pivmin, integer *eigcnt, integer *lcnt,
+                             integer *rcnt, integer *info);
+
+/* Subroutine */ int slarrd_(char *range, char *order, integer *n, real *vl,
+                             real *vu, integer *il, integer *iu, real *gers, real *reltol, real *d__,
+                             real *e, real *e2, real *pivmin, integer *nsplit, integer *isplit,
+                             integer *m, real *w, real *werr, real *wl, real *wu, integer *iblock,
+                             integer *indexw, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slarre_(char *range, integer *n, real *vl, real *vu,
+                             integer *il, integer *iu, real *d__, real *e, real *e2, real *rtol1,
+                             real *rtol2, real *spltol, integer *nsplit, integer *isplit, integer *m,
+                             real *w, real *werr, real *wgap, integer *iblock, integer *indexw,
+                             real *gers, real *pivmin, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slarrf_(integer *n, real *d__, real *l, real *ld,
+                             integer *clstrt, integer *clend, real *w, real *wgap, real *werr,
+                             real *spdiam, real *clgapl, real *clgapr, real *pivmin, real *sigma,
+                             real *dplus, real *lplus, real *work, integer *info);
+
+/* Subroutine */ int slarrj_(integer *n, real *d__, real *e2, integer *ifirst,
+                             integer *ilast, real *rtol, integer *offset, real *w, real *werr,
+                             real *work, integer *iwork, real *pivmin, real *spdiam, integer *info);
+
+/* Subroutine */ int slarrk_(integer *n, integer *iw, real *gl, real *gu,
+                             real *d__, real *e2, real *pivmin, real *reltol, real *w, real *werr,
+                             integer *info);
+
+/* Subroutine */ int slarrr_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int slarrv_(integer *n, real *vl, real *vu, real *d__,
+                             real *l, real *pivmin, integer *isplit, integer *m, integer *dol,
+                             integer *dou, real *minrgp, real *rtol1, real *rtol2, real *w,
+                             real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
+                             real *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slarscl2_(integer *m, integer *n, real *d__, real *x,
+                               integer *ldx);
+
+/* Subroutine */ int slartg_(real *f, real *g, real *cs, real *sn, real *r__);
+
+/* Subroutine */ int slartv_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *c__, real *s, integer *incc);
+
+/* Subroutine */ int slaruv_(integer *iseed, integer *n, real *x);
+
+/* Subroutine */ int slarz_(char *side, integer *m, integer *n, integer *l,
+                            real *v, integer *incv, real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l, real *v,
+                             integer *ldv, real *t, integer *ldt, real *c__, integer *ldc, real *work,
+                             integer *ldwork);
+
+/* Subroutine */ int slarzt_(char *direct, char *storev, integer *n,
+                             integer *k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
+
+/* Subroutine */ int slas2_(real *f, real *g, real *h__, real *ssmin,
+                            real *ssmax);
+
+/* Subroutine */ int slascl_(char *type__, integer *kl, integer *ku,
+                             real *cfrom, real *cto, integer *m, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int slascl2_(integer *m, integer *n, real *d__, real *x,
+                              integer *ldx);
+
+/* Subroutine */ int slasd0_(integer *n, integer *sqre, real *d__, real *e,
+                             real *u, integer *ldu, real *vt, integer *ldvt, integer *smlsiz,
+                             integer *iwork, real *work, integer *info);
+
+/* Subroutine */ int slasd1_(integer *nl, integer *nr, integer *sqre,
+                             real *d__, real *alpha, real *beta, real *u, integer *ldu, real *vt,
+                             integer *ldvt, integer *idxq, integer *iwork, real *work, integer *info);
+
+/* Subroutine */ int slasd2_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, real *d__, real *z__, real *alpha, real *beta, real *u,
+                             integer *ldu, real *vt, integer *ldvt, real *dsigma, real *u2,
+                             integer *ldu2, real *vt2, integer *ldvt2, integer *idxp, integer *idx,
+                             integer *idxc, integer *idxq, integer *coltyp, integer *info);
+
+/* Subroutine */ int slasd3_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, real *d__, real *q, integer *ldq, real *dsigma, real *u,
+                             integer *ldu, real *u2, integer *ldu2, real *vt, integer *ldvt,
+                             real *vt2, integer *ldvt2, integer *idxc, integer *ctot, real *z__,
+                             integer *info);
+
+/* Subroutine */ int slasd4_(integer *n, integer *i__, real *d__, real *z__,
+                             real *delta, real *rho, real *sigma, real *work, integer *info);
+
+/* Subroutine */ int slasd5_(integer *i__, real *d__, real *z__, real *delta,
+                             real *rho, real *dsigma, real *work);
+
+/* Subroutine */ int slasd6_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, real *d__, real *vf, real *vl, real *alpha, real *beta,
+                             integer *idxq, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int slasd7_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *k, real *d__, real *z__, real *zw, real *vf,
+                             real *vfw, real *vl, real *vlw, real *alpha, real *beta, real *dsigma,
+                             integer *idx, integer *idxp, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, real *givnum,
+                             integer *ldgnum, real *c__, real *s, integer *info);
+
+/* Subroutine */ int slasd8_(integer *icompq, integer *k, real *d__,
+                             real *z__, real *vf, real *vl, real *difl, real *difr, integer *lddifr,
+                             real *dsigma, real *work, integer *info);
+
+/* Subroutine */ int slasda_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *sqre, real *d__, real *e, real *u, integer *ldu, real *vt,
+                             integer *k, real *difl, real *difr, real *z__, real *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             real *givnum, real *c__, real *s, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slasdq_(char *uplo, integer *sqre, integer *n,
+                             integer *ncvt, integer *nru, integer *ncc, real *d__, real *e, real *vt,
+                             integer *ldvt, real *u, integer *ldu, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int slasdt_(integer *n, integer *lvl, integer *nd,
+                             integer *inode, integer *ndiml, integer *ndimr, integer *msub);
+
+/* Subroutine */ int slaset_(char *uplo, integer *m, integer *n, real *alpha,
+                             real *beta, real *a, integer *lda);
+
+/* Subroutine */ int slasq1_(integer *n, real *d__, real *e, real *work,
+                             integer *info);
+
+/* Subroutine */ int slasq2_(integer *n, real *z__, integer *info);
+
+/* Subroutine */ int slasq3_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *dmin__, real *sigma, real *desig, real *qmax, integer *nfail,
+                             integer *iter, integer *ndiv, logical *ieee, integer *ttype, real *dmin1,
+                             real *dmin2, real *dn, real *dn1, real *dn2, real *g, real *tau);
+
+/* Subroutine */ int slasq4_(integer *i0, integer *n0, real *z__, integer *pp,
+                             integer *n0in, real *dmin__, real *dmin1, real *dmin2, real *dn,
+                             real *dn1, real *dn2, real *tau, integer *ttype, real *g);
+
+/* Subroutine */ int slasq5_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *tau, real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
+                             real *dnm2, logical *ieee);
+
+/* Subroutine */ int slasq6_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
+                             real *dnm2);
+
+/* Subroutine */ int slasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, real *c__, real *s, real *a, integer *lda);
+
+/* Subroutine */ int slasrt_(char *id, integer *n, real *d__, integer *info);
+
+/* Subroutine */ int slassq_(integer *n, real *x, integer *incx, real *scale,
+                             real *sumsq);
+
+/* Subroutine */ int slasv2_(real *f, real *g, real *h__, real *ssmin,
+                             real *ssmax, real *snr, real *csr, real *snl, real *csl);
+
+/* Subroutine */ int slaswp_(integer *n, real *a, integer *lda, integer *k1,
+                             integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int slasy2_(logical *ltranl, logical *ltranr, integer *isgn,
+                             integer *n1, integer *n2, real *tl, integer *ldtl, real *tr,
+                             integer *ldtr, real *b, integer *ldb, real *scale, real *x, integer *ldx,
+                             real *xnorm, integer *info);
+
+/* Subroutine */ int slasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             real *a, integer *lda, integer *ipiv, real *w, integer *ldw,
+                             integer *info);
+
+/* Subroutine */ int slatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, real *ab, integer *ldab, real *x,
+                             real *scale, real *cnorm, integer *info);
+
+/* Subroutine */ int slatdf_(integer *ijob, integer *n, real *z__,
+                             integer *ldz, real *rhs, real *rdsum, real *rdscal, integer *ipiv,
+                             integer *jpiv);
+
+/* Subroutine */ int slatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, real *ap, real *x, real *scale, real *cnorm,
+                             integer *info);
+
+/* Subroutine */ int slatrd_(char *uplo, integer *n, integer *nb, real *a,
+                             integer *lda, real *e, real *tau, real *w, integer *ldw);
+
+/* Subroutine */ int slatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, real *a, integer *lda, real *x, real *scale,
+                             real *cnorm, integer *info);
+
+/* Subroutine */ int slatrz_(integer *m, integer *n, integer *l, real *a,
+                             integer *lda, real *tau, real *work);
+
+/* Subroutine */ int slatzm_(char *side, integer *m, integer *n, real *v,
+                             integer *incv, real *tau, real *c1, real *c2, integer *ldc, real *work);
+
+/* Subroutine */ int slauu2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int slauum_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int sopgtr_(char *uplo, integer *n, real *ap, real *tau,
+                             real *q, integer *ldq, real *work, integer *info);
+
+/* Subroutine */ int sopmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, real *ap, real *tau, real *c__, integer *ldc, real *work,
+                             integer *info);
+
+/* Subroutine */ int sorg2l_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorg2r_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorgbr_(char *vect, integer *m, integer *n, integer *k,
+                             real *a, integer *lda, real *tau, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int sorghr_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgl2_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorglq_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgql_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgqr_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgr2_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorgrq_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgtr_(char *uplo, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sorm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *info);
+
+/* Subroutine */ int sormrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int spbcon_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *anorm, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int spbequ_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *s, real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                             real *b, integer *ldb, real *x, integer *ldx, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spbstf_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, real *ab, integer *ldab, real *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int spbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                             char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int spbtf2_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbtrf_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int spftrf_(char *transr, char *uplo, integer *n, real *a,
+                             integer *info);
+
+/* Subroutine */ int spftri_(char *transr, char *uplo, integer *n, real *a,
+                             integer *info);
+
+/* Subroutine */ int spftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, real *a, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int spocon_(char *uplo, integer *n, real *a, integer *lda,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spoequ_(integer *n, real *a, integer *lda, real *s,
+                             real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spoequb_(integer *n, real *a, integer *lda, real *s,
+                              real *scond, real *amax, integer *info);
+
+/* Subroutine */ int sporfs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf, real *s,
+                              real *b, integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sposv_(char *uplo, integer *n, integer *nrhs, real *a,
+                            integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spotf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotri_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotrs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sppcon_(char *uplo, integer *n, real *ap, real *anorm,
+                             real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sppequ_(char *uplo, integer *n, real *ap, real *s,
+                             real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *afp, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
+                             real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sppsv_(char *uplo, integer *n, integer *nrhs, real *ap,
+                            real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *ap, real *afp, char *equed, real *s, real *b,
+                             integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spptrf_(char *uplo, integer *n, real *ap, integer *info);
+
+/* Subroutine */ int spptri_(char *uplo, integer *n, real *ap, integer *info);
+
+/* Subroutine */ int spptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int spstf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
+
+/* Subroutine */ int spstrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
+
+/* Subroutine */ int sptcon_(integer *n, real *d__, real *e, real *anorm,
+                             real *rcond, real *work, integer *info);
+
+/* Subroutine */ int spteqr_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sptrfs_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *info);
+
+/* Subroutine */ int sptsv_(integer *n, integer *nrhs, real *d__, real *e,
+                            real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
+                             real *e, real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *info);
+
+/* Subroutine */ int spttrf_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int spttrs_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sptts2_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *b, integer *ldb);
+
+/* Subroutine */ int srscl_(integer *n, real *sa, real *sx, integer *incx);
+
+/* Subroutine */ int ssbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
+                            integer *info);
+
+/* Subroutine */ int ssbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int ssbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, real *ab, integer *ldab, real *q, integer *ldq, real *vl,
+                             real *vu, integer *il, integer *iu, real *abstol, integer *m, real *w,
+                             real *z__, integer *ldz, real *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int ssbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *x,
+                             integer *ldx, real *work, integer *info);
+
+/* Subroutine */ int ssbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *w,
+                            real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int ssbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *w,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, real *ab, integer *ldab, real *bb,
+                             integer *ldbb, real *q, integer *ldq, real *vl, real *vu, integer *il,
+                             integer *iu, real *abstol, integer *m, real *w, real *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             real *ab, integer *ldab, real *d__, real *e, real *q, integer *ldq,
+                             real *work, integer *info);
+
+/* Subroutine */ int ssfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, real *alpha, real *a, integer *lda, real *beta, real *c__);
+
+/* Subroutine */ int sspcon_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sspev_(char *jobz, char *uplo, integer *n, real *ap,
+                            real *w, real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sspevd_(char *jobz, char *uplo, integer *n, real *ap,
+                             real *w, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int sspevx_(char *jobz, char *range, char *uplo, integer *n,
+                             real *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, real *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int sspgst_(integer *itype, char *uplo, integer *n, real *ap,
+                             real *bp, integer *info);
+
+/* Subroutine */ int sspgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, real *ap, real *bp, real *w, real *z__, integer *ldz,
+                            real *work, integer *info);
+
+/* Subroutine */ int sspgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, real *ap, real *bp, real *w, real *z__, integer *ldz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sspgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, real *ap, real *bp, real *vl, real *vu,
+                             integer *il, integer *iu, real *abstol, integer *m, real *w, real *z__,
+                             integer *ldz, real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *afp, integer *ipiv, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sspsv_(char *uplo, integer *n, integer *nrhs, real *ap,
+                            integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *ap, real *afp, integer *ipiv, real *b, integer *ldb,
+                             real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int ssptrd_(char *uplo, integer *n, real *ap, real *d__,
+                             real *e, real *tau, integer *info);
+
+/* Subroutine */ int ssptrf_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             integer *info);
+
+/* Subroutine */ int ssptri_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             real *work, integer *info);
+
+/* Subroutine */ int ssptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sstebz_(char *range, char *order, integer *n, real *vl,
+                             real *vu, integer *il, integer *iu, real *abstol, real *d__, real *e,
+                             integer *m, integer *nsplit, real *w, integer *iblock, integer *isplit,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sstedc_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int sstegr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sstein_(integer *n, real *d__, real *e, integer *m,
+                             real *w, integer *iblock, integer *isplit, real *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int sstemr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
+                             real *w, real *z__, integer *ldz, integer *nzc, integer *isuppz,
+                             logical *tryrac, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssteqr_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int ssterf_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int sstev_(char *jobz, integer *n, real *d__, real *e,
+                            real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sstevd_(char *jobz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int sstevr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sstevx_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, real *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int ssycon_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int ssyequb_(char *uplo, integer *n, real *a, integer *lda,
+                              real *s, real *scond, real *amax, real *work, integer *info);
+
+/* Subroutine */ int ssyev_(char *jobz, char *uplo, integer *n, real *a,
+                            integer *lda, real *w, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssyevd_(char *jobz, char *uplo, integer *n, real *a,
+                             integer *lda, real *w, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssyevr_(char *jobz, char *range, char *uplo, integer *n,
+                             real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, real *z__, integer *ldz,
+                             integer *isuppz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssyevx_(char *jobz, char *range, char *uplo, integer *n,
+                             real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssygs2_(integer *itype, char *uplo, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ssygst_(integer *itype, char *uplo, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ssygv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, real *a, integer *lda, real *b, integer *ldb, real *w,
+                            real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssygvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *w,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int ssygvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
+                             real *w, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssyrfs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int ssyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                              real *rcond, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, real *work,
+                              integer *iwork, integer *info);
+
+/* Subroutine */ int ssysv_(char *uplo, integer *n, integer *nrhs, real *a,
+                            integer *lda, integer *ipiv, real *b, integer *ldb, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int ssysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, real *work, integer *lwork, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int ssysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, real *b, integer *ldb, real *x,
+                              integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int ssytd2_(char *uplo, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tau, integer *info);
+
+/* Subroutine */ int ssytf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int ssytrd_(char *uplo, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tau, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int ssytrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssytri_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *work, integer *info);
+
+/* Subroutine */ int ssytrs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int stbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, real *ab, integer *ldab, real *rcond, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int stfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, real *alpha, real *a, real *b,
+                            integer *ldb);
+
+/* Subroutine */ int stftri_(char *transr, char *uplo, char *diag, integer *n,
+                             real *a, integer *info);
+
+/* Subroutine */ int stfttp_(char *transr, char *uplo, integer *n, real *arf,
+                             real *ap, integer *info);
+
+/* Subroutine */ int stfttr_(char *transr, char *uplo, integer *n, real *arf,
+                             real *a, integer *lda, integer *info);
+
+/* Subroutine */ int stgevc_(char *side, char *howmny, logical *select,
+                             integer *n, real *s, integer *lds, real *p, integer *ldp, real *vl,
+                             integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
+                             real *work, integer *info);
+
+/* Subroutine */ int stgex2_(logical *wantq, logical *wantz, integer *n,
+                             real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
+                             real *z__, integer *ldz, integer *j1, integer *n1, integer *n2,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int stgexc_(logical *wantq, logical *wantz, integer *n,
+                             real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
+                             real *z__, integer *ldz, integer *ifst, integer *ilst, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int stgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, real *a, integer *lda, real *b,
+                             integer *ldb, real *alphar, real *alphai, real *beta, real *q,
+                             integer *ldq, real *z__, integer *ldz, integer *m, real *pl, real *pr,
+                             real *dif, real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int stgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, real *a, integer *lda,
+                             real *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
+                             real *u, integer *ldu, real *v, integer *ldv, real *q, integer *ldq,
+                             real *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int stgsna_(char *job, char *howmny, logical *select,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *vl,
+                             integer *ldvl, real *vr, integer *ldvr, real *s, real *dif, integer *mm,
+                             integer *m, real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int stgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *c__,
+                             integer *ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
+                             integer *ldf, real *scale, real *rdsum, real *rdscal, integer *iwork,
+                             integer *pq, integer *info);
+
+/* Subroutine */ int stgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *c__,
+                             integer *ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
+                             integer *ldf, real *scale, real *dif, real *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             real *ap, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int stprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *ap, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int stptri_(char *uplo, char *diag, integer *n, real *ap,
+                             integer *info);
+
+/* Subroutine */ int stptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *ap, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int stpttf_(char *transr, char *uplo, integer *n, real *ap,
+                             real *arf, integer *info);
+
+/* Subroutine */ int stpttr_(char *uplo, integer *n, real *ap, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strcon_(char *norm, char *uplo, char *diag, integer *n,
+                             real *a, integer *lda, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int strevc_(char *side, char *howmny, logical *select,
+                             integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, integer *mm, integer *m, real *work, integer *info);
+
+/* Subroutine */ int strexc_(char *compq, integer *n, real *t, integer *ldt,
+                             real *q, integer *ldq, integer *ifst, integer *ilst, real *work,
+                             integer *info);
+
+/* Subroutine */ int strrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int strsen_(char *job, char *compq, logical *select,
+                             integer *n, real *t, integer *ldt, real *q, integer *ldq, real *wr,
+                             real *wi, integer *m, real *s, real *sep, real *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int strsna_(char *job, char *howmny, logical *select,
+                             integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, real *s, real *sep, integer *mm, integer *m, real *work,
+                             integer *ldwork, integer *iwork, integer *info);
+
+/* Subroutine */ int strsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *c__, integer *ldc, real *scale, integer *info);
+
+/* Subroutine */ int strti2_(char *uplo, char *diag, integer *n, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strtri_(char *uplo, char *diag, integer *n, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int strttf_(char *transr, char *uplo, integer *n, real *a,
+                             integer *lda, real *arf, integer *info);
+
+/* Subroutine */ int strttp_(char *uplo, integer *n, real *a, integer *lda,
+                             real *ap, integer *info);
+
+/* Subroutine */ int stzrqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, integer *info);
+
+/* Subroutine */ int stzrzf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int xerbla_(char *srname, integer *info);
+
+/* Subroutine */ int xerbla_array__(char *srname_array__,
+                                    integer *srname_len__, integer *info, ftnlen srname_array_len);
+
+/* Subroutine */ int zbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, doublereal *d__, doublereal *e,
+                             doublecomplex *vt, integer *ldvt, doublecomplex *u, integer *ldu,
+                             doublecomplex *c__, integer *ldc, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zcgesv_(integer *n, integer *nrhs, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
+                             doublereal *rwork, integer *iter, integer *info);
+
+/* Subroutine */ int zcposv_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
+                             doublereal *rwork, integer *iter, integer *info);
+
+/* Subroutine */ int zdrscl_(integer *n, doublereal *sa, doublecomplex *sx,
+                             integer *incx);
+
+/* Subroutine */ int zgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, doublecomplex *ab, integer *ldab,
+                             doublereal *d__, doublereal *e, doublecomplex *q, integer *ldq,
+                             doublecomplex *pt, integer *ldpt, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, doublereal *anorm,
+                             doublereal *rcond, doublecomplex *work, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, doublecomplex *ab, integer *ldab, doublereal *r__,
+                              doublereal *c__, doublereal *rowcnd, doublereal *colcnd,
+                              doublereal *amax, integer *info);
+
+/* Subroutine */ int zgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *afb, integer *ldafb, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublecomplex *ab,
+                              integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
+                              doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
+                              doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, doublecomplex *ab, integer *ldab, integer *ipiv,
+                            doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *afb, integer *ldafb, integer *ipiv, char *equed,
+                             doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublecomplex *ab,
+                              integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
+                              char *equed, doublereal *r__, doublereal *c__, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             integer *ipiv, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *scale, integer *m, doublecomplex *v,
+                             integer *ldv, integer *info);
+
+/* Subroutine */ int zgebal_(char *job, integer *n, doublecomplex *a,
+                             integer *lda, integer *ilo, integer *ihi, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int zgebd2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
+                             doublecomplex *taup, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgebrd_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
+                             doublecomplex *taup, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgecon_(char *norm, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeequ_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgeequb_(integer *m, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                              doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            doublecomplex *a, integer *lda, integer *sdim, doublecomplex *w,
+                            doublecomplex *vs, integer *ldvs, doublecomplex *work, integer *lwork,
+                            doublereal *rwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, doublecomplex *a, integer *lda, integer *sdim,
+                             doublecomplex *w, doublecomplex *vs, integer *ldvs, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zgeev_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *w, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
+                             doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vsl,
+                            integer *ldvsl, doublecomplex *vsr, integer *ldvsr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgegv_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgehd2_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zgehrd_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zgelq2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgelqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgelsd_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zgelss_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgelsx_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgelsy_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeql2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgeqlf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgeqp3_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeqpf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeqr2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgeqrf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgerfs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgerq2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgerqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgesc2_(integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
+
+/* Subroutine */ int zgesdd_(char *jobz, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
+                             integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zgesv_(integer *n, integer *nrhs, doublecomplex *a,
+                            integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
+                             integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                             doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                              doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
+                              integer *ldx, doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgetc2_(integer *n, doublecomplex *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
+
+/* Subroutine */ int zgetf2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgetrf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgetri_(integer *n, doublecomplex *a, integer *lda,
+                             integer *ipiv, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgetrs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
+                             doublecomplex *v, integer *ldv, integer *info);
+
+/* Subroutine */ int zggbal_(char *job, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, integer *ilo, integer *ihi,
+                             doublereal *lscale, doublereal *rscale, doublereal *work, integer *info);
+
+/* Subroutine */ int zgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, integer *sdim, doublecomplex *alpha, doublecomplex *beta,
+                            doublecomplex *vsl, integer *ldvsl, doublecomplex *vsr, integer *ldvsr,
+                            doublecomplex *work, integer *lwork, doublereal *rwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int zggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, integer *sdim, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *vsl, integer *ldvsl,
+                             doublecomplex *vsr, integer *ldvsr, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, integer *liwork, logical *bwork,
+                             integer *info);
+
+/* Subroutine */ int zggev_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *alpha, doublecomplex *beta,
+                             doublecomplex *vl, integer *ldvl, doublecomplex *vr, integer *ldvr,
+                             integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
+                             doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zggglm_(integer *n, integer *m, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *d__, doublecomplex *x, doublecomplex *y,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *q, integer *ldq,
+                             doublecomplex *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int zgglse_(integer *m, integer *n, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *c__, doublecomplex *d__, doublecomplex *x,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zggqrf_(integer *n, integer *m, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
+                             integer *ldb, doublecomplex *taub, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zggrqf_(integer *m, integer *p, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
+                             integer *ldb, doublecomplex *taub, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublereal *alpha,
+                             doublereal *beta, doublecomplex *u, integer *ldu, doublecomplex *v,
+                             integer *ldv, doublecomplex *q, integer *ldq, doublecomplex *work,
+                             doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
+                             doublecomplex *u, integer *ldu, doublecomplex *v, integer *ldv,
+                             doublecomplex *q, integer *ldq, integer *iwork, doublereal *rwork,
+                             doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgtcon_(char *norm, integer *n, doublecomplex *dl,
+                             doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
+                             doublereal *anorm, doublereal *rcond, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgtrfs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgtsv_(integer *n, integer *nrhs, doublecomplex *dl,
+                            doublecomplex *d__, doublecomplex *du, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgttrf_(integer *n, doublecomplex *dl,
+                             doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
+                             integer *info);
+
+/* Subroutine */ int zgttrs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zhbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
+                            integer *ldz, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, doublecomplex *ab, integer *ldab, doublecomplex *q,
+                             integer *ldq, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                             integer *ldbb, doublecomplex *x, integer *ldx, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                            integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
+                            doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                             integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, doublecomplex *ab, integer *ldab,
+                             doublecomplex *bb, integer *ldbb, doublecomplex *q, integer *ldq,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *d__, doublereal *e,
+                             doublecomplex *q, integer *ldq, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhecon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, integer *info);
+
+/* Subroutine */ int zheequb_(char *uplo, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublecomplex *work, integer *info);
+
+/* Subroutine */ int zheev_(char *jobz, char *uplo, integer *n,
+                            doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zheevd_(char *jobz, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zheevr_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zheevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zhegs2_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhegst_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhegv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
+                            doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhegvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zhegvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zherfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zherfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhesv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zhesvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zhesvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhetd2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
+                             integer *info);
+
+/* Subroutine */ int zhetf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zhetrd_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zhetrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zhetri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhetrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zhfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, doublereal *alpha, doublecomplex *a, integer *lda,
+                            doublereal *beta, doublecomplex *c__);
+
+/* Subroutine */ int zhgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *t, integer *ldt, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zhpcon_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zhpev_(char *jobz, char *uplo, integer *n,
+                            doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
+                            doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhpevd_(char *jobz, char *uplo, integer *n,
+                             doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhpevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *ap, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zhpgst_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *ap, doublecomplex *bp, integer *info);
+
+/* Subroutine */ int zhpgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
+                            doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
+                            integer *info);
+
+/* Subroutine */ int zhpgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zhpgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublecomplex *ap, doublecomplex *bp,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhpsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zhpsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhptrd_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *d__, doublereal *e, doublecomplex *tau, integer *info);
+
+/* Subroutine */ int zhptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int zhptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *mm, integer *m, doublecomplex *work,
+                             doublereal *rwork, integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int zhseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, doublecomplex *h__, integer *ldh, doublecomplex *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, doublereal *alpha, doublecomplex *ab,
+                                 integer *ldab, doublecomplex *x, integer *incx, doublereal *beta,
+                                 doublereal *y, integer *incy);
+
+doublereal zla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
+                           doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
+                           integer *ipiv, doublereal *c__, logical *capply, integer *info,
+                           doublecomplex *work, doublereal *rwork, ftnlen trans_len);
+
+doublereal zla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
+                           doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
+                           integer *ipiv, doublecomplex *x, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen trans_len);
+
+/* Subroutine */ int zla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                                           integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
+                                           doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+doublereal zla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                          integer *ldafb);
+
+/* Subroutine */ int zla_geamv__(integer *trans, integer *m, integer *n,
+                                 doublereal *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                                 integer *incx, doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_gercond_c__(char *trans, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen trans_len);
+
+doublereal zla_gercond_x__(char *trans, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen trans_len);
+
+/* Subroutine */ int zla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, doublecomplex *a,
+                                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                                           logical *colequ, doublereal *c__, doublecomplex *b, integer *ldb,
+                                           doublecomplex *y, integer *ldy, doublereal *berr_out__,
+                                           integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
+                                           doublecomplex *res, doublereal *ayb, doublecomplex *dy,
+                                           doublecomplex *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
+
+/* Subroutine */ int zla_heamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_hercond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen uplo_len);
+
+doublereal zla_hercond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+/* Subroutine */ int zla_herfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
+                                           integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublecomplex *res,
+                                           doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal zla_herpvgrw__(char *uplo, integer *n, integer *info,
+                          doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int zla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    doublecomplex *res, doublereal *ayb, doublereal *berr);
+
+doublereal zla_porcond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, doublereal *c__,
+                           logical *capply, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+doublereal zla_porcond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, doublecomplex *x,
+                           integer *info, doublecomplex *work, doublereal *rwork, ftnlen uplo_len);
+
+/* Subroutine */ int zla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, logical *colequ, doublereal *c__,
+                                           doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
+                                           doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal zla_porpvgrw__(char *uplo, integer *ncols, doublecomplex *a,
+                          integer *lda, doublecomplex *af, integer *ldaf, doublereal *work,
+                          ftnlen uplo_len);
+
+doublereal zla_rpvgrw__(integer *n, integer *ncols, doublecomplex *a,
+                        integer *lda, doublecomplex *af, integer *ldaf);
+
+/* Subroutine */ int zla_syamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_syrcond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen uplo_len);
+
+doublereal zla_syrcond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+/* Subroutine */ int zla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
+                                           integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublecomplex *res,
+                                           doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal zla_syrpvgrw__(char *uplo, integer *n, integer *info,
+                          doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int zla_wwaddw__(integer *n, doublecomplex *x,
+                                  doublecomplex *y, doublecomplex *w);
+
+/* Subroutine */ int zlabrd_(integer *m, integer *n, integer *nb,
+                             doublecomplex *a, integer *lda, doublereal *d__, doublereal *e,
+                             doublecomplex *tauq, doublecomplex *taup, doublecomplex *x, integer *ldx,
+                             doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlacgv_(integer *n, doublecomplex *x, integer *incx);
+
+/* Subroutine */ int zlacn2_(integer *n, doublecomplex *v, doublecomplex *x,
+                             doublereal *est, integer *kase, integer *isave);
+
+/* Subroutine */ int zlacon_(integer *n, doublecomplex *v, doublecomplex *x,
+                             doublereal *est, integer *kase);
+
+/* Subroutine */ int zlacp2_(char *uplo, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlacpy_(char *uplo, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlacrm_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *b, integer *ldb, doublecomplex *c__,
+                             integer *ldc, doublereal *rwork);
+
+/* Subroutine */ int zlacrt_(integer *n, doublecomplex *cx, integer *incx,
+                             doublecomplex *cy, integer *incy, doublecomplex *c__, doublecomplex *s);
+
+/* Double Complex */ VOID zladiv_(doublecomplex *ret_val, doublecomplex *x,
+                                  doublecomplex *y);
+
+/* Subroutine */ int zlaed0_(integer *qsiz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *q, integer *ldq, doublecomplex *qstore,
+                             integer *ldqs, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zlaed7_(integer *n, integer *cutpnt, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
+                             doublecomplex *q, integer *ldq, doublereal *rho, integer *indxq,
+                             doublereal *qstore, integer *qptr, integer *prmptr, integer *perm,
+                             integer *givptr, integer *givcol, doublereal *givnum,
+                             doublecomplex *work, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zlaed8_(integer *k, integer *n, integer *qsiz,
+                             doublecomplex *q, integer *ldq, doublereal *d__, doublereal *rho,
+                             integer *cutpnt, doublereal *z__, doublereal *dlamda, doublecomplex *q2,
+                             integer *ldq2, doublereal *w, integer *indxp, integer *indx,
+                             integer *indxq, integer *perm, integer *givptr, integer *givcol,
+                             doublereal *givnum, integer *info);
+
+/* Subroutine */ int zlaein_(logical *rightv, logical *noinit, integer *n,
+                             doublecomplex *h__, integer *ldh, doublecomplex *w, doublecomplex *v,
+                             doublecomplex *b, integer *ldb, doublereal *rwork, doublereal *eps3,
+                             doublereal *smlnum, integer *info);
+
+/* Subroutine */ int zlaesy_(doublecomplex *a, doublecomplex *b,
+                             doublecomplex *c__, doublecomplex *rt1, doublecomplex *rt2,
+                             doublecomplex *evscal, doublecomplex *cs1, doublecomplex *sn1);
+
+/* Subroutine */ int zlaev2_(doublecomplex *a, doublecomplex *b,
+                             doublecomplex *c__, doublereal *rt1, doublereal *rt2, doublereal *cs1,
+                             doublecomplex *sn1);
+
+/* Subroutine */ int zlag2c_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, complex *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int zlags2_(logical *upper, doublereal *a1,
+                             doublecomplex *a2, doublereal *a3, doublereal *b1, doublecomplex *b2,
+                             doublereal *b3, doublereal *csu, doublecomplex *snu, doublereal *csv,
+                             doublecomplex *snv, doublereal *csq, doublecomplex *snq);
+
+/* Subroutine */ int zlagtm_(char *trans, integer *n, integer *nrhs,
+                             doublereal *alpha, doublecomplex *dl, doublecomplex *d__,
+                             doublecomplex *du, doublecomplex *x, integer *ldx, doublereal *beta,
+                             doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlahef_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
+                             integer *ldw, integer *info);
+
+/* Subroutine */ int zlahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *info);
+
+/* Subroutine */ int zlahr2_(integer *n, integer *k, integer *nb,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
+                             integer *ldt, doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlahrd_(integer *n, integer *k, integer *nb,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
+                             integer *ldt, doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlaic1_(integer *job, integer *j, doublecomplex *x,
+                             doublereal *sest, doublecomplex *w, doublecomplex *gamma,
+                             doublereal *sestpr, doublecomplex *s, doublecomplex *c__);
+
+/* Subroutine */ int zlals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, doublecomplex *b, integer *ldb,
+                             doublecomplex *bx, integer *ldbx, integer *perm, integer *givptr,
+                             integer *givcol, integer *ldgcol, doublereal *givnum, integer *ldgnum,
+                             doublereal *poles, doublereal *difl, doublereal *difr, doublereal *z__,
+                             integer *k, doublereal *c__, doublereal *s, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zlalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, doublecomplex *b, integer *ldb, doublecomplex *bx,
+                             integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
+                             doublereal *difl, doublereal *difr, doublereal *z__, doublereal *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             doublereal *givnum, doublereal *c__, doublereal *s, doublereal *rwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int zlalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *d__, doublereal *e, doublecomplex *b,
+                             integer *ldb, doublereal *rcond, integer *rank, doublecomplex *work,
+                             doublereal *rwork, integer *iwork, integer *info);
+
+doublereal zlangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlange_(char *norm, integer *m, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlangt_(char *norm, integer *n, doublecomplex *dl,
+                   doublecomplex *d__, doublecomplex *du);
+
+doublereal zlanhb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlanhf_(char *norm, char *transr, char *uplo, integer *n,
+                   doublecomplex *a, doublereal *work);
+
+doublereal zlanhp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
+                   doublereal *work);
+
+doublereal zlanhs_(char *norm, integer *n, doublecomplex *a, integer *lda,
+                   doublereal *work);
+
+doublereal zlanht_(char *norm, integer *n, doublereal *d__, doublecomplex *e);
+
+doublereal zlansb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlansp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
+                   doublereal *work);
+
+doublereal zlansy_(char *norm, char *uplo, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlantp_(char *norm, char *uplo, char *diag, integer *n,
+                   doublecomplex *ap, doublereal *work);
+
+doublereal zlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   doublecomplex *a, integer *lda, doublereal *work);
+
+/* Subroutine */ int zlapll_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *ssmin);
+
+/* Subroutine */ int zlapmt_(logical *forwrd, integer *m, integer *n,
+                             doublecomplex *x, integer *ldx, integer *k);
+
+/* Subroutine */ int zlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqge_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqhb_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqhe_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int zlaqhp_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqp2_(integer *m, integer *n, integer *offset,
+                             doublecomplex *a, integer *lda, integer *jpvt, doublecomplex *tau,
+                             doublereal *vn1, doublereal *vn2, doublecomplex *work);
+
+/* Subroutine */ int zlaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, doublecomplex *a, integer *lda, integer *jpvt,
+                             doublecomplex *tau, doublereal *vn1, doublereal *vn2,
+                             doublecomplex *auxv, doublecomplex *f, integer *ldf);
+
+/* Subroutine */ int zlaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zlaqr1_(integer *n, doublecomplex *h__, integer *ldh,
+                             doublecomplex *s1, doublecomplex *s2, doublecomplex *v);
+
+/* Subroutine */ int zlaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
+                             integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
+                             doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
+                             integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
+                             doublecomplex *work, integer *lwork);
+
+/* Subroutine */ int zlaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
+                             integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
+                             doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
+                             integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
+                             doublecomplex *work, integer *lwork);
+
+/* Subroutine */ int zlaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts,
+                             doublecomplex *s, doublecomplex *h__, integer *ldh, integer *iloz,
+                             integer *ihiz, doublecomplex *z__, integer *ldz, doublecomplex *v,
+                             integer *ldv, doublecomplex *u, integer *ldu, integer *nv,
+                             doublecomplex *wv, integer *ldwv, integer *nh, doublecomplex *wh,
+                             integer *ldwh);
+
+/* Subroutine */ int zlaqsb_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqsp_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqsy_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int zlar1v_(integer *n, integer *b1, integer *bn,
+                             doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
+                             doublereal *lld, doublereal *pivmin, doublereal *gaptol,
+                             doublecomplex *z__, logical *wantnc, integer *negcnt, doublereal *ztz,
+                             doublereal *mingma, integer *r__, integer *isuppz, doublereal *nrminv,
+                             doublereal *resid, doublereal *rqcorr, doublereal *work);
+
+/* Subroutine */ int zlar2v_(integer *n, doublecomplex *x, doublecomplex *y,
+                             doublecomplex *z__, integer *incx, doublereal *c__, doublecomplex *s,
+                             integer *incc);
+
+/* Subroutine */ int zlarcm_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublecomplex *c__,
+                             integer *ldc, doublereal *rwork);
+
+/* Subroutine */ int zlarf_(char *side, integer *m, integer *n,
+                            doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
+                            integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, doublecomplex *v,
+                             integer *ldv, doublecomplex *t, integer *ldt, doublecomplex *c__,
+                             integer *ldc, doublecomplex *work, integer *ldwork);
+
+/* Subroutine */ int zlarfg_(integer *n, doublecomplex *alpha,
+                             doublecomplex *x, integer *incx, doublecomplex *tau);
+
+/* Subroutine */ int zlarfp_(integer *n, doublecomplex *alpha,
+                             doublecomplex *x, integer *incx, doublecomplex *tau);
+
+/* Subroutine */ int zlarft_(char *direct, char *storev, integer *n,
+                             integer *k, doublecomplex *v, integer *ldv, doublecomplex *tau,
+                             doublecomplex *t, integer *ldt);
+
+/* Subroutine */ int zlarfx_(char *side, integer *m, integer *n,
+                             doublecomplex *v, doublecomplex *tau, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work);
+
+/* Subroutine */ int zlargv_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *c__, integer *incc);
+
+/* Subroutine */ int zlarnv_(integer *idist, integer *iseed, integer *n,
+                             doublecomplex *x);
+
+/* Subroutine */ int zlarrv_(integer *n, doublereal *vl, doublereal *vu,
+                             doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
+                             integer *m, integer *dol, integer *dou, doublereal *minrgp,
+                             doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
+                             doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int zlarscl2_(integer *m, integer *n, doublereal *d__,
+                               doublecomplex *x, integer *ldx);
+
+/* Subroutine */ int zlartg_(doublecomplex *f, doublecomplex *g,
+                             doublereal *cs, doublecomplex *sn, doublecomplex *r__);
+
+/* Subroutine */ int zlartv_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *c__, doublecomplex *s,
+                             integer *incc);
+
+/* Subroutine */ int zlarz_(char *side, integer *m, integer *n, integer *l,
+                            doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
+                            integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l,
+                             doublecomplex *v, integer *ldv, doublecomplex *t, integer *ldt,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *ldwork);
+
+/* Subroutine */ int zlarzt_(char *direct, char *storev, integer *n,
+                             integer *k, doublecomplex *v, integer *ldv, doublecomplex *tau,
+                             doublecomplex *t, integer *ldt);
+
+/* Subroutine */ int zlascl_(char *type__, integer *kl, integer *ku,
+                             doublereal *cfrom, doublereal *cto, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int zlascl2_(integer *m, integer *n, doublereal *d__,
+                              doublecomplex *x, integer *ldx);
+
+/* Subroutine */ int zlaset_(char *uplo, integer *m, integer *n,
+                             doublecomplex *alpha, doublecomplex *beta, doublecomplex *a,
+                             integer *lda);
+
+/* Subroutine */ int zlasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, doublereal *c__, doublereal *s, doublecomplex *a,
+                            integer *lda);
+
+/* Subroutine */ int zlassq_(integer *n, doublecomplex *x, integer *incx,
+                             doublereal *scale, doublereal *sumsq);
+
+/* Subroutine */ int zlaswp_(integer *n, doublecomplex *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int zlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
+                             integer *ldw, integer *info);
+
+/* Subroutine */ int zlat2c_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, complex *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int zlatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, doublecomplex *ab, integer *ldab,
+                             doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatdf_(integer *ijob, integer *n, doublecomplex *z__,
+                             integer *ldz, doublecomplex *rhs, doublereal *rdsum, doublereal *rdscal,
+                             integer *ipiv, integer *jpiv);
+
+/* Subroutine */ int zlatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublecomplex *ap, doublecomplex *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatrd_(char *uplo, integer *n, integer *nb,
+                             doublecomplex *a, integer *lda, doublereal *e, doublecomplex *tau,
+                             doublecomplex *w, integer *ldw);
+
+/* Subroutine */ int zlatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatrz_(integer *m, integer *n, integer *l,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work);
+
+/* Subroutine */ int zlatzm_(char *side, integer *m, integer *n,
+                             doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c1,
+                             doublecomplex *c2, integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlauu2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zlauum_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpbcon_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbequ_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, integer *info);
+
+/* Subroutine */ int zpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                             integer *ldafb, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbstf_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int zpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                             integer *ldafb, char *equed, doublereal *s, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbtf2_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbtrf_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zpftrf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int zpftri_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int zpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zpocon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpoequ_(integer *n, doublecomplex *a, integer *lda,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zpoequb_(integer *n, doublecomplex *a, integer *lda,
+                              doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zporfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, doublereal *s, doublecomplex *b, integer *ldb,
+                              doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zposv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, char *equed, doublereal *s, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, char *equed, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpotf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zppcon_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zppequ_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zpprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zppsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, char *equed,
+                             doublereal *s, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *info);
+
+/* Subroutine */ int zpptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *info);
+
+/* Subroutine */ int zpptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zpstf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int zpstrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int zptcon_(integer *n, doublereal *d__, doublecomplex *e,
+                             doublereal *anorm, doublereal *rcond, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int zptrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zptsv_(integer *n, integer *nrhs, doublereal *d__,
+                            doublecomplex *e, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zptsvx_(char *fact, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpttrf_(integer *n, doublereal *d__, doublecomplex *e,
+                             integer *info);
+
+/* Subroutine */ int zpttrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zptts2_(integer *iuplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zrot_(integer *n, doublecomplex *cx, integer *incx,
+                           doublecomplex *cy, integer *incy, doublereal *c__, doublecomplex *s);
+
+/* Subroutine */ int zspcon_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zspmv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta,
+                            doublecomplex *y, integer *incy);
+
+/* Subroutine */ int zspr_(char *uplo, integer *n, doublecomplex *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *ap);
+
+/* Subroutine */ int zsprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zspsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int zsptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zstedc_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zstegr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zstein_(integer *n, doublereal *d__, doublereal *e,
+                             integer *m, doublereal *w, integer *iblock, integer *isplit,
+                             doublecomplex *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zstemr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zsteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int zsycon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsyequb_(char *uplo, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsymv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                            doublecomplex *beta, doublecomplex *y, integer *incy);
+
+/* Subroutine */ int zsyr_(char *uplo, integer *n, doublecomplex *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
+
+/* Subroutine */ int zsyrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsysv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zsysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zsysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsytf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zsytrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zsytri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsytrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int ztbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, doublecomplex *ab, integer *ldab, doublereal *rcond,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ztfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int ztftri_(char *transr, char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int ztfttp_(char *transr, char *uplo, integer *n,
+                             doublecomplex *arf, doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztfttr_(char *transr, char *uplo, integer *n,
+                             doublecomplex *arf, doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztgevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublecomplex *s, integer *lds, doublecomplex *p,
+                             integer *ldp, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *mm, integer *m, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztgex2_(logical *wantq, logical *wantz, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
+                             integer *j1, integer *info);
+
+/* Subroutine */ int ztgexc_(logical *wantq, logical *wantz, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
+                             integer *ifst, integer *ilst, integer *info);
+
+/* Subroutine */ int ztgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
+                             integer *ldz, integer *m, doublereal *pl, doublereal *pr,
+                             doublereal *dif, doublecomplex *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ztgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublereal *tola,
+                             doublereal *tolb, doublereal *alpha, doublereal *beta, doublecomplex *u,
+                             integer *ldu, doublecomplex *v, integer *ldv, doublecomplex *q,
+                             integer *ldq, doublecomplex *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int ztgsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, doublereal *s, doublereal *dif, integer *mm, integer *m,
+                             doublecomplex *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int ztgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
+                             integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
+                             integer *ldf, doublereal *scale, doublereal *rdsum, doublereal *rdscal,
+                             integer *info);
+
+/* Subroutine */ int ztgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
+                             integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
+                             integer *ldf, doublereal *scale, doublereal *dif, doublecomplex *work,
+                             integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int ztpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublecomplex *ap, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztptri_(char *uplo, char *diag, integer *n,
+                             doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int ztpttf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *ap, doublecomplex *arf, integer *info);
+
+/* Subroutine */ int ztpttr_(char *uplo, integer *n, doublecomplex *ap,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
+                             integer *ldvl, doublecomplex *vr, integer *ldvr, integer *mm, integer *m,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrexc_(char *compq, integer *n, doublecomplex *t,
+                             integer *ldt, doublecomplex *q, integer *ldq, integer *ifst,
+                             integer *ilst, integer *info);
+
+/* Subroutine */ int ztrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrsen_(char *job, char *compq, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *q,
+                             integer *ldq, doublecomplex *w, integer *m, doublereal *s,
+                             doublereal *sep, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ztrsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
+                             integer *ldvl, doublecomplex *vr, integer *ldvr, doublereal *s,
+                             doublereal *sep, integer *mm, integer *m, doublecomplex *work,
+                             integer *ldwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int ztrti2_(char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrtri_(char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int ztrttf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *arf, integer *info);
+
+/* Subroutine */ int ztrttp_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztzrqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, integer *info);
+
+/* Subroutine */ int ztzrzf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zung2l_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zung2r_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zungbr_(char *vect, integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunghr_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungl2_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zunglq_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungql_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungqr_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungr2_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zungrq_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungtr_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunmhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zunml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zunmrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zupgtr_(char *uplo, integer *n, doublecomplex *ap,
+                             doublecomplex *tau, doublecomplex *q, integer *ldq, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zupmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublecomplex *ap, doublecomplex *tau, doublecomplex *c__,
+                             integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int dlamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+doublereal dsecnd_();
+
+/* Subroutine */ int ilaver_(integer *vers_major__, integer *vers_minor__,
+                             integer *vers_patch__);
+
+logical lsame_(char *ca, char *cb);
+
+doublereal second_();
+
+doublereal slamch_(char *cmach);
+
+/* Subroutine */ int slamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+/* Subroutine */ int slamc2_(integer *beta, integer *t, logical *rnd,
+                             real *eps, integer *emin, real *rmin, integer *emax, real *rmax);
+
+doublereal slamc3_(real *a, real *b);
+
+/* Subroutine */ int slamc4_(integer *emin, real *start, integer *base);
+
+/* Subroutine */ int slamc5_(integer *beta, integer *p, integer *emin,
+                             logical *ieee, integer *emax, real *rmax);
+
+doublereal dlamch_(char *cmach);
+
+/* Subroutine */ int dlamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+/* Subroutine */ int dlamc2_(integer *beta, integer *t, logical *rnd,
+                             doublereal *eps, integer *emin, doublereal *rmin, integer *emax,
+                             doublereal *rmax);
+
+doublereal dlamc3_(doublereal *a, doublereal *b);
+
+/* Subroutine */ int dlamc4_(integer *emin, doublereal *start, integer *base);
+
+/* Subroutine */ int dlamc5_(integer *beta, integer *p, integer *emin,
+                             logical *ieee, integer *emax, doublereal *rmax);
+
+integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
+                integer *n2, integer *n3, integer *n4);
 
 #ifdef __cplusplus
 }

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -36,7 +36,6 @@
  *
  */
 
-
 /** \file AICOsolver.h
  \brief Approximate Inference Control */
 
@@ -46,92 +45,92 @@ REGISTER_MOTIONSOLVER_TYPE("AICOsolver", exotica::AICOsolver)
 
 namespace exotica
 {
-  void AICOsolver::Instantiate(AICOsolverInitializer& init)
-  {
-      std::string mode = init.SweepMode;
-      if (mode=="Forwardly")
+void AICOsolver::Instantiate(AICOsolverInitializer& init)
+{
+    std::string mode = init.SweepMode;
+    if (mode == "Forwardly")
         sweepMode = smForwardly;
-      else if (mode=="Symmetric")
+    else if (mode == "Symmetric")
         sweepMode = smSymmetric;
-      else if (mode=="LocalGaussNewton")
+    else if (mode == "LocalGaussNewton")
         sweepMode = smLocalGaussNewton;
-      else if (mode=="LocalGaussNewtonDamped")
+    else if (mode == "LocalGaussNewtonDamped")
         sweepMode = smLocalGaussNewtonDamped;
-      else
-      {
-        throw_named("Unknown sweep mode '"<<init.SweepMode<<"'");
-      }
-      max_iterations = init.MaxIterations;
-      tolerance = init.Tolerance;
-      damping_init = init.Damping;
-      useBwdMsg = init.UseBackwardMessage;
-      dynamic = init.Dynamic;
-  }
+    else
+    {
+        throw_named("Unknown sweep mode '" << init.SweepMode << "'");
+    }
+    max_iterations = init.MaxIterations;
+    tolerance = init.Tolerance;
+    damping_init = init.Damping;
+    useBwdMsg = init.UseBackwardMessage;
+    dynamic = init.Dynamic;
+}
 
-  void AICOsolver::saveCosts(std::string file_name)
-  {
+void AICOsolver::saveCosts(std::string file_name)
+{
     std::ofstream myfile;
     myfile.open(file_name.c_str());
     myfile << "Control";
     for (auto s : taskNames)
-      myfile << " " << s;
+        myfile << " " << s;
     for (int t = 0; t < T; t++)
     {
-      myfile << "\n" << costControl(t);
-      for (int i = 0; i < costTask.cols(); i++)
-      {
-        myfile << " " << costTask(t, i);
-      }
+        myfile << "\n"
+               << costControl(t);
+        for (int i = 0; i < costTask.cols(); i++)
+        {
+            myfile << " " << costTask(t, i);
+        }
     }
     myfile.close();
-  }
+}
 
-  AICOsolver::AICOsolver()
-      : damping(0.01), tolerance(1e-2), max_iterations(100), useBwdMsg(false), bwdMsg_v(), bwdMsg_Vinv(), s(), Sinv(), v(), Vinv(), r(), R(), rhat(), b(), Binv(), q(), qhat(), s_old(), Sinv_old(), v_old(), Vinv_old(), r_old(), R_old(), rhat_old(), b_old(), Binv_old(), q_old(), qhat_old(), dampingReference(),
-          cost(0.0), cost_old(0.0), b_step(0.0), A(), tA(), Ainv(), invtA(), a(), B(), tB(), Winv(), Hinv(), Q(), sweep(
-          0), sweepMode(0), W(), H(), T(0), dynamic(false), n(0), updateCount(
-          0), damping_init(0.0), preupdateTrajectory_(false), q_stat()
-  {
+AICOsolver::AICOsolver()
+    : damping(0.01), tolerance(1e-2), max_iterations(100), useBwdMsg(false), bwdMsg_v(), bwdMsg_Vinv(), s(), Sinv(), v(), Vinv(), r(), R(), rhat(), b(), Binv(), q(), qhat(), s_old(), Sinv_old(), v_old(), Vinv_old(), r_old(), R_old(), rhat_old(), b_old(), Binv_old(), q_old(), qhat_old(), dampingReference(), cost(0.0), cost_old(0.0), b_step(0.0), A(), tA(), Ainv(), invtA(), a(), B(), tB(), Winv(), Hinv(), Q(), sweep(0), sweepMode(0), W(), H(), T(0), dynamic(false), n(0), updateCount(0), damping_init(0.0), preupdateTrajectory_(false), q_stat()
+{
+}
 
-  }
-
-  void AICOsolver::getStats(std::vector<SinglePassMeanCoviariance>& q_stat_)
-  {
+void AICOsolver::getStats(std::vector<SinglePassMeanCoviariance>& q_stat_)
+{
     q_stat_ = q_stat;
-  }
+}
 
-  AICOsolver::~AICOsolver()
-  {
+AICOsolver::~AICOsolver()
+{
     // If this is not empty, your code is bad and you should feel bad!
     // Whoop whoop whoop whoop ...
-  }
+}
 
-  void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
-  {
+void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
+{
     if (problem->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-      throw_named("This solver can't use problem of type '" << problem->type() << "'!");
+        throw_named("This solver can't use problem of type '" << problem->type() << "'!");
     }
     MotionSolver::specifyProblem(problem);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(problem);
 
     T = prob_->T;
     initMessages();
-  }
+}
 
-  void AICOsolver::Solve(Eigen::MatrixXd & solution)
-  {
+void AICOsolver::Solve(Eigen::MatrixXd& solution)
+{
     Eigen::VectorXd q0 = prob_->applyStartState();
     std::vector<Eigen::VectorXd> q_init = prob_->getInitialTrajectory();
 
     // If the initial value of the initial trajectory does not equal the start
     // state, assume that no initial guess is provided and fill the trajectory
     // with the start state
-    if (!(q0 - q_init[0]).isMuchSmallerThan(1e-6)) {
-      q_init.resize(T, Eigen::VectorXd::Zero(q0.rows()));
-      for (int i = 0; i < q_init.size(); i++) q_init[i] = q0;
-    } else {
-      HIGHLIGHT("AICO::Solve called with initial trajectory guess");
+    if (!(q0 - q_init[0]).isMuchSmallerThan(1e-6))
+    {
+        q_init.resize(T, Eigen::VectorXd::Zero(q0.rows()));
+        for (int i = 0; i < q_init.size(); i++) q_init[i] = q0;
+    }
+    else
+    {
+        HIGHLIGHT("AICO::Solve called with initial trajectory guess");
     }
 
     prob_->preupdate();
@@ -146,52 +145,52 @@ namespace exotica
     double d;
     if (!(T > 0))
     {
-      throw_named("Problem has not been initialized properly: T=0!");
+        throw_named("Problem has not been initialized properly: T=0!");
     }
     initTrajectory(q_init);
     sweep = 0;
     ROS_WARN_STREAM("AICO: Solving");
     for (int k = 0; k < max_iterations && !(Server::isRos() && !ros::ok()); k++)
     {
-      d = step();
-      if (d < 0)
-      {
-        throw_named("Negative step size!");
-      }
-      if (k && d < tolerance) break;
+        d = step();
+        if (d < 0)
+        {
+            throw_named("Negative step size!");
+        }
+        if (k && d < tolerance) break;
     }
     Eigen::MatrixXd sol(T, n);
     for (int tt = 0; tt < T; tt++)
     {
-      sol.row(tt) = q[tt];
+        sol.row(tt) = q[tt];
     }
     solution = sol;
     planning_time_ = timer.getDuration();
-  }
+}
 
-  void AICOsolver::initMessages()
-  {
+void AICOsolver::initMessages()
+{
     if (prob_ == nullptr) throw_named("Problem definition is a NULL pointer!");
     // TODO: Issue #4
     n = prob_->N;
     int n2 = n / 2;
     if (dynamic)
     {
-      if (n < 2)
-      {
-        throw_named("State dimension is too small: n="<<n);
-      }
+        if (n < 2)
+        {
+            throw_named("State dimension is too small: n=" << n);
+        }
     }
     else
     {
-      if (n < 1)
-      {
-        throw_named("State dimension is too small: n="<<n);
-      }
+        if (n < 1)
+        {
+            throw_named("State dimension is too small: n=" << n);
+        }
     }
     if (T < 2)
     {
-      throw_named("Number of time steps is too small: T="<<T);
+        throw_named("Number of time steps is too small: T=" << T);
     }
 
     s.assign(T, Eigen::VectorXd::Zero(n));
@@ -201,16 +200,16 @@ namespace exotica
     Vinv.assign(T, Eigen::MatrixXd::Zero(n, n));
     if (useBwdMsg)
     {
-      if (bwdMsg_v.rows() == n && bwdMsg_Vinv.rows() == n && bwdMsg_Vinv.cols() == n)
-      {
-        v[T] = bwdMsg_v;
-        Vinv[T] = bwdMsg_Vinv;
-      }
-      else
-      {
-        useBwdMsg = false;
-        WARNING("Backward message initialisation skipped, matrices have incorrect dimensions.");
-      }
+        if (bwdMsg_v.rows() == n && bwdMsg_Vinv.rows() == n && bwdMsg_Vinv.cols() == n)
+        {
+            v[T] = bwdMsg_v;
+            Vinv[T] = bwdMsg_Vinv;
+        }
+        else
+        {
+            useBwdMsg = false;
+            WARNING("Backward message initialisation skipped, matrices have incorrect dimensions.");
+        }
     }
     b.assign(T, Eigen::VectorXd::Zero(n));
     dampingReference.assign(T, Eigen::VectorXd::Zero(n));
@@ -223,50 +222,50 @@ namespace exotica
     qhat.assign(T, Eigen::VectorXd::Zero(n));
     linSolverTmp.resize(n, n);
     {
-      if (dynamic)
-      {
-        q.resize(T);
-        for (int i = 0; i < q.size(); i++)
-          q.at(i) = b.at(i).head(n2);
-        if (prob_->W.rows() != n2)
+        if (dynamic)
         {
-          throw_named(prob_->W.rows()<<"!="<<n2);
+            q.resize(T);
+            for (int i = 0; i < q.size(); i++)
+                q.at(i) = b.at(i).head(n2);
+            if (prob_->W.rows() != n2)
+            {
+                throw_named(prob_->W.rows() << "!=" << n2);
+            }
         }
-      }
-      else
-      {
-        q = b;
-        if (prob_->W.rows() != n)
+        else
         {
-          throw_named(prob_->W.rows()<<"!="<<n);
+            q = b;
+            if (prob_->W.rows() != n)
+            {
+                throw_named(prob_->W.rows() << "!=" << n);
+            }
         }
-      }
-      // All the process parameters are assumed to be constant throughout the trajectory.
-      // This is possible for a pseudo-dynamic system.
-      // A dynamic system would have to update these based on forces acting on the system.
-      Eigen::MatrixXd A_(n, n), B_(dynamic ? n2 : n, dynamic ? n2 : n), tB_,
-          tA_, Ainv_, invtA_;
-      Eigen::VectorXd a_(n);
-      getProcess(A_, a_, B_);
-      tB_ = B_.transpose();
-      tA_ = A_.transpose();
-      Ainv_ = A_.inverse();
-      invtA_ = Ainv_.transpose();
-      B.assign(T, B_);
-      tB.assign(T, tB_);
-      A.assign(T, A_);
-      tA.assign(T, tA_);
-      Ainv.assign(T, Ainv_);
-      invtA.assign(T, invtA_);
-      a.assign(T, a_);
+        // All the process parameters are assumed to be constant throughout the trajectory.
+        // This is possible for a pseudo-dynamic system.
+        // A dynamic system would have to update these based on forces acting on the system.
+        Eigen::MatrixXd A_(n, n), B_(dynamic ? n2 : n, dynamic ? n2 : n), tB_,
+            tA_, Ainv_, invtA_;
+        Eigen::VectorXd a_(n);
+        getProcess(A_, a_, B_);
+        tB_ = B_.transpose();
+        tA_ = A_.transpose();
+        Ainv_ = A_.inverse();
+        invtA_ = Ainv_.transpose();
+        B.assign(T, B_);
+        tB.assign(T, tB_);
+        A.assign(T, A_);
+        tA.assign(T, tA_);
+        Ainv.assign(T, Ainv_);
+        invtA.assign(T, invtA_);
+        a.assign(T, a_);
     }
     {
-      // Set constant W,Win,H,Hinv
-      W.assign(T, prob_->W);
-      Winv.assign(T, prob_->W.inverse());
-      H.assign(T, prob_->H);
-      Hinv.assign(T, prob_->H.inverse());
-      Q.assign(T, prob_->Q);
+        // Set constant W,Win,H,Hinv
+        W.assign(T, prob_->W);
+        Winv.assign(T, prob_->W.inverse());
+        H.assign(T, prob_->H);
+        Hinv.assign(T, prob_->H.inverse());
+        Q.assign(T, prob_->Q);
     }
 
     costControl.resize(T);
@@ -277,44 +276,44 @@ namespace exotica
     q_stat.resize(T);
     for (int t = 0; t < T; t++)
     {
-      q_stat[t].resize(n);
+        q_stat[t].resize(n);
     }
-  }
+}
 
-  void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
-      Eigen::Ref<Eigen::VectorXd> a_, Eigen::Ref<Eigen::MatrixXd> B_)
-  {
+void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
+                            Eigen::Ref<Eigen::VectorXd> a_, Eigen::Ref<Eigen::MatrixXd> B_)
+{
     if (!dynamic)
     {
-      A_ = Eigen::MatrixXd::Identity(n, n);
-      B_ = Eigen::MatrixXd::Identity(n, n);
-      a_ = Eigen::VectorXd::Zero(n);
+        A_ = Eigen::MatrixXd::Identity(n, n);
+        B_ = Eigen::MatrixXd::Identity(n, n);
+        a_ = Eigen::VectorXd::Zero(n);
     }
     else
     {
-      double tau = prob_->tau;
-      int n2 = n / 2;
-      A_ = Eigen::MatrixXd::Identity(n, n);
-      B_ = Eigen::MatrixXd::Zero(n, n2);
-      a_ = Eigen::VectorXd::Zero(n);
+        double tau = prob_->tau;
+        int n2 = n / 2;
+        A_ = Eigen::MatrixXd::Identity(n, n);
+        B_ = Eigen::MatrixXd::Zero(n, n2);
+        a_ = Eigen::VectorXd::Zero(n);
 
-      // Assuming pseudo dynamic process (M is identity matrix and F is zero vector)
-      Eigen::MatrixXd Minv = Eigen::MatrixXd::Identity(n2, n2);
-      Eigen::VectorXd F = Eigen::VectorXd::Zero(n2);
+        // Assuming pseudo dynamic process (M is identity matrix and F is zero vector)
+        Eigen::MatrixXd Minv = Eigen::MatrixXd::Identity(n2, n2);
+        Eigen::VectorXd F = Eigen::VectorXd::Zero(n2);
 
-      A_.topRightCorner(n2, n2).diagonal().setConstant(tau);
-      B_.topLeftCorner(n2, n2) = Minv * (tau * tau * 0.5);
-      B_.bottomLeftCorner(n2, n2) = Minv * tau;
-      a_.head(n2) = Minv * F * (tau * tau * 0.5);
-      a_.tail(n2) = Minv * F * tau;
+        A_.topRightCorner(n2, n2).diagonal().setConstant(tau);
+        B_.topLeftCorner(n2, n2) = Minv * (tau * tau * 0.5);
+        B_.bottomLeftCorner(n2, n2) = Minv * tau;
+        a_.head(n2) = Minv * F * (tau * tau * 0.5);
+        a_.tail(n2) = Minv * F * tau;
     }
-  }
+}
 
-  void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
-  {
+void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
+{
     if (q_init.size() != T)
     {
-      throw_named("Incorrect number of timesteps provided!");
+        throw_named("Incorrect number of timesteps provided!");
     }
     qhat[0] = q_init[0];
     dampingReference[0] = q_init[0];
@@ -324,156 +323,157 @@ namespace exotica
     int n2 = n / 2;
     b = q_init;
     for (int i = 0; i < q.size(); i++)
-      q.at(i) = b.at(i).head(n2);
+        q.at(i) = b.at(i).head(n2);
     s = b;
     for (int t = 1; t < T; t++)
     {
-      Sinv.at(t).setZero(); 
-      Sinv.at(t).diagonal().setConstant(damping);
+        Sinv.at(t).setZero();
+        Sinv.at(t).diagonal().setConstant(damping);
     }
     v = b;
     for (int t = 0; t < T; t++)
     {
-      Vinv.at(t).setZero();  
-      Vinv.at(t).diagonal().setConstant(damping);
+        Vinv.at(t).setZero();
+        Vinv.at(t).diagonal().setConstant(damping);
     }
     dampingReference = b;
     for (int t = 0; t < T; t++)
     {
-      // Compute task message reference
-      updateTaskMessage(t, b.at(t), 0.0);
+        // Compute task message reference
+        updateTaskMessage(t, b.at(t), 0.0);
     }
 
     cost = evaluateTrajectory(b, true);
-    if (cost < 0) throw_named("Invalid cost! "<<cost);
-    INFO("Initial cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost <<", updates: "<<updateCount);
+    if (cost < 0) throw_named("Invalid cost! " << cost);
+    INFO("Initial cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << ", updates: " << updateCount);
     rememberOldState();
-  }
+}
 
-  void AICOsolver::inverseSymPosDef(Eigen::Ref<Eigen::MatrixXd> Ainv_,
-      const Eigen::Ref<const Eigen::MatrixXd> & A_)
-  {
+void AICOsolver::inverseSymPosDef(Eigen::Ref<Eigen::MatrixXd> Ainv_,
+                                  const Eigen::Ref<const Eigen::MatrixXd>& A_)
+{
     Ainv_ = A_;
     double* AA = Ainv_.data();
     integer info;
     integer nn = A_.rows();
     // Compute Cholesky
-    dpotrf_((char*) "L", &nn, AA, &nn, &info);
+    dpotrf_((char*)"L", &nn, AA, &nn, &info);
     if (info != 0)
     {
-      throw_named("Cholesky decomposition error: "<<info<<"\n"<<A_);
+        throw_named("Cholesky decomposition error: " << info << "\n"
+                                                     << A_);
     }
     // Invert
-    dpotri_((char*) "L", &nn, AA, &nn, &info);
+    dpotri_((char*)"L", &nn, AA, &nn, &info);
     if (info != 0)
     {
-      throw_named("Matrix inversion error: "<<info);
+        throw_named("Matrix inversion error: " << info);
     }
     Ainv_.triangularView<Eigen::Upper>() = Ainv_.transpose();
-  }
+}
 
-  void AICOsolver::AinvBSymPosDef(Eigen::Ref<Eigen::VectorXd> x_,
-      const Eigen::Ref<const Eigen::MatrixXd> & A_,
-      const Eigen::Ref<const Eigen::VectorXd> & b_)
-  {
+void AICOsolver::AinvBSymPosDef(Eigen::Ref<Eigen::VectorXd> x_,
+                                const Eigen::Ref<const Eigen::MatrixXd>& A_,
+                                const Eigen::Ref<const Eigen::VectorXd>& b_)
+{
     integer n_ = n, m_ = 1;
     integer info;
     linSolverTmp = A_;
     x_ = b_;
     double* AA = linSolverTmp.data();
     double* xx = x_.data();
-    dposv_((char*) "L", &n_, &m_, AA, &n_, xx, &n_, &info);
+    dposv_((char*)"L", &n_, &m_, AA, &n_, xx, &n_, &info);
     if (info != 0)
     {
-      throw_named("Linear solver error: "<<info<<"\nA:\n"<<A_<<"\nb: "<<b_.transpose()<<"\nx: "<<x_.transpose());
+        throw_named("Linear solver error: " << info << "\nA:\n"
+                                            << A_ << "\nb: " << b_.transpose() << "\nx: " << x_.transpose());
     }
-  }
+}
 
-  void AICOsolver::updateFwdMessage(int t)
-  {
+void AICOsolver::updateFwdMessage(int t)
+{
     Eigen::MatrixXd barS(n, n), St;
     if (dynamic)
     {
-      inverseSymPosDef(barS, Sinv[t - 1] + R[t - 1]);
-      St = Q[t - 1] + B[t - 1] * Hinv[t - 1] * tB[t - 1]
-          + A[t - 1] * barS * tA[t - 1];
-      s[t] = a[t - 1] + A[t - 1] * (barS * (Sinv[t - 1] * s[t - 1] + r[t - 1]));
-      inverseSymPosDef(Sinv[t], St);
+        inverseSymPosDef(barS, Sinv[t - 1] + R[t - 1]);
+        St = Q[t - 1] + B[t - 1] * Hinv[t - 1] * tB[t - 1] + A[t - 1] * barS * tA[t - 1];
+        s[t] = a[t - 1] + A[t - 1] * (barS * (Sinv[t - 1] * s[t - 1] + r[t - 1]));
+        inverseSymPosDef(Sinv[t], St);
     }
     else
     {
-      inverseSymPosDef(barS, Sinv[t - 1] + R[t - 1]);
-      s[t] = barS * (Sinv[t - 1] * s[t - 1] + r[t - 1]);
-      St = Winv[t - 1] + barS;
-      inverseSymPosDef(Sinv[t], St);
+        inverseSymPosDef(barS, Sinv[t - 1] + R[t - 1]);
+        s[t] = barS * (Sinv[t - 1] * s[t - 1] + r[t - 1]);
+        St = Winv[t - 1] + barS;
+        inverseSymPosDef(Sinv[t], St);
     }
-  }
+}
 
-  void AICOsolver::updateBwdMessage(int t)
-  {
+void AICOsolver::updateBwdMessage(int t)
+{
     Eigen::MatrixXd barV(n, n), Vt;
     if (dynamic)
     {
-      if (t < T-1)
-      {
-        inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
-        Vt = Ainv[t] * (Q[t] + B[t] * Hinv[t] * tB[t] + barV) * invtA[t];
-        v[t] = Ainv[t] * (-a[t] + barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]));
-        inverseSymPosDef(Vinv[t], Vt);
-      }
-      if (t == T-1)
-      {
-        if (!useBwdMsg)
+        if (t < T - 1)
         {
-          v[t] = b[t];
-          Vinv[t].diagonal().setConstant(1e-4);
+            inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
+            Vt = Ainv[t] * (Q[t] + B[t] * Hinv[t] * tB[t] + barV) * invtA[t];
+            v[t] = Ainv[t] * (-a[t] + barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]));
+            inverseSymPosDef(Vinv[t], Vt);
         }
-        else
+        if (t == T - 1)
         {
-          v[T-1] = bwdMsg_v;
-          Vinv[T-1] = bwdMsg_Vinv;
+            if (!useBwdMsg)
+            {
+                v[t] = b[t];
+                Vinv[t].diagonal().setConstant(1e-4);
+            }
+            else
+            {
+                v[T - 1] = bwdMsg_v;
+                Vinv[T - 1] = bwdMsg_Vinv;
+            }
         }
-      }
     }
     else
     {
-      if (t < T-1)
-      {
-        inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
-        v[t] = barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]);
-        Vt = Winv[t] + barV;
-        inverseSymPosDef(Vinv[t], Vt);
-      }
-      if (t == T-1)
-      {
-        if (!useBwdMsg)
+        if (t < T - 1)
         {
-          v[t] = b[t];
-          Vinv[t].diagonal().setConstant(1e-0);
+            inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
+            v[t] = barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]);
+            Vt = Winv[t] + barV;
+            inverseSymPosDef(Vinv[t], Vt);
         }
-        else
+        if (t == T - 1)
         {
-          v[T-1] = bwdMsg_v;
-          Vinv[T-1] = bwdMsg_Vinv;
+            if (!useBwdMsg)
+            {
+                v[t] = b[t];
+                Vinv[t].diagonal().setConstant(1e-0);
+            }
+            else
+            {
+                v[T - 1] = bwdMsg_v;
+                Vinv[T - 1] = bwdMsg_Vinv;
+            }
         }
-      }
     }
-  }
+}
 
-  void AICOsolver::updateTaskMessage(int t,
-      const Eigen::Ref<const Eigen::VectorXd> & qhat_t, double tolerance_,
-      double maxStepSize)
-  {
+void AICOsolver::updateTaskMessage(int t,
+                                   const Eigen::Ref<const Eigen::VectorXd>& qhat_t, double tolerance_,
+                                   double maxStepSize)
+{
     Eigen::VectorXd diff = qhat_t - qhat[t];
     if ((diff.array().abs().maxCoeff() < tolerance_)) return;
     double nrm = diff.norm();
     if (maxStepSize > 0. && nrm > maxStepSize)
     {
-      qhat[t] += diff * (maxStepSize / nrm);
+        qhat[t] += diff * (maxStepSize / nrm);
     }
     else
     {
-      qhat[t] = qhat_t;
+        qhat[t] = qhat_t;
     }
 
     prob_->Update(dynamic ? qhat[t].head(n / 2) : qhat[t], t);
@@ -482,93 +482,82 @@ namespace exotica
     q_stat[t].addw(c > 0 ? 1.0 / (1.0 + c) : 1.0, qhat_t);
 
     // If using fully dynamic system, update Q, Hinv and process variables here.
-  }
+}
 
-  double AICOsolver::getTaskCosts(int t)
-  {
+double AICOsolver::getTaskCosts(int t)
+{
     double C = 0;
     if (!dynamic)
     {
-      Eigen::MatrixXd Jt;
-      double prec;
-      rhat[t] = 0;
-      R[t].setZero();
-      r[t].setZero();
-      for (int i = 0; i < prob_->getTasks().size(); i++)
-      {
-        prec = prob_->Rho[t](i);
-        if (prec > 0)
+        Eigen::MatrixXd Jt;
+        double prec;
+        rhat[t] = 0;
+        R[t].setZero();
+        r[t].setZero();
+        for (int i = 0; i < prob_->getTasks().size(); i++)
         {
-            int start = prob_->getTasks()[i]->StartJ;
-            int len = prob_->getTasks()[i]->LengthJ;
-          Jt = prob_->J[t].middleRows(start, len).transpose();
-          C += prec
-              * (prob_->ydiff[t].segment(start, len)).squaredNorm();
-          R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
-          r[t] += prec * Jt
-              * (prob_->ydiff[t].segment(start, len)
-                  + prob_->J[t].middleRows(start, len) * qhat[t]);
-          rhat[t] += prec
-              * (prob_->ydiff[t].segment(start, len)
-                  + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
+            prec = prob_->Rho[t](i);
+            if (prec > 0)
+            {
+                int start = prob_->getTasks()[i]->StartJ;
+                int len = prob_->getTasks()[i]->LengthJ;
+                Jt = prob_->J[t].middleRows(start, len).transpose();
+                C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
+                R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
+                r[t] += prec * Jt * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
+                rhat[t] += prec * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
+            }
         }
-      }
     }
     else
     {
-      Eigen::MatrixXd Jt;
-      int n2 = n / 2;
-      double prec;
-      rhat[t] = 0;
-      R[t].setZero();
-      r[t].setZero();
-      for (int i = 0; i < prob_->getTasks().size(); i++)
-      {
-          prec = prob_->Rho[t](i);
-          if (prec > 0)
-          {
-              int start = prob_->getTasks()[i]->StartJ;
-              int len = prob_->getTasks()[i]->LengthJ;
+        Eigen::MatrixXd Jt;
+        int n2 = n / 2;
+        double prec;
+        rhat[t] = 0;
+        R[t].setZero();
+        r[t].setZero();
+        for (int i = 0; i < prob_->getTasks().size(); i++)
+        {
+            prec = prob_->Rho[t](i);
+            if (prec > 0)
+            {
+                int start = prob_->getTasks()[i]->StartJ;
+                int len = prob_->getTasks()[i]->LengthJ;
                 Jt = prob_->J[t].middleRows(start, len).transpose();
-                C += prec
-                    * (prob_->ydiff[t].segment(start, len)).squaredNorm();
+                C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t].topLeftCorner(n2, n2) += prec * Jt * prob_->J[t].middleRows(start, len);
-                r[t].head(n2) += prec * Jt
-                    * (prob_->ydiff[t].segment(start, len)
-                        + prob_->J[t].middleRows(start, len) * qhat[t]);
-                rhat[t] += prec
-                    * (prob_->ydiff[t].segment(start, len)
-                            + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
-          }
-      }
+                r[t].head(n2) += prec * Jt * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
+                rhat[t] += prec * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
+            }
+        }
     }
     return C;
-  }
+}
 
-  void AICOsolver::updateTimeStep(int t, bool updateFwd, bool updateBwd,
-      int maxRelocationIterations, double tolerance_, bool forceRelocation,
-      double maxStepSize)
-  {
+void AICOsolver::updateTimeStep(int t, bool updateFwd, bool updateBwd,
+                                int maxRelocationIterations, double tolerance_, bool forceRelocation,
+                                double maxStepSize)
+{
     if (updateFwd) updateFwdMessage(t);
     if (updateBwd) updateBwdMessage(t);
 
     if (damping)
     {
-      Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(n, n) * damping;
-      AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * dampingReference[t]);
+        Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(n, n) * damping;
+        AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * dampingReference[t]);
     }
     else
     {
-      Binv[t] = Sinv[t] + Vinv[t] + R[t];
-      AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t]);
+        Binv[t] = Sinv[t] + Vinv[t] + R[t];
+        AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t]);
     }
 
     for (int k = 0; k < maxRelocationIterations && !(Server::isRos() && !ros::ok()); k++)
     {
-      if (!((!k && forceRelocation)
-          || (b[t] - qhat[t]).array().abs().maxCoeff() > tolerance_)) break;
+        if (!((!k && forceRelocation) || (b[t] - qhat[t]).array().abs().maxCoeff() > tolerance_)) break;
 
-      updateTaskMessage(t, b.at(t), 0., maxStepSize);
+        updateTaskMessage(t, b.at(t), 0., maxStepSize);
 
         //optional reUpdate fwd or bwd message (if the Dynamics might have changed...)
         if (updateFwd) updateFwdMessage(t);
@@ -576,30 +565,29 @@ namespace exotica
 
         if (damping)
         {
-          Binv[t] = Sinv[t] + Vinv[t] + R[t]+ Eigen::MatrixXd::Identity(n, n) * damping;
-          AinvBSymPosDef(b[t], Binv[t],Sinv[t] * s[t] + Vinv[t] * v[t] + r[t]+ damping * dampingReference[t]);
+            Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(n, n) * damping;
+            AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * dampingReference[t]);
         }
         else
         {
-          Binv[t] = Sinv[t] + Vinv[t] + R[t];
-          AinvBSymPosDef(b[t], Binv[t],Sinv[t] * s[t] + Vinv[t] * v[t] + r[t]);
+            Binv[t] = Sinv[t] + Vinv[t] + R[t];
+            AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t]);
         }
-
     }
-  }
+}
 
-  void AICOsolver::updateTimeStepGaussNewton(int t, bool updateFwd,
-      bool updateBwd, int maxRelocationIterations, double tolerance,
-      double maxStepSize)
-  {
+void AICOsolver::updateTimeStepGaussNewton(int t, bool updateFwd,
+                                           bool updateBwd, int maxRelocationIterations, double tolerance,
+                                           double maxStepSize)
+{
     // TODO: implement updateTimeStepGaussNewton
     throw_named("Not implemented yet!");
-  }
+}
 
-  double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
-      bool skipUpdate)
-  {
-    ROS_WARN_STREAM("Evaluating, sweep "<<sweep);
+double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
+                                      bool skipUpdate)
+{
+    ROS_WARN_STREAM("Evaluating, sweep " << sweep);
     Timer timer;
     double dSet, dPre, dUpd, dCtrl, dTask;
     double ret = 0.0;
@@ -610,163 +598,161 @@ namespace exotica
 
     if (dynamic)
     {
-      for (int i = 0; i < q.size(); i++)
-        q.at(i) = x.at(i).head(n2);
+        for (int i = 0; i < q.size(); i++)
+            q.at(i) = x.at(i).head(n2);
     }
     else
     {
-      q = x;
+        q = x;
     }
     dSet = timer.getDuration();
     if (preupdateTrajectory_)
     {
-      ROS_WARN_STREAM("Pre-update, sweep "<<sweep);
-      for (int t = 0; t < T; t++)
-      {
-        if (Server::isRos() && !ros::ok()) return -1.0;
-        updateCount++;
-        prob_->Update(q[t], t);
-      }
+        ROS_WARN_STREAM("Pre-update, sweep " << sweep);
+        for (int t = 0; t < T; t++)
+        {
+            if (Server::isRos() && !ros::ok()) return -1.0;
+            updateCount++;
+            prob_->Update(q[t], t);
+        }
     }
     dPre = timer.getDuration();
 
     for (int t = 0; t < T; t++)
     {
-      timer.reset();
-      if (Server::isRos() && !ros::ok()) return -1.0;
-      if (!skipUpdate)
-      {
-        updateCount++;
-        prob_->Update(q[t], t);
-      }
-      dUpd += timer.getDuration();
-      timer.reset();
-
-      // Control cost
-      if (!dynamic)
-      {
-        if (t == 0)
+        timer.reset();
+        if (Server::isRos() && !ros::ok()) return -1.0;
+        if (!skipUpdate)
         {
-          costControl(t) = 0.0;
+            updateCount++;
+            prob_->Update(q[t], t);
+        }
+        dUpd += timer.getDuration();
+        timer.reset();
+
+        // Control cost
+        if (!dynamic)
+        {
+            if (t == 0)
+            {
+                costControl(t) = 0.0;
+            }
+            else
+            {
+                vv = q[t] - q[t - 1];
+                costControl(t) = vv.transpose() * W[t] * vv;
+            }
         }
         else
         {
-          vv = q[t] - q[t - 1];
-          costControl(t) = vv.transpose() * W[t] * vv;
+            if (t < T - 1 && t > 0)
+            {
+                // For fully dynamic system use: v=tau_2*M*(q[t+1]+q[t-1]-2.0*q[t])-F;
+                vv = tau_2 * (q[t + 1] + q[t - 1] - 2.0 * q[t]);
+                costControl(t) = vv.transpose() * H[t] * vv;
+            }
+            else if (t == 0)
+            {
+                // For fully dynamic system use: v=tau_2*M*(q[t+1]+q[t])-F;
+                vv = tau_2 * (q[t + 1] + q[t]);
+                costControl(t) = vv.transpose() * H[t] * vv;
+            }
+            else
+                costControl(t) = 0.0;
         }
-      }
-      else
-      {
-        if (t < T-1 && t > 0)
-        {
-          // For fully dynamic system use: v=tau_2*M*(q[t+1]+q[t-1]-2.0*q[t])-F;
-          vv = tau_2 * (q[t + 1] + q[t - 1] - 2.0 * q[t]);
-          costControl(t) = vv.transpose() * H[t] * vv;
-        }
-        else if (t == 0)
-        {
-          // For fully dynamic system use: v=tau_2*M*(q[t+1]+q[t])-F;
-          vv = tau_2 * (q[t + 1] + q[t]);
-          costControl(t) = vv.transpose() * H[t] * vv;
-        }
-        else
-          costControl(t) = 0.0;
-      }
 
-      ret += costControl(t);
-      dCtrl += timer.getDuration();
-      timer.reset();
-      // Task cost
-      for (int i = 0; i < prob_->NumTasks; i++)
-      {
-          // Position cost
-          double prec = prob_->Rho[t](i);
-          if (prec > 0)
-          {
-              int start = prob_->getTasks()[i]->StartJ;
-              int len = prob_->getTasks()[i]->LengthJ;
-                costTask(t, i) = prec
-                    * (prob_->ydiff[t].segment(start, len)).squaredNorm();
+        ret += costControl(t);
+        dCtrl += timer.getDuration();
+        timer.reset();
+        // Task cost
+        for (int i = 0; i < prob_->NumTasks; i++)
+        {
+            // Position cost
+            double prec = prob_->Rho[t](i);
+            if (prec > 0)
+            {
+                int start = prob_->getTasks()[i]->StartJ;
+                int len = prob_->getTasks()[i]->LengthJ;
+                costTask(t, i) = prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 ret += costTask(t, i);
-          }
-      }
-      dTask += timer.getDuration();
+            }
+        }
+        dTask += timer.getDuration();
     }
     return ret;
-  }
+}
 
-  double AICOsolver::step()
-  {
+double AICOsolver::step()
+{
     rememberOldState();
     int t;
     switch (sweepMode)
     {
-    //NOTE: the dependence on (Sweep?..:..) could perhaps be replaced by (DampingReference.N?..:..)
-    case smForwardly:
-      for (t = 1; t < T; t++)
-      {
-        updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.); //relocate once on fwd Sweep
-      }
-      for (t = T - 2; t>=0 ;t--)
-      {
-        updateTimeStep(t, false, true, 0, tolerance, false, 1.); //...not on bwd Sweep
-      }
-      break;
-    case smSymmetric:
-      //ROS_WARN_STREAM("Updating forward, sweep "<<sweep);
-      for (t = 1; t < T; t++)
-      {
-        updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.); //relocate once on fwd & bwd Sweep
-      }
-      //ROS_WARN_STREAM("Updating backward, sweep "<<sweep);
-      for (t = T - 2; t>=0; t--)
-      {
-        updateTimeStep(t, false, true, (sweep ? 1 : 0), tolerance, false,1.);
-      }
-      break;
-    case smLocalGaussNewton:
-      for (t = 1; t < T; t++)
-      {
-        updateTimeStep(t, true, false, (sweep ? 5 : 1), tolerance, !sweep, 1.); //relocate iteratively on
-      }
-      for (t = T - 2; t>=0; t--)
-      {
-        updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.); //...fwd & bwd Sweep
-      }
-      break;
-    case smLocalGaussNewtonDamped:
-      for (t = 1; t < T; t++)
-      {
-        updateTimeStepGaussNewton(t, true, false, (sweep ? 5 : 1),
-            tolerance, 1.); //GaussNewton in fwd & bwd Sweep
-      }
-      for (t = T - 2; t>=0; t--)
-      {
-        updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false,1.);
-      }
-      break;
-    default:
-      throw_named("non-existing Sweep mode");
+        //NOTE: the dependence on (Sweep?..:..) could perhaps be replaced by (DampingReference.N?..:..)
+        case smForwardly:
+            for (t = 1; t < T; t++)
+            {
+                updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd Sweep
+            }
+            for (t = T - 2; t >= 0; t--)
+            {
+                updateTimeStep(t, false, true, 0, tolerance, false, 1.);  //...not on bwd Sweep
+            }
+            break;
+        case smSymmetric:
+            //ROS_WARN_STREAM("Updating forward, sweep "<<sweep);
+            for (t = 1; t < T; t++)
+            {
+                updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd & bwd Sweep
+            }
+            //ROS_WARN_STREAM("Updating backward, sweep "<<sweep);
+            for (t = T - 2; t >= 0; t--)
+            {
+                updateTimeStep(t, false, true, (sweep ? 1 : 0), tolerance, false, 1.);
+            }
+            break;
+        case smLocalGaussNewton:
+            for (t = 1; t < T; t++)
+            {
+                updateTimeStep(t, true, false, (sweep ? 5 : 1), tolerance, !sweep, 1.);  //relocate iteratively on
+            }
+            for (t = T - 2; t >= 0; t--)
+            {
+                updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);  //...fwd & bwd Sweep
+            }
+            break;
+        case smLocalGaussNewtonDamped:
+            for (t = 1; t < T; t++)
+            {
+                updateTimeStepGaussNewton(t, true, false, (sweep ? 5 : 1),
+                                          tolerance, 1.);  //GaussNewton in fwd & bwd Sweep
+            }
+            for (t = T - 2; t >= 0; t--)
+            {
+                updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);
+            }
+            break;
+        default:
+            throw_named("non-existing Sweep mode");
     }
     b_step = 0.0;
     for (t = 0; t < b.size(); t++)
     {
-      b_step = std::max((b_old[t] - b[t]).array().abs().maxCoeff(), b_step);
+        b_step = std::max((b_old[t] - b[t]).array().abs().maxCoeff(), b_step);
     }
     dampingReference = b;
     // q is set inside of evaluateTrajectory() function
     cost = evaluateTrajectory(b);
-    HIGHLIGHT("Sweep: " << sweep << ", updates: " << updateCount << ", cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << " (dq="<<b_step<<", damping="<<damping<<")");
+    HIGHLIGHT("Sweep: " << sweep << ", updates: " << updateCount << ", cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << " (dq=" << b_step << ", damping=" << damping << ")");
     if (cost < 0) return -1.0;
-
 
     if (sweep && damping) perhapsUndoStep();
     sweep++;
     return b_step;
-  }
+}
 
-  void AICOsolver::rememberOldState()
-  {
+void AICOsolver::rememberOldState()
+{
     s_old = s;
     Sinv_old = Sinv;
     v_old = v;
@@ -783,44 +769,44 @@ namespace exotica
     costControl_old = costControl;
     costTask_old = costTask;
     dim_old = dim;
-  }
+}
 
-  void AICOsolver::perhapsUndoStep()
-  {
+void AICOsolver::perhapsUndoStep()
+{
     if (cost > cost_old)
     {
-      damping *= 10.;
-      s = s_old;
-      Sinv = Sinv_old;
-      v = v_old;
-      Vinv = Vinv_old;
-      r = r_old;
-      R = R_old;
-      Binv = Binv_old;
-      rhat = rhat_old;
-      b = b_old;
-      r = r_old;
-      q = q_old;
-      qhat = qhat_old;
-      cost = cost_old;
-      dampingReference = b_old;
-      costControl = costControl_old;
-      costTask = costTask_old;
-      dim = dim_old;
-      if (preupdateTrajectory_)
-      {
-        for (int t = 0; t < T; t++)
+        damping *= 10.;
+        s = s_old;
+        Sinv = Sinv_old;
+        v = v_old;
+        Vinv = Vinv_old;
+        r = r_old;
+        R = R_old;
+        Binv = Binv_old;
+        rhat = rhat_old;
+        b = b_old;
+        r = r_old;
+        q = q_old;
+        qhat = qhat_old;
+        cost = cost_old;
+        dampingReference = b_old;
+        costControl = costControl_old;
+        costTask = costTask_old;
+        dim = dim_old;
+        if (preupdateTrajectory_)
         {
-          updateCount++;
-          prob_->Update(q[t], t);
+            for (int t = 0; t < T; t++)
+            {
+                updateCount++;
+                prob_->Update(q[t], t);
+            }
         }
-      }
-      INFO("Reverting to previous step");
+        INFO("Reverting to previous step");
     }
     else
     {
-      damping /= 5.;
+        damping /= 5.;
     }
-  }
+}
 
 } /* namespace exotica */

--- a/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
+++ b/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
@@ -37,52 +37,52 @@
 #include <exotica/Exotica.h>
 #include <exotica/Problems/UnconstrainedEndPoseProblem.h>
 #include <ik_solver/IKsolverInitializer.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 namespace exotica
 {
-  /**
+/**
    * \brief	IK position solver
    */
-  class IKsolver: public MotionSolver, public Instantiable<IKsolverInitializer>
-  {
-    public:
-      IKsolver();
-      virtual ~IKsolver();
+class IKsolver : public MotionSolver, public Instantiable<IKsolverInitializer>
+{
+public:
+    IKsolver();
+    virtual ~IKsolver();
 
-      virtual void Instantiate(IKsolverInitializer& init);
+    virtual void Instantiate(IKsolverInitializer& init);
 
-      virtual void Solve(Eigen::MatrixXd & solution);
+    virtual void Solve(Eigen::MatrixXd& solution);
 
-      virtual void specifyProblem(PlanningProblem_ptr pointer);
+    virtual void specifyProblem(PlanningProblem_ptr pointer);
 
-      UnconstrainedEndPoseProblem_ptr& getProblem();
+    UnconstrainedEndPoseProblem_ptr& getProblem();
 
-      Eigen::MatrixXd PseudoInverse(Eigen::MatrixXdRefConst J);
+    Eigen::MatrixXd PseudoInverse(Eigen::MatrixXdRefConst J);
 
-      double error;
-      double planning_time_;
+    double error;
+    double planning_time_;
 
-      int getMaxIteration();
-      int getLastIteration();
+    int getMaxIteration();
+    int getLastIteration();
 
-    private:
-      IKsolverInitializer parameters_;
+private:
+    IKsolverInitializer parameters_;
 
-      inline void vel_solve(double & err, int t, Eigen::VectorXdRefConst q);
+    inline void vel_solve(double& err, int t, Eigen::VectorXdRefConst q);
 
-      void ScaleToStepSize(Eigen::VectorXdRef xd);
+    void ScaleToStepSize(Eigen::VectorXdRef xd);
 
-      UnconstrainedEndPoseProblem_ptr prob_; // Shared pointer to the planning problem.
+    UnconstrainedEndPoseProblem_ptr prob_;  // Shared pointer to the planning problem.
 
-      Eigen::MatrixXd Cinv; //!< Weight Matrices
-      Eigen::MatrixXd C;
-      Eigen::MatrixXd W;
-      Eigen::MatrixXd Winv;
-      int iterations_;
-  };
-  typedef std::shared_ptr<exotica::IKsolver> IKsolver_ptr;
+    Eigen::MatrixXd Cinv;  //!< Weight Matrices
+    Eigen::MatrixXd C;
+    Eigen::MatrixXd W;
+    Eigen::MatrixXd Winv;
+    int iterations_;
+};
+typedef std::shared_ptr<exotica::IKsolver> IKsolver_ptr;
 }
 
 #endif /* IK_SOLVER_H_ */

--- a/exotations/solvers/ik_solver/include/lapack/cblas.h
+++ b/exotations/solvers/ik_solver/include/lapack/cblas.h
@@ -13,27 +13,33 @@ ISBN = 0-89871-447-8 (paperback)
 #define CBLAS_H
 #include <cstddef>
 
-#define CBLAS_INDEX size_t 
+#define CBLAS_INDEX size_t
 
 enum CBLAS_ORDER
 {
-  CblasRowMajor = 101, CblasColMajor = 102
+    CblasRowMajor = 101,
+    CblasColMajor = 102
 };
 enum CBLAS_TRANSPOSE
 {
-  CblasNoTrans = 111, CblasTrans = 112, CblasConjTrans = 113
+    CblasNoTrans = 111,
+    CblasTrans = 112,
+    CblasConjTrans = 113
 };
 enum CBLAS_UPLO
 {
-  CblasUpper = 121, CblasLower = 122
+    CblasUpper = 121,
+    CblasLower = 122
 };
 enum CBLAS_DIAG
 {
-  CblasNonUnit = 131, CblasUnit = 132
+    CblasNonUnit = 131,
+    CblasUnit = 132
 };
 enum CBLAS_SIDE
 {
-  CblasLeft = 141, CblasRight = 142
+    CblasLeft = 141,
+    CblasRight = 142
 };
 
 int cblas_errprn(int ierr, int info, char *form, ...);
@@ -44,25 +50,25 @@ int cblas_errprn(int ierr, int info, char *form, ...);
  * ===========================================================================
  */
 float cblas_sdsdot(const int N, const float alpha, const float *X,
-    const int incX, const float *Y, const int incY);
+                   const int incX, const float *Y, const int incY);
 double cblas_dsdot(const int N, const float *X, const int incX, const float *Y,
-    const int incY);
+                   const int incY);
 float cblas_sdot(const int N, const float *X, const int incX, const float *Y,
-    const int incY);
+                 const int incY);
 double cblas_ddot(const int N, const double *X, const int incX, const double *Y,
-    const int incY);
+                  const int incY);
 /*
  * Functions having prefixes Z and C only
  */
 void cblas_cdotu_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotu);
+                     const int incY, void *dotu);
 void cblas_cdotc_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotc);
+                     const int incY, void *dotc);
 
 void cblas_zdotu_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotu);
+                     const int incY, void *dotu);
 void cblas_zdotc_sub(const int N, const void *X, const int incX, const void *Y,
-    const int incY, void *dotc);
+                     const int incY, void *dotc);
 
 /*
  * Functions having prefixes S D SC DZ
@@ -97,30 +103,30 @@ CBLAS_INDEX cblas_izamax(const int N, const void *X, const int incX);
  * Routines with standard 4 prefixes (s, d, c, z)
  */
 void cblas_sswap(const int N, float *X, const int incX, float *Y,
-    const int incY);
+                 const int incY);
 void cblas_scopy(const int N, const float *X, const int incX, float *Y,
-    const int incY);
+                 const int incY);
 void cblas_saxpy(const int N, const float alpha, const float *X, const int incX,
-    float *Y, const int incY);
+                 float *Y, const int incY);
 
 void cblas_dswap(const int N, double *X, const int incX, double *Y,
-    const int incY);
+                 const int incY);
 void cblas_dcopy(const int N, const double *X, const int incX, double *Y,
-    const int incY);
+                 const int incY);
 void cblas_daxpy(const int N, const double alpha, const double *X,
-    const int incX, double *Y, const int incY);
+                 const int incX, double *Y, const int incY);
 
 void cblas_cswap(const int N, void *X, const int incX, void *Y, const int incY);
 void cblas_ccopy(const int N, const void *X, const int incX, void *Y,
-    const int incY);
+                 const int incY);
 void cblas_caxpy(const int N, const void *alpha, const void *X, const int incX,
-    void *Y, const int incY);
+                 void *Y, const int incY);
 
 void cblas_zswap(const int N, void *X, const int incX, void *Y, const int incY);
 void cblas_zcopy(const int N, const void *X, const int incX, void *Y,
-    const int incY);
+                 const int incY);
 void cblas_zaxpy(const int N, const void *alpha, const void *X, const int incX,
-    void *Y, const int incY);
+                 void *Y, const int incY);
 
 /*
  * Routines with S and D prefix only
@@ -128,17 +134,17 @@ void cblas_zaxpy(const int N, const void *alpha, const void *X, const int incX,
 void cblas_srotg(float *a, float *b, float *c, float *s);
 void cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
 void cblas_srot(const int N, float *X, const int incX, float *Y, const int incY,
-    const float c, const float s);
+                const float c, const float s);
 void cblas_srotm(const int N, float *X, const int incX, float *Y,
-    const int incY, const float *P);
+                 const int incY, const float *P);
 
 void cblas_drotg(double *a, double *b, double *c, double *s);
 void cblas_drotmg(double *d1, double *d2, double *b1, const double b2,
-    double *P);
+                  double *P);
 void cblas_drot(const int N, double *X, const int incX, double *Y,
-    const int incY, const double c, const double s);
+                const int incY, const double c, const double s);
 void cblas_drotm(const int N, double *X, const int incX, double *Y,
-    const int incY, const double *P);
+                 const int incY, const double *P);
 
 /*
  * Routines with S D C Z CS and ZD prefixes
@@ -160,224 +166,224 @@ void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const float alpha, const float *A, const int lda, const float *X,
-    const int incX, const float beta, float *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const float alpha, const float *A, const int lda, const float *X,
+                 const int incX, const float beta, float *Y, const int incY);
 void cblas_sgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_strmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *A, const int lda, float *X, const int incX);
 void cblas_stbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const float *A, const int lda, float *X, const int incX);
 void cblas_stpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *Ap, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *Ap, float *X, const int incX);
 void cblas_strsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *A, const int lda, float *X, const int incX);
 void cblas_stbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const float *A, const int lda, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const float *A, const int lda, float *X, const int incX);
 void cblas_stpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const float *Ap, float *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const float *Ap, float *X, const int incX);
 
 void cblas_dgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const double alpha, const double *A, const int lda, const double *X,
-    const int incX, const double beta, double *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const double alpha, const double *A, const int lda, const double *X,
+                 const int incX, const double beta, double *Y, const int incY);
 void cblas_dgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const double alpha, const double *A, const int lda,
-    const double *X, const int incX, const double beta, double *Y,
-    const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const double alpha, const double *A, const int lda,
+                 const double *X, const int incX, const double beta, double *Y,
+                 const int incY);
 void cblas_dtrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *A, const int lda, double *X, const int incX);
 void cblas_dtbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const double *A, const int lda, double *X, const int incX);
 void cblas_dtpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *Ap, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *Ap, double *X, const int incX);
 void cblas_dtrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *A, const int lda, double *X, const int incX);
 void cblas_dtbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const double *A, const int lda, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const double *A, const int lda, double *X, const int incX);
 void cblas_dtpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const double *Ap, double *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const double *Ap, double *X, const int incX);
 
 void cblas_cgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_cgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_ctrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ctbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ctpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 void cblas_ctrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ctbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ctpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 
 void cblas_zgemv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-    const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zgbmv(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
-    const int KU, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N, const int KL,
+                 const int KU, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_ztrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ztbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ztpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 void cblas_ztrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *A, const int lda, void *X, const int incX);
 void cblas_ztbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const int K, const void *A, const int lda, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const int K, const void *A, const int lda, void *X, const int incX);
 void cblas_ztpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
-    const void *Ap, void *X, const int incX);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag, const int N,
+                 const void *Ap, void *X, const int incX);
 
 /*
  * Routines with S and D prefixes only
  */
 void cblas_ssymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const int N, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_ssbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const float alpha, const float *A, const int lda,
-    const float *X, const int incX, const float beta, float *Y, const int incY);
+                 const int N, const int K, const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta, float *Y, const int incY);
 void cblas_sspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *Ap, const float *X,
-    const int incX, const float beta, float *Y, const int incY);
+                 const int N, const float alpha, const float *Ap, const float *X,
+                 const int incX, const float beta, float *Y, const int incY);
 void cblas_sger(const enum CBLAS_ORDER Order, const int M, const int N,
-    const float alpha, const float *X, const int incX, const float *Y,
-    const int incY, float *A, const int lda);
+                const float alpha, const float *X, const int incX, const float *Y,
+                const int incY, float *A, const int lda);
 void cblas_ssyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX, float *A,
-    const int lda);
+                const int N, const float alpha, const float *X, const int incX, float *A,
+                const int lda);
 void cblas_sspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX, float *Ap);
+                const int N, const float alpha, const float *X, const int incX, float *Ap);
 void cblas_ssyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX,
-    const float *Y, const int incY, float *A, const int lda);
+                 const int N, const float alpha, const float *X, const int incX,
+                 const float *Y, const int incY, float *A, const int lda);
 void cblas_sspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const float *X, const int incX,
-    const float *Y, const int incY, float *A);
+                 const int N, const float alpha, const float *X, const int incX,
+                 const float *Y, const int incY, float *A);
 
 void cblas_dsymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *A, const int lda,
-    const double *X, const int incX, const double beta, double *Y,
-    const int incY);
+                 const int N, const double alpha, const double *A, const int lda,
+                 const double *X, const int incX, const double beta, double *Y,
+                 const int incY);
 void cblas_dsbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const double alpha, const double *A,
-    const int lda, const double *X, const int incX, const double beta,
-    double *Y, const int incY);
+                 const int N, const int K, const double alpha, const double *A,
+                 const int lda, const double *X, const int incX, const double beta,
+                 double *Y, const int incY);
 void cblas_dspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *Ap, const double *X,
-    const int incX, const double beta, double *Y, const int incY);
+                 const int N, const double alpha, const double *Ap, const double *X,
+                 const int incX, const double beta, double *Y, const int incY);
 void cblas_dger(const enum CBLAS_ORDER Order, const int M, const int N,
-    const double alpha, const double *X, const int incX, const double *Y,
-    const int incY, double *A, const int lda);
+                const double alpha, const double *X, const int incX, const double *Y,
+                const int incY, double *A, const int lda);
 void cblas_dsyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX, double *A,
-    const int lda);
+                const int N, const double alpha, const double *X, const int incX, double *A,
+                const int lda);
 void cblas_dspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    double *Ap);
+                const int N, const double alpha, const double *X, const int incX,
+                double *Ap);
 void cblas_dsyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    const double *Y, const int incY, double *A, const int lda);
+                 const int N, const double alpha, const double *X, const int incX,
+                 const double *Y, const int incY, double *A, const int lda);
 void cblas_dspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const double *X, const int incX,
-    const double *Y, const int incY, double *A);
+                 const int N, const double alpha, const double *X, const int incX,
+                 const double *Y, const int incY, double *A);
 
 /*
  * Routines with C and Z prefixes only
  */
 void cblas_chemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_chbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const int K, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_chpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *Ap, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *Ap, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_cgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_cgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_cher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const void *X, const int incX, void *A,
-    const int lda);
+                const int N, const float alpha, const void *X, const int incX, void *A,
+                const int lda);
 void cblas_chpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const float alpha, const void *X, const int incX, void *A);
+                const int N, const float alpha, const void *X, const int incX, void *A);
 void cblas_cher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *A, const int lda);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
 void cblas_chpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *Ap);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *Ap);
 
 void cblas_zhemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *A, const int lda, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zhbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const int K, const void *alpha, const void *A, const int lda,
-    const void *X, const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const int K, const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta, void *Y, const int incY);
 void cblas_zhpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *Ap, const void *X,
-    const int incX, const void *beta, void *Y, const int incY);
+                 const int N, const void *alpha, const void *Ap, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
 void cblas_zgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_zgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-    const void *alpha, const void *X, const int incX, const void *Y,
-    const int incY, void *A, const int lda);
+                 const void *alpha, const void *X, const int incX, const void *Y,
+                 const int incY, void *A, const int lda);
 void cblas_zher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const void *X, const int incX, void *A,
-    const int lda);
+                const int N, const double alpha, const void *X, const int incX, void *A,
+                const int lda);
 void cblas_zhpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const double alpha, const void *X, const int incX, void *A);
+                const int N, const double alpha, const void *X, const int incX, void *A);
 void cblas_zher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *A, const int lda);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
 void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const int N, const void *alpha, const void *X, const int incX,
-    const void *Y, const int incY, void *Ap);
+                 const int N, const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *Ap);
 
 /*
  * ===========================================================================
@@ -389,136 +395,136 @@ void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const float alpha, const float *A,
-    const int lda, const float *B, const int ldb, const float beta, float *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const float alpha, const float *A,
+                 const int lda, const float *B, const int ldb, const float beta, float *C,
+                 const int ldc);
 void cblas_ssymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const float alpha,
-    const float *A, const int lda, const float *B, const int ldb,
-    const float beta, float *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const float alpha,
+                 const float *A, const int lda, const float *B, const int ldb,
+                 const float beta, float *C, const int ldc);
 void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const float *A, const int lda, const float beta,
-    float *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const float *A, const int lda, const float beta,
+                 float *C, const int ldc);
 void cblas_ssyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const float *A, const int lda, const float *B,
-    const int ldb, const float beta, float *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const float alpha, const float *A, const int lda, const float *B,
+                  const int ldb, const float beta, float *C, const int ldc);
 void cblas_strmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
-    const float *A, const int lda, float *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
+                 const float *A, const int lda, float *B, const int ldb);
 void cblas_strsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
-    const float *A, const int lda, float *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const float alpha,
+                 const float *A, const int lda, float *B, const int ldb);
 
 void cblas_dgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const double alpha, const double *A,
-    const int lda, const double *B, const int ldb, const double beta, double *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const double alpha, const double *A,
+                 const int lda, const double *B, const int ldb, const double beta, double *C,
+                 const int ldc);
 void cblas_dsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const double alpha,
-    const double *A, const int lda, const double *B, const int ldb,
-    const double beta, double *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const double alpha,
+                 const double *A, const int lda, const double *B, const int ldb,
+                 const double beta, double *C, const int ldc);
 void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const double *A, const int lda, const double beta,
-    double *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const double *A, const int lda, const double beta,
+                 double *C, const int ldc);
 void cblas_dsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const double *A, const int lda, const double *B,
-    const int ldb, const double beta, double *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const double alpha, const double *A, const int lda, const double *B,
+                  const int ldb, const double beta, double *C, const int ldc);
 void cblas_dtrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
-    const double *A, const int lda, double *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
+                 const double *A, const int lda, double *B, const int ldb);
 void cblas_dtrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
-    const double *A, const int lda, double *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const double alpha,
+                 const double *A, const int lda, double *B, const int ldb);
 
 void cblas_cgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const void *alpha, const void *A,
-    const int lda, const void *B, const int ldb, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb, const void *beta, void *C,
+                 const int ldc);
 void cblas_csymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_csyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda, const void *beta, void *C,
+                 const int ldc);
 void cblas_csyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const void *beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const void *beta, void *C, const int ldc);
 void cblas_ctrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 void cblas_ctrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 
 void cblas_zgemm(const enum CBLAS_ORDER Order,
-    const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
-    const int M, const int N, const int K, const void *alpha, const void *A,
-    const int lda, const void *B, const int ldb, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB,
+                 const int M, const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb, const void *beta, void *C,
+                 const int ldc);
 void cblas_zsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_zsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda, const void *beta, void *C,
+                 const int ldc);
 void cblas_zsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const void *beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const void *beta, void *C, const int ldc);
 void cblas_ztrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-    const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
-    const void *A, const int lda, void *B, const int ldb);
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, void *B, const int ldb);
 
 /*
  * Routines with prefixes C and Z only
  */
 void cblas_chemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_cherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const float alpha, const void *A, const int lda, const float beta, void *C,
-    const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const void *A, const int lda, const float beta, void *C,
+                 const int ldc);
 void cblas_cher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const float beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const float beta, void *C, const int ldc);
 void cblas_zhemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-    const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
-    const void *A, const int lda, const void *B, const int ldb,
-    const void *beta, void *C, const int ldc);
+                 const enum CBLAS_UPLO Uplo, const int M, const int N, const void *alpha,
+                 const void *A, const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
 void cblas_zherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const double alpha, const void *A, const int lda, const double beta,
-    void *C, const int ldc);
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const void *A, const int lda, const double beta,
+                 void *C, const int ldc);
 void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-    const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-    const void *alpha, const void *A, const int lda, const void *B,
-    const int ldb, const double beta, void *C, const int ldc);
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda, const void *B,
+                  const int ldb, const double beta, void *C, const int ldc);
 
 int cblas_errprn(int ierr, int info, char *form, ...);
 

--- a/exotations/solvers/ik_solver/include/lapack/clapack.h
+++ b/exotations/solvers/ik_solver/include/lapack/clapack.h
@@ -14,7292 +14,7291 @@ ISBN = 0-89871-447-8 (paperback)
 #ifndef __CLAPACK_H
 #define __CLAPACK_H
 
-#ifdef __cplusplus 	
-extern "C"
-{
-#endif		
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-  /* Subroutine */int caxpy_(integer *n, complex *ca, complex *cx,
-      integer * incx, complex *cy, integer *incy);
+/* Subroutine */ int caxpy_(integer *n, complex *ca, complex *cx,
+                            integer *incx, complex *cy, integer *incy);
 
-  /* Subroutine */int ccopy_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy);
+/* Subroutine */ int ccopy_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy);
 
-  /* Complex */VOID cdotc_(complex * ret_val, integer *n, complex *cx,
-      integer *incx, complex *cy, integer *incy);
+/* Complex */ VOID cdotc_(complex *ret_val, integer *n, complex *cx,
+                          integer *incx, complex *cy, integer *incy);
 
-  /* Complex */VOID cdotu_(complex * ret_val, integer *n, complex *cx,
-      integer *incx, complex *cy, integer *incy);
+/* Complex */ VOID cdotu_(complex *ret_val, integer *n, complex *cx,
+                          integer *incx, complex *cy, integer *incy);
 
-  /* Subroutine */int cgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, complex *alpha, complex *a, integer *lda, complex *x,
-      integer *incx, complex *beta, complex *y, integer *incy);
+/* Subroutine */ int cgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, complex *alpha, complex *a, integer *lda, complex *x,
+                            integer *incx, complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int cgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb, complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int cgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb, complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int cgemv_(char *trans, integer *m, integer *n,
-      complex * alpha, complex *a, integer *lda, complex *x, integer *incx,
-      complex * beta, complex *y, integer *incy);
+/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                            complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int cgerc_(integer *m, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cgerc_(integer *m, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int cgeru_(integer *m, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cgeru_(integer *m, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int chbmv_(char *uplo, integer *n, integer *k,
-      complex * alpha, complex *a, integer *lda, complex *x, integer *incx,
-      complex * beta, complex *y, integer *incy);
+/* Subroutine */ int chbmv_(char *uplo, integer *n, integer *k,
+                            complex *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                            complex *beta, complex *y, integer *incy);
 
-  /* Subroutine */int chemm_(char *side, char *uplo, integer *m, integer *n,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int chemm_(char *side, char *uplo, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int chemv_(char *uplo, integer *n, complex *alpha,
-      complex * a, integer *lda, complex *x, integer *incx, complex *beta,
-      complex *y, integer *incy);
+/* Subroutine */ int chemv_(char *uplo, integer *n, complex *alpha,
+                            complex *a, integer *lda, complex *x, integer *incx, complex *beta,
+                            complex *y, integer *incy);
 
-  /* Subroutine */int cher_(char *uplo, integer *n, real *alpha, complex *x,
-      integer *incx, complex *a, integer *lda);
+/* Subroutine */ int cher_(char *uplo, integer *n, real *alpha, complex *x,
+                           integer *incx, complex *a, integer *lda);
 
-  /* Subroutine */int cher2_(char *uplo, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *a,
-      integer *lda);
+/* Subroutine */ int cher2_(char *uplo, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *a,
+                            integer *lda);
 
-  /* Subroutine */int cher2k_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      real *beta, complex *c__, integer *ldc);
+/* Subroutine */ int cher2k_(char *uplo, char *trans, integer *n, integer *k,
+                             complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                             real *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int cherk_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, complex *a, integer *lda, real *beta, complex *c__,
-      integer *ldc);
+/* Subroutine */ int cherk_(char *uplo, char *trans, integer *n, integer *k,
+                            real *alpha, complex *a, integer *lda, real *beta, complex *c__,
+                            integer *ldc);
 
-  /* Subroutine */int chpmv_(char *uplo, integer *n, complex *alpha,
-      complex * ap, complex *x, integer *incx, complex *beta, complex *y,
-      integer * incy);
+/* Subroutine */ int chpmv_(char *uplo, integer *n, complex *alpha,
+                            complex *ap, complex *x, integer *incx, complex *beta, complex *y,
+                            integer *incy);
 
-  /* Subroutine */int chpr_(char *uplo, integer *n, real *alpha, complex *x,
-      integer *incx, complex *ap);
+/* Subroutine */ int chpr_(char *uplo, integer *n, real *alpha, complex *x,
+                           integer *incx, complex *ap);
 
-  /* Subroutine */int chpr2_(char *uplo, integer *n, complex *alpha,
-      complex * x, integer *incx, complex *y, integer *incy, complex *ap);
+/* Subroutine */ int chpr2_(char *uplo, integer *n, complex *alpha,
+                            complex *x, integer *incx, complex *y, integer *incy, complex *ap);
 
-  /* Subroutine */int crotg_(complex *ca, complex *cb, real *c__, complex *s);
+/* Subroutine */ int crotg_(complex *ca, complex *cb, real *c__, complex *s);
 
-  /* Subroutine */int cscal_(integer *n, complex *ca, complex *cx,
-      integer * incx);
+/* Subroutine */ int cscal_(integer *n, complex *ca, complex *cx,
+                            integer *incx);
 
-  /* Subroutine */int csrot_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, real *c__, real *s);
+/* Subroutine */ int csrot_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy, real *c__, real *s);
 
-  /* Subroutine */int csscal_(integer *n, real *sa, complex *cx, integer *incx);
+/* Subroutine */ int csscal_(integer *n, real *sa, complex *cx, integer *incx);
 
-  /* Subroutine */int cswap_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy);
+/* Subroutine */ int cswap_(integer *n, complex *cx, integer *incx,
+                            complex *cy, integer *incy);
 
-  /* Subroutine */int csymm_(char *side, char *uplo, integer *m, integer *n,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int csymm_(char *side, char *uplo, integer *m, integer *n,
+                            complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int csyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *beta, complex *c__, integer *ldc);
+/* Subroutine */ int csyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             complex *alpha, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *beta, complex *c__, integer *ldc);
 
-  /* Subroutine */int csyrk_(char *uplo, char *trans, integer *n, integer *k,
-      complex *alpha, complex *a, integer *lda, complex *beta, complex *c__,
-      integer *ldc);
+/* Subroutine */ int csyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            complex *alpha, complex *a, integer *lda, complex *beta, complex *c__,
+                            integer *ldc);
 
-  /* Subroutine */int ctbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctpmv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *ap, complex *x, integer *incx);
+/* Subroutine */ int ctpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *ap, complex *x, integer *incx);
 
-  /* Subroutine */int ctpsv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *ap, complex *x, integer *incx);
+/* Subroutine */ int ctpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *ap, complex *x, integer *incx);
 
-  /* Subroutine */int ctrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctrmv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *a, integer *lda, complex *x, integer *incx);
 
-  /* Subroutine */int ctrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, complex *alpha, complex *a, integer *lda,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, complex *alpha, complex *a, integer *lda,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctrsv_(char *uplo, char *trans, char *diag, integer *n,
-      complex *a, integer *lda, complex *x, integer *incx);
+/* Subroutine */ int ctrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            complex *a, integer *lda, complex *x, integer *incx);
 
-  doublereal dasum_(integer *n, doublereal *dx, integer *incx);
+doublereal dasum_(integer *n, doublereal *dx, integer *incx);
 
-  /* Subroutine */int daxpy_(integer *n, doublereal *da, doublereal *dx,
-      integer *incx, doublereal *dy, integer *incy);
+/* Subroutine */ int daxpy_(integer *n, doublereal *da, doublereal *dx,
+                            integer *incx, doublereal *dy, integer *incy);
 
-  doublereal dcabs1_(doublecomplex *z__);
+doublereal dcabs1_(doublecomplex *z__);
 
-  /* Subroutine */int dcopy_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy);
+/* Subroutine */ int dcopy_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy);
 
-  doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
-      integer *incy);
+doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
+                 integer *incy);
 
-  /* Subroutine */int dgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *x, integer *incx, doublereal *beta, doublereal *y,
-      integer *incy);
+/* Subroutine */ int dgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *x, integer *incx, doublereal *beta, doublereal *y,
+                            integer *incy);
 
-  /* Subroutine */int dgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *b, integer *ldb, doublereal *beta, doublereal *c__,
-      integer *ldc);
+/* Subroutine */ int dgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb, doublereal *beta, doublereal *c__,
+                            integer *ldc);
 
-  /* Subroutine */int dgemv_(char *trans, integer *m, integer *n,
-      doublereal * alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dgemv_(char *trans, integer *m, integer *n,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                            integer *incx, doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dger_(integer *m, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
-      integer *lda);
+/* Subroutine */ int dger_(integer *m, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
+                           integer *lda);
 
-  doublereal dnrm2_(integer *n, doublereal *x, integer *incx);
+doublereal dnrm2_(integer *n, doublereal *x, integer *incx);
 
-  /* Subroutine */int drot_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy, doublereal *c__, doublereal *s);
+/* Subroutine */ int drot_(integer *n, doublereal *dx, integer *incx,
+                           doublereal *dy, integer *incy, doublereal *c__, doublereal *s);
 
-  /* Subroutine */int drotg_(doublereal *da, doublereal *db, doublereal *c__,
-      doublereal *s);
+/* Subroutine */ int drotg_(doublereal *da, doublereal *db, doublereal *c__,
+                            doublereal *s);
 
-  /* Subroutine */int drotm_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy, doublereal *dparam);
+/* Subroutine */ int drotm_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy, doublereal *dparam);
 
-  /* Subroutine */int drotmg_(doublereal *dd1, doublereal *dd2,
-      doublereal * dx1, doublereal *dy1, doublereal *dparam);
+/* Subroutine */ int drotmg_(doublereal *dd1, doublereal *dd2,
+                             doublereal *dx1, doublereal *dy1, doublereal *dparam);
 
-  /* Subroutine */int dsbmv_(char *uplo, integer *n, integer *k,
-      doublereal * alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dsbmv_(char *uplo, integer *n, integer *k,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                            integer *incx, doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dscal_(integer *n, doublereal *da, doublereal *dx,
-      integer *incx);
+/* Subroutine */ int dscal_(integer *n, doublereal *da, doublereal *dx,
+                            integer *incx);
 
-  doublereal dsdot_(integer *n, real *sx, integer *incx, real *sy,
-      integer * incy);
+doublereal dsdot_(integer *n, real *sx, integer *incx, real *sy,
+                  integer *incy);
 
-  /* Subroutine */int dspmv_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *ap, doublereal *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
+/* Subroutine */ int dspmv_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *ap, doublereal *x, integer *incx, doublereal *beta,
+                            doublereal *y, integer *incy);
 
-  /* Subroutine */int dspr_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *ap);
+/* Subroutine */ int dspr_(char *uplo, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *ap);
 
-  /* Subroutine */int dspr2_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy,
-      doublereal *ap);
+/* Subroutine */ int dspr2_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *x, integer *incx, doublereal *y, integer *incy,
+                            doublereal *ap);
 
-  /* Subroutine */int dswap_(integer *n, doublereal *dx, integer *incx,
-      doublereal *dy, integer *incy);
+/* Subroutine */ int dswap_(integer *n, doublereal *dx, integer *incx,
+                            doublereal *dy, integer *incy);
 
-  /* Subroutine */int dsymm_(char *side, char *uplo, integer *m, integer *n,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
+/* Subroutine */ int dsymm_(char *side, char *uplo, integer *m, integer *n,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dsymv_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *a, integer *lda, doublereal *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
+/* Subroutine */ int dsymv_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx,
+                            doublereal *beta, doublereal *y, integer *incy);
 
-  /* Subroutine */int dsyr_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *a, integer *lda);
+/* Subroutine */ int dsyr_(char *uplo, integer *n, doublereal *alpha,
+                           doublereal *x, integer *incx, doublereal *a, integer *lda);
 
-  /* Subroutine */int dsyr2_(char *uplo, integer *n, doublereal *alpha,
-      doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
-      integer *lda);
+/* Subroutine */ int dsyr2_(char *uplo, integer *n, doublereal *alpha,
+                            doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *a,
+                            integer *lda);
 
-  /* Subroutine */int dsyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
+/* Subroutine */ int dsyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublereal *alpha, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *beta, doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dsyrk_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *beta,
-      doublereal *c__, integer *ldc);
+/* Subroutine */ int dsyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublereal *alpha, doublereal *a, integer *lda, doublereal *beta,
+                            doublereal *c__, integer *ldc);
 
-  /* Subroutine */int dtbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtpmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *ap, doublereal *x, integer *incx);
+/* Subroutine */ int dtpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *ap, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtpsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *ap, doublereal *x, integer *incx);
+/* Subroutine */ int dtpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *ap, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublereal *alpha, doublereal *a, integer * lda,
-      doublereal *b, integer *ldb);
+/* Subroutine */ int dtrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb);
 
-  /* Subroutine */int dtrmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  /* Subroutine */int dtrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublereal *alpha, doublereal *a, integer * lda,
-      doublereal *b, integer *ldb);
+/* Subroutine */ int dtrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *b, integer *ldb);
 
-  /* Subroutine */int dtrsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *x, integer *incx);
+/* Subroutine */ int dtrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublereal *a, integer *lda, doublereal *x, integer *incx);
 
-  doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx);
+doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx);
 
-  doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx);
+doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx);
 
-  integer icamax_(integer *n, complex *cx, integer *incx);
+integer icamax_(integer *n, complex *cx, integer *incx);
 
-  integer idamax_(integer *n, doublereal *dx, integer *incx);
+integer idamax_(integer *n, doublereal *dx, integer *incx);
 
-  integer isamax_(integer *n, real *sx, integer *incx);
+integer isamax_(integer *n, real *sx, integer *incx);
 
-  integer izamax_(integer *n, doublecomplex *zx, integer *incx);
+integer izamax_(integer *n, doublecomplex *zx, integer *incx);
 
-  logical lsame_(char *ca, char *cb);
+logical lsame_(char *ca, char *cb);
 
-  doublereal sasum_(integer *n, real *sx, integer *incx);
+doublereal sasum_(integer *n, real *sx, integer *incx);
 
-  /* Subroutine */int saxpy_(integer *n, real *sa, real *sx, integer *incx,
-      real *sy, integer *incy);
+/* Subroutine */ int saxpy_(integer *n, real *sa, real *sx, integer *incx,
+                            real *sy, integer *incy);
 
-  doublereal scabs1_(complex *z__);
+doublereal scabs1_(complex *z__);
 
-  doublereal scasum_(integer *n, complex *cx, integer *incx);
+doublereal scasum_(integer *n, complex *cx, integer *incx);
 
-  doublereal scnrm2_(integer *n, complex *x, integer *incx);
+doublereal scnrm2_(integer *n, complex *x, integer *incx);
 
-  /* Subroutine */int scopy_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+/* Subroutine */ int scopy_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy);
 
-  doublereal sdot_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+doublereal sdot_(integer *n, real *sx, integer *incx, real *sy,
+                 integer *incy);
 
-  doublereal sdsdot_(integer *n, real *sb, real *sx, integer *incx, real *sy,
-      integer *incy);
+doublereal sdsdot_(integer *n, real *sb, real *sx, integer *incx, real *sy,
+                   integer *incy);
 
-  /* Subroutine */int sgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, real *alpha, real *a, integer *lda, real *x, integer * incx,
-      real *beta, real *y, integer *incy);
+/* Subroutine */ int sgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, real *alpha, real *a, integer *lda, real *x, integer *incx,
+                            real *beta, real *y, integer *incy);
 
-  /* Subroutine */int sgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, real *alpha, real *a, integer *lda, real *b,
-      integer * ldb, real *beta, real *c__, integer *ldc);
+/* Subroutine */ int sgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb, real *beta, real *c__, integer *ldc);
 
-  /* Subroutine */int sgemv_(char *trans, integer *m, integer *n, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int sgemv_(char *trans, integer *m, integer *n, real *alpha,
+                            real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int sger_(integer *m, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *a, integer *lda);
+/* Subroutine */ int sger_(integer *m, integer *n, real *alpha, real *x,
+                           integer *incx, real *y, integer *incy, real *a, integer *lda);
 
-  doublereal snrm2_(integer *n, real *x, integer *incx);
+doublereal snrm2_(integer *n, real *x, integer *incx);
 
-  /* Subroutine */int srot_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy, real *c__, real *s);
+/* Subroutine */ int srot_(integer *n, real *sx, integer *incx, real *sy,
+                           integer *incy, real *c__, real *s);
 
-  /* Subroutine */int srotg_(real *sa, real *sb, real *c__, real *s);
+/* Subroutine */ int srotg_(real *sa, real *sb, real *c__, real *s);
 
-  /* Subroutine */int srotm_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy, real *sparam);
+/* Subroutine */ int srotm_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy, real *sparam);
 
-  /* Subroutine */int srotmg_(real *sd1, real *sd2, real *sx1, real *sy1,
-      real *sparam);
+/* Subroutine */ int srotmg_(real *sd1, real *sd2, real *sx1, real *sy1,
+                             real *sparam);
 
-  /* Subroutine */int ssbmv_(char *uplo, integer *n, integer *k, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int ssbmv_(char *uplo, integer *n, integer *k, real *alpha,
+                            real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int sscal_(integer *n, real *sa, real *sx, integer *incx);
+/* Subroutine */ int sscal_(integer *n, real *sa, real *sx, integer *incx);
 
-  /* Subroutine */int sspmv_(char *uplo, integer *n, real *alpha, real *ap,
-      real *x, integer *incx, real *beta, real *y, integer *incy);
+/* Subroutine */ int sspmv_(char *uplo, integer *n, real *alpha, real *ap,
+                            real *x, integer *incx, real *beta, real *y, integer *incy);
 
-  /* Subroutine */int sspr_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *ap);
+/* Subroutine */ int sspr_(char *uplo, integer *n, real *alpha, real *x,
+                           integer *incx, real *ap);
 
-  /* Subroutine */int sspr2_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *ap);
+/* Subroutine */ int sspr2_(char *uplo, integer *n, real *alpha, real *x,
+                            integer *incx, real *y, integer *incy, real *ap);
 
-  /* Subroutine */int sswap_(integer *n, real *sx, integer *incx, real *sy,
-      integer *incy);
+/* Subroutine */ int sswap_(integer *n, real *sx, integer *incx, real *sy,
+                            integer *incy);
 
-  /* Subroutine */int ssymm_(char *side, char *uplo, integer *m, integer *n,
-      real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
-      real *c__, integer *ldc);
+/* Subroutine */ int ssymm_(char *side, char *uplo, integer *m, integer *n,
+                            real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
+                            real *c__, integer *ldc);
 
-  /* Subroutine */int ssymv_(char *uplo, integer *n, real *alpha, real *a,
-      integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer * incy);
+/* Subroutine */ int ssymv_(char *uplo, integer *n, real *alpha, real *a,
+                            integer *lda, real *x, integer *incx, real *beta, real *y,
+                            integer *incy);
 
-  /* Subroutine */int ssyr_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *a, integer *lda);
+/* Subroutine */ int ssyr_(char *uplo, integer *n, real *alpha, real *x,
+                           integer *incx, real *a, integer *lda);
 
-  /* Subroutine */int ssyr2_(char *uplo, integer *n, real *alpha, real *x,
-      integer *incx, real *y, integer *incy, real *a, integer *lda);
+/* Subroutine */ int ssyr2_(char *uplo, integer *n, real *alpha, real *x,
+                            integer *incx, real *y, integer *incy, real *a, integer *lda);
 
-  /* Subroutine */int ssyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
-      real *c__, integer *ldc);
+/* Subroutine */ int ssyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             real *alpha, real *a, integer *lda, real *b, integer *ldb, real *beta,
+                             real *c__, integer *ldc);
 
-  /* Subroutine */int ssyrk_(char *uplo, char *trans, integer *n, integer *k,
-      real *alpha, real *a, integer *lda, real *beta, real *c__, integer * ldc);
+/* Subroutine */ int ssyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            real *alpha, real *a, integer *lda, real *beta, real *c__, integer *ldc);
 
-  /* Subroutine */int stbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int stbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int stbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int stbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int stpmv_(char *uplo, char *trans, char *diag, integer *n,
-      real *ap, real *x, integer *incx);
+/* Subroutine */ int stpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *ap, real *x, integer *incx);
 
-  /* Subroutine */int stpsv_(char *uplo, char *trans, char *diag, integer *n,
-      real *ap, real *x, integer *incx);
+/* Subroutine */ int stpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *ap, real *x, integer *incx);
 
-  /* Subroutine */int strmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
-      integer *ldb);
+/* Subroutine */ int strmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb);
 
-  /* Subroutine */int strmv_(char *uplo, char *trans, char *diag, integer *n,
-      real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int strmv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int strsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
-      integer *ldb);
+/* Subroutine */ int strsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, real *alpha, real *a, integer *lda, real *b,
+                            integer *ldb);
 
-  /* Subroutine */int strsv_(char *uplo, char *trans, char *diag, integer *n,
-      real *a, integer *lda, real *x, integer *incx);
+/* Subroutine */ int strsv_(char *uplo, char *trans, char *diag, integer *n,
+                            real *a, integer *lda, real *x, integer *incx);
 
-  /* Subroutine */int xerbla_(char *srname, integer *info);
+/* Subroutine */ int xerbla_(char *srname, integer *info);
 
-  /* Subroutine */int xerbla_array__(char *srname_array__,
-      integer * srname_len__, integer *info, ftnlen srname_array_len);
+/* Subroutine */ int xerbla_array__(char *srname_array__,
+                                    integer *srname_len__, integer *info, ftnlen srname_array_len);
 
-  /* Subroutine */int zaxpy_(integer *n, doublecomplex *za, doublecomplex *zx,
-      integer *incx, doublecomplex *zy, integer *incy);
+/* Subroutine */ int zaxpy_(integer *n, doublecomplex *za, doublecomplex *zx,
+                            integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zcopy_(integer *n, doublecomplex *zx, integer *incx,
-      doublecomplex *zy, integer *incy);
+/* Subroutine */ int zcopy_(integer *n, doublecomplex *zx, integer *incx,
+                            doublecomplex *zy, integer *incy);
 
-  /* Double Complex */VOID zdotc_(doublecomplex * ret_val, integer *n,
-      doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
+/* Double Complex */ VOID zdotc_(doublecomplex *ret_val, integer *n,
+                                 doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Double Complex */VOID zdotu_(doublecomplex * ret_val, integer *n,
-      doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
+/* Double Complex */ VOID zdotu_(doublecomplex *ret_val, integer *n,
+                                 doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zdrot_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublereal *c__, doublereal *s);
+/* Subroutine */ int zdrot_(integer *n, doublecomplex *cx, integer *incx,
+                            doublecomplex *cy, integer *incy, doublereal *c__, doublereal *s);
 
-  /* Subroutine */int zdscal_(integer *n, doublereal *da, doublecomplex *zx,
-      integer *incx);
+/* Subroutine */ int zdscal_(integer *n, doublereal *da, doublecomplex *zx,
+                             integer *incx);
 
-  /* Subroutine */int zgbmv_(char *trans, integer *m, integer *n, integer *kl,
-      integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda,
-      doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex * y,
-      integer *incy);
+/* Subroutine */ int zgbmv_(char *trans, integer *m, integer *n, integer *kl,
+                            integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda,
+                            doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex *y,
+                            integer *incy);
 
-  /* Subroutine */int zgemm_(char *transa, char *transb, integer *m,
-      integer * n, integer *k, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublecomplex *beta,
-      doublecomplex * c__, integer *ldc);
+/* Subroutine */ int zgemm_(char *transa, char *transb, integer *m,
+                            integer *n, integer *k, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb, doublecomplex *beta,
+                            doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zgemv_(char *trans, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * x,
-      integer *incx, doublecomplex *beta, doublecomplex *y, integer * incy);
+/* Subroutine */ int zgemv_(char *trans, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zgerc_(integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zgerc_(integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zgeru_(integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zgeru_(integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zhbmv_(char *uplo, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer * incx, doublecomplex *beta, doublecomplex *y, integer *incy);
+/* Subroutine */ int zhbmv_(char *uplo, integer *n, integer *k,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zhemm_(char *side, char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zhemm_(char *side, char *uplo, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zhemv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublecomplex *beta, doublecomplex *y, integer *incy);
+/* Subroutine */ int zhemv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                            doublecomplex *beta, doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zher_(char *uplo, integer *n, doublereal *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
+/* Subroutine */ int zher_(char *uplo, integer *n, doublereal *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zher2_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *a, integer *lda);
+/* Subroutine */ int zher2_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *a, integer *lda);
 
-  /* Subroutine */int zher2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublereal *beta, doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zher2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zherk_(char *uplo, char *trans, integer *n, integer *k,
-      doublereal *alpha, doublecomplex *a, integer *lda, doublereal *beta,
-      doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zherk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublereal *alpha, doublecomplex *a, integer *lda, doublereal *beta,
+                            doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zhpmv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex * beta,
-      doublecomplex *y, integer *incy);
+/* Subroutine */ int zhpmv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta,
+                            doublecomplex *y, integer *incy);
 
-  /* Subroutine */int zhpr_(char *uplo, integer *n, doublereal *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *ap);
+/* Subroutine */ int zhpr_(char *uplo, integer *n, doublereal *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *ap);
 
-  /* Subroutine */int zhpr2_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
-      doublecomplex *ap);
+/* Subroutine */ int zhpr2_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *x, integer *incx, doublecomplex *y, integer *incy,
+                            doublecomplex *ap);
 
-  /* Subroutine */int zrotg_(doublecomplex *ca, doublecomplex *cb,
-      doublereal * c__, doublecomplex *s);
+/* Subroutine */ int zrotg_(doublecomplex *ca, doublecomplex *cb,
+                            doublereal *c__, doublecomplex *s);
 
-  /* Subroutine */int zscal_(integer *n, doublecomplex *za, doublecomplex *zx,
-      integer *incx);
+/* Subroutine */ int zscal_(integer *n, doublecomplex *za, doublecomplex *zx,
+                            integer *incx);
 
-  /* Subroutine */int zswap_(integer *n, doublecomplex *zx, integer *incx,
-      doublecomplex *zy, integer *incy);
+/* Subroutine */ int zswap_(integer *n, doublecomplex *zx, integer *incx,
+                            doublecomplex *zy, integer *incy);
 
-  /* Subroutine */int zsymm_(char *side, char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zsymm_(char *side, char *uplo, integer *m, integer *n,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zsyr2k_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex * b,
-      integer *ldb, doublecomplex *beta, doublecomplex *c__, integer * ldc);
+/* Subroutine */ int zsyr2k_(char *uplo, char *trans, integer *n, integer *k,
+                             doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int zsyrk_(char *uplo, char *trans, integer *n, integer *k,
-      doublecomplex *alpha, doublecomplex *a, integer *lda,
-      doublecomplex * beta, doublecomplex *c__, integer *ldc);
+/* Subroutine */ int zsyrk_(char *uplo, char *trans, integer *n, integer *k,
+                            doublecomplex *alpha, doublecomplex *a, integer *lda,
+                            doublecomplex *beta, doublecomplex *c__, integer *ldc);
 
-  /* Subroutine */int ztbmv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx);
+/* Subroutine */ int ztbmv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx);
 
-  /* Subroutine */int ztbsv_(char *uplo, char *trans, char *diag, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx);
+/* Subroutine */ int ztbsv_(char *uplo, char *trans, char *diag, integer *n,
+                            integer *k, doublecomplex *a, integer *lda, doublecomplex *x,
+                            integer *incx);
 
-  /* Subroutine */int ztpmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *ap, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztpmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *ap, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztpsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *ap, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztpsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *ap, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztrmm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb);
+/* Subroutine */ int ztrmm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb);
 
-  /* Subroutine */int ztrmv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztrmv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int ztrsm_(char *side, char *uplo, char *transa, char *diag,
-      integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb);
+/* Subroutine */ int ztrsm_(char *side, char *uplo, char *transa, char *diag,
+                            integer *m, integer *n, doublecomplex *alpha, doublecomplex *a,
+                            integer *lda, doublecomplex *b, integer *ldb);
 
-  /* Subroutine */int ztrsv_(char *uplo, char *trans, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+/* Subroutine */ int ztrsv_(char *uplo, char *trans, char *diag, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
 
-  /* Subroutine */int cbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, real *d__, real *e, complex *vt,
-      integer *ldvt, complex *u, integer *ldu, complex *c__, integer *ldc,
-      real *rwork, integer *info);
+/* Subroutine */ int cbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, real *d__, real *e, complex *vt,
+                             integer *ldvt, complex *u, integer *ldu, complex *c__, integer *ldc,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, complex *ab, integer *ldab, real *d__, real *e,
-      complex *q, integer *ldq, complex *pt, integer *ldpt, complex *c__,
-      integer *ldc, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, complex *ab, integer *ldab, real *d__, real *e,
+                             complex *q, integer *ldq, complex *pt, integer *ldpt, complex *c__,
+                             integer *ldc, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, integer *info);
+/* Subroutine */ int cgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, integer *info);
 
-  /* Subroutine */int cgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, complex *ab, integer *ldab, real *r__, real *c__,
-      real *rowcnd, real *colcnd, real *amax, integer *info);
+/* Subroutine */ int cgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, complex *ab, integer *ldab, real *r__, real *c__,
+                              real *rowcnd, real *colcnd, real *amax, integer *info);
 
-  /* Subroutine */int cgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
-      integer * ldafb, integer *ipiv, complex *b, integer *ldb, complex *x,
-      integer * ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer * info);
+/* Subroutine */ int cgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
+                             integer *ldafb, integer *ipiv, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
-      complex * afb, integer *ldafb, integer *ipiv, real *r__, real *c__,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real *rwork, integer * info);
+/* Subroutine */ int cgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
+                              complex *afb, integer *ldafb, integer *ipiv, real *r__, real *c__,
+                              complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, complex *ab, integer *ldab, integer *ipiv, complex *b,
-      integer * ldb, integer *info);
+/* Subroutine */ int cgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, complex *ab, integer *ldab, integer *ipiv, complex *b,
+                            integer *ldb, integer *info);
 
-  /* Subroutine */int cgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
-      integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, complex *afb,
+                             integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
-      complex * afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
-      real *c__, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, complex *ab, integer *ldab,
+                              complex *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
+                              real *c__, complex *b, integer *ldb, complex *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int cgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int cgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, complex *ab, integer *ldab, integer *ipiv,
-      complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, complex *ab, integer *ldab, integer *ipiv,
+                             complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *scale, integer *m, complex *v, integer *ldv,
-      integer *info);
+/* Subroutine */ int cgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *scale, integer *m, complex *v, integer *ldv,
+                             integer *info);
 
-  /* Subroutine */int cgebal_(char *job, integer *n, complex *a, integer *lda,
-      integer *ilo, integer *ihi, real *scale, integer *info);
+/* Subroutine */ int cgebal_(char *job, integer *n, complex *a, integer *lda,
+                             integer *ilo, integer *ihi, real *scale, integer *info);
 
-  /* Subroutine */int cgebd2_(integer *m, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tauq, complex *taup, complex *work,
-      integer *info);
+/* Subroutine */ int cgebd2_(integer *m, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tauq, complex *taup, complex *work,
+                             integer *info);
 
-  /* Subroutine */int cgebrd_(integer *m, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tauq, complex *taup, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int cgebrd_(integer *m, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tauq, complex *taup, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int cgecon_(char *norm, integer *n, complex *a, integer *lda,
-      real *anorm, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgecon_(char *norm, integer *n, complex *a, integer *lda,
+                             real *anorm, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgeequ_(integer *m, integer *n, complex *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
+/* Subroutine */ int cgeequ_(integer *m, integer *n, complex *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             integer *info);
 
-  /* Subroutine */int cgeequb_(integer *m, integer *n, complex *a,
-      integer * lda, real *r__, real *c__, real *rowcnd, real *colcnd,
-      real *amax, integer *info);
+/* Subroutine */ int cgeequb_(integer *m, integer *n, complex *a,
+                              integer *lda, real *r__, real *c__, real *rowcnd, real *colcnd,
+                              real *amax, integer *info);
 
-  /* Subroutine */int cgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      complex *a, integer *lda, integer *sdim, complex *w, complex *vs,
-      integer *ldvs, complex *work, integer *lwork, real *rwork,
-      logical * bwork, integer *info);
+/* Subroutine */ int cgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            complex *a, integer *lda, integer *sdim, complex *w, complex *vs,
+                            integer *ldvs, complex *work, integer *lwork, real *rwork,
+                            logical *bwork, integer *info);
 
-  /* Subroutine */int cgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, complex *a, integer *lda, integer *sdim,
-      complex * w, complex *vs, integer *ldvs, real *rconde, real *rcondv,
-      complex * work, integer *lwork, real *rwork, logical *bwork,
-      integer *info);
+/* Subroutine */ int cgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, complex *a, integer *lda, integer *sdim,
+                             complex *w, complex *vs, integer *ldvs, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, logical *bwork,
+                             integer *info);
 
-  /* Subroutine */int cgeev_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *w, complex *vl, integer *ldvl, complex *vr,
-      integer *ldvr, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgeev_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *w, complex *vl, integer *ldvl, complex *vr,
+                            integer *ldvr, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, complex *a, integer *lda, complex *w,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *ilo,
-      integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
-      complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, complex *a, integer *lda, complex *w,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *ilo,
+                             integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgegs_(char *jobvsl, char *jobvsr, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, complex *alpha,
-      complex * beta, complex *vsl, integer *ldvsl, complex *vsr,
-      integer *ldvsr, complex *work, integer *lwork, real *rwork,
-      integer *info);
+/* Subroutine */ int cgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            complex *a, integer *lda, complex *b, integer *ldb, complex *alpha,
+                            complex *beta, complex *vsl, integer *ldvsl, complex *vsr,
+                            integer *ldvsr, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cgegv_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex * work,
-      integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgegv_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
+                            complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex *work,
+                            integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgehd2_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgehd2_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgehrd_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cgehrd_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cgelq2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgelq2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgelqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgelqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      complex * work, integer *lwork, integer *info);
+/* Subroutine */ int cgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                            complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgelsd_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
-      integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * iwork, integer *info);
+/* Subroutine */ int cgelsd_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
+                             integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int cgelss_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
-      integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgelss_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, real *s, real *rcond,
+                             integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgelsx_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *jpvt,
-      real *rcond, integer *rank, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgelsx_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *jpvt,
+                             real *rcond, integer *rank, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgelsy_(integer *m, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *jpvt,
-      real *rcond, integer *rank, complex *work, integer *lwork, real *rwork,
-      integer * info);
+/* Subroutine */ int cgelsy_(integer *m, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *jpvt,
+                             real *rcond, integer *rank, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgeql2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgeql2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgeqlf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgeqlf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgeqp3_(integer *m, integer *n, complex *a, integer *lda,
-      integer *jpvt, complex *tau, complex *work, integer *lwork, real * rwork,
-      integer *info);
+/* Subroutine */ int cgeqp3_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *jpvt, complex *tau, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cgeqpf_(integer *m, integer *n, complex *a, integer *lda,
-      integer *jpvt, complex *tau, complex *work, real *rwork, integer * info);
+/* Subroutine */ int cgeqpf_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *jpvt, complex *tau, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgeqr2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgeqr2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgeqrf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgeqrf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgerfs_(char *trans, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgerfs_(char *trans, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *r__, real *c__, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *r__, real *c__, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgerq2_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *info);
+/* Subroutine */ int cgerq2_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgerqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgerqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgesc2_(integer *n, complex *a, integer *lda,
-      complex * rhs, integer *ipiv, integer *jpiv, real *scale);
+/* Subroutine */ int cgesc2_(integer *n, complex *a, integer *lda,
+                             complex *rhs, integer *ipiv, integer *jpiv, real *scale);
 
-  /* Subroutine */int cgesdd_(char *jobz, integer *m, integer *n, complex *a,
-      integer *lda, real *s, complex *u, integer *ldu, complex *vt,
-      integer *ldvt, complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer *info);
+/* Subroutine */ int cgesdd_(char *jobz, integer *m, integer *n, complex *a,
+                             integer *lda, real *s, complex *u, integer *ldu, complex *vt,
+                             integer *ldvt, complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int cgesv_(integer *n, integer *nrhs, complex *a,
-      integer * lda, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgesv_(integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      complex *a, integer *lda, real *s, complex *u, integer *ldu, complex * vt,
-      integer *ldvt, complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             complex *a, integer *lda, real *s, complex *u, integer *ldu, complex *vt,
+                             integer *ldvt, complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *r__, real *c__, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, char *equed, real *r__, real *c__, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *r__, real *c__, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *rcond, real *rpvgrw,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real *rwork, integer * info);
+/* Subroutine */ int cgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *r__, real *c__, complex *b,
+                              integer *ldb, complex *x, integer *ldx, real *rcond, real *rpvgrw,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cgetc2_(integer *n, complex *a, integer *lda,
-      integer * ipiv, integer *jpiv, integer *info);
+/* Subroutine */ int cgetc2_(integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
 
-  /* Subroutine */int cgetf2_(integer *m, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int cgetf2_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int cgetrf_(integer *m, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int cgetrf_(integer *m, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int cgetri_(integer *n, complex *a, integer *lda,
-      integer * ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgetri_(integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgetrs_(char *trans, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cgetrs_(char *trans, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int cggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *lscale, real *rscale, integer *m, complex *v,
-      integer *ldv, integer *info);
+/* Subroutine */ int cggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *lscale, real *rscale, integer *m, complex *v,
+                             integer *ldv, integer *info);
 
-  /* Subroutine */int cggbal_(char *job, integer *n, complex *a, integer *lda,
-      complex *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
-      real *rscale, real *work, integer *info);
+/* Subroutine */ int cggbal_(char *job, integer *n, complex *a, integer *lda,
+                             complex *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *work, integer *info);
 
-  /* Subroutine */int cgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, complex *a, integer *lda, complex *b,
-      integer * ldb, integer *sdim, complex *alpha, complex *beta, complex *vsl,
-      integer *ldvsl, complex *vsr, integer *ldvsr, complex *work,
-      integer * lwork, real *rwork, logical *bwork, integer *info);
+/* Subroutine */ int cgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, complex *a, integer *lda, complex *b,
+                            integer *ldb, integer *sdim, complex *alpha, complex *beta, complex *vsl,
+                            integer *ldvsl, complex *vsr, integer *ldvsr, complex *work,
+                            integer *lwork, real *rwork, logical *bwork, integer *info);
 
-  /* Subroutine */int cggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, complex *a, integer *lda,
-      complex *b, integer *ldb, integer *sdim, complex *alpha, complex *beta,
-      complex * vsl, integer *ldvsl, complex *vsr, integer *ldvsr, real *rconde,
-      real *rcondv, complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer *liwork, logical *bwork, integer *info);
+/* Subroutine */ int cggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, complex *a, integer *lda,
+                             complex *b, integer *ldb, integer *sdim, complex *alpha, complex *beta,
+                             complex *vsl, integer *ldvsl, complex *vsr, integer *ldvsr, real *rconde,
+                             real *rcondv, complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *liwork, logical *bwork, integer *info);
 
-  /* Subroutine */int cggev_(char *jobvl, char *jobvr, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex * work,
-      integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int cggev_(char *jobvl, char *jobvr, integer *n, complex *a,
+                            integer *lda, complex *b, integer *ldb, complex *alpha, complex *beta,
+                            complex *vl, integer *ldvl, complex *vr, integer *ldvr, complex *work,
+                            integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int cggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *alpha, complex *beta, complex *vl, integer *ldvl,
-      complex * vr, integer *ldvr, integer *ilo, integer *ihi, real *lscale,
-      real * rscale, real *abnrm, real *bbnrm, real *rconde, real *rcondv,
-      complex *work, integer *lwork, real *rwork, integer *iwork,
-      logical *bwork, integer *info);
+/* Subroutine */ int cggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *alpha, complex *beta, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *abnrm, real *bbnrm, real *rconde, real *rcondv,
+                             complex *work, integer *lwork, real *rwork, integer *iwork,
+                             logical *bwork, integer *info);
 
-  /* Subroutine */int cggglm_(integer *n, integer *m, integer *p, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *d__, complex *x,
-      complex *y, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggglm_(integer *n, integer *m, integer *p, complex *a,
+                             integer *lda, complex *b, integer *ldb, complex *d__, complex *x,
+                             complex *y, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *q, integer *ldq, complex *z__, integer *ldz,
-      integer *info);
+/* Subroutine */ int cgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *q, integer *ldq, complex *z__, integer *ldz,
+                             integer *info);
 
-  /* Subroutine */int cgglse_(integer *m, integer *n, integer *p, complex *a,
-      integer *lda, complex *b, integer *ldb, complex *c__, complex *d__,
-      complex *x, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cgglse_(integer *m, integer *n, integer *p, complex *a,
+                             integer *lda, complex *b, integer *ldb, complex *c__, complex *d__,
+                             complex *x, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggqrf_(integer *n, integer *m, integer *p, complex *a,
-      integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
-      complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggqrf_(integer *n, integer *m, integer *p, complex *a,
+                             integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
+                             complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggrqf_(integer *m, integer *p, integer *n, complex *a,
-      integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
-      complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cggrqf_(integer *m, integer *p, integer *n, complex *a,
+                             integer *lda, complex *taua, complex *b, integer *ldb, complex *taub,
+                             complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, complex *a, integer * lda,
-      complex *b, integer *ldb, real *alpha, real *beta, complex *u,
-      integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
-      complex *work, real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int cggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, complex *a, integer *lda,
+                             complex *b, integer *ldb, real *alpha, real *beta, complex *u,
+                             integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
+                             complex *work, real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int cggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, real *tola, real *tolb, integer *k, integer *l, complex *u,
-      integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
-      integer *iwork, real *rwork, complex *tau, complex *work, integer * info);
+/* Subroutine */ int cggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, real *tola, real *tolb, integer *k, integer *l, complex *u,
+                             integer *ldu, complex *v, integer *ldv, complex *q, integer *ldq,
+                             integer *iwork, real *rwork, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cgtcon_(char *norm, integer *n, complex *dl,
-      complex * d__, complex *du, complex *du2, integer *ipiv, real *anorm,
-      real * rcond, complex *work, integer *info);
+/* Subroutine */ int cgtcon_(char *norm, integer *n, complex *dl,
+                             complex *d__, complex *du, complex *du2, integer *ipiv, real *anorm,
+                             real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cgtrfs_(char *trans, integer *n, integer *nrhs,
-      complex * dl, complex *d__, complex *du, complex *dlf, complex *df,
-      complex * duf, complex *du2, integer *ipiv, complex *b, integer *ldb,
-      complex * x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int cgtrfs_(char *trans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *dlf, complex *df,
+                             complex *duf, complex *du2, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cgtsv_(integer *n, integer *nrhs, complex *dl,
-      complex * d__, complex *du, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cgtsv_(integer *n, integer *nrhs, complex *dl,
+                            complex *d__, complex *du, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, complex *dl, complex *d__, complex *du, complex *dlf,
-      complex * df, complex *duf, complex *du2, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, complex *dl, complex *d__, complex *du, complex *dlf,
+                             complex *df, complex *duf, complex *du2, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cgttrf_(integer *n, complex *dl, complex *d__,
-      complex * du, complex *du2, integer *ipiv, integer *info);
+/* Subroutine */ int cgttrf_(integer *n, complex *dl, complex *d__,
+                             complex *du, complex *du2, integer *ipiv, integer *info);
 
-  /* Subroutine */int cgttrs_(char *trans, integer *n, integer *nrhs,
-      complex * dl, complex *d__, complex *du, complex *du2, integer *ipiv,
-      complex * b, integer *ldb, integer *info);
+/* Subroutine */ int cgttrs_(char *trans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
+                             complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cgtts2_(integer *itrans, integer *n, integer *nrhs,
-      complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
-      complex *b, integer *ldb);
+/* Subroutine */ int cgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             complex *dl, complex *d__, complex *du, complex *du2, integer *ipiv,
+                             complex *b, integer *ldb);
 
-  /* Subroutine */int chbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int chbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
+                            complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
-      complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             complex *ab, integer *ldab, real *w, complex *z__, integer *ldz,
+                             complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, complex *ab, integer *ldab, complex *q, integer *ldq,
-      real *vl, real *vu, integer *il, integer *iu, real *abstol, integer * m,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int chbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, complex *ab, integer *ldab, complex *q, integer *ldq,
+                             real *vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
+                             real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                             integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int chbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      complex *x, integer *ldx, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                             complex *x, integer *ldx, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                            real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int chbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
-      real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
-      real *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int chbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, complex *ab, integer *ldab, complex *bb, integer *ldbb,
+                             real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
+                             real *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int chbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, complex *ab, integer *ldab, complex *bb,
-      integer *ldbb, complex *q, integer *ldq, real *vl, real *vu, integer * il,
-      integer *iu, real *abstol, integer *m, real *w, complex *z__,
-      integer *ldz, complex *work, real *rwork, integer *iwork, integer * ifail,
-      integer *info);
+/* Subroutine */ int chbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, complex *ab, integer *ldab, complex *bb,
+                             integer *ldbb, complex *q, integer *ldq, real *vl, real *vu, integer *il,
+                             integer *iu, real *abstol, integer *m, real *w, complex *z__,
+                             integer *ldz, complex *work, real *rwork, integer *iwork, integer *ifail,
+                             integer *info);
 
-  /* Subroutine */int chbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      complex *ab, integer *ldab, real *d__, real *e, complex *q, integer * ldq,
-      complex *work, integer *info);
+/* Subroutine */ int chbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             complex *ab, integer *ldab, real *d__, real *e, complex *q, integer *ldq,
+                             complex *work, integer *info);
 
-  /* Subroutine */int checon_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, complex *work, integer * info);
+/* Subroutine */ int checon_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cheequb_(char *uplo, integer *n, complex *a,
-      integer * lda, real *s, real *scond, real *amax, complex *work,
-      integer *info);
+/* Subroutine */ int cheequb_(char *uplo, integer *n, complex *a,
+                              integer *lda, real *s, real *scond, real *amax, complex *work,
+                              integer *info);
 
-  /* Subroutine */int cheev_(char *jobz, char *uplo, integer *n, complex *a,
-      integer *lda, real *w, complex *work, integer *lwork, real *rwork,
-      integer *info);
+/* Subroutine */ int cheev_(char *jobz, char *uplo, integer *n, complex *a,
+                            integer *lda, real *w, complex *work, integer *lwork, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int cheevd_(char *jobz, char *uplo, integer *n, complex *a,
-      integer *lda, real *w, complex *work, integer *lwork, real *rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer *info);
+/* Subroutine */ int cheevd_(char *jobz, char *uplo, integer *n, complex *a,
+                             integer *lda, real *w, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cheevr_(char *jobz, char *range, char *uplo, integer *n,
-      complex *a, integer *lda, real *vl, real *vu, integer *il, integer * iu,
-      real *abstol, integer *m, real *w, complex *z__, integer *ldz,
-      integer *isuppz, complex *work, integer *lwork, real *rwork,
-      integer * lrwork, integer *iwork, integer *liwork, integer *info);
+/* Subroutine */ int cheevr_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, complex *z__, integer *ldz,
+                             integer *isuppz, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cheevx_(char *jobz, char *range, char *uplo, integer *n,
-      complex *a, integer *lda, real *vl, real *vu, integer *il, integer * iu,
-      real *abstol, integer *m, real *w, complex *z__, integer *ldz,
-      complex *work, integer *lwork, real *rwork, integer *iwork,
-      integer * ifail, integer *info);
+/* Subroutine */ int cheevx_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, complex *z__, integer *ldz,
+                             complex *work, integer *lwork, real *rwork, integer *iwork,
+                             integer *ifail, integer *info);
 
-  /* Subroutine */int chegs2_(integer *itype, char *uplo, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chegs2_(integer *itype, char *uplo, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chegst_(integer *itype, char *uplo, integer *n,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chegst_(integer *itype, char *uplo, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chegv_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
-      complex *work, integer *lwork, real *rwork, integer *info);
+/* Subroutine */ int chegv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
+                            complex *work, integer *lwork, real *rwork, integer *info);
 
-  /* Subroutine */int chegvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
-      complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chegvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb, real *w,
+                             complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chegvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer * m, real *w, complex *z__, integer *ldz, complex *work,
-      integer *lwork, real *rwork, integer *iwork, integer *ifail,
-      integer *info);
+/* Subroutine */ int chegvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, real *rwork, integer *iwork, integer *ifail,
+                             integer *info);
 
-  /* Subroutine */int cherfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cherfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cherfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *s, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cherfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *s, complex *b, integer *ldb, complex *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chesv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int chesv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int chesvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
-      real *rwork, integer *info);
+/* Subroutine */ int chesvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int chesvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *s, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chesvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, complex *work, real *rwork,
+                              integer *info);
 
-  /* Subroutine */int chetd2_(char *uplo, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tau, integer *info);
+/* Subroutine */ int chetd2_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tau, integer *info);
 
-  /* Subroutine */int chetf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int chetf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int chetrd_(char *uplo, integer *n, complex *a, integer *lda,
-      real *d__, real *e, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int chetrd_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *d__, real *e, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int chetrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int chetrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int chetri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *info);
+/* Subroutine */ int chetri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int chetrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int chetrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int chfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, real *alpha, complex *a, integer *lda, real *beta,
-      complex *c__);
+/* Subroutine */ int chfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, real *alpha, complex *a, integer *lda, real *beta,
+                            complex *c__);
 
-  /* Subroutine */int chgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *t,
-      integer *ldt, complex *alpha, complex *beta, complex *q, integer *ldq,
-      complex *z__, integer *ldz, complex *work, integer *lwork, real * rwork,
-      integer *info);
+/* Subroutine */ int chgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *t,
+                             integer *ldt, complex *alpha, complex *beta, complex *q, integer *ldq,
+                             complex *z__, integer *ldz, complex *work, integer *lwork, real *rwork,
+                             integer *info);
 
-  /* Character */VOID chla_transtype__(char *ret_val, ftnlen ret_val_len,
-      integer *trans);
+/* Character */ VOID chla_transtype__(char *ret_val, ftnlen ret_val_len,
+                                      integer *trans);
 
-  /* Subroutine */int chpcon_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, real *anorm, real *rcond, complex *work, integer *info);
+/* Subroutine */ int chpcon_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int chpev_(char *jobz, char *uplo, integer *n, complex *ap,
-      real *w, complex *z__, integer *ldz, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int chpev_(char *jobz, char *uplo, integer *n, complex *ap,
+                            real *w, complex *z__, integer *ldz, complex *work, real *rwork,
+                            integer *info);
 
-  /* Subroutine */int chpevd_(char *jobz, char *uplo, integer *n, complex *ap,
-      real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
-      real *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int chpevd_(char *jobz, char *uplo, integer *n, complex *ap,
+                             real *w, complex *z__, integer *ldz, complex *work, integer *lwork,
+                             real *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int chpevx_(char *jobz, char *range, char *uplo, integer *n,
-      complex *ap, real *vl, real *vu, integer *il, integer *iu, real * abstol,
-      integer *m, real *w, complex *z__, integer *ldz, complex * work,
-      real *rwork, integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int chpevx_(char *jobz, char *range, char *uplo, integer *n,
+                             complex *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, complex *work,
+                             real *rwork, integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int chpgst_(integer *itype, char *uplo, integer *n,
-      complex * ap, complex *bp, integer *info);
+/* Subroutine */ int chpgst_(integer *itype, char *uplo, integer *n,
+                             complex *ap, complex *bp, integer *info);
 
-  /* Subroutine */int chpgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *ap, complex *bp, real *w, complex *z__,
-      integer *ldz, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chpgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, complex *ap, complex *bp, real *w, complex *z__,
+                            integer *ldz, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chpgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, complex *ap, complex *bp, real *w, complex *z__,
-      integer *ldz, complex *work, integer *lwork, real *rwork, integer *lrwork,
-      integer * iwork, integer *liwork, integer *info);
+/* Subroutine */ int chpgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, complex *ap, complex *bp, real *w, complex *z__,
+                             integer *ldz, complex *work, integer *lwork, real *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int chpgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, complex *ap, complex *bp, real *vl, real *vu,
-      integer *il, integer *iu, real *abstol, integer *m, real *w,
-      complex * z__, integer *ldz, complex *work, real *rwork, integer *iwork,
-      integer *ifail, integer *info);
+/* Subroutine */ int chpgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, complex *ap, complex *bp, real *vl, real *vu,
+                             integer *il, integer *iu, real *abstol, integer *m, real *w,
+                             complex *z__, integer *ldz, complex *work, real *rwork, integer *iwork,
+                             integer *ifail, integer *info);
 
-  /* Subroutine */int chprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int chprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int chpsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chpsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chpsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int chpsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int chptrd_(char *uplo, integer *n, complex *ap, real *d__,
-      real *e, complex *tau, integer *info);
+/* Subroutine */ int chptrd_(char *uplo, integer *n, complex *ap, real *d__,
+                             real *e, complex *tau, integer *info);
 
-  /* Subroutine */int chptrf_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, integer *info);
+/* Subroutine */ int chptrf_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int chptri_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, complex *work, integer *info);
+/* Subroutine */ int chptri_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int chptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int chptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int chsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, complex *h__, integer *ldh, complex *w,
-      complex * vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
-      integer * m, complex *work, real *rwork, integer *ifaill, integer *ifailr,
-      integer *info);
+/* Subroutine */ int chsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, complex *h__, integer *ldh, complex *w,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
+                             integer *m, complex *work, real *rwork, integer *ifaill, integer *ifailr,
+                             integer *info);
 
-  /* Subroutine */int chseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, complex *h__, integer *ldh, complex *w, complex *z__,
-      integer *ldz, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int chseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, complex *h__, integer *ldh, complex *w, complex *z__,
+                             integer *ldz, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, real *alpha, complex *ab, integer *ldab,
-      complex *x, integer *incx, real *beta, real *y, integer *incy);
+/* Subroutine */ int cla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, real *alpha, complex *ab, integer *ldab,
+                                 complex *x, integer *incx, real *beta, real *y, integer *incy);
 
-  doublereal cla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, complex *afb, integer *ldafb, integer * ipiv,
-      real *c__, logical *capply, integer *info, complex *work, real * rwork,
-      ftnlen trans_len);
+doublereal cla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
+                           complex *ab, integer *ldab, complex *afb, integer *ldafb, integer *ipiv,
+                           real *c__, logical *capply, integer *info, complex *work, real *rwork,
+                           ftnlen trans_len);
 
-  doublereal cla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, complex *afb, integer *ldafb, integer * ipiv,
-      complex *x, integer *info, complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
+                           complex *ab, integer *ldab, complex *afb, integer *ldafb, integer *ipiv,
+                           complex *x, integer *info, complex *work, real *rwork, ftnlen trans_len);
 
-  /* Subroutine */int cla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
-      integer * ipiv, logical *colequ, real *c__, complex *b, integer *ldb,
-      complex * y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
-      complex * y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info);
+/* Subroutine */ int cla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                                           integer *ipiv, logical *colequ, real *c__, complex *b, integer *ldb,
+                                           complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
+                                           complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info);
 
-  doublereal cla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, complex *ab, integer *ldab, complex *afb,
-      integer *ldafb);
+doublereal cla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, complex *ab, integer *ldab, complex *afb,
+                          integer *ldafb);
 
-  /* Subroutine */int cla_geamv__(integer *trans, integer *m, integer *n,
-      real *alpha, complex *a, integer *lda, complex *x, integer *incx,
-      real * beta, real *y, integer *incy);
+/* Subroutine */ int cla_geamv__(integer *trans, integer *m, integer *n,
+                                 real *alpha, complex *a, integer *lda, complex *x, integer *incx,
+                                 real *beta, real *y, integer *incy);
 
-  doublereal cla_gercond_c__(char *trans, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gercond_c__(char *trans, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen trans_len);
 
-  doublereal cla_gercond_x__(char *trans, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen trans_len);
+doublereal cla_gercond_x__(char *trans, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen trans_len);
 
-  /* Subroutine */int cla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      real *c__, complex *b, integer *ldb, complex *y, integer *ldy,
-      real *berr_out__, integer *n_norms__, real *errs_n__, real *errs_c__,
-      complex *res, real *ayb, complex *dy, complex *y_tail__, real *rcond,
-      integer * ithresh, real *rthresh, real *dz_ub__, logical *ignore_cwise__,
-      integer *info);
+/* Subroutine */ int cla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, complex *a,
+                                           integer *lda, complex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           real *c__, complex *b, integer *ldb, complex *y, integer *ldy,
+                                           real *berr_out__, integer *n_norms__, real *errs_n__, real *errs_c__,
+                                           complex *res, real *ayb, complex *dy, complex *y_tail__, real *rcond,
+                                           integer *ithresh, real *rthresh, real *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
 
-  /* Subroutine */int cla_heamv__(integer *uplo, integer *n, real *alpha,
-      complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int cla_heamv__(integer *uplo, integer *n, real *alpha,
+                                 complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
 
-  doublereal cla_hercond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_hercond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_hercond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_hercond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_herfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
-      integer *ldb, complex *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, complex *res,
-      real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
-      real * rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
+/* Subroutine */ int cla_herfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
+                                           integer *ldb, complex *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, complex *res,
+                                           real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
+                                           real *rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
 
-  doublereal cla_herpvgrw__(char *uplo, integer *n, integer *info, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
+doublereal cla_herpvgrw__(char *uplo, integer *n, integer *info, complex *a,
+                          integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
 
-  /* Subroutine */int cla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      complex *res, real *ayb, real *berr);
+/* Subroutine */ int cla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    complex *res, real *ayb, real *berr);
 
-  doublereal cla_porcond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, real *c__, logical *capply, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_porcond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, real *c__, logical *capply, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_porcond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, complex *x, integer *info, complex *work,
-      real *rwork, ftnlen uplo_len);
+doublereal cla_porcond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, complex *x, integer *info, complex *work,
+                           real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, logical *colequ, real *c__, complex *b, integer *ldb,
-      complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real * errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
-      complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+/* Subroutine */ int cla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, logical *colequ, real *c__, complex *b, integer *ldb,
+                                           complex *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, complex *res, real *ayb, complex *dy,
+                                           complex *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
 
-  doublereal cla_porpvgrw__(char *uplo, integer *ncols, complex *a,
-      integer * lda, complex *af, integer *ldaf, real *work, ftnlen uplo_len);
+doublereal cla_porpvgrw__(char *uplo, integer *ncols, complex *a,
+                          integer *lda, complex *af, integer *ldaf, real *work, ftnlen uplo_len);
 
-  doublereal cla_rpvgrw__(integer *n, integer *ncols, complex *a, integer *lda,
-      complex *af, integer *ldaf);
+doublereal cla_rpvgrw__(integer *n, integer *ncols, complex *a, integer *lda,
+                        complex *af, integer *ldaf);
 
-  /* Subroutine */int cla_syamv__(integer *uplo, integer *n, real *alpha,
-      complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
-      integer *incy);
+/* Subroutine */ int cla_syamv__(integer *uplo, integer *n, real *alpha,
+                                 complex *a, integer *lda, complex *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
 
-  doublereal cla_syrcond_c__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
-      integer *info, complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_syrcond_c__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, real *c__, logical *capply,
+                           integer *info, complex *work, real *rwork, ftnlen uplo_len);
 
-  doublereal cla_syrcond_x__(char *uplo, integer *n, complex *a, integer *lda,
-      complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
-      complex *work, real *rwork, ftnlen uplo_len);
+doublereal cla_syrcond_x__(char *uplo, integer *n, complex *a, integer *lda,
+                           complex *af, integer *ldaf, integer *ipiv, complex *x, integer *info,
+                           complex *work, real *rwork, ftnlen uplo_len);
 
-  /* Subroutine */int cla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
-      integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
-      integer *ldb, complex *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, complex *res,
-      real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
-      real * rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
+/* Subroutine */ int cla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, complex *a, integer *lda, complex *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, complex *b,
+                                           integer *ldb, complex *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, complex *res,
+                                           real *ayb, complex *dy, complex *y_tail__, real *rcond, integer *ithresh,
+                                           real *rthresh, real *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
 
-  doublereal cla_syrpvgrw__(char *uplo, integer *n, integer *info, complex *a,
-      integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
+doublereal cla_syrpvgrw__(char *uplo, integer *n, integer *info, complex *a,
+                          integer *lda, complex *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
 
-  /* Subroutine */int cla_wwaddw__(integer *n, complex *x, complex *y,
-      complex *w);
+/* Subroutine */ int cla_wwaddw__(integer *n, complex *x, complex *y,
+                                  complex *w);
 
-  /* Subroutine */int clabrd_(integer *m, integer *n, integer *nb, complex *a,
-      integer *lda, real *d__, real *e, complex *tauq, complex *taup,
-      complex *x, integer *ldx, complex *y, integer *ldy);
+/* Subroutine */ int clabrd_(integer *m, integer *n, integer *nb, complex *a,
+                             integer *lda, real *d__, real *e, complex *tauq, complex *taup,
+                             complex *x, integer *ldx, complex *y, integer *ldy);
 
-  /* Subroutine */int clacgv_(integer *n, complex *x, integer *incx);
+/* Subroutine */ int clacgv_(integer *n, complex *x, integer *incx);
 
-  /* Subroutine */int clacn2_(integer *n, complex *v, complex *x, real *est,
-      integer *kase, integer *isave);
+/* Subroutine */ int clacn2_(integer *n, complex *v, complex *x, real *est,
+                             integer *kase, integer *isave);
 
-  /* Subroutine */int clacon_(integer *n, complex *v, complex *x, real *est,
-      integer *kase);
+/* Subroutine */ int clacon_(integer *n, complex *v, complex *x, real *est,
+                             integer *kase);
 
-  /* Subroutine */int clacp2_(char *uplo, integer *m, integer *n, real *a,
-      integer *lda, complex *b, integer *ldb);
+/* Subroutine */ int clacp2_(char *uplo, integer *m, integer *n, real *a,
+                             integer *lda, complex *b, integer *ldb);
 
-  /* Subroutine */int clacpy_(char *uplo, integer *m, integer *n, complex *a,
-      integer *lda, complex *b, integer *ldb);
+/* Subroutine */ int clacpy_(char *uplo, integer *m, integer *n, complex *a,
+                             integer *lda, complex *b, integer *ldb);
 
-  /* Subroutine */int clacrm_(integer *m, integer *n, complex *a, integer *lda,
-      real *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
+/* Subroutine */ int clacrm_(integer *m, integer *n, complex *a, integer *lda,
+                             real *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
 
-  /* Subroutine */int clacrt_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, complex *c__, complex *s);
+/* Subroutine */ int clacrt_(integer *n, complex *cx, integer *incx,
+                             complex *cy, integer *incy, complex *c__, complex *s);
 
-  /* Complex */VOID cladiv_(complex * ret_val, complex *x, complex *y);
+/* Complex */ VOID cladiv_(complex *ret_val, complex *x, complex *y);
 
-  /* Subroutine */int claed0_(integer *qsiz, integer *n, real *d__, real *e,
-      complex *q, integer *ldq, complex *qstore, integer *ldqs, real *rwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int claed0_(integer *qsiz, integer *n, real *d__, real *e,
+                             complex *q, integer *ldq, complex *qstore, integer *ldqs, real *rwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int claed7_(integer *n, integer *cutpnt, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, real *d__, complex * q,
-      integer *ldq, real *rho, integer *indxq, real *qstore, integer * qptr,
-      integer *prmptr, integer *perm, integer *givptr, integer * givcol,
-      real *givnum, complex *work, real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int claed7_(integer *n, integer *cutpnt, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, real *d__, complex *q,
+                             integer *ldq, real *rho, integer *indxq, real *qstore, integer *qptr,
+                             integer *prmptr, integer *perm, integer *givptr, integer *givcol,
+                             real *givnum, complex *work, real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int claed8_(integer *k, integer *n, integer *qsiz,
-      complex * q, integer *ldq, real *d__, real *rho, integer *cutpnt,
-      real *z__, real *dlamda, complex *q2, integer *ldq2, real *w,
-      integer *indxp, integer *indx, integer *indxq, integer *perm,
-      integer *givptr, integer *givcol, real *givnum, integer *info);
+/* Subroutine */ int claed8_(integer *k, integer *n, integer *qsiz,
+                             complex *q, integer *ldq, real *d__, real *rho, integer *cutpnt,
+                             real *z__, real *dlamda, complex *q2, integer *ldq2, real *w,
+                             integer *indxp, integer *indx, integer *indxq, integer *perm,
+                             integer *givptr, integer *givcol, real *givnum, integer *info);
 
-  /* Subroutine */int claein_(logical *rightv, logical *noinit, integer *n,
-      complex *h__, integer *ldh, complex *w, complex *v, complex *b,
-      integer *ldb, real *rwork, real *eps3, real *smlnum, integer *info);
+/* Subroutine */ int claein_(logical *rightv, logical *noinit, integer *n,
+                             complex *h__, integer *ldh, complex *w, complex *v, complex *b,
+                             integer *ldb, real *rwork, real *eps3, real *smlnum, integer *info);
 
-  /* Subroutine */int claesy_(complex *a, complex *b, complex *c__,
-      complex * rt1, complex *rt2, complex *evscal, complex *cs1, complex *sn1);
+/* Subroutine */ int claesy_(complex *a, complex *b, complex *c__,
+                             complex *rt1, complex *rt2, complex *evscal, complex *cs1, complex *sn1);
 
-  /* Subroutine */int claev2_(complex *a, complex *b, complex *c__, real *rt1,
-      real *rt2, real *cs1, complex *sn1);
+/* Subroutine */ int claev2_(complex *a, complex *b, complex *c__, real *rt1,
+                             real *rt2, real *cs1, complex *sn1);
 
-  /* Subroutine */int clag2z_(integer *m, integer *n, complex *sa,
-      integer * ldsa, doublecomplex *a, integer *lda, integer *info);
+/* Subroutine */ int clag2z_(integer *m, integer *n, complex *sa,
+                             integer *ldsa, doublecomplex *a, integer *lda, integer *info);
 
-  /* Subroutine */int clags2_(logical *upper, real *a1, complex *a2, real *a3,
-      real *b1, complex *b2, real *b3, real *csu, complex *snu, real *csv,
-      complex *snv, real *csq, complex *snq);
+/* Subroutine */ int clags2_(logical *upper, real *a1, complex *a2, real *a3,
+                             real *b1, complex *b2, real *b3, real *csu, complex *snu, real *csv,
+                             complex *snv, real *csq, complex *snq);
 
-  /* Subroutine */int clagtm_(char *trans, integer *n, integer *nrhs,
-      real * alpha, complex *dl, complex *d__, complex *du, complex *x,
-      integer * ldx, real *beta, complex *b, integer *ldb);
+/* Subroutine */ int clagtm_(char *trans, integer *n, integer *nrhs,
+                             real *alpha, complex *dl, complex *d__, complex *du, complex *x,
+                             integer *ldx, real *beta, complex *b, integer *ldb);
 
-  /* Subroutine */int clahef_(char *uplo, integer *n, integer *nb, integer *kb,
-      complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
-      integer *info);
+/* Subroutine */ int clahef_(char *uplo, integer *n, integer *nb, integer *kb,
+                             complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
+                             integer *info);
 
-  /* Subroutine */int clahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * info);
+/* Subroutine */ int clahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *info);
 
-  /* Subroutine */int clahr2_(integer *n, integer *k, integer *nb, complex *a,
-      integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
-      integer *ldy);
+/* Subroutine */ int clahr2_(integer *n, integer *k, integer *nb, complex *a,
+                             integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
+                             integer *ldy);
 
-  /* Subroutine */int clahrd_(integer *n, integer *k, integer *nb, complex *a,
-      integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
-      integer *ldy);
+/* Subroutine */ int clahrd_(integer *n, integer *k, integer *nb, complex *a,
+                             integer *lda, complex *tau, complex *t, integer *ldt, complex *y,
+                             integer *ldy);
 
-  /* Subroutine */int claic1_(integer *job, integer *j, complex *x, real *sest,
-      complex *w, complex *gamma, real *sestpr, complex *s, complex *c__);
+/* Subroutine */ int claic1_(integer *job, integer *j, complex *x, real *sest,
+                             complex *w, complex *gamma, real *sestpr, complex *s, complex *c__);
 
-  /* Subroutine */int clals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, complex *b, integer *ldb, complex *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * rwork,
-      integer *info);
+/* Subroutine */ int clals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, complex *b, integer *ldb, complex *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int clalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, complex *b, integer *ldb, complex *bx, integer *ldbx,
-      real *u, integer *ldu, real *vt, integer *k, real *difl, real *difr,
-      real *z__, real *poles, integer *givptr, integer *givcol,
-      integer * ldgcol, integer *perm, real *givnum, real *c__, real *s,
-      real *rwork, integer *iwork, integer *info);
+/* Subroutine */ int clalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, complex *b, integer *ldb, complex *bx, integer *ldbx,
+                             real *u, integer *ldu, real *vt, integer *k, real *difl, real *difr,
+                             real *z__, real *poles, integer *givptr, integer *givcol,
+                             integer *ldgcol, integer *perm, real *givnum, real *c__, real *s,
+                             real *rwork, integer *iwork, integer *info);
 
-  /* Subroutine */int clalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, real *d__, real *e, complex *b, integer *ldb, real *rcond,
-      integer *rank, complex *work, real *rwork, integer *iwork,
-      integer * info);
+/* Subroutine */ int clalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, real *d__, real *e, complex *b, integer *ldb, real *rcond,
+                             integer *rank, complex *work, real *rwork, integer *iwork,
+                             integer *info);
 
-  doublereal clangb_(char *norm, integer *n, integer *kl, integer *ku,
-      complex * ab, integer *ldab, real *work);
+doublereal clangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clange_(char *norm, integer *m, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clange_(char *norm, integer *m, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clangt_(char *norm, integer *n, complex *dl, complex *d__,
-      complex *du);
+doublereal clangt_(char *norm, integer *n, complex *dl, complex *d__,
+                   complex *du);
 
-  doublereal clanhb_(char *norm, char *uplo, integer *n, integer *k,
-      complex * ab, integer *ldab, real *work);
+doublereal clanhb_(char *norm, char *uplo, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clanhe_(char *norm, char *uplo, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clanhf_(char *norm, char *transr, char *uplo, integer *n,
-      complex * a, real *work);
+doublereal clanhf_(char *norm, char *transr, char *uplo, integer *n,
+                   complex *a, real *work);
 
-  doublereal clanhp_(char *norm, char *uplo, integer *n, complex *ap,
-      real * work);
+doublereal clanhp_(char *norm, char *uplo, integer *n, complex *ap,
+                   real *work);
 
-  doublereal clanhs_(char *norm, integer *n, complex *a, integer *lda,
-      real * work);
+doublereal clanhs_(char *norm, integer *n, complex *a, integer *lda,
+                   real *work);
 
-  doublereal clanht_(char *norm, integer *n, real *d__, complex *e);
+doublereal clanht_(char *norm, integer *n, real *d__, complex *e);
 
-  doublereal clansb_(char *norm, char *uplo, integer *n, integer *k,
-      complex * ab, integer *ldab, real *work);
+doublereal clansb_(char *norm, char *uplo, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clansp_(char *norm, char *uplo, integer *n, complex *ap,
-      real * work);
+doublereal clansp_(char *norm, char *uplo, integer *n, complex *ap,
+                   real *work);
 
-  doublereal clansy_(char *norm, char *uplo, integer *n, complex *a,
-      integer * lda, real *work);
+doublereal clansy_(char *norm, char *uplo, integer *n, complex *a,
+                   integer *lda, real *work);
 
-  doublereal clantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      complex *ab, integer *ldab, real *work);
+doublereal clantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   complex *ab, integer *ldab, real *work);
 
-  doublereal clantp_(char *norm, char *uplo, char *diag, integer *n,
-      complex * ap, real *work);
+doublereal clantp_(char *norm, char *uplo, char *diag, integer *n,
+                   complex *ap, real *work);
 
-  doublereal clantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      complex *a, integer *lda, real *work);
+doublereal clantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   complex *a, integer *lda, real *work);
 
-  /* Subroutine */int clapll_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *ssmin);
+/* Subroutine */ int clapll_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *ssmin);
 
-  /* Subroutine */int clapmt_(logical *forwrd, integer *m, integer *n,
-      complex *x, integer *ldx, integer *k);
+/* Subroutine */ int clapmt_(logical *forwrd, integer *m, integer *n,
+                             complex *x, integer *ldx, integer *k);
 
-  /* Subroutine */int claqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, char *equed);
+/* Subroutine */ int claqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             complex *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, char *equed);
 
-  /* Subroutine */int claqge_(integer *m, integer *n, complex *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      char * equed);
+/* Subroutine */ int claqge_(integer *m, integer *n, complex *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             char *equed);
 
-  /* Subroutine */int claqhb_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhb_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqhe_(char *uplo, integer *n, complex *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhe_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqhp_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, char *equed);
+/* Subroutine */ int claqhp_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqp2_(integer *m, integer *n, integer *offset,
-      complex *a, integer *lda, integer *jpvt, complex *tau, real *vn1,
-      real *vn2, complex *work);
+/* Subroutine */ int claqp2_(integer *m, integer *n, integer *offset,
+                             complex *a, integer *lda, integer *jpvt, complex *tau, real *vn1,
+                             real *vn2, complex *work);
 
-  /* Subroutine */int claqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, complex *a, integer *lda, integer *jpvt,
-      complex * tau, real *vn1, real *vn2, complex *auxv, complex *f,
-      integer *ldf);
+/* Subroutine */ int claqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, complex *a, integer *lda, integer *jpvt,
+                             complex *tau, real *vn1, real *vn2, complex *auxv, complex *f,
+                             integer *ldf);
 
-  /* Subroutine */int claqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex * work,
-      integer *lwork, integer *info);
+/* Subroutine */ int claqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int claqr1_(integer *n, complex *h__, integer *ldh,
-      complex * s1, complex *s2, complex *v);
+/* Subroutine */ int claqr1_(integer *n, complex *h__, integer *ldh,
+                             complex *s1, complex *s2, complex *v);
 
-  /* Subroutine */int claqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * ns,
-      integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
-      complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
-      complex *work, integer *lwork);
+/* Subroutine */ int claqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *ns,
+                             integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
+                             complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
+                             complex *work, integer *lwork);
 
-  /* Subroutine */int claqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer * ns,
-      integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
-      complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
-      complex *work, integer *lwork);
+/* Subroutine */ int claqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, complex *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, integer *ns,
+                             integer *nd, complex *sh, complex *v, integer *ldv, integer *nh,
+                             complex *t, integer *ldt, integer *nv, complex *wv, integer *ldwv,
+                             complex *work, integer *lwork);
 
-  /* Subroutine */int claqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
-      integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex * work,
-      integer *lwork, integer *info);
+/* Subroutine */ int claqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, complex *h__, integer *ldh, complex *w,
+                             integer *iloz, integer *ihiz, complex *z__, integer *ldz, complex *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int claqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, complex *s,
-      complex *h__, integer *ldh, integer *iloz, integer *ihiz, complex * z__,
-      integer *ldz, complex *v, integer *ldv, complex *u, integer *ldu,
-      integer *nv, complex *wv, integer *ldwv, integer *nh, complex *wh,
-      integer *ldwh);
+/* Subroutine */ int claqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, complex *s,
+                             complex *h__, integer *ldh, integer *iloz, integer *ihiz, complex *z__,
+                             integer *ldz, complex *v, integer *ldv, complex *u, integer *ldu,
+                             integer *nv, complex *wv, integer *ldwv, integer *nh, complex *wh,
+                             integer *ldwh);
 
-  /* Subroutine */int claqsb_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsb_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqsp_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsp_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, char *equed);
 
-  /* Subroutine */int claqsy_(char *uplo, integer *n, complex *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
+/* Subroutine */ int claqsy_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
 
-  /* Subroutine */int clar1v_(integer *n, integer *b1, integer *bn,
-      real * lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
-      real * gaptol, complex *z__, logical *wantnc, integer *negcnt, real *ztz,
-      real *mingma, integer *r__, integer *isuppz, real *nrminv, real * resid,
-      real *rqcorr, real *work);
+/* Subroutine */ int clar1v_(integer *n, integer *b1, integer *bn,
+                             real *lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
+                             real *gaptol, complex *z__, logical *wantnc, integer *negcnt, real *ztz,
+                             real *mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
+                             real *rqcorr, real *work);
 
-  /* Subroutine */int clar2v_(integer *n, complex *x, complex *y, complex *z__,
-      integer *incx, real *c__, complex *s, integer *incc);
+/* Subroutine */ int clar2v_(integer *n, complex *x, complex *y, complex *z__,
+                             integer *incx, real *c__, complex *s, integer *incc);
 
-  /* Subroutine */int clarcm_(integer *m, integer *n, real *a, integer *lda,
-      complex *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
+/* Subroutine */ int clarcm_(integer *m, integer *n, real *a, integer *lda,
+                             complex *b, integer *ldb, complex *c__, integer *ldc, real *rwork);
 
-  /* Subroutine */int clarf_(char *side, integer *m, integer *n, complex *v,
-      integer *incv, complex *tau, complex *c__, integer *ldc, complex * work);
+/* Subroutine */ int clarf_(char *side, integer *m, integer *n, complex *v,
+                            integer *incv, complex *tau, complex *c__, integer *ldc, complex *work);
 
-  /* Subroutine */int clarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, complex *v,
-      integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
-      complex *work, integer *ldwork);
+/* Subroutine */ int clarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, complex *v,
+                             integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
+                             complex *work, integer *ldwork);
 
-  /* Subroutine */int clarfg_(integer *n, complex *alpha, complex *x,
-      integer * incx, complex *tau);
+/* Subroutine */ int clarfg_(integer *n, complex *alpha, complex *x,
+                             integer *incx, complex *tau);
 
-  /* Subroutine */int clarfp_(integer *n, complex *alpha, complex *x,
-      integer * incx, complex *tau);
+/* Subroutine */ int clarfp_(integer *n, complex *alpha, complex *x,
+                             integer *incx, complex *tau);
 
-  /* Subroutine */int clarft_(char *direct, char *storev, integer *n,
-      integer * k, complex *v, integer *ldv, complex *tau, complex *t,
-      integer *ldt);
+/* Subroutine */ int clarft_(char *direct, char *storev, integer *n,
+                             integer *k, complex *v, integer *ldv, complex *tau, complex *t,
+                             integer *ldt);
 
-  /* Subroutine */int clarfx_(char *side, integer *m, integer *n, complex *v,
-      complex *tau, complex *c__, integer *ldc, complex *work);
+/* Subroutine */ int clarfx_(char *side, integer *m, integer *n, complex *v,
+                             complex *tau, complex *c__, integer *ldc, complex *work);
 
-  /* Subroutine */int clargv_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *c__, integer *incc);
+/* Subroutine */ int clargv_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *c__, integer *incc);
 
-  /* Subroutine */int clarnv_(integer *idist, integer *iseed, integer *n,
-      complex *x);
+/* Subroutine */ int clarnv_(integer *idist, integer *iseed, integer *n,
+                             complex *x);
 
-  /* Subroutine */int clarrv_(integer *n, real *vl, real *vu, real *d__,
-      real * l, real *pivmin, integer *isplit, integer *m, integer *dol,
-      integer * dou, real *minrgp, real *rtol1, real *rtol2, real *w,
-      real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
-      complex * z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int clarrv_(integer *n, real *vl, real *vu, real *d__,
+                             real *l, real *pivmin, integer *isplit, integer *m, integer *dol,
+                             integer *dou, real *minrgp, real *rtol1, real *rtol2, real *w,
+                             real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
+                             complex *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int clarscl2_(integer *m, integer *n, real *d__, complex *x,
-      integer *ldx);
+/* Subroutine */ int clarscl2_(integer *m, integer *n, real *d__, complex *x,
+                               integer *ldx);
 
-  /* Subroutine */int clartg_(complex *f, complex *g, real *cs, complex *sn,
-      complex *r__);
+/* Subroutine */ int clartg_(complex *f, complex *g, real *cs, complex *sn,
+                             complex *r__);
 
-  /* Subroutine */int clartv_(integer *n, complex *x, integer *incx,
-      complex * y, integer *incy, real *c__, complex *s, integer *incc);
+/* Subroutine */ int clartv_(integer *n, complex *x, integer *incx,
+                             complex *y, integer *incy, real *c__, complex *s, integer *incc);
 
-  /* Subroutine */int clarz_(char *side, integer *m, integer *n, integer *l,
-      complex *v, integer *incv, complex *tau, complex *c__, integer *ldc,
-      complex *work);
+/* Subroutine */ int clarz_(char *side, integer *m, integer *n, integer *l,
+                            complex *v, integer *incv, complex *tau, complex *c__, integer *ldc,
+                            complex *work);
 
-  /* Subroutine */int clarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l, complex *v,
-      integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
-      complex *work, integer *ldwork);
+/* Subroutine */ int clarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l, complex *v,
+                             integer *ldv, complex *t, integer *ldt, complex *c__, integer *ldc,
+                             complex *work, integer *ldwork);
 
-  /* Subroutine */int clarzt_(char *direct, char *storev, integer *n,
-      integer * k, complex *v, integer *ldv, complex *tau, complex *t,
-      integer *ldt);
+/* Subroutine */ int clarzt_(char *direct, char *storev, integer *n,
+                             integer *k, complex *v, integer *ldv, complex *tau, complex *t,
+                             integer *ldt);
 
-  /* Subroutine */int clascl_(char *type__, integer *kl, integer *ku,
-      real * cfrom, real *cto, integer *m, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clascl_(char *type__, integer *kl, integer *ku,
+                             real *cfrom, real *cto, integer *m, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int clascl2_(integer *m, integer *n, real *d__, complex *x,
-      integer *ldx);
+/* Subroutine */ int clascl2_(integer *m, integer *n, real *d__, complex *x,
+                              integer *ldx);
 
-  /* Subroutine */int claset_(char *uplo, integer *m, integer *n,
-      complex * alpha, complex *beta, complex *a, integer *lda);
+/* Subroutine */ int claset_(char *uplo, integer *m, integer *n,
+                             complex *alpha, complex *beta, complex *a, integer *lda);
 
-  /* Subroutine */int clasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, real *c__, real *s, complex *a, integer *lda);
+/* Subroutine */ int clasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, real *c__, real *s, complex *a, integer *lda);
 
-  /* Subroutine */int classq_(integer *n, complex *x, integer *incx,
-      real * scale, real *sumsq);
+/* Subroutine */ int classq_(integer *n, complex *x, integer *incx,
+                             real *scale, real *sumsq);
 
-  /* Subroutine */int claswp_(integer *n, complex *a, integer *lda,
-      integer * k1, integer *k2, integer *ipiv, integer *incx);
+/* Subroutine */ int claswp_(integer *n, complex *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
 
-  /* Subroutine */int clasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
-      integer *info);
+/* Subroutine */ int clasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             complex *a, integer *lda, integer *ipiv, complex *w, integer *ldw,
+                             integer *info);
 
-  /* Subroutine */int clatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, complex *ab, integer *ldab,
-      complex * x, real *scale, real *cnorm, integer *info);
+/* Subroutine */ int clatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, complex *ab, integer *ldab,
+                             complex *x, real *scale, real *cnorm, integer *info);
 
-  /* Subroutine */int clatdf_(integer *ijob, integer *n, complex *z__,
-      integer *ldz, complex *rhs, real *rdsum, real *rdscal, integer *ipiv,
-      integer *jpiv);
+/* Subroutine */ int clatdf_(integer *ijob, integer *n, complex *z__,
+                             integer *ldz, complex *rhs, real *rdsum, real *rdscal, integer *ipiv,
+                             integer *jpiv);
 
-  /* Subroutine */int clatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, complex *ap, complex *x, real *scale,
-      real *cnorm, integer *info);
+/* Subroutine */ int clatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, complex *ap, complex *x, real *scale,
+                             real *cnorm, integer *info);
 
-  /* Subroutine */int clatrd_(char *uplo, integer *n, integer *nb, complex *a,
-      integer *lda, real *e, complex *tau, complex *w, integer *ldw);
+/* Subroutine */ int clatrd_(char *uplo, integer *n, integer *nb, complex *a,
+                             integer *lda, real *e, complex *tau, complex *w, integer *ldw);
 
-  /* Subroutine */int clatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, complex *a, integer *lda, complex *x,
-      real *scale, real *cnorm, integer *info);
+/* Subroutine */ int clatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, complex *a, integer *lda, complex *x,
+                             real *scale, real *cnorm, integer *info);
 
-  /* Subroutine */int clatrz_(integer *m, integer *n, integer *l, complex *a,
-      integer *lda, complex *tau, complex *work);
+/* Subroutine */ int clatrz_(integer *m, integer *n, integer *l, complex *a,
+                             integer *lda, complex *tau, complex *work);
 
-  /* Subroutine */int clatzm_(char *side, integer *m, integer *n, complex *v,
-      integer *incv, complex *tau, complex *c1, complex *c2, integer *ldc,
-      complex *work);
+/* Subroutine */ int clatzm_(char *side, integer *m, integer *n, complex *v,
+                             integer *incv, complex *tau, complex *c1, complex *c2, integer *ldc,
+                             complex *work);
 
-  /* Subroutine */int clauu2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clauu2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int clauum_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int clauum_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpbcon_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *anorm, real *rcond, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpbcon_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *anorm, real *rcond, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cpbequ_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, real *s, real *scond, real *amax, integer *info);
+/* Subroutine */ int cpbequ_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, real *s, real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real * berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpbstf_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbstf_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
+                            integer *info);
 
-  /* Subroutine */int cpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, complex *ab, integer *ldab, complex *afb, integer * ldafb,
-      char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *afb, integer *ldafb,
+                             char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cpbtf2_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbtf2_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbtrf_(char *uplo, integer *n, integer *kd, complex *ab,
-      integer *ldab, integer *info);
+/* Subroutine */ int cpbtrf_(char *uplo, integer *n, integer *kd, complex *ab,
+                             integer *ldab, integer *info);
 
-  /* Subroutine */int cpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int cpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, complex *ab, integer *ldab, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int cpftrf_(char *transr, char *uplo, integer *n, complex *a,
-      integer *info);
+/* Subroutine */ int cpftrf_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *info);
 
-  /* Subroutine */int cpftri_(char *transr, char *uplo, integer *n, complex *a,
-      integer *info);
+/* Subroutine */ int cpftri_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *info);
 
-  /* Subroutine */int cpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, complex *a, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, complex *a, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cpocon_(char *uplo, integer *n, complex *a, integer *lda,
-      real *anorm, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cpocon_(char *uplo, integer *n, complex *a, integer *lda,
+                             real *anorm, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpoequ_(integer *n, complex *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cpoequ_(integer *n, complex *a, integer *lda, real *s,
+                             real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpoequb_(integer *n, complex *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cpoequb_(integer *n, complex *a, integer *lda, real *s,
+                              real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cporfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int cporfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      real *s, complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real * err_bnds_comp__, integer *nparams, real *params, complex *work,
-      real * rwork, integer *info);
+/* Subroutine */ int cporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              real *s, complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                              real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, complex *work,
+                              real *rwork, integer *info);
 
-  /* Subroutine */int cposv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cposv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      char * equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      char * equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              char *equed, real *s, complex *b, integer *ldb, complex *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpotf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *info);
+/* Subroutine */ int cpotri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *info);
 
-  /* Subroutine */int cpotrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpotrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cppcon_(char *uplo, integer *n, complex *ap, real *anorm,
-      real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cppcon_(char *uplo, integer *n, complex *ap, real *anorm,
+                             real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cppequ_(char *uplo, integer *n, complex *ap, real *s,
-      real *scond, real *amax, integer *info);
+/* Subroutine */ int cppequ_(char *uplo, integer *n, complex *ap, real *s,
+                             real *scond, real *amax, integer *info);
 
-  /* Subroutine */int cpprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cpprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cppsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cppsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, char *equed, real *s,
-      complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, char *equed, real *s,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int cpptrf_(char *uplo, integer *n, complex *ap,
-      integer * info);
+/* Subroutine */ int cpptrf_(char *uplo, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int cpptri_(char *uplo, integer *n, complex *ap,
-      integer * info);
+/* Subroutine */ int cpptri_(char *uplo, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int cpptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cpstf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
+/* Subroutine */ int cpstf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
 
-  /* Subroutine */int cpstrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
+/* Subroutine */ int cpstrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
 
-  /* Subroutine */int cptcon_(integer *n, real *d__, complex *e, real *anorm,
-      real *rcond, real *rwork, integer *info);
+/* Subroutine */ int cptcon_(integer *n, real *d__, complex *e, real *anorm,
+                             real *rcond, real *rwork, integer *info);
 
-  /* Subroutine */int cpteqr_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, real *work, integer *info);
+/* Subroutine */ int cpteqr_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, real *work, integer *info);
 
-  /* Subroutine */int cptrfs_(char *uplo, integer *n, integer *nrhs, real *d__,
-      complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int cptrfs_(char *uplo, integer *n, integer *nrhs, real *d__,
+                             complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int cptsv_(integer *n, integer *nrhs, real *d__, complex *e,
-      complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cptsv_(integer *n, integer *nrhs, real *d__, complex *e,
+                            complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
-      complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int cptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
+                             complex *e, real *df, complex *ef, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *rcond, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cpttrf_(integer *n, real *d__, complex *e, integer *info);
+/* Subroutine */ int cpttrf_(integer *n, real *d__, complex *e, integer *info);
 
-  /* Subroutine */int cpttrs_(char *uplo, integer *n, integer *nrhs, real *d__,
-      complex *e, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cpttrs_(char *uplo, integer *n, integer *nrhs, real *d__,
+                             complex *e, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cptts2_(integer *iuplo, integer *n, integer *nrhs,
-      real * d__, complex *e, complex *b, integer *ldb);
+/* Subroutine */ int cptts2_(integer *iuplo, integer *n, integer *nrhs,
+                             real *d__, complex *e, complex *b, integer *ldb);
 
-  /* Subroutine */int crot_(integer *n, complex *cx, integer *incx,
-      complex * cy, integer *incy, real *c__, complex *s);
+/* Subroutine */ int crot_(integer *n, complex *cx, integer *incx,
+                           complex *cy, integer *incy, real *c__, complex *s);
 
-  /* Subroutine */int cspcon_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, real *anorm, real *rcond, complex *work, integer *info);
+/* Subroutine */ int cspcon_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int cspmv_(char *uplo, integer *n, complex *alpha,
-      complex * ap, complex *x, integer *incx, complex *beta, complex *y,
-      integer * incy);
+/* Subroutine */ int cspmv_(char *uplo, integer *n, complex *alpha,
+                            complex *ap, complex *x, integer *incx, complex *beta, complex *y,
+                            integer *incy);
 
-  /* Subroutine */int cspr_(char *uplo, integer *n, complex *alpha, complex *x,
-      integer *incx, complex *ap);
+/* Subroutine */ int cspr_(char *uplo, integer *n, complex *alpha, complex *x,
+                           integer *incx, complex *ap);
 
-  /* Subroutine */int csprfs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int csprfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, complex *afp, integer *ipiv, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int cspsv_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int cspsv_(char *uplo, integer *n, integer *nrhs,
+                            complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int cspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
-      integer * ldb, complex *x, integer *ldx, real *rcond, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int cspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *ap, complex *afp, integer *ipiv, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *rcond, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csptrf_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, integer *info);
+/* Subroutine */ int csptrf_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int csptri_(char *uplo, integer *n, complex *ap,
-      integer * ipiv, complex *work, integer *info);
+/* Subroutine */ int csptri_(char *uplo, integer *n, complex *ap,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int csptrs_(char *uplo, integer *n, integer *nrhs,
-      complex * ap, integer *ipiv, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int csptrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *ap, integer *ipiv, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int csrscl_(integer *n, real *sa, complex *sx, integer *incx);
+/* Subroutine */ int csrscl_(integer *n, real *sa, complex *sx, integer *incx);
 
-  /* Subroutine */int cstedc_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, complex *work, integer *lwork, real * rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer * info);
+/* Subroutine */ int cstedc_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, complex *work, integer *lwork, real *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
 
-  /* Subroutine */int cstegr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, complex *z__, integer *ldz, integer *isuppz,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer * info);
+/* Subroutine */ int cstegr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, complex *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int cstein_(integer *n, real *d__, real *e, integer *m,
-      real *w, integer *iblock, integer *isplit, complex *z__, integer *ldz,
-      real *work, integer *iwork, integer *ifail, integer *info);
+/* Subroutine */ int cstein_(integer *n, real *d__, real *e, integer *m,
+                             real *w, integer *iblock, integer *isplit, complex *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
 
-  /* Subroutine */int cstemr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
-      real *w, complex *z__, integer *ldz, integer *nzc, integer *isuppz,
-      logical *tryrac, real *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
+/* Subroutine */ int cstemr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
+                             real *w, complex *z__, integer *ldz, integer *nzc, integer *isuppz,
+                             logical *tryrac, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
 
-  /* Subroutine */int csteqr_(char *compz, integer *n, real *d__, real *e,
-      complex *z__, integer *ldz, real *work, integer *info);
+/* Subroutine */ int csteqr_(char *compz, integer *n, real *d__, real *e,
+                             complex *z__, integer *ldz, real *work, integer *info);
 
-  /* Subroutine */int csycon_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, complex *work, integer * info);
+/* Subroutine */ int csycon_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, complex *work, integer *info);
 
-  /* Subroutine */int csyequb_(char *uplo, integer *n, complex *a,
-      integer * lda, real *s, real *scond, real *amax, complex *work,
-      integer *info);
+/* Subroutine */ int csyequb_(char *uplo, integer *n, complex *a,
+                              integer *lda, real *s, real *scond, real *amax, complex *work,
+                              integer *info);
 
-  /* Subroutine */int csymv_(char *uplo, integer *n, complex *alpha,
-      complex * a, integer *lda, complex *x, integer *incx, complex *beta,
-      complex *y, integer *incy);
+/* Subroutine */ int csymv_(char *uplo, integer *n, complex *alpha,
+                            complex *a, integer *lda, complex *x, integer *incx, complex *beta,
+                            complex *y, integer *incy);
 
-  /* Subroutine */int csyr_(char *uplo, integer *n, complex *alpha, complex *x,
-      integer *incx, complex *a, integer *lda);
+/* Subroutine */ int csyr_(char *uplo, integer *n, complex *alpha, complex *x,
+                           integer *incx, complex *a, integer *lda);
 
-  /* Subroutine */int csyrfs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
-      complex * b, integer *ldb, complex *x, integer *ldx, real *ferr,
-      real *berr, complex *work, real *rwork, integer *info);
+/* Subroutine */ int csyrfs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, complex *af, integer *ldaf, integer *ipiv,
+                             complex *b, integer *ldb, complex *x, integer *ldx, real *ferr,
+                             real *berr, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, real *s, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, complex *work, real *rwork, integer *info);
+/* Subroutine */ int csyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, real *s, complex *b, integer *ldb, complex *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int csysv_(char *uplo, integer *n, integer *nrhs, complex *a,
-      integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int csysv_(char *uplo, integer *n, integer *nrhs, complex *a,
+                            integer *lda, integer *ipiv, complex *b, integer *ldb, complex *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int csysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
-      real *rwork, integer *info);
+/* Subroutine */ int csysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                             integer *ipiv, complex *b, integer *ldb, complex *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, complex *work, integer *lwork,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int csysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
-      integer * ipiv, char *equed, real *s, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int csysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, complex *a, integer *lda, complex *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, complex *b, integer *ldb,
+                              complex *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, complex *work, real *rwork,
+                              integer *info);
 
-  /* Subroutine */int csytf2_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, integer *info);
+/* Subroutine */ int csytf2_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, integer *info);
 
-  /* Subroutine */int csytrf_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int csytrf_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int csytri_(char *uplo, integer *n, complex *a, integer *lda,
-      integer *ipiv, complex *work, integer *info);
+/* Subroutine */ int csytri_(char *uplo, integer *n, complex *a, integer *lda,
+                             integer *ipiv, complex *work, integer *info);
 
-  /* Subroutine */int csytrs_(char *uplo, integer *n, integer *nrhs,
-      complex * a, integer *lda, integer *ipiv, complex *b, integer *ldb,
-      integer * info);
+/* Subroutine */ int csytrs_(char *uplo, integer *n, integer *nrhs,
+                             complex *a, integer *lda, integer *ipiv, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int ctbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, complex *ab, integer *ldab, real *rcond, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, complex *ab, integer *ldab, real *rcond, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
-      integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
-      complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
+                             integer *ldb, complex *x, integer *ldx, real *ferr, real *berr,
+                             complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
-      integer *ldb, integer *info);
+/* Subroutine */ int ctbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, complex *ab, integer *ldab, complex *b,
+                             integer *ldb, integer *info);
 
-  /* Subroutine */int ctfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, complex *alpha, complex *a,
-      complex *b, integer *ldb);
+/* Subroutine */ int ctfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, complex *alpha, complex *a,
+                            complex *b, integer *ldb);
 
-  /* Subroutine */int ctftri_(char *transr, char *uplo, char *diag, integer *n,
-      complex *a, integer *info);
+/* Subroutine */ int ctftri_(char *transr, char *uplo, char *diag, integer *n,
+                             complex *a, integer *info);
 
-  /* Subroutine */int ctfttp_(char *transr, char *uplo, integer *n,
-      complex * arf, complex *ap, integer *info);
+/* Subroutine */ int ctfttp_(char *transr, char *uplo, integer *n,
+                             complex *arf, complex *ap, integer *info);
 
-  /* Subroutine */int ctfttr_(char *transr, char *uplo, integer *n,
-      complex * arf, complex *a, integer *lda, integer *info);
+/* Subroutine */ int ctfttr_(char *transr, char *uplo, integer *n,
+                             complex *arf, complex *a, integer *lda, integer *info);
 
-  /* Subroutine */int ctgevc_(char *side, char *howmny, logical *select,
-      integer *n, complex *s, integer *lds, complex *p, integer *ldp,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
-      integer *m, complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctgevc_(char *side, char *howmny, logical *select,
+                             integer *n, complex *s, integer *lds, complex *p, integer *ldp,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, integer *mm,
+                             integer *m, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctgex2_(logical *wantq, logical *wantz, integer *n,
-      complex *a, integer *lda, complex *b, integer *ldb, complex *q,
-      integer *ldq, complex *z__, integer *ldz, integer *j1, integer *info);
+/* Subroutine */ int ctgex2_(logical *wantq, logical *wantz, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, complex *q,
+                             integer *ldq, complex *z__, integer *ldz, integer *j1, integer *info);
 
-  /* Subroutine */int ctgexc_(logical *wantq, logical *wantz, integer *n,
-      complex *a, integer *lda, complex *b, integer *ldb, complex *q,
-      integer *ldq, complex *z__, integer *ldz, integer *ifst, integer * ilst,
-      integer *info);
+/* Subroutine */ int ctgexc_(logical *wantq, logical *wantz, integer *n,
+                             complex *a, integer *lda, complex *b, integer *ldb, complex *q,
+                             integer *ldq, complex *z__, integer *ldz, integer *ifst, integer *ilst,
+                             integer *info);
 
-  /* Subroutine */int ctgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *alpha, complex *beta, complex *q, integer *ldq,
-      complex *z__, integer *ldz, integer *m, real *pl, real *pr, real * dif,
-      complex *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
+/* Subroutine */ int ctgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *alpha, complex *beta, complex *q, integer *ldq,
+                             complex *z__, integer *ldz, integer *m, real *pl, real *pr, real *dif,
+                             complex *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
 
-  /* Subroutine */int ctgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, complex *a, integer * lda,
-      complex *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
-      complex *u, integer *ldu, complex *v, integer *ldv, complex *q,
-      integer *ldq, complex *work, integer *ncycle, integer * info);
+/* Subroutine */ int ctgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, complex *a, integer *lda,
+                             complex *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
+                             complex *u, integer *ldu, complex *v, integer *ldv, complex *q,
+                             integer *ldq, complex *work, integer *ncycle, integer *info);
 
-  /* Subroutine */int ctgsna_(char *job, char *howmny, logical *select,
-      integer *n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *vl, integer *ldvl, complex *vr, integer *ldvr, real *s,
-      real *dif, integer *mm, integer *m, complex *work, integer *lwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int ctgsna_(char *job, char *howmny, logical *select,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *vl, integer *ldvl, complex *vr, integer *ldvr, real *s,
+                             real *dif, integer *mm, integer *m, complex *work, integer *lwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int ctgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
-      integer *lde, complex *f, integer *ldf, real *scale, real *rdsum,
-      real *rdscal, integer *info);
+/* Subroutine */ int ctgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
+                             integer *lde, complex *f, integer *ldf, real *scale, real *rdsum,
+                             real *rdscal, integer *info);
 
-  /* Subroutine */int ctgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
-      integer *lde, complex *f, integer *ldf, real *scale, real *dif,
-      complex *work, integer *lwork, integer *iwork, integer *info);
+/* Subroutine */ int ctgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *c__, integer *ldc, complex *d__, integer *ldd, complex *e,
+                             integer *lde, complex *f, integer *ldf, real *scale, real *dif,
+                             complex *work, integer *lwork, integer *iwork, integer *info);
 
-  /* Subroutine */int ctpcon_(char *norm, char *uplo, char *diag, integer *n,
-      complex *ap, real *rcond, complex *work, real *rwork, integer *info);
+/* Subroutine */ int ctpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             complex *ap, real *rcond, complex *work, real *rwork, integer *info);
 
-  /* Subroutine */int ctprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *ap, complex *b, integer *ldb, complex *x,
-      integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int ctprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *ap, complex *b, integer *ldb, complex *x,
+                             integer *ldx, real *ferr, real *berr, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int ctptri_(char *uplo, char *diag, integer *n, complex *ap,
-      integer *info);
+/* Subroutine */ int ctptri_(char *uplo, char *diag, integer *n, complex *ap,
+                             integer *info);
 
-  /* Subroutine */int ctptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *ap, complex *b, integer *ldb, integer *info);
+/* Subroutine */ int ctptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *ap, complex *b, integer *ldb, integer *info);
 
-  /* Subroutine */int ctpttf_(char *transr, char *uplo, integer *n,
-      complex * ap, complex *arf, integer *info);
+/* Subroutine */ int ctpttf_(char *transr, char *uplo, integer *n,
+                             complex *ap, complex *arf, integer *info);
 
-  /* Subroutine */int ctpttr_(char *uplo, integer *n, complex *ap, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctpttr_(char *uplo, integer *n, complex *ap, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrcon_(char *norm, char *uplo, char *diag, integer *n,
-      complex *a, integer *lda, real *rcond, complex *work, real *rwork,
-      integer *info);
+/* Subroutine */ int ctrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             complex *a, integer *lda, real *rcond, complex *work, real *rwork,
+                             integer *info);
 
-  /* Subroutine */int ctrevc_(char *side, char *howmny, logical *select,
-      integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
-      complex *vr, integer *ldvr, integer *mm, integer *m, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctrevc_(char *side, char *howmny, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, integer *mm, integer *m, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctrexc_(char *compq, integer *n, complex *t,
-      integer * ldt, complex *q, integer *ldq, integer *ifst, integer *ilst,
-      integer * info);
+/* Subroutine */ int ctrexc_(char *compq, integer *n, complex *t,
+                             integer *ldt, complex *q, integer *ldq, integer *ifst, integer *ilst,
+                             integer *info);
 
-  /* Subroutine */int ctrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      complex *x, integer *ldx, real *ferr, real *berr, complex *work,
-      real *rwork, integer *info);
+/* Subroutine */ int ctrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                             complex *x, integer *ldx, real *ferr, real *berr, complex *work,
+                             real *rwork, integer *info);
 
-  /* Subroutine */int ctrsen_(char *job, char *compq, logical *select,
-      integer *n, complex *t, integer *ldt, complex *q, integer *ldq,
-      complex *w, integer *m, real *s, real *sep, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int ctrsen_(char *job, char *compq, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *q, integer *ldq,
+                             complex *w, integer *m, real *s, real *sep, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int ctrsna_(char *job, char *howmny, logical *select,
-      integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
-      complex *vr, integer *ldvr, real *s, real *sep, integer *mm, integer * m,
-      complex *work, integer *ldwork, real *rwork, integer *info);
+/* Subroutine */ int ctrsna_(char *job, char *howmny, logical *select,
+                             integer *n, complex *t, integer *ldt, complex *vl, integer *ldvl,
+                             complex *vr, integer *ldvr, real *s, real *sep, integer *mm, integer *m,
+                             complex *work, integer *ldwork, real *rwork, integer *info);
 
-  /* Subroutine */int ctrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, complex *a, integer *lda, complex *b,
-      integer *ldb, complex *c__, integer *ldc, real *scale, integer *info);
+/* Subroutine */ int ctrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, complex *a, integer *lda, complex *b,
+                             integer *ldb, complex *c__, integer *ldc, real *scale, integer *info);
 
-  /* Subroutine */int ctrti2_(char *uplo, char *diag, integer *n, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctrti2_(char *uplo, char *diag, integer *n, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrtri_(char *uplo, char *diag, integer *n, complex *a,
-      integer *lda, integer *info);
+/* Subroutine */ int ctrtri_(char *uplo, char *diag, integer *n, complex *a,
+                             integer *lda, integer *info);
 
-  /* Subroutine */int ctrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
-      integer *info);
+/* Subroutine */ int ctrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, complex *a, integer *lda, complex *b, integer *ldb,
+                             integer *info);
 
-  /* Subroutine */int ctrttf_(char *transr, char *uplo, integer *n, complex *a,
-      integer *lda, complex *arf, integer *info);
+/* Subroutine */ int ctrttf_(char *transr, char *uplo, integer *n, complex *a,
+                             integer *lda, complex *arf, integer *info);
 
-  /* Subroutine */int ctrttp_(char *uplo, integer *n, complex *a, integer *lda,
-      complex *ap, integer *info);
+/* Subroutine */ int ctrttp_(char *uplo, integer *n, complex *a, integer *lda,
+                             complex *ap, integer *info);
 
-  /* Subroutine */int ctzrqf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, integer *info);
+/* Subroutine */ int ctzrqf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, integer *info);
 
-  /* Subroutine */int ctzrzf_(integer *m, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int ctzrzf_(integer *m, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cung2l_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cung2l_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cung2r_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cung2r_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cungbr_(char *vect, integer *m, integer *n, integer *k,
-      complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cungbr_(char *vect, integer *m, integer *n, integer *k,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunghr_(integer *n, integer *ilo, integer *ihi,
-      complex * a, integer *lda, complex *tau, complex *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int cunghr_(integer *n, integer *ilo, integer *ihi,
+                             complex *a, integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungl2_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cungl2_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cunglq_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunglq_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungql_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungql_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungqr_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungqr_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungr2_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *info);
+/* Subroutine */ int cungr2_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *info);
 
-  /* Subroutine */int cungrq_(integer *m, integer *n, integer *k, complex *a,
-      integer *lda, complex *tau, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cungrq_(integer *m, integer *n, integer *k, complex *a,
+                             integer *lda, complex *tau, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cungtr_(char *uplo, integer *n, complex *a, integer *lda,
-      complex *tau, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cungtr_(char *uplo, integer *n, complex *a, integer *lda,
+                             complex *tau, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunmhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunmr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *info);
+/* Subroutine */ int cunmr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *info);
 
-  /* Subroutine */int cunmrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cunmrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, complex *a, integer *lda, complex *tau,
-      complex *c__, integer *ldc, complex *work, integer *lwork,
-      integer * info);
+/* Subroutine */ int cunmrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, complex *a, integer *lda, complex *tau,
+                             complex *c__, integer *ldc, complex *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int cunmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, complex *a, integer *lda, complex *tau, complex *c__,
-      integer *ldc, complex *work, integer *lwork, integer *info);
+/* Subroutine */ int cunmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, complex *a, integer *lda, complex *tau, complex *c__,
+                             integer *ldc, complex *work, integer *lwork, integer *info);
 
-  /* Subroutine */int cupgtr_(char *uplo, integer *n, complex *ap,
-      complex * tau, complex *q, integer *ldq, complex *work, integer *info);
+/* Subroutine */ int cupgtr_(char *uplo, integer *n, complex *ap,
+                             complex *tau, complex *q, integer *ldq, complex *work, integer *info);
 
-  /* Subroutine */int cupmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, complex *ap, complex *tau, complex *c__, integer *ldc,
-      complex *work, integer *info);
+/* Subroutine */ int cupmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, complex *ap, complex *tau, complex *c__, integer *ldc,
+                             complex *work, integer *info);
 
-  /* Subroutine */int dbdsdc_(char *uplo, char *compq, integer *n,
-      doublereal * d__, doublereal *e, doublereal *u, integer *ldu,
-      doublereal *vt, integer *ldvt, doublereal *q, integer *iq,
-      doublereal *work, integer * iwork, integer *info);
+/* Subroutine */ int dbdsdc_(char *uplo, char *compq, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *q, integer *iq,
+                             doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, doublereal *d__, doublereal *e,
-      doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
-      doublereal *c__, integer * ldc, doublereal *work, integer *info);
+/* Subroutine */ int dbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, doublereal *d__, doublereal *e,
+                             doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
 
-  /* Subroutine */int ddisna_(char *job, integer *m, integer *n,
-      doublereal * d__, doublereal *sep, integer *info);
+/* Subroutine */ int ddisna_(char *job, integer *m, integer *n,
+                             doublereal *d__, doublereal *sep, integer *info);
 
-  /* Subroutine */int dgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, doublereal *ab, integer *ldab, doublereal * d__,
-      doublereal *e, doublereal *q, integer *ldq, doublereal *pt, integer *ldpt,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
+/* Subroutine */ int dgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, doublereal *ab, integer *ldab, doublereal *d__,
+                             doublereal *e, doublereal *q, integer *ldq, doublereal *pt, integer *ldpt,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
 
-  /* Subroutine */int dgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, doublereal *anorm,
-      doublereal *rcond, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, doublereal *anorm,
+                             doublereal *rcond, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer * info);
+/* Subroutine */ int dgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, doublereal *ab, integer *ldab, doublereal *r__,
-      doublereal *c__, doublereal *rowcnd, doublereal *colcnd, doublereal *amax,
-      integer * info);
+/* Subroutine */ int dgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, doublereal *ab, integer *ldab, doublereal *r__,
+                              doublereal *c__, doublereal *rowcnd, doublereal *colcnd, doublereal *amax,
+                              integer *info);
 
-  /* Subroutine */int dgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                             doublereal *afb, integer *ldafb, integer *ipiv, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer * nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                              doublereal *afb, integer *ldafb, integer *ipiv, doublereal *r__,
+                              doublereal *c__, doublereal *b, integer *ldb, doublereal *x,
+                              integer *ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
 
-  /* Subroutine */int dgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, doublereal *ab, integer *ldab, integer *ipiv,
-      doublereal *b, integer *ldb, integer *info);
+/* Subroutine */ int dgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
+                            doublereal *b, integer *ldb, integer *info);
 
-  /* Subroutine */int dgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                             doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
+                             doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
-      doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal *work, integer *iwork, integer *info);
+/* Subroutine */ int dgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublereal *ab, integer *ldab,
+                              doublereal *afb, integer *ldafb, integer *ipiv, char *equed,
+                              doublereal *r__, doublereal *c__, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
 
-  /* Subroutine */int dgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int dgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int dgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, integer *ipiv, integer *info);
+/* Subroutine */ int dgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, integer *ipiv, integer *info);
 
-  /* Subroutine */int dgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
-      doublereal *b, integer *ldb, integer *info);
+/* Subroutine */ int dgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublereal *ab, integer *ldab, integer *ipiv,
+                             doublereal *b, integer *ldb, integer *info);
 
-  /* Subroutine */int dgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *scale, integer *m, doublereal *v, integer * ldv,
-      integer *info);
+/* Subroutine */ int dgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *scale, integer *m, doublereal *v, integer *ldv,
+                             integer *info);
 
-  /* Subroutine */int dgebal_(char *job, integer *n, doublereal *a,
-      integer * lda, integer *ilo, integer *ihi, doublereal *scale,
-      integer *info);
+/* Subroutine */ int dgebal_(char *job, integer *n, doublereal *a,
+                             integer *lda, integer *ilo, integer *ihi, doublereal *scale,
+                             integer *info);
 
-  /* Subroutine */int dgebd2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tauq,
-      doublereal * taup, doublereal *work, integer *info);
+/* Subroutine */ int dgebd2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tauq,
+                             doublereal *taup, doublereal *work, integer *info);
 
-  /* Subroutine */int dgebrd_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tauq,
-      doublereal * taup, doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgebrd_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tauq,
+                             doublereal *taup, doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgecon_(char *norm, integer *n, doublereal *a,
-      integer * lda, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer * iwork, integer *info);
+/* Subroutine */ int dgecon_(char *norm, integer *n, doublereal *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int dgeequ_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
+/* Subroutine */ int dgeequ_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgeequb_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
+/* Subroutine */ int dgeequb_(integer *m, integer *n, doublereal *a,
+                              integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                              doublereal *colcnd, doublereal *amax, integer *info);
 
-  /* Subroutine */int dgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      doublereal *a, integer *lda, integer *sdim, doublereal *wr,
-      doublereal *wi, doublereal *vs, integer *ldvs, doublereal *work,
-      integer *lwork, logical *bwork, integer *info);
+/* Subroutine */ int dgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            doublereal *a, integer *lda, integer *sdim, doublereal *wr,
+                            doublereal *wi, doublereal *vs, integer *ldvs, doublereal *work,
+                            integer *lwork, logical *bwork, integer *info);
 
-  /* Subroutine */int dgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, doublereal *a, integer *lda, integer *sdim,
-      doublereal *wr, doublereal *wi, doublereal *vs, integer *ldvs,
-      doublereal *rconde, doublereal *rcondv, doublereal *work, integer * lwork,
-      integer *iwork, integer *liwork, logical *bwork, integer *info);
+/* Subroutine */ int dgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, doublereal *a, integer *lda, integer *sdim,
+                             doublereal *wr, doublereal *wi, doublereal *vs, integer *ldvs,
+                             doublereal *rconde, doublereal *rcondv, doublereal *work, integer *lwork,
+                             integer *iwork, integer *liwork, logical *bwork, integer *info);
 
-  /* Subroutine */int dgeev_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *wr, doublereal *wi,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgeev_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *wr, doublereal *wi,
+                            doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublereal *a, integer *lda, doublereal *wr,
-      doublereal *wi, doublereal *vl, integer *ldvl, doublereal *vr,
-      integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
-      doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
-      doublereal *work, integer *lwork, integer *iwork, integer *info);
+/* Subroutine */ int dgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublereal *a, integer *lda, doublereal *wr,
+                             doublereal *wi, doublereal *vl, integer *ldvl, doublereal *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
+                             doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
 
-  /* Subroutine */int dgegs_(char *jobvsl, char *jobvsr, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal * alphar, doublereal *alphai, doublereal *beta,
-      doublereal *vsl, integer *ldvsl, doublereal *vsr, integer *ldvsr,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta,
+                            doublereal *vsl, integer *ldvsl, doublereal *vsr, integer *ldvsr,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgegv_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
-      integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgegv_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
+                            integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
+                            integer *lwork, integer *info);
 
-  /* Subroutine */int dgehd2_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
+/* Subroutine */ int dgehd2_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
 
-  /* Subroutine */int dgehrd_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgehrd_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int dgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
-      char *jobt, char *jobp, integer *m, integer *n, doublereal *a,
-      integer *lda, doublereal *sva, doublereal *u, integer *ldu, doublereal *v,
-      integer *ldv, doublereal *work, integer *lwork, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
+                             char *jobt, char *jobp, integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *sva, doublereal *u, integer *ldu, doublereal *v,
+                             integer *ldv, doublereal *work, integer *lwork, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int dgelq2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgelq2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgelqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgelqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *work, integer *lwork, integer *info);
+/* Subroutine */ int dgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *work, integer *lwork, integer *info);
 
-  /* Subroutine */int dgelsd_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * s,
-      doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
-      integer *iwork, integer *info);
+/* Subroutine */ int dgelsd_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *s,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
 
-  /* Subroutine */int dgelss_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * s,
-      doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgelss_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *s,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgelsx_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * jpvt,
-      doublereal *rcond, integer *rank, doublereal *work, integer * info);
+/* Subroutine */ int dgelsx_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *jpvt,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *info);
 
-  /* Subroutine */int dgelsy_(integer *m, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * jpvt,
-      doublereal *rcond, integer *rank, doublereal *work, integer * lwork,
-      integer *info);
+/* Subroutine */ int dgelsy_(integer *m, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *jpvt,
+                             doublereal *rcond, integer *rank, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgeql2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgeql2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgeqlf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgeqlf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgeqp3_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *jpvt, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
+/* Subroutine */ int dgeqp3_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *jpvt, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
 
-  /* Subroutine */int dgeqpf_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *jpvt, doublereal *tau, doublereal *work,
-      integer *info);
+/* Subroutine */ int dgeqpf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *jpvt, doublereal *tau, doublereal *work,
+                             integer *info);
 
-  /* Subroutine */int dgeqr2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
+/* Subroutine */ int dgeqr2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
 
-  /* Subroutine */int dgeqrf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
+/* Subroutine */ int dgeqrf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
 
-  /* Subroutine */int dgerfs_(char *trans, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf,
-      integer * ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgerfs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
 
-  /* Subroutine */int dgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
+/* Subroutine */ int dgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
+                              doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                              doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
 
-  /* Subroutine */int dgerq2_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *info);
-
-  /* Subroutine */int dgerqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesc2_(integer *n, doublereal *a, integer *lda,
-      doublereal *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
-
-  /* Subroutine */int dgesdd_(char *jobz, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
-      doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dgesv_(integer *n, integer *nrhs, doublereal *a,
-      integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      doublereal *a, integer *lda, doublereal *s, doublereal *u, integer * ldu,
-      doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesvj_(char *joba, char *jobu, char *jobv, integer *m,
-      integer *n, doublereal *a, integer *lda, doublereal *sva, integer *mv,
-      doublereal *v, integer *ldv, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dgetc2_(integer *n, doublereal *a, integer *lda,
-      integer *ipiv, integer *jpiv, integer *info);
-
-  /* Subroutine */int dgetf2_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgetrf_(integer *m, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgetri_(integer *n, doublereal *a, integer *lda,
-      integer *ipiv, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dgetrs_(char *trans, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
-      doublereal *v, integer *ldv, integer *info);
-
-  /* Subroutine */int dggbal_(char *job, integer *n, doublereal *a,
-      integer * lda, doublereal *b, integer *ldb, integer *ilo, integer *ihi,
-      doublereal *lscale, doublereal *rscale, doublereal *work, integer * info);
-
-  /* Subroutine */int dgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, integer *sdim, doublereal *alphar, doublereal *alphai,
-      doublereal *beta, doublereal *vsl, integer *ldvsl, doublereal *vsr,
-      integer *ldvsr, doublereal *work, integer *lwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int dggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, doublereal *a, integer *lda,
-      doublereal *b, integer *ldb, integer *sdim, doublereal *alphar,
-      doublereal *alphai, doublereal *beta, doublereal *vsl, integer *ldvsl,
-      doublereal *vsr, integer *ldvsr, doublereal *rconde, doublereal * rcondv,
-      doublereal *work, integer *lwork, integer *iwork, integer * liwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int dggev_(char *jobvl, char *jobvr, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
-      integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
-      doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
-      doublereal * rcondv, doublereal *work, integer *lwork, integer *iwork,
-      logical * bwork, integer *info);
-
-  /* Subroutine */int dggglm_(integer *n, integer *m, integer *p,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *d__, doublereal *x, doublereal *y, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *q, integer *ldq, doublereal *z__, integer * ldz,
-      integer *info);
-
-  /* Subroutine */int dgglse_(integer *m, integer *n, integer *p,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, doublereal *d__, doublereal *x, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dggqrf_(integer *n, integer *m, integer *p,
-      doublereal * a, integer *lda, doublereal *taua, doublereal *b,
-      integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dggrqf_(integer *m, integer *p, integer *n,
-      doublereal * a, integer *lda, doublereal *taua, doublereal *b,
-      integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, doublereal *a,
-      integer *lda, doublereal *b, integer *ldb, doublereal *alpha,
-      doublereal *beta, doublereal *u, integer *ldu, doublereal *v,
-      integer *ldv, doublereal *q, integer *ldq, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
-      doublereal *u, integer *ldu, doublereal *v, integer *ldv, doublereal *q,
-      integer *ldq, integer *iwork, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dgsvj0_(char *jobv, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *d__, doublereal *sva,
-      integer *mv, doublereal *v, integer *ldv, doublereal *eps,
-      doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
-      doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
-      integer *mv, doublereal *v, integer *ldv, doublereal *eps,
-      doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int dgtcon_(char *norm, integer *n, doublereal *dl,
-      doublereal *d__, doublereal *du, doublereal *du2, integer *ipiv,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dgtrfs_(char *trans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *dlf,
-      doublereal *df, doublereal *duf, doublereal *du2, integer *ipiv,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int dgtsv_(integer *n, integer *nrhs, doublereal *dl,
-      doublereal *d__, doublereal *du, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublereal *dl, doublereal *d__, doublereal *du,
-      doublereal * dlf, doublereal *df, doublereal *duf, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dgttrf_(integer *n, doublereal *dl, doublereal *d__,
-      doublereal *du, doublereal *du2, integer *ipiv, integer *info);
-
-  /* Subroutine */int dgttrs_(char *trans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dgtts2_(integer *itrans, integer *n, integer *nrhs,
-      doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
-      integer *ipiv, doublereal *b, integer *ldb);
-
-  /* Subroutine */int dhgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *t,
-      integer *ldt, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dhsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, doublereal *h__, integer *ldh,
-      doublereal *wr, doublereal *wi, doublereal *vl, integer *ldvl,
-      doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
-      integer * ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int dhseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *info);
-
-  logical disnan_(doublereal *din);
-
-  /* Subroutine */int dla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, doublereal *alpha, doublereal *ab,
-      integer * ldab, doublereal *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
-
-  doublereal dla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *afb, integer *ldafb,
-      integer *ipiv, integer *cmode, doublereal *c__, integer *info,
-      doublereal *work, integer *iwork, ftnlen trans_len);
-
-  /* Subroutine */int dla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
-      doublereal * y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
-      integer *info);
-
-  doublereal dla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb);
-
-  /* Subroutine */int dla_geamv__(integer *trans, integer *m, integer *n,
-      doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal dla_gercond__(char *trans, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
-      doublereal *c__, integer *info, doublereal *work, integer *iwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int dla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, doublereal *a,
-      integer *lda, doublereal *af, integer *ldaf, integer *ipiv,
-      logical *colequ, doublereal *c__, doublereal *b, integer *ldb,
-      doublereal *y, integer * ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal *errs_n__, doublereal *errs_c__, doublereal *res,
-      doublereal *ayb, doublereal * dy, doublereal *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical *ignore_cwise__, integer *info);
-
-  /* Subroutine */int dla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      doublereal *res, doublereal *ayb, doublereal *berr);
-
-  doublereal dla_porcond__(char *uplo, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *cmode, doublereal *c__,
-      integer *info, doublereal *work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int dla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal * af,
-      integer *ldaf, logical *colequ, doublereal *c__, doublereal *b,
-      integer *ldb, doublereal *y, integer *ldy, doublereal *berr_out__,
-      integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
-      doublereal *res, doublereal *ayb, doublereal *dy, doublereal * y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal dla_porpvgrw__(char *uplo, integer *ncols, doublereal *a,
-      integer * lda, doublereal *af, integer *ldaf, doublereal *work,
-      ftnlen uplo_len);
-
-  doublereal dla_rpvgrw__(integer *n, integer *ncols, doublereal *a,
-      integer * lda, doublereal *af, integer *ldaf);
-
-  /* Subroutine */int dla_syamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublereal *a, integer *lda, doublereal *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal dla_syrcond__(char *uplo, integer *n, doublereal *a, integer *lda,
-      doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
-      doublereal *c__, integer *info, doublereal *work, integer *iwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int dla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal * af,
-      integer *ldaf, integer *ipiv, logical *colequ, doublereal *c__,
-      doublereal *b, integer *ldb, doublereal *y, integer *ldy,
-      doublereal * berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal * errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
-      doublereal *y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
-      integer *info, ftnlen uplo_len);
-
-  doublereal dla_syrpvgrw__(char *uplo, integer *n, integer *info,
-      doublereal * a, integer *lda, doublereal *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int dla_wwaddw__(integer *n, doublereal *x, doublereal *y,
-      doublereal *w);
-
-  /* Subroutine */int dlabad_(doublereal *small, doublereal *large);
-
-  /* Subroutine */int dlabrd_(integer *m, integer *n, integer *nb,
-      doublereal * a, integer *lda, doublereal *d__, doublereal *e,
-      doublereal *tauq, doublereal *taup, doublereal *x, integer *ldx,
-      doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlacn2_(integer *n, doublereal *v, doublereal *x,
-      integer *isgn, doublereal *est, integer *kase, integer *isave);
-
-  /* Subroutine */int dlacon_(integer *n, doublereal *v, doublereal *x,
-      integer *isgn, doublereal *est, integer *kase);
-
-  /* Subroutine */int dlacpy_(char *uplo, integer *m, integer *n,
-      doublereal * a, integer *lda, doublereal *b, integer *ldb);
-
-  /* Subroutine */int dladiv_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *d__, doublereal *p, doublereal *q);
-
-  /* Subroutine */int dlae2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *rt1, doublereal *rt2);
-
-  /* Subroutine */int dlaebz_(integer *ijob, integer *nitmax, integer *n,
-      integer *mmax, integer *minp, integer *nbmin, doublereal *abstol,
-      doublereal *reltol, doublereal *pivmin, doublereal *d__, doublereal * e,
-      doublereal *e2, integer *nval, doublereal *ab, doublereal *c__,
-      integer *mout, integer *nab, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlaed0_(integer *icompq, integer *qsiz, integer *n,
-      doublereal *d__, doublereal *e, doublereal *q, integer *ldq,
-      doublereal *qstore, integer *ldqs, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlaed1_(integer *n, doublereal *d__, doublereal *q,
-      integer *ldq, integer *indxq, doublereal *rho, integer *cutpnt,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlaed2_(integer *k, integer *n, integer *n1,
-      doublereal * d__, doublereal *q, integer *ldq, integer *indxq,
-      doublereal *rho, doublereal *z__, doublereal *dlamda, doublereal *w,
-      doublereal *q2, integer *indx, integer *indxc, integer *indxp,
-      integer *coltyp, integer *info);
-
-  /* Subroutine */int dlaed3_(integer *k, integer *n, integer *n1,
-      doublereal * d__, doublereal *q, integer *ldq, doublereal *rho,
-      doublereal *dlamda, doublereal *q2, integer *indx, integer *ctot,
-      doublereal *w, doublereal *s, integer *info);
-
-  /* Subroutine */int dlaed4_(integer *n, integer *i__, doublereal *d__,
-      doublereal *z__, doublereal *delta, doublereal *rho, doublereal *dlam,
-      integer *info);
-
-  /* Subroutine */int dlaed5_(integer *i__, doublereal *d__, doublereal *z__,
-      doublereal *delta, doublereal *rho, doublereal *dlam);
-
-  /* Subroutine */int dlaed6_(integer *kniter, logical *orgati,
-      doublereal * rho, doublereal *d__, doublereal *z__, doublereal *finit,
-      doublereal * tau, integer *info);
-
-  /* Subroutine */int dlaed7_(integer *icompq, integer *n, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
-      doublereal *q, integer *ldq, integer *indxq, doublereal *rho,
-      integer *cutpnt, doublereal *qstore, integer *qptr, integer *prmptr,
-      integer * perm, integer *givptr, integer *givcol, doublereal *givnum,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlaed8_(integer *icompq, integer *k, integer *n,
-      integer *qsiz, doublereal *d__, doublereal *q, integer *ldq,
-      integer *indxq, doublereal *rho, integer *cutpnt, doublereal *z__,
-      doublereal *dlamda, doublereal *q2, integer *ldq2, doublereal *w,
-      integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
-      integer *indxp, integer *indx, integer *info);
-
-  /* Subroutine */int dlaed9_(integer *k, integer *kstart, integer *kstop,
-      integer *n, doublereal *d__, doublereal *q, integer *ldq,
-      doublereal * rho, doublereal *dlamda, doublereal *w, doublereal *s,
-      integer *lds, integer *info);
-
-  /* Subroutine */int dlaeda_(integer *n, integer *tlvls, integer *curlvl,
-      integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
-      integer *givcol, doublereal *givnum, doublereal *q, integer *qptr,
-      doublereal *z__, doublereal *ztemp, integer *info);
-
-  /* Subroutine */int dlaein_(logical *rightv, logical *noinit, integer *n,
-      doublereal *h__, integer *ldh, doublereal *wr, doublereal *wi,
-      doublereal *vr, doublereal *vi, doublereal *b, integer *ldb,
-      doublereal *work, doublereal *eps3, doublereal *smlnum,
-      doublereal * bignum, integer *info);
-
-  /* Subroutine */int dlaev2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *rt1, doublereal *rt2, doublereal *cs1, doublereal *sn1);
-
-  /* Subroutine */int dlaexc_(logical *wantq, integer *n, doublereal *t,
-      integer *ldt, doublereal *q, integer *ldq, integer *j1, integer *n1,
-      integer *n2, doublereal *work, integer *info);
-
-  /* Subroutine */int dlag2_(doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *safmin, doublereal *scale1, doublereal * scale2,
-      doublereal *wr1, doublereal *wr2, doublereal *wi);
-
-  /* Subroutine */int dlag2s_(integer *m, integer *n, doublereal *a,
-      integer * lda, real *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int dlags2_(logical *upper, doublereal *a1, doublereal *a2,
-      doublereal *a3, doublereal *b1, doublereal *b2, doublereal *b3,
-      doublereal *csu, doublereal *snu, doublereal *csv, doublereal *snv,
-      doublereal *csq, doublereal *snq);
-
-  /* Subroutine */int dlagtf_(integer *n, doublereal *a, doublereal *lambda,
-      doublereal *b, doublereal *c__, doublereal *tol, doublereal *d__,
-      integer *in, integer *info);
-
-  /* Subroutine */int dlagtm_(char *trans, integer *n, integer *nrhs,
-      doublereal *alpha, doublereal *dl, doublereal *d__, doublereal *du,
-      doublereal *x, integer *ldx, doublereal *beta, doublereal *b,
-      integer *ldb);
-
-  /* Subroutine */int dlagts_(integer *job, integer *n, doublereal *a,
-      doublereal *b, doublereal *c__, doublereal *d__, integer *in,
-      doublereal *y, doublereal *tol, integer *info);
-
-  /* Subroutine */int dlagv2_(doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *csl, doublereal *snl, doublereal *csr, doublereal * snr);
-
-  /* Subroutine */int dlahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, integer *info);
-
-  /* Subroutine */int dlahr2_(integer *n, integer *k, integer *nb,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *t,
-      integer *ldt, doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlahrd_(integer *n, integer *k, integer *nb,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *t,
-      integer *ldt, doublereal *y, integer *ldy);
-
-  /* Subroutine */int dlaic1_(integer *job, integer *j, doublereal *x,
-      doublereal *sest, doublereal *w, doublereal *gamma, doublereal * sestpr,
-      doublereal *s, doublereal *c__);
-
-  logical dlaisnan_(doublereal *din1, doublereal *din2);
-
-  /* Subroutine */int dlaln2_(logical *ltrans, integer *na, integer *nw,
-      doublereal *smin, doublereal *ca, doublereal *a, integer *lda,
-      doublereal *d1, doublereal *d2, doublereal *b, integer *ldb,
-      doublereal *wr, doublereal *wi, doublereal *x, integer *ldx,
-      doublereal *scale, doublereal *xnorm, integer *info);
-
-  /* Subroutine */int dlals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, doublereal *givnum, integer *ldgnum, doublereal * poles,
-      doublereal *difl, doublereal *difr, doublereal *z__, integer * k,
-      doublereal *c__, doublereal *s, doublereal *work, integer *info);
-
-  /* Subroutine */int dlalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
-      integer * ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
-      doublereal *difl, doublereal *difr, doublereal *z__, doublereal * poles,
-      integer *givptr, integer *givcol, integer *ldgcol, integer * perm,
-      doublereal *givnum, doublereal *c__, doublereal *s, doublereal * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *d__, doublereal *e, doublereal *b,
-      integer *ldb, doublereal *rcond, integer *rank, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlamrg_(integer *n1, integer *n2, doublereal *a,
-      integer *dtrd1, integer *dtrd2, integer *index);
-
-  integer dlaneg_(integer *n, doublereal *d__, doublereal *lld,
-      doublereal * sigma, doublereal *pivmin, integer *r__);
-
-  doublereal dlangb_(char *norm, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlange_(char *norm, integer *m, integer *n, doublereal *a,
-      integer *lda, doublereal *work);
-
-  doublereal dlangt_(char *norm, integer *n, doublereal *dl, doublereal *d__,
-      doublereal *du);
-
-  doublereal dlanhs_(char *norm, integer *n, doublereal *a, integer *lda,
-      doublereal *work);
-
-  doublereal dlansb_(char *norm, char *uplo, integer *n, integer *k,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlansf_(char *norm, char *transr, char *uplo, integer *n,
-      doublereal *a, doublereal *work);
-
-  doublereal dlansp_(char *norm, char *uplo, integer *n, doublereal *ap,
-      doublereal *work);
-
-  doublereal dlanst_(char *norm, integer *n, doublereal *d__, doublereal *e);
-
-  doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a,
-      integer *lda, doublereal *work);
-
-  doublereal dlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      doublereal *ab, integer *ldab, doublereal *work);
-
-  doublereal dlantp_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *ap, doublereal *work);
-
-  doublereal dlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      doublereal *a, integer *lda, doublereal *work);
-
-  /* Subroutine */int dlanv2_(doublereal *a, doublereal *b, doublereal *c__,
-      doublereal *d__, doublereal *rt1r, doublereal *rt1i, doublereal *rt2r,
-      doublereal *rt2i, doublereal *cs, doublereal *sn);
-
-  /* Subroutine */int dlapll_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *ssmin);
-
-  /* Subroutine */int dlapmt_(logical *forwrd, integer *m, integer *n,
-      doublereal *x, integer *ldx, integer *k);
-
-  doublereal dlapy2_(doublereal *x, doublereal *y);
-
-  doublereal dlapy3_(doublereal *x, doublereal *y, doublereal *z__);
-
-  /* Subroutine */int dlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqge_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqp2_(integer *m, integer *n, integer *offset,
-      doublereal *a, integer *lda, integer *jpvt, doublereal *tau,
-      doublereal *vn1, doublereal *vn2, doublereal *work);
-
-  /* Subroutine */int dlaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, doublereal *a, integer *lda, integer *jpvt,
-      doublereal *tau, doublereal *vn1, doublereal *vn2, doublereal *auxv,
-      doublereal *f, integer *ldf);
-
-  /* Subroutine */int dlaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dlaqr1_(integer *n, doublereal *h__, integer *ldh,
-      doublereal *sr1, doublereal *si1, doublereal *sr2, doublereal *si2,
-      doublereal *v);
-
-  /* Subroutine */int dlaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer * ldh,
-      integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
-      integer *nd, doublereal *sr, doublereal *si, doublereal * v, integer *ldv,
-      integer *nh, doublereal *t, integer *ldt, integer * nv, doublereal *wv,
-      integer *ldwv, doublereal *work, integer *lwork);
-
-  /* Subroutine */int dlaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer * ldh,
-      integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
-      integer *nd, doublereal *sr, doublereal *si, doublereal * v, integer *ldv,
-      integer *nh, doublereal *t, integer *ldt, integer * nv, doublereal *wv,
-      integer *ldwv, doublereal *work, integer *lwork);
-
-  /* Subroutine */int dlaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
-      doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, doublereal *sr,
-      doublereal *si, doublereal *h__, integer *ldh, integer *iloz,
-      integer *ihiz, doublereal *z__, integer *ldz, doublereal *v,
-      integer * ldv, doublereal *u, integer *ldu, integer *nv, doublereal *wv,
-      integer *ldwv, integer *nh, doublereal *wh, integer *ldwh);
-
-  /* Subroutine */int dlaqsb_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqsp_(char *uplo, integer *n, doublereal *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int dlaqsy_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int dlaqtr_(logical *ltran, logical *lreal, integer *n,
-      doublereal *t, integer *ldt, doublereal *b, doublereal *w,
-      doublereal *scale, doublereal *x, doublereal *work, integer *info);
-
-  /* Subroutine */int dlar1v_(integer *n, integer *b1, integer *bn,
-      doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
-      doublereal * lld, doublereal *pivmin, doublereal *gaptol, doublereal *z__,
-      logical *wantnc, integer *negcnt, doublereal *ztz, doublereal *mingma,
-      integer *r__, integer *isuppz, doublereal *nrminv, doublereal *resid,
-      doublereal *rqcorr, doublereal *work);
-
-  /* Subroutine */int dlar2v_(integer *n, doublereal *x, doublereal *y,
-      doublereal *z__, integer *incx, doublereal *c__, doublereal *s,
-      integer *incc);
-
-  /* Subroutine */int dlarf_(char *side, integer *m, integer *n, doublereal *v,
-      integer *incv, doublereal *tau, doublereal *c__, integer *ldc,
-      doublereal *work);
-
-  /* Subroutine */int dlarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, doublereal *v,
-      integer * ldv, doublereal *t, integer *ldt, doublereal *c__, integer *ldc,
-      doublereal *work, integer *ldwork);
-
-  /* Subroutine */int dlarfg_(integer *n, doublereal *alpha, doublereal *x,
-      integer *incx, doublereal *tau);
-
-  /* Subroutine */int dlarfp_(integer *n, doublereal *alpha, doublereal *x,
-      integer *incx, doublereal *tau);
-
-  /* Subroutine */int dlarft_(char *direct, char *storev, integer *n,
-      integer * k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
-      integer *ldt);
-
-  /* Subroutine */int dlarfx_(char *side, integer *m, integer *n,
-      doublereal * v, doublereal *tau, doublereal *c__, integer *ldc,
-      doublereal *work);
-
-  /* Subroutine */int dlargv_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *c__, integer *incc);
-
-  /* Subroutine */int dlarnv_(integer *idist, integer *iseed, integer *n,
-      doublereal *x);
-
-  /* Subroutine */int dlarra_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *spltol, doublereal *tnrm, integer *nsplit,
-      integer *isplit, integer *info);
-
-  /* Subroutine */int dlarrb_(integer *n, doublereal *d__, doublereal *lld,
-      integer *ifirst, integer *ilast, doublereal *rtol1, doublereal *rtol2,
-      integer *offset, doublereal *w, doublereal *wgap, doublereal *werr,
-      doublereal *work, integer *iwork, doublereal *pivmin, doublereal * spdiam,
-      integer *twist, integer *info);
-
-  /* Subroutine */int dlarrc_(char *jobt, integer *n, doublereal *vl,
-      doublereal *vu, doublereal *d__, doublereal *e, doublereal *pivmin,
-      integer *eigcnt, integer *lcnt, integer *rcnt, integer *info);
-
-  /* Subroutine */int dlarrd_(char *range, char *order, integer *n,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *gers, doublereal *reltol, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *pivmin, integer *nsplit, integer *isplit,
-      integer *m, doublereal *w, doublereal *werr, doublereal *wl,
-      doublereal *wu, integer *iblock, integer *indexw, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlarre_(char *range, integer *n, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *d__, doublereal *e,
-      doublereal *e2, doublereal *rtol1, doublereal *rtol2, doublereal * spltol,
-      integer *nsplit, integer *isplit, integer *m, doublereal *w,
-      doublereal *werr, doublereal *wgap, integer *iblock, integer *indexw,
-      doublereal *gers, doublereal *pivmin, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dlarrf_(integer *n, doublereal *d__, doublereal *l,
-      doublereal *ld, integer *clstrt, integer *clend, doublereal *w,
-      doublereal *wgap, doublereal *werr, doublereal *spdiam,
-      doublereal * clgapl, doublereal *clgapr, doublereal *pivmin,
-      doublereal *sigma, doublereal *dplus, doublereal *lplus, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dlarrj_(integer *n, doublereal *d__, doublereal *e2,
-      integer *ifirst, integer *ilast, doublereal *rtol, integer *offset,
-      doublereal *w, doublereal *werr, doublereal *work, integer *iwork,
-      doublereal *pivmin, doublereal *spdiam, integer *info);
-
-  /* Subroutine */int dlarrk_(integer *n, integer *iw, doublereal *gl,
-      doublereal *gu, doublereal *d__, doublereal *e2, doublereal *pivmin,
-      doublereal *reltol, doublereal *w, doublereal *werr, integer *info);
-
-  /* Subroutine */int dlarrr_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dlarrv_(integer *n, doublereal *vl, doublereal *vu,
-      doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
-      integer *m, integer *dol, integer *dou, doublereal *minrgp,
-      doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
-      doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dlarscl2_(integer *m, integer *n, doublereal *d__,
-      doublereal *x, integer *ldx);
-
-  /* Subroutine */int dlartg_(doublereal *f, doublereal *g, doublereal *cs,
-      doublereal *sn, doublereal *r__);
-
-  /* Subroutine */int dlartv_(integer *n, doublereal *x, integer *incx,
-      doublereal *y, integer *incy, doublereal *c__, doublereal *s,
-      integer *incc);
-
-  /* Subroutine */int dlaruv_(integer *iseed, integer *n, doublereal *x);
-
-  /* Subroutine */int dlarz_(char *side, integer *m, integer *n, integer *l,
-      doublereal *v, integer *incv, doublereal *tau, doublereal *c__,
-      integer *ldc, doublereal *work);
-
-  /* Subroutine */int dlarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l,
-      doublereal *v, integer *ldv, doublereal *t, integer *ldt, doublereal *c__,
-      integer * ldc, doublereal *work, integer *ldwork);
-
-  /* Subroutine */int dlarzt_(char *direct, char *storev, integer *n,
-      integer * k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
-      integer *ldt);
-
-  /* Subroutine */int dlas2_(doublereal *f, doublereal *g, doublereal *h__,
-      doublereal *ssmin, doublereal *ssmax);
-
-  /* Subroutine */int dlascl_(char *type__, integer *kl, integer *ku,
-      doublereal *cfrom, doublereal *cto, integer *m, integer *n, doublereal *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int dlascl2_(integer *m, integer *n, doublereal *d__,
-      doublereal *x, integer *ldx);
-
-  /* Subroutine */int dlasd0_(integer *n, integer *sqre, doublereal *d__,
-      doublereal *e, doublereal *u, integer *ldu, doublereal *vt,
-      integer * ldvt, integer *smlsiz, integer *iwork, doublereal *work,
-      integer * info);
-
-  /* Subroutine */int dlasd1_(integer *nl, integer *nr, integer *sqre,
-      doublereal *d__, doublereal *alpha, doublereal *beta, doublereal *u,
-      integer *ldu, doublereal *vt, integer *ldvt, integer *idxq,
-      integer * iwork, doublereal *work, integer *info);
-
-  /* Subroutine */int dlasd2_(integer *nl, integer *nr, integer *sqre,
-      integer *k, doublereal *d__, doublereal *z__, doublereal *alpha,
-      doublereal * beta, doublereal *u, integer *ldu, doublereal *vt,
-      integer *ldvt, doublereal *dsigma, doublereal *u2, integer *ldu2,
-      doublereal *vt2, integer *ldvt2, integer *idxp, integer *idx,
-      integer *idxc, integer * idxq, integer *coltyp, integer *info);
-
-  /* Subroutine */int dlasd3_(integer *nl, integer *nr, integer *sqre,
-      integer *k, doublereal *d__, doublereal *q, integer *ldq,
-      doublereal *dsigma, doublereal *u, integer *ldu, doublereal *u2,
-      integer *ldu2, doublereal *vt, integer *ldvt, doublereal *vt2,
-      integer *ldvt2, integer *idxc, integer *ctot, doublereal *z__,
-      integer *info);
-
-  /* Subroutine */int dlasd4_(integer *n, integer *i__, doublereal *d__,
-      doublereal *z__, doublereal *delta, doublereal *rho, doublereal * sigma,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dlasd5_(integer *i__, doublereal *d__, doublereal *z__,
-      doublereal *delta, doublereal *rho, doublereal *dsigma,
-      doublereal * work);
-
-  /* Subroutine */int dlasd6_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, doublereal *d__, doublereal *vf, doublereal *vl,
-      doublereal *alpha, doublereal *beta, integer *idxq, integer *perm,
-      integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
-      integer *ldgnum, doublereal *poles, doublereal *difl, doublereal * difr,
-      doublereal *z__, integer *k, doublereal *c__, doublereal *s,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dlasd7_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *k, doublereal *d__, doublereal *z__,
-      doublereal *zw, doublereal *vf, doublereal *vfw, doublereal *vl,
-      doublereal *vlw, doublereal *alpha, doublereal *beta, doublereal * dsigma,
-      integer *idx, integer *idxp, integer *idxq, integer *perm,
-      integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
-      integer *ldgnum, doublereal *c__, doublereal *s, integer *info);
-
-  /* Subroutine */int dlasd8_(integer *icompq, integer *k, doublereal *d__,
-      doublereal *z__, doublereal *vf, doublereal *vl, doublereal *difl,
-      doublereal *difr, integer *lddifr, doublereal *dsigma, doublereal * work,
-      integer *info);
-
-  /* Subroutine */int dlasda_(integer *icompq, integer *smlsiz, integer *n,
-      integer *sqre, doublereal *d__, doublereal *e, doublereal *u,
-      integer *ldu, doublereal *vt, integer *k, doublereal *difl,
-      doublereal *difr, doublereal *z__, doublereal *poles, integer *givptr,
-      integer *givcol, integer *ldgcol, integer *perm, doublereal *givnum,
-      doublereal *c__, doublereal *s, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dlasdq_(char *uplo, integer *sqre, integer *n,
-      integer * ncvt, integer *nru, integer *ncc, doublereal *d__,
-      doublereal *e, doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dlasdt_(integer *n, integer *lvl, integer *nd,
-      integer * inode, integer *ndiml, integer *ndimr, integer *msub);
-
-  /* Subroutine */int dlaset_(char *uplo, integer *m, integer *n,
-      doublereal * alpha, doublereal *beta, doublereal *a, integer *lda);
-
-  /* Subroutine */int dlasq1_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dlasq2_(integer *n, doublereal *z__, integer *info);
-
-  /* Subroutine */int dlasq3_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *dmin__, doublereal *sigma, doublereal *desig,
-      doublereal *qmax, integer *nfail, integer *iter, integer *ndiv,
-      logical *ieee, integer *ttype, doublereal *dmin1, doublereal *dmin2,
-      doublereal *dn, doublereal *dn1, doublereal *dn2, doublereal *g,
-      doublereal *tau);
-
-  /* Subroutine */int dlasq4_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, integer *n0in, doublereal *dmin__, doublereal *dmin1,
-      doublereal *dmin2, doublereal *dn, doublereal *dn1, doublereal *dn2,
-      doublereal *tau, integer *ttype, doublereal *g);
-
-  /* Subroutine */int dlasq5_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *tau, doublereal *dmin__, doublereal *dmin1,
-      doublereal *dmin2, doublereal *dn, doublereal *dnm1, doublereal *dnm2,
-      logical *ieee);
-
-  /* Subroutine */int dlasq6_(integer *i0, integer *n0, doublereal *z__,
-      integer *pp, doublereal *dmin__, doublereal *dmin1, doublereal *dmin2,
-      doublereal *dn, doublereal *dnm1, doublereal *dnm2);
-
-  /* Subroutine */int dlasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, doublereal *c__, doublereal *s, doublereal *a, integer * lda);
-
-  /* Subroutine */int dlasrt_(char *id, integer *n, doublereal *d__,
-      integer * info);
-
-  /* Subroutine */int dlassq_(integer *n, doublereal *x, integer *incx,
-      doublereal *scale, doublereal *sumsq);
-
-  /* Subroutine */int dlasv2_(doublereal *f, doublereal *g, doublereal *h__,
-      doublereal *ssmin, doublereal *ssmax, doublereal *snr, doublereal * csr,
-      doublereal *snl, doublereal *csl);
-
-  /* Subroutine */int dlaswp_(integer *n, doublereal *a, integer *lda,
-      integer *k1, integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int dlasy2_(logical *ltranl, logical *ltranr, integer *isgn,
-      integer *n1, integer *n2, doublereal *tl, integer *ldtl, doublereal * tr,
-      integer *ldtr, doublereal *b, integer *ldb, doublereal *scale,
-      doublereal *x, integer *ldx, doublereal *xnorm, integer *info);
-
-  /* Subroutine */int dlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *w, integer * ldw,
-      integer *info);
-
-  /* Subroutine */int dlat2s_(char *uplo, integer *n, doublereal *a,
-      integer * lda, real *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int dlatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, doublereal *ab, integer *ldab,
-      doublereal *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatdf_(integer *ijob, integer *n, doublereal *z__,
-      integer *ldz, doublereal *rhs, doublereal *rdsum, doublereal *rdscal,
-      integer *ipiv, integer *jpiv);
-
-  /* Subroutine */int dlatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublereal *ap, doublereal *x,
-      doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatrd_(char *uplo, integer *n, integer *nb,
-      doublereal * a, integer *lda, doublereal *e, doublereal *tau,
-      doublereal *w, integer *ldw);
-
-  /* Subroutine */int dlatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublereal *a, integer *lda, doublereal *x,
-      doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int dlatrz_(integer *m, integer *n, integer *l,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work);
-
-  /* Subroutine */int dlatzm_(char *side, integer *m, integer *n,
-      doublereal * v, integer *incv, doublereal *tau, doublereal *c1,
-      doublereal *c2, integer *ldc, doublereal *work);
-
-  /* Subroutine */int dlauu2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dlauum_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dopgtr_(char *uplo, integer *n, doublereal *ap,
-      doublereal *tau, doublereal *q, integer *ldq, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dopmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublereal *ap, doublereal *tau, doublereal *c__,
-      integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dorg2l_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorg2r_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorgbr_(char *vect, integer *m, integer *n, integer *k,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorghr_(integer *n, integer *ilo, integer *ihi,
-      doublereal *a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgl2_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorglq_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgql_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgqr_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgr2_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dorgrq_(integer *m, integer *n, integer *k,
-      doublereal * a, integer *lda, doublereal *tau, doublereal *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int dorgtr_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dorm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dorm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal * tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dorml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *info);
-
-  /* Subroutine */int dormrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
-      doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dormtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublereal *a, integer *lda, doublereal *tau,
-      doublereal * c__, integer *ldc, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dpbcon_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *anorm, doublereal *rcond,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpbequ_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int dpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int dpbstf_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
-      integer *ldafb, char *equed, doublereal *s, doublereal *b, integer * ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpbtf2_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbtrf_(char *uplo, integer *n, integer *kd,
-      doublereal * ab, integer *ldab, integer *info);
-
-  /* Subroutine */int dpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dpftrf_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dpftri_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dpocon_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dpoequ_(integer *n, doublereal *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dpoequb_(integer *n, doublereal *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dporfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal * ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer * info);
-
-  /* Subroutine */int dporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, doublereal *s, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer * nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dposv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
-      doublereal * x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal * berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
-      doublereal * x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
-      doublereal * berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dpotf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotri_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *info);
-
-  /* Subroutine */int dpotrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dppcon_(char *uplo, integer *n, doublereal *ap,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int dppequ_(char *uplo, integer *n, doublereal *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int dpprfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *afp, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dppsv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *ap, doublereal *afp, char *equed,
-      doublereal *s, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dpptrf_(char *uplo, integer *n, doublereal *ap,
-      integer * info);
-
-  /* Subroutine */int dpptri_(char *uplo, integer *n, doublereal *ap,
-      integer * info);
-
-  /* Subroutine */int dpptrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dpstf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dpstrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dptcon_(integer *n, doublereal *d__, doublereal *e,
-      doublereal *anorm, doublereal *rcond, doublereal *work, integer *info);
-
-  /* Subroutine */int dpteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dptrfs_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *df, doublereal *ef, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *info);
-
-  /* Subroutine */int dptsv_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dptsvx_(char *fact, integer *n, integer *nrhs,
-      doublereal *d__, doublereal *e, doublereal *df, doublereal *ef,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal * rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer * info);
-
-  /* Subroutine */int dpttrf_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dpttrs_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb, integer *info);
-
-  /* Subroutine */int dptts2_(integer *n, integer *nrhs, doublereal *d__,
-      doublereal *e, doublereal *b, integer *ldb);
-
-  /* Subroutine */int drscl_(integer *n, doublereal *sa, doublereal *sx,
-      integer *incx);
-
-  /* Subroutine */int dsbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *info);
-
-  /* Subroutine */int dsbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int dsbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, doublereal *ab, integer *ldab, doublereal *q, integer * ldq,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *iwork, integer *ifail,
-      integer *info);
-
-  /* Subroutine */int dsbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *x, integer *ldx, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dsbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dsbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
-      integer * ldbb, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dsbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, doublereal *ab, integer *ldab, doublereal * bb,
-      integer *ldbb, doublereal *q, integer *ldq, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
-      doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      doublereal *ab, integer *ldab, doublereal *d__, doublereal *e,
-      doublereal *q, integer *ldq, doublereal *work, integer *info);
-
-  /* Subroutine */int dsfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, doublereal *alpha, doublereal *a, integer *lda,
-      doublereal *beta, doublereal *c__);
-
-  /* Subroutine */int dsgesv_(integer *n, integer *nrhs, doublereal *a,
-      integer *lda, integer *ipiv, doublereal *b, integer *ldb, doublereal * x,
-      integer *ldx, doublereal *work, real *swork, integer *iter,
-      integer *info);
-
-  /* Subroutine */int dspcon_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, doublereal *anorm, doublereal *rcond, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dspev_(char *jobz, char *uplo, integer *n,
-      doublereal * ap, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dspevd_(char *jobz, char *uplo, integer *n,
-      doublereal * ap, doublereal *w, doublereal *z__, integer *ldz,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dspevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *ap, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *iwork, integer *ifail,
-      integer *info);
-
-  /* Subroutine */int dspgst_(integer *itype, char *uplo, integer *n,
-      doublereal *ap, doublereal *bp, integer *info);
-
-  /* Subroutine */int dspgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *ap, doublereal *bp, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *info);
-
-  /* Subroutine */int dspgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *ap, doublereal *bp, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dspgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublereal *ap, doublereal *bp, doublereal *vl,
-      doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
-      doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsposv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * x,
-      integer *ldx, doublereal *work, real *swork, integer *iter,
-      integer *info);
-
-  /* Subroutine */int dsprfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, doublereal *afp, integer *ipiv, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dspsv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int dspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *ap, doublereal *afp, integer *ipiv,
-      doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dsptrd_(char *uplo, integer *n, doublereal *ap,
-      doublereal *d__, doublereal *e, doublereal *tau, integer *info);
-
-  /* Subroutine */int dsptrf_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, integer *info);
-
-  /* Subroutine */int dsptri_(char *uplo, integer *n, doublereal *ap,
-      integer * ipiv, doublereal *work, integer *info);
-
-  /* Subroutine */int dsptrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int dstebz_(char *range, char *order, integer *n,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, doublereal *d__, doublereal *e, integer *m,
-      integer *nsplit, doublereal *w, integer *iblock, integer *isplit,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dstedc_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstegr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstein_(integer *n, doublereal *d__, doublereal *e,
-      integer *m, doublereal *w, integer *iblock, integer *isplit,
-      doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dstemr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int dsteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dsterf_(integer *n, doublereal *d__, doublereal *e,
-      integer *info);
-
-  /* Subroutine */int dstev_(char *jobz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dstevd_(char *jobz, integer *n, doublereal *d__,
-      doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstevr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dstevx_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dsycon_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dsyequb_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublereal * work, integer *info);
-
-  /* Subroutine */int dsyev_(char *jobz, char *uplo, integer *n, doublereal *a,
-      integer *lda, doublereal *w, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dsyevd_(char *jobz, char *uplo, integer *n,
-      doublereal * a, integer *lda, doublereal *w, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dsyevr_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer * il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dsyevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer * il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int dsygs2_(integer *itype, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dsygst_(integer *itype, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, integer * info);
-
-  /* Subroutine */int dsygv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *w, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsygvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *w, doublereal *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int dsygvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
-      integer *ldz, doublereal *work, integer *lwork, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int dsyrfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, doublereal *af, integer *ldaf,
-      integer * ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dsyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *s, doublereal *b, integer *ldb,
-      doublereal *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublereal * work, integer *iwork, integer *info);
-
-  /* Subroutine */int dsysv_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
-      integer * ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int dsysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublereal *a, integer *lda, doublereal *af,
-      integer *ldaf, integer *ipiv, char *equed, doublereal *s, doublereal *b,
-      integer * ldb, doublereal *x, integer *ldx, doublereal *rcond,
-      doublereal * rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal * err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dsytd2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tau,
-      integer *info);
-
-  /* Subroutine */int dsytf2_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int dsytrd_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *d__, doublereal *e, doublereal *tau,
-      doublereal * work, integer *lwork, integer *info);
-
-  /* Subroutine */int dsytrf_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int dsytri_(char *uplo, integer *n, doublereal *a,
-      integer * lda, integer *ipiv, doublereal *work, integer *info);
-
-  /* Subroutine */int dsytrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dtbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, doublereal *ab, integer *ldab, doublereal *rcond,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int dtfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, doublereal *alpha, doublereal *a,
-      doublereal *b, integer *ldb);
-
-  /* Subroutine */int dtftri_(char *transr, char *uplo, char *diag, integer *n,
-      doublereal *a, integer *info);
-
-  /* Subroutine */int dtfttp_(char *transr, char *uplo, integer *n,
-      doublereal *arf, doublereal *ap, integer *info);
-
-  /* Subroutine */int dtfttr_(char *transr, char *uplo, integer *n,
-      doublereal *arf, doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int dtgevc_(char *side, char *howmny, logical *select,
-      integer *n, doublereal *s, integer *lds, doublereal *p, integer *ldp,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr, integer *mm,
-      integer *m, doublereal *work, integer *info);
-
-  /* Subroutine */int dtgex2_(logical *wantq, logical *wantz, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * q,
-      integer *ldq, doublereal *z__, integer *ldz, integer *j1, integer * n1,
-      integer *n2, doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dtgexc_(logical *wantq, logical *wantz, integer *n,
-      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal * q,
-      integer *ldq, doublereal *z__, integer *ldz, integer *ifst, integer *ilst,
-      doublereal *work, integer *lwork, integer *info);
-
-  /* Subroutine */int dtgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, doublereal *a, integer *lda, doublereal * b,
-      integer *ldb, doublereal *alphar, doublereal *alphai, doublereal * beta,
-      doublereal *q, integer *ldq, doublereal *z__, integer *ldz, integer *m,
-      doublereal *pl, doublereal *pr, doublereal *dif, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int dtgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, doublereal *a,
-      integer *lda, doublereal *b, integer *ldb, doublereal *tola,
-      doublereal *tolb, doublereal *alpha, doublereal *beta, doublereal *u,
-      integer *ldu, doublereal *v, integer *ldv, doublereal *q, integer * ldq,
-      doublereal *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int dtgsna_(char *job, char *howmny, logical *select,
-      integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
-      doublereal *s, doublereal *dif, integer *mm, integer *m,
-      doublereal * work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int dtgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
-      doublereal *e, integer *lde, doublereal *f, integer *ldf,
-      doublereal * scale, doublereal *rdsum, doublereal *rdscal, integer *iwork,
-      integer *pq, integer *info);
-
-  /* Subroutine */int dtgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
-      doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
-      doublereal *e, integer *lde, doublereal *f, integer *ldf,
-      doublereal * scale, doublereal *dif, doublereal *work, integer *lwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dtpcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *ap, doublereal *rcond, doublereal *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int dtprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *ap, doublereal *b, integer *ldb, doublereal *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dtptri_(char *uplo, char *diag, integer *n,
-      doublereal * ap, integer *info);
-
-  /* Subroutine */int dtptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *ap, doublereal *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int dtpttf_(char *transr, char *uplo, integer *n,
-      doublereal *ap, doublereal *arf, integer *info);
-
-  /* Subroutine */int dtpttr_(char *uplo, integer *n, doublereal *ap,
-      doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublereal *a, integer *lda, doublereal *rcond, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int dtrevc_(char *side, char *howmny, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *vl, integer * ldvl,
-      doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int dtrexc_(char *compq, integer *n, doublereal *t,
-      integer * ldt, doublereal *q, integer *ldq, integer *ifst, integer *ilst,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int dtrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer * ldb,
-      doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublereal *work, integer *iwork, integer *info);
-
-  /* Subroutine */int dtrsen_(char *job, char *compq, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *q, integer *ldq,
-      doublereal *wr, doublereal *wi, integer *m, doublereal *s,
-      doublereal *sep, doublereal *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
-
-  /* Subroutine */int dtrsna_(char *job, char *howmny, logical *select,
-      integer *n, doublereal *t, integer *ldt, doublereal *vl, integer * ldvl,
-      doublereal *vr, integer *ldvr, doublereal *s, doublereal *sep,
-      integer *mm, integer *m, doublereal *work, integer *ldwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int dtrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, doublereal *a, integer *lda, doublereal *b,
-      integer * ldb, doublereal *c__, integer *ldc, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int dtrti2_(char *uplo, char *diag, integer *n,
-      doublereal * a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrtri_(char *uplo, char *diag, integer *n,
-      doublereal * a, integer *lda, integer *info);
-
-  /* Subroutine */int dtrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer * ldb,
-      integer *info);
-
-  /* Subroutine */int dtrttf_(char *transr, char *uplo, integer *n,
-      doublereal *a, integer *lda, doublereal *arf, integer *info);
-
-  /* Subroutine */int dtrttp_(char *uplo, integer *n, doublereal *a,
-      integer * lda, doublereal *ap, integer *info);
-
-  /* Subroutine */int dtzrqf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, integer *info);
-
-  /* Subroutine */int dtzrzf_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublereal *tau, doublereal *work, integer *lwork,
-      integer *info);
-
-  doublereal dzsum1_(integer *n, doublecomplex *cx, integer *incx);
-
-  integer icmax1_(integer *n, complex *cx, integer *incx);
-
-  integer ieeeck_(integer *ispec, real *zero, real *one);
-
-  integer ilaclc_(integer *m, integer *n, complex *a, integer *lda);
-
-  integer ilaclr_(integer *m, integer *n, complex *a, integer *lda);
-
-  integer iladiag_(char *diag);
-
-  integer iladlc_(integer *m, integer *n, doublereal *a, integer *lda);
-
-  integer iladlr_(integer *m, integer *n, doublereal *a, integer *lda);
-
-  integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
-      integer *n2, integer *n3, integer *n4);
-
-  integer ilaprec_(char *prec);
-
-  integer ilaslc_(integer *m, integer *n, real *a, integer *lda);
-
-  integer ilaslr_(integer *m, integer *n, real *a, integer *lda);
-
-  integer ilatrans_(char *trans);
-
-  integer ilauplo_(char *uplo);
-
-  /* Subroutine */int ilaver_(integer *vers_major__, integer *vers_minor__,
-      integer *vers_patch__);
-
-  integer ilazlc_(integer *m, integer *n, doublecomplex *a, integer *lda);
-
-  integer ilazlr_(integer *m, integer *n, doublecomplex *a, integer *lda);
-
-  integer iparmq_(integer *ispec, char *name__, char *opts, integer *n,
-      integer *ilo, integer *ihi, integer *lwork);
-
-  integer izmax1_(integer *n, doublecomplex *cx, integer *incx);
-
-  logical lsamen_(integer *n, char *ca, char *cb);
-
-  integer smaxloc_(real *a, integer *dimm);
-
-  /* Subroutine */int sbdsdc_(char *uplo, char *compq, integer *n, real *d__,
-      real *e, real *u, integer *ldu, real *vt, integer *ldvt, real *q,
-      integer *iq, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, real *d__, real *e, real *vt, integer *ldvt,
-      real * u, integer *ldu, real *c__, integer *ldc, real *work,
-      integer *info);
-
-  doublereal scsum1_(integer *n, complex *cx, integer *incx);
-
-  /* Subroutine */int sdisna_(char *job, integer *m, integer *n, real *d__,
-      real *sep, integer *info);
-
-  /* Subroutine */int sgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, real *ab, integer *ldab, real *d__, real * e,
-      real *q, integer *ldq, real *pt, integer *ldpt, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real * colcnd, real *amax, integer *info);
-
-  /* Subroutine */int sgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real *colcnd, real *amax, integer *info);
-
-  /* Subroutine */int sgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, real *ab, integer *ldab, real *afb,
-      integer *ldafb, integer *ipiv, real *b, integer *ldb, real *x,
-      integer *ldx, real * ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
-      real *afb, integer *ldafb, integer *ipiv, real *r__, real *c__, real *b,
-      integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, real *ab, integer *ldab, integer *ipiv, real *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int sgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
-      integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__, real *b,
-      integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
-      real *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
-      real *c__, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
-      real * rpvgrw, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real *err_bnds_comp__, integer *nparams, real *params, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, real *ab, integer *ldab, integer *ipiv,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *scale, integer *m, real *v, integer *ldv,
-      integer *info);
-
-  /* Subroutine */int sgebal_(char *job, integer *n, real *a, integer *lda,
-      integer *ilo, integer *ihi, real *scale, integer *info);
-
-  /* Subroutine */int sgebd2_(integer *m, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tauq, real *taup, real *work, integer *info);
-
-  /* Subroutine */int sgebrd_(integer *m, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tauq, real *taup, real *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int sgecon_(char *norm, integer *n, real *a, integer *lda,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgeequ_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
-
-  /* Subroutine */int sgeequb_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      integer *info);
-
-  /* Subroutine */int sgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      real *a, integer *lda, integer *sdim, real *wr, real *wi, real *vs,
-      integer *ldvs, real *work, integer *lwork, logical *bwork,
-      integer * info);
-
-  /* Subroutine */int sgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, real *a, integer *lda, integer *sdim, real *wr,
-      real *wi, real *vs, integer *ldvs, real *rconde, real *rcondv,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int sgeev_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *wr, real *wi, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, real *a, integer *lda, real *wr, real *wi,
-      real * vl, integer *ldvl, real *vr, integer *ldvr, integer *ilo,
-      integer * ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgegs_(char *jobvsl, char *jobvsr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vsl, integer *ldvsl, real *vsr, integer *ldvsr,
-      real * work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgegv_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgehd2_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgehrd_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
-      char *jobt, char *jobp, integer *m, integer *n, real *a, integer *lda,
-      real *sva, real *u, integer *ldu, real *v, integer *ldv, real *work,
-      integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgelq2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgelqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, real *a, integer *lda, real *b, integer *ldb, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgelsd_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, real *s, real *rcond, integer * rank,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgelss_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, real *s, real *rcond, integer * rank,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgelsx_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
-      integer *rank, real *work, integer *info);
-
-  /* Subroutine */int sgelsy_(integer *m, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
-      integer *rank, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeql2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqlf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeqp3_(integer *m, integer *n, real *a, integer *lda,
-      integer *jpvt, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgeqpf_(integer *m, integer *n, real *a, integer *lda,
-      integer *jpvt, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqr2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgeqrf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgerfs_(char *trans, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *r__, real *c__, real *b, integer *ldb, real *x,
-      integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
-      real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real *params, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgerq2_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *info);
-
-  /* Subroutine */int sgerqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesc2_(integer *n, real *a, integer *lda, real *rhs,
-      integer *ipiv, integer *jpiv, real *scale);
-
-  /* Subroutine */int sgesdd_(char *jobz, integer *m, integer *n, real *a,
-      integer *lda, real *s, real *u, integer *ldu, real *vt, integer *ldvt,
-      real *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int sgesv_(integer *n, integer *nrhs, real *a, integer *lda,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      real *a, integer *lda, real *s, real *u, integer *ldu, real *vt,
-      integer *ldvt, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesvj_(char *joba, char *jobu, char *jobv, integer *m,
-      integer *n, real *a, integer *lda, real *sva, integer *mv, real *v,
-      integer *ldv, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer * n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer * nparams, real *params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sgetc2_(integer *n, real *a, integer *lda, integer *ipiv,
-      integer *jpiv, integer *info);
-
-  /* Subroutine */int sgetf2_(integer *m, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int sgetrf_(integer *m, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int sgetri_(integer *n, real *a, integer *lda, integer *ipiv,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgetrs_(char *trans, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, real *lscale, real *rscale, integer *m, real *v,
-      integer *ldv, integer *info);
-
-  /* Subroutine */int sggbal_(char *job, integer *n, real *a, integer *lda,
-      real *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
-      real *rscale, real *work, integer *info);
-
-  /* Subroutine */int sgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      integer *sdim, real *alphar, real *alphai, real *beta, real *vsl,
-      integer *ldvsl, real *vsr, integer *ldvsr, real *work, integer *lwork,
-      logical *bwork, integer *info);
-
-  /* Subroutine */int sggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, real *a, integer *lda, real *b,
-      integer *ldb, integer *sdim, real *alphar, real *alphai, real *beta,
-      real *vsl, integer *ldvsl, real *vsr, integer *ldvsr, real *rconde,
-      real *rcondv, real *work, integer *lwork, integer *iwork,
-      integer * liwork, logical *bwork, integer *info);
-
-  /* Subroutine */int sggev_(char *jobvl, char *jobvr, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
-      real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real *alphar, real *alphai, real *beta, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, integer *ilo, integer *ihi, real *lscale, real *rscale,
-      real *abnrm, real *bbnrm, real *rconde, real *rcondv, real *work,
-      integer *lwork, integer *iwork, logical *bwork, integer *info);
-
-  /* Subroutine */int sggglm_(integer *n, integer *m, integer *p, real *a,
-      integer *lda, real *b, integer *ldb, real *d__, real *x, real *y,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, real *a, integer *lda, real *b, integer *ldb,
-      real *q, integer *ldq, real *z__, integer *ldz, integer *info);
-
-  /* Subroutine */int sgglse_(integer *m, integer *n, integer *p, real *a,
-      integer *lda, real *b, integer *ldb, real *c__, real *d__, real *x,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sggqrf_(integer *n, integer *m, integer *p, real *a,
-      integer *lda, real *taua, real *b, integer *ldb, real *taub, real * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggrqf_(integer *m, integer *p, integer *n, real *a,
-      integer *lda, real *taua, real *b, integer *ldb, real *taub, real * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, real *a, integer *lda,
-      real *b, integer *ldb, real *alpha, real *beta, real *u, integer * ldu,
-      real *v, integer *ldv, real *q, integer *ldq, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real *tola, real *tolb, integer *k, integer *l, real *u, integer *ldu,
-      real *v, integer *ldv, real *q, integer *ldq, integer *iwork, real * tau,
-      real *work, integer *info);
-
-  /* Subroutine */int sgsvj0_(char *jobv, integer *m, integer *n, real *a,
-      integer *lda, real *d__, real *sva, integer *mv, real *v, integer * ldv,
-      real *eps, real *sfmin, real *tol, integer *nsweep, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int sgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
-      real *a, integer *lda, real *d__, real *sva, integer *mv, real *v,
-      integer *ldv, real *eps, real *sfmin, real *tol, integer *nsweep,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sgtcon_(char *norm, integer *n, real *dl, real *d__,
-      real *du, real *du2, integer *ipiv, real *anorm, real *rcond, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgtrfs_(char *trans, integer *n, integer *nrhs, real *dl,
-      real *d__, real *du, real *dlf, real *df, real *duf, real *du2,
-      integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real * ferr,
-      real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sgtsv_(integer *n, integer *nrhs, real *dl, real *d__,
-      real *du, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, real *dl, real *d__, real *du, real *dlf, real *df,
-      real *duf, real *du2, integer *ipiv, real *b, integer *ldb, real *x,
-      integer * ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int sgttrf_(integer *n, real *dl, real *d__, real *du,
-      real * du2, integer *ipiv, integer *info);
-
-  /* Subroutine */int sgttrs_(char *trans, integer *n, integer *nrhs, real *dl,
-      real *d__, real *du, real *du2, integer *ipiv, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int sgtts2_(integer *itrans, integer *n, integer *nrhs,
-      real *dl, real *d__, real *du, real *du2, integer *ipiv, real *b,
-      integer * ldb);
-
-  /* Subroutine */int shgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *t,
-      integer *ldt, real *alphar, real *alphai, real *beta, real *q,
-      integer *ldq, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int shsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, real *h__, integer *ldh, real *wr, real *wi,
-      real *vl, integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
-      real *work, integer *ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int shseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, real *h__, integer *ldh, real *wr, real *wi, real *z__,
-      integer *ldz, real *work, integer *lwork, integer *info);
-
-  logical sisnan_(real *sin__);
-
-  /* Subroutine */int sla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, real *alpha, real *ab, integer *ldab, real * x,
-      integer *incx, real *beta, real *y, integer *incy);
-
-  doublereal sla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *afb, integer *ldafb, integer *ipiv,
-      integer *cmode, real *c__, integer *info, real *work, integer *iwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int sla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      integer *ipiv, logical *colequ, real *c__, real *b, integer *ldb, real *y,
-      integer * ldy, real *berr_out__, integer *n_norms__, real *errs_n__,
-      real * errs_c__, real *res, real *ayb, real *dy, real *y_tail__,
-      real *rcond, integer *ithresh, real *rthresh, real *dz_ub__,
-      logical * ignore_cwise__, integer *info);
-
-  doublereal sla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, real *ab, integer *ldab, real *afb, integer *ldafb);
-
-  /* Subroutine */int sla_geamv__(integer *trans, integer *m, integer *n,
-      real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta,
-      real *y, integer *incy);
-
-  doublereal sla_gercond__(char *trans, integer *n, real *a, integer *lda,
-      real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
-      integer *info, real *work, integer *iwork, ftnlen trans_len);
-
-  /* Subroutine */int sla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, real *a, integer *lda,
-      real * af, integer *ldaf, integer *ipiv, logical *colequ, real *c__,
-      real *b, integer *ldb, real *y, integer *ldy, real *berr_out__,
-      integer * n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
-      real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info);
-
-  /* Subroutine */int sla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      real *res, real *ayb, real *berr);
-
-  doublereal sla_porcond__(char *uplo, integer *n, real *a, integer *lda,
-      real * af, integer *ldaf, integer *cmode, real *c__, integer *info,
-      real * work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int sla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, real *a, integer *lda, real *af,
-      integer * ldaf, logical *colequ, real *c__, real *b, integer *ldb,
-      real *y, integer *ldy, real *berr_out__, integer *n_norms__,
-      real *errs_n__, real *errs_c__, real *res, real *ayb, real *dy,
-      real *y_tail__, real * rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical * ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal sla_porpvgrw__(char *uplo, integer *ncols, real *a, integer *lda,
-      real *af, integer *ldaf, real *work, ftnlen uplo_len);
-
-  doublereal sla_rpvgrw__(integer *n, integer *ncols, real *a, integer *lda,
-      real *af, integer *ldaf);
-
-  /* Subroutine */int sla_syamv__(integer *uplo, integer *n, real *alpha,
-      real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
-      integer *incy);
-
-  doublereal sla_syrcond__(char *uplo, integer *n, real *a, integer *lda,
-      real * af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
-      integer * info, real *work, integer *iwork, ftnlen uplo_len);
-
-  /* Subroutine */int sla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, real *a, integer *lda, real *af,
-      integer * ldaf, integer *ipiv, logical *colequ, real *c__, real *b,
-      integer * ldb, real *y, integer *ldy, real *berr_out__,
-      integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
-      real *dy, real * y_tail__, real *rcond, integer *ithresh, real *rthresh,
-      real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal sla_syrpvgrw__(char *uplo, integer *n, integer *info, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *work,
-      ftnlen uplo_len);
-
-  /* Subroutine */int sla_wwaddw__(integer *n, real *x, real *y, real *w);
-
-  /* Subroutine */int slabad_(real *small, real *large);
-
-  /* Subroutine */int slabrd_(integer *m, integer *n, integer *nb, real *a,
-      integer *lda, real *d__, real *e, real *tauq, real *taup, real *x,
-      integer *ldx, real *y, integer *ldy);
-
-  /* Subroutine */int slacn2_(integer *n, real *v, real *x, integer *isgn,
-      real *est, integer *kase, integer *isave);
-
-  /* Subroutine */int slacon_(integer *n, real *v, real *x, integer *isgn,
-      real *est, integer *kase);
-
-  /* Subroutine */int slacpy_(char *uplo, integer *m, integer *n, real *a,
-      integer *lda, real *b, integer *ldb);
-
-  /* Subroutine */int sladiv_(real *a, real *b, real *c__, real *d__, real *p,
-      real *q);
-
-  /* Subroutine */int slae2_(real *a, real *b, real *c__, real *rt1, real *rt2);
-
-  /* Subroutine */int slaebz_(integer *ijob, integer *nitmax, integer *n,
-      integer *mmax, integer *minp, integer *nbmin, real *abstol, real * reltol,
-      real *pivmin, real *d__, real *e, real *e2, integer *nval, real *ab,
-      real *c__, integer *mout, integer *nab, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int slaed0_(integer *icompq, integer *qsiz, integer *n,
-      real *d__, real *e, real *q, integer *ldq, real *qstore, integer *ldqs,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slaed1_(integer *n, real *d__, real *q, integer *ldq,
-      integer *indxq, real *rho, integer *cutpnt, real *work, integer * iwork,
-      integer *info);
-
-  /* Subroutine */int slaed2_(integer *k, integer *n, integer *n1, real *d__,
-      real *q, integer *ldq, integer *indxq, real *rho, real *z__,
-      real * dlamda, real *w, real *q2, integer *indx, integer *indxc,
-      integer * indxp, integer *coltyp, integer *info);
-
-  /* Subroutine */int slaed3_(integer *k, integer *n, integer *n1, real *d__,
-      real *q, integer *ldq, real *rho, real *dlamda, real *q2, integer * indx,
-      integer *ctot, real *w, real *s, integer *info);
-
-  /* Subroutine */int slaed4_(integer *n, integer *i__, real *d__, real *z__,
-      real *delta, real *rho, real *dlam, integer *info);
-
-  /* Subroutine */int slaed5_(integer *i__, real *d__, real *z__, real *delta,
-      real *rho, real *dlam);
-
-  /* Subroutine */int slaed6_(integer *kniter, logical *orgati, real *rho,
-      real *d__, real *z__, real *finit, real *tau, integer *info);
-
-  /* Subroutine */int slaed7_(integer *icompq, integer *n, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, real *d__, real *q,
-      integer *ldq, integer *indxq, real *rho, integer *cutpnt, real * qstore,
-      integer *qptr, integer *prmptr, integer *perm, integer * givptr,
-      integer *givcol, real *givnum, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slaed8_(integer *icompq, integer *k, integer *n,
-      integer *qsiz, real *d__, real *q, integer *ldq, integer *indxq,
-      real *rho, integer *cutpnt, real *z__, real *dlamda, real *q2,
-      integer *ldq2, real *w, integer *perm, integer *givptr, integer *givcol,
-      real * givnum, integer *indxp, integer *indx, integer *info);
-
-  /* Subroutine */int slaed9_(integer *k, integer *kstart, integer *kstop,
-      integer *n, real *d__, real *q, integer *ldq, real *rho, real *dlamda,
-      real *w, real *s, integer *lds, integer *info);
-
-  /* Subroutine */int slaeda_(integer *n, integer *tlvls, integer *curlvl,
-      integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
-      integer *givcol, real *givnum, real *q, integer *qptr, real *z__,
-      real *ztemp, integer *info);
-
-  /* Subroutine */int slaein_(logical *rightv, logical *noinit, integer *n,
-      real *h__, integer *ldh, real *wr, real *wi, real *vr, real *vi, real *b,
-      integer *ldb, real *work, real *eps3, real *smlnum, real *bignum,
-      integer *info);
-
-  /* Subroutine */int slaev2_(real *a, real *b, real *c__, real *rt1,
-      real * rt2, real *cs1, real *sn1);
-
-  /* Subroutine */int slaexc_(logical *wantq, integer *n, real *t,
-      integer * ldt, real *q, integer *ldq, integer *j1, integer *n1,
-      integer *n2, real *work, integer *info);
-
-  /* Subroutine */int slag2_(real *a, integer *lda, real *b, integer *ldb,
-      real *safmin, real *scale1, real *scale2, real *wr1, real *wr2,
-      real * wi);
-
-  /* Subroutine */int slag2d_(integer *m, integer *n, real *sa, integer *ldsa,
-      doublereal *a, integer *lda, integer *info);
-
-  /* Subroutine */int slags2_(logical *upper, real *a1, real *a2, real *a3,
-      real *b1, real *b2, real *b3, real *csu, real *snu, real *csv, real * snv,
-      real *csq, real *snq);
-
-  /* Subroutine */int slagtf_(integer *n, real *a, real *lambda, real *b,
-      real *c__, real *tol, real *d__, integer *in, integer *info);
-
-  /* Subroutine */int slagtm_(char *trans, integer *n, integer *nrhs,
-      real * alpha, real *dl, real *d__, real *du, real *x, integer *ldx,
-      real * beta, real *b, integer *ldb);
-
-  /* Subroutine */int slagts_(integer *job, integer *n, real *a, real *b,
-      real *c__, real *d__, integer *in, real *y, real *tol, integer *info);
-
-  /* Subroutine */int slagv2_(real *a, integer *lda, real *b, integer *ldb,
-      real *alphar, real *alphai, real *beta, real *csl, real *snl, real * csr,
-      real *snr);
-
-  /* Subroutine */int slahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer * info);
-
-  /* Subroutine */int slahr2_(integer *n, integer *k, integer *nb, real *a,
-      integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
-
-  /* Subroutine */int slahrd_(integer *n, integer *k, integer *nb, real *a,
-      integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
-
-  /* Subroutine */int slaic1_(integer *job, integer *j, real *x, real *sest,
-      real *w, real *gamma, real *sestpr, real *s, real *c__);
-
-  logical slaisnan_(real *sin1, real *sin2);
-
-  /* Subroutine */int slaln2_(logical *ltrans, integer *na, integer *nw,
-      real * smin, real *ca, real *a, integer *lda, real *d1, real *d2, real *b,
-      integer *ldb, real *wr, real *wi, real *x, integer *ldx, real *scale,
-      real *xnorm, integer *info);
-
-  /* Subroutine */int slals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, real *b, integer *ldb, real *bx,
-      integer *ldbx, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * work,
-      integer *info);
-
-  /* Subroutine */int slalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, real *b, integer *ldb, real *bx, integer *ldbx, real * u,
-      integer *ldu, real *vt, integer *k, real *difl, real *difr, real * z__,
-      real *poles, integer *givptr, integer *givcol, integer *ldgcol,
-      integer *perm, real *givnum, real *c__, real *s, real *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int slalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, real *d__, real *e, real *b, integer *ldb, real *rcond,
-      integer *rank, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slamrg_(integer *n1, integer *n2, real *a,
-      integer * strd1, integer *strd2, integer *index);
-
-  integer slaneg_(integer *n, real *d__, real *lld, real *sigma, real *pivmin,
-      integer *r__);
-
-  doublereal slangb_(char *norm, integer *n, integer *kl, integer *ku, real *ab,
-      integer *ldab, real *work);
-
-  doublereal slange_(char *norm, integer *m, integer *n, real *a, integer *lda,
-      real *work);
-
-  doublereal slangt_(char *norm, integer *n, real *dl, real *d__, real *du);
-
-  doublereal slanhs_(char *norm, integer *n, real *a, integer *lda, real *work);
-
-  doublereal slansb_(char *norm, char *uplo, integer *n, integer *k, real *ab,
-      integer *ldab, real *work);
-
-  doublereal slansf_(char *norm, char *transr, char *uplo, integer *n, real *a,
-      real *work);
-
-  doublereal slansp_(char *norm, char *uplo, integer *n, real *ap, real *work);
-
-  doublereal slanst_(char *norm, integer *n, real *d__, real *e);
-
-  doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
-      real *work);
-
-  doublereal slantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      real *ab, integer *ldab, real *work);
-
-  doublereal slantp_(char *norm, char *uplo, char *diag, integer *n, real *ap,
-      real *work);
-
-  doublereal slantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      real *a, integer *lda, real *work);
-
-  /* Subroutine */int slanv2_(real *a, real *b, real *c__, real *d__,
-      real * rt1r, real *rt1i, real *rt2r, real *rt2i, real *cs, real *sn);
-
-  /* Subroutine */int slapll_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *ssmin);
-
-  /* Subroutine */int slapmt_(logical *forwrd, integer *m, integer *n, real *x,
-      integer *ldx, integer *k);
-
-  doublereal slapy2_(real *x, real *y);
-
-  doublereal slapy3_(real *x, real *y, real *z__);
-
-  /* Subroutine */int slaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
-      real * colcnd, real *amax, char *equed);
-
-  /* Subroutine */int slaqge_(integer *m, integer *n, real *a, integer *lda,
-      real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
-      char * equed);
-
-  /* Subroutine */int slaqp2_(integer *m, integer *n, integer *offset, real *a,
-      integer *lda, integer *jpvt, real *tau, real *vn1, real *vn2,
-      real * work);
-
-  /* Subroutine */int slaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, real *a, integer *lda, integer *jpvt, real *tau,
-      real *vn1, real *vn2, real *auxv, real *f, integer *ldf);
-
-  /* Subroutine */int slaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int slaqr1_(integer *n, real *h__, integer *ldh, real *sr1,
-      real *si1, real *sr2, real *si2, real *v);
-
-  /* Subroutine */int slaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
-      integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
-      real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real * work,
-      integer *lwork);
-
-  /* Subroutine */int slaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
-      integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
-      real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real * work,
-      integer *lwork);
-
-  /* Subroutine */int slaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real * wi,
-      integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int slaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts, real *sr,
-      real *si, real *h__, integer *ldh, integer *iloz, integer *ihiz,
-      real *z__, integer *ldz, real *v, integer *ldv, real *u, integer *ldu,
-      integer *nv, real *wv, integer *ldwv, integer *nh, real *wh,
-      integer * ldwh);
-
-  /* Subroutine */int slaqsb_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *s, real *scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqsp_(char *uplo, integer *n, real *ap, real *s,
-      real * scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqsy_(char *uplo, integer *n, real *a, integer *lda,
-      real *s, real *scond, real *amax, char *equed);
-
-  /* Subroutine */int slaqtr_(logical *ltran, logical *lreal, integer *n,
-      real *t, integer *ldt, real *b, real *w, real *scale, real *x, real *work,
-      integer *info);
-
-  /* Subroutine */int slar1v_(integer *n, integer *b1, integer *bn,
-      real * lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
-      real * gaptol, real *z__, logical *wantnc, integer *negcnt, real *ztz,
-      real * mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
-      real *rqcorr, real *work);
-
-  /* Subroutine */int slar2v_(integer *n, real *x, real *y, real *z__,
-      integer *incx, real *c__, real *s, integer *incc);
-
-  /* Subroutine */int slarf_(char *side, integer *m, integer *n, real *v,
-      integer *incv, real *tau, real *c__, integer *ldc, real *work);
-
-  /* Subroutine */int slarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, real *v, integer *ldv,
-      real *t, integer *ldt, real *c__, integer *ldc, real *work,
-      integer * ldwork);
-
-  /* Subroutine */int slarfg_(integer *n, real *alpha, real *x, integer *incx,
-      real *tau);
-
-  /* Subroutine */int slarfp_(integer *n, real *alpha, real *x, integer *incx,
-      real *tau);
-
-  /* Subroutine */int slarft_(char *direct, char *storev, integer *n,
-      integer * k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
-
-  /* Subroutine */int slarfx_(char *side, integer *m, integer *n, real *v,
-      real *tau, real *c__, integer *ldc, real *work);
-
-  /* Subroutine */int slargv_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *c__, integer *incc);
-
-  /* Subroutine */int slarnv_(integer *idist, integer *iseed, integer *n,
-      real *x);
-
-  /* Subroutine */int slarra_(integer *n, real *d__, real *e, real *e2,
-      real * spltol, real *tnrm, integer *nsplit, integer *isplit,
-      integer *info);
-
-  /* Subroutine */int slarrb_(integer *n, real *d__, real *lld,
-      integer * ifirst, integer *ilast, real *rtol1, real *rtol2,
-      integer *offset, real *w, real *wgap, real *werr, real *work,
-      integer *iwork, real * pivmin, real *spdiam, integer *twist,
-      integer *info);
-
-  /* Subroutine */int slarrc_(char *jobt, integer *n, real *vl, real *vu,
-      real *d__, real *e, real *pivmin, integer *eigcnt, integer *lcnt,
-      integer * rcnt, integer *info);
-
-  /* Subroutine */int slarrd_(char *range, char *order, integer *n, real *vl,
-      real *vu, integer *il, integer *iu, real *gers, real *reltol, real * d__,
-      real *e, real *e2, real *pivmin, integer *nsplit, integer * isplit,
-      integer *m, real *w, real *werr, real *wl, real *wu, integer * iblock,
-      integer *indexw, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slarre_(char *range, integer *n, real *vl, real *vu,
-      integer *il, integer *iu, real *d__, real *e, real *e2, real *rtol1,
-      real *rtol2, real *spltol, integer *nsplit, integer *isplit, integer * m,
-      real *w, real *werr, real *wgap, integer *iblock, integer *indexw,
-      real *gers, real *pivmin, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int slarrf_(integer *n, real *d__, real *l, real *ld,
-      integer *clstrt, integer *clend, real *w, real *wgap, real *werr,
-      real *spdiam, real *clgapl, real *clgapr, real *pivmin, real *sigma,
-      real *dplus, real *lplus, real *work, integer *info);
-
-  /* Subroutine */int slarrj_(integer *n, real *d__, real *e2, integer *ifirst,
-      integer *ilast, real *rtol, integer *offset, real *w, real *werr,
-      real *work, integer *iwork, real *pivmin, real *spdiam, integer *info);
-
-  /* Subroutine */int slarrk_(integer *n, integer *iw, real *gl, real *gu,
-      real *d__, real *e2, real *pivmin, real *reltol, real *w, real *werr,
-      integer *info);
-
-  /* Subroutine */int slarrr_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int slarrv_(integer *n, real *vl, real *vu, real *d__,
-      real * l, real *pivmin, integer *isplit, integer *m, integer *dol,
-      integer * dou, real *minrgp, real *rtol1, real *rtol2, real *w,
-      real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
-      real *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int slarscl2_(integer *m, integer *n, real *d__, real *x,
-      integer *ldx);
-
-  /* Subroutine */int slartg_(real *f, real *g, real *cs, real *sn, real *r__);
-
-  /* Subroutine */int slartv_(integer *n, real *x, integer *incx, real *y,
-      integer *incy, real *c__, real *s, integer *incc);
-
-  /* Subroutine */int slaruv_(integer *iseed, integer *n, real *x);
-
-  /* Subroutine */int slarz_(char *side, integer *m, integer *n, integer *l,
-      real *v, integer *incv, real *tau, real *c__, integer *ldc, real * work);
-
-  /* Subroutine */int slarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l, real *v,
-      integer *ldv, real *t, integer *ldt, real *c__, integer *ldc, real * work,
-      integer *ldwork);
-
-  /* Subroutine */int slarzt_(char *direct, char *storev, integer *n,
-      integer * k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
-
-  /* Subroutine */int slas2_(real *f, real *g, real *h__, real *ssmin,
-      real * ssmax);
-
-  /* Subroutine */int slascl_(char *type__, integer *kl, integer *ku,
-      real * cfrom, real *cto, integer *m, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int slascl2_(integer *m, integer *n, real *d__, real *x,
-      integer *ldx);
-
-  /* Subroutine */int slasd0_(integer *n, integer *sqre, real *d__, real *e,
-      real *u, integer *ldu, real *vt, integer *ldvt, integer *smlsiz,
-      integer *iwork, real *work, integer *info);
-
-  /* Subroutine */int slasd1_(integer *nl, integer *nr, integer *sqre,
-      real * d__, real *alpha, real *beta, real *u, integer *ldu, real *vt,
-      integer *ldvt, integer *idxq, integer *iwork, real *work, integer * info);
-
-  /* Subroutine */int slasd2_(integer *nl, integer *nr, integer *sqre,
-      integer *k, real *d__, real *z__, real *alpha, real *beta, real *u,
-      integer * ldu, real *vt, integer *ldvt, real *dsigma, real *u2,
-      integer *ldu2, real *vt2, integer *ldvt2, integer *idxp, integer *idx,
-      integer *idxc, integer *idxq, integer *coltyp, integer *info);
-
-  /* Subroutine */int slasd3_(integer *nl, integer *nr, integer *sqre,
-      integer *k, real *d__, real *q, integer *ldq, real *dsigma, real *u,
-      integer * ldu, real *u2, integer *ldu2, real *vt, integer *ldvt,
-      real *vt2, integer *ldvt2, integer *idxc, integer *ctot, real *z__,
-      integer * info);
-
-  /* Subroutine */int slasd4_(integer *n, integer *i__, real *d__, real *z__,
-      real *delta, real *rho, real *sigma, real *work, integer *info);
-
-  /* Subroutine */int slasd5_(integer *i__, real *d__, real *z__, real *delta,
-      real *rho, real *dsigma, real *work);
-
-  /* Subroutine */int slasd6_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, real *d__, real *vf, real *vl, real *alpha, real *beta,
-      integer *idxq, integer *perm, integer *givptr, integer *givcol,
-      integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real * difl,
-      real *difr, real *z__, integer *k, real *c__, real *s, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int slasd7_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *k, real *d__, real *z__, real *zw, real *vf,
-      real *vfw, real *vl, real *vlw, real *alpha, real *beta, real *dsigma,
-      integer *idx, integer *idxp, integer *idxq, integer *perm,
-      integer * givptr, integer *givcol, integer *ldgcol, real *givnum,
-      integer * ldgnum, real *c__, real *s, integer *info);
-
-  /* Subroutine */int slasd8_(integer *icompq, integer *k, real *d__,
-      real * z__, real *vf, real *vl, real *difl, real *difr, integer *lddifr,
-      real *dsigma, real *work, integer *info);
-
-  /* Subroutine */int slasda_(integer *icompq, integer *smlsiz, integer *n,
-      integer *sqre, real *d__, real *e, real *u, integer *ldu, real *vt,
-      integer *k, real *difl, real *difr, real *z__, real *poles,
-      integer * givptr, integer *givcol, integer *ldgcol, integer *perm,
-      real *givnum, real *c__, real *s, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int slasdq_(char *uplo, integer *sqre, integer *n,
-      integer * ncvt, integer *nru, integer *ncc, real *d__, real *e, real *vt,
-      integer *ldvt, real *u, integer *ldu, real *c__, integer *ldc,
-      real * work, integer *info);
-
-  /* Subroutine */int slasdt_(integer *n, integer *lvl, integer *nd,
-      integer * inode, integer *ndiml, integer *ndimr, integer *msub);
-
-  /* Subroutine */int slaset_(char *uplo, integer *m, integer *n, real *alpha,
-      real *beta, real *a, integer *lda);
-
-  /* Subroutine */int slasq1_(integer *n, real *d__, real *e, real *work,
-      integer *info);
-
-  /* Subroutine */int slasq2_(integer *n, real *z__, integer *info);
-
-  /* Subroutine */int slasq3_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *dmin__, real *sigma, real *desig, real *qmax, integer *nfail,
-      integer *iter, integer *ndiv, logical *ieee, integer *ttype, real * dmin1,
-      real *dmin2, real *dn, real *dn1, real *dn2, real *g, real * tau);
-
-  /* Subroutine */int slasq4_(integer *i0, integer *n0, real *z__, integer *pp,
-      integer *n0in, real *dmin__, real *dmin1, real *dmin2, real *dn,
-      real *dn1, real *dn2, real *tau, integer *ttype, real *g);
-
-  /* Subroutine */int slasq5_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *tau, real *dmin__, real *dmin1, real *dmin2, real *dn, real * dnm1,
-      real *dnm2, logical *ieee);
-
-  /* Subroutine */int slasq6_(integer *i0, integer *n0, real *z__, integer *pp,
-      real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
-      real * dnm2);
-
-  /* Subroutine */int slasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, real *c__, real *s, real *a, integer *lda);
-
-  /* Subroutine */int slasrt_(char *id, integer *n, real *d__, integer *info);
-
-  /* Subroutine */int slassq_(integer *n, real *x, integer *incx, real *scale,
-      real *sumsq);
-
-  /* Subroutine */int slasv2_(real *f, real *g, real *h__, real *ssmin,
-      real * ssmax, real *snr, real *csr, real *snl, real *csl);
-
-  /* Subroutine */int slaswp_(integer *n, real *a, integer *lda, integer *k1,
-      integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int slasy2_(logical *ltranl, logical *ltranr, integer *isgn,
-      integer *n1, integer *n2, real *tl, integer *ldtl, real *tr,
-      integer * ldtr, real *b, integer *ldb, real *scale, real *x, integer *ldx,
-      real *xnorm, integer *info);
-
-  /* Subroutine */int slasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      real *a, integer *lda, integer *ipiv, real *w, integer *ldw,
-      integer *info);
-
-  /* Subroutine */int slatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, real *ab, integer *ldab, real *x,
-      real *scale, real *cnorm, integer *info);
-
-  /* Subroutine */int slatdf_(integer *ijob, integer *n, real *z__,
-      integer * ldz, real *rhs, real *rdsum, real *rdscal, integer *ipiv,
-      integer * jpiv);
-
-  /* Subroutine */int slatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, real *ap, real *x, real *scale, real *cnorm,
-      integer *info);
-
-  /* Subroutine */int slatrd_(char *uplo, integer *n, integer *nb, real *a,
-      integer *lda, real *e, real *tau, real *w, integer *ldw);
-
-  /* Subroutine */int slatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, real *a, integer *lda, real *x, real *scale,
-      real *cnorm, integer *info);
-
-  /* Subroutine */int slatrz_(integer *m, integer *n, integer *l, real *a,
-      integer *lda, real *tau, real *work);
-
-  /* Subroutine */int slatzm_(char *side, integer *m, integer *n, real *v,
-      integer *incv, real *tau, real *c1, real *c2, integer *ldc, real * work);
-
-  /* Subroutine */int slauu2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int slauum_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int sopgtr_(char *uplo, integer *n, real *ap, real *tau,
-      real *q, integer *ldq, real *work, integer *info);
-
-  /* Subroutine */int sopmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, real *ap, real *tau, real *c__, integer *ldc, real *work,
-      integer *info);
-
-  /* Subroutine */int sorg2l_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorg2r_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorgbr_(char *vect, integer *m, integer *n, integer *k,
-      real *a, integer *lda, real *tau, real *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int sorghr_(integer *n, integer *ilo, integer *ihi, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgl2_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorglq_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgql_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgqr_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgr2_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *info);
-
-  /* Subroutine */int sorgrq_(integer *m, integer *n, integer *k, real *a,
-      integer *lda, real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorgtr_(char *uplo, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sorm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, real *a, integer *lda, real *tau, real * c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sorml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *info);
-
-  /* Subroutine */int sormr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *info);
-
-  /* Subroutine */int sormrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
-      integer *ldc, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int sormtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, real *a, integer *lda, real *tau, real *c__, integer *ldc,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int spbcon_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *anorm, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int spbequ_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, real *s, real *scond, real *amax, integer *info);
-
-  /* Subroutine */int spbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      real *b, integer *ldb, real *x, integer *ldx, real *ferr, real *berr,
-      real * work, integer *iwork, integer *info);
-
-  /* Subroutine */int spbstf_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int spbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int spbtf2_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbtrf_(char *uplo, integer *n, integer *kd, real *ab,
-      integer *ldab, integer *info);
-
-  /* Subroutine */int spbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, real *ab, integer *ldab, real *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int spftrf_(char *transr, char *uplo, integer *n, real *a,
-      integer *info);
-
-  /* Subroutine */int spftri_(char *transr, char *uplo, integer *n, real *a,
-      integer *info);
-
-  /* Subroutine */int spftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, real *a, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int spocon_(char *uplo, integer *n, real *a, integer *lda,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spoequ_(integer *n, real *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
-
-  /* Subroutine */int spoequb_(integer *n, real *a, integer *lda, real *s,
-      real *scond, real *amax, integer *info);
-
-  /* Subroutine */int sporfs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, real *b, integer *ldb, real *x,
-      integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf, real *s,
-      real * b, integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
-      integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
-      integer *nparams, real *params, real *work, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int sposv_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int sposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
-      real * err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
-      real * params, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spotf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotri_(char *uplo, integer *n, real *a, integer *lda,
-      integer *info);
-
-  /* Subroutine */int spotrs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sppcon_(char *uplo, integer *n, real *ap, real *anorm,
-      real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sppequ_(char *uplo, integer *n, real *ap, real *s,
-      real * scond, real *amax, integer *info);
-
-  /* Subroutine */int spprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *afp, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
-      real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sppsv_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *ap, real *afp, char *equed, real *s, real *b,
-      integer * ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int spptrf_(char *uplo, integer *n, real *ap, integer *info);
-
-  /* Subroutine */int spptri_(char *uplo, integer *n, real *ap, integer *info);
-
-  /* Subroutine */int spptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int spstf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
-
-  /* Subroutine */int spstrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *piv, integer *rank, real *tol, real *work, integer *info);
-
-  /* Subroutine */int sptcon_(integer *n, real *d__, real *e, real *anorm,
-      real *rcond, real *work, integer *info);
-
-  /* Subroutine */int spteqr_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sptrfs_(integer *n, integer *nrhs, real *d__, real *e,
-      real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
-      real *ferr, real *berr, real *work, integer *info);
-
-  /* Subroutine */int sptsv_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
-      real *e, real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *ferr, real *berr, real *work, integer *info);
-
-  /* Subroutine */int spttrf_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int spttrs_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sptts2_(integer *n, integer *nrhs, real *d__, real *e,
-      real *b, integer *ldb);
-
-  /* Subroutine */int srscl_(integer *n, real *sa, real *sx, integer *incx);
-
-  /* Subroutine */int ssbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
-      integer *info);
-
-  /* Subroutine */int ssbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int ssbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, real *ab, integer *ldab, real *q, integer *ldq, real *vl,
-      real *vu, integer *il, integer *iu, real *abstol, integer *m, real * w,
-      real *z__, integer *ldz, real *work, integer *iwork, integer * ifail,
-      integer *info);
-
-  /* Subroutine */int ssbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * x,
-      integer *ldx, real *work, integer *info);
-
-  /* Subroutine */int ssbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * w,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int ssbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real * w,
-      real *z__, integer *ldz, real *work, integer *lwork, integer * iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, real *ab, integer *ldab, real *bb,
-      integer * ldbb, real *q, integer *ldq, real *vl, real *vu, integer *il,
-      integer *iu, real *abstol, integer *m, real *w, real *z__, integer *ldz,
-      real *work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      real *ab, integer *ldab, real *d__, real *e, real *q, integer *ldq,
-      real *work, integer *info);
-
-  /* Subroutine */int ssfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, real *alpha, real *a, integer *lda, real *beta, real * c__);
-
-  /* Subroutine */int sspcon_(char *uplo, integer *n, real *ap, integer *ipiv,
-      real *anorm, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sspev_(char *jobz, char *uplo, integer *n, real *ap,
-      real *w, real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sspevd_(char *jobz, char *uplo, integer *n, real *ap,
-      real *w, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int sspevx_(char *jobz, char *range, char *uplo, integer *n,
-      real *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, real *work, integer * iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int sspgst_(integer *itype, char *uplo, integer *n, real *ap,
-      real *bp, integer *info);
-
-  /* Subroutine */int sspgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *ap, real *bp, real *w, real *z__, integer *ldz,
-      real *work, integer *info);
-
-  /* Subroutine */int sspgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *ap, real *bp, real *w, real *z__, integer *ldz,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sspgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, real *ap, real *bp, real *vl, real *vu,
-      integer *il, integer *iu, real *abstol, integer *m, real *w, real *z__,
-      integer * ldz, real *work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      real *afp, integer *ipiv, real *b, integer *ldb, real *x, integer * ldx,
-      real *ferr, real *berr, real *work, integer *iwork, integer * info);
-
-  /* Subroutine */int sspsv_(char *uplo, integer *n, integer *nrhs, real *ap,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *ap, real *afp, integer *ipiv, real *b, integer *ldb,
-      real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int ssptrd_(char *uplo, integer *n, real *ap, real *d__,
-      real *e, real *tau, integer *info);
-
-  /* Subroutine */int ssptrf_(char *uplo, integer *n, real *ap, integer *ipiv,
-      integer *info);
-
-  /* Subroutine */int ssptri_(char *uplo, integer *n, real *ap, integer *ipiv,
-      real *work, integer *info);
-
-  /* Subroutine */int ssptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
-      integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int sstebz_(char *range, char *order, integer *n, real *vl,
-      real *vu, integer *il, integer *iu, real *abstol, real *d__, real *e,
-      integer *m, integer *nsplit, real *w, integer *iblock, integer * isplit,
-      real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int sstedc_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int sstegr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sstein_(integer *n, real *d__, real *e, integer *m,
-      real *w, integer *iblock, integer *isplit, real *z__, integer *ldz,
-      real * work, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int sstemr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
-      real *w, real *z__, integer *ldz, integer *nzc, integer *isuppz,
-      logical *tryrac, real *work, integer *lwork, integer *iwork,
-      integer * liwork, integer *info);
-
-  /* Subroutine */int ssteqr_(char *compz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int ssterf_(integer *n, real *d__, real *e, integer *info);
-
-  /* Subroutine */int sstev_(char *jobz, integer *n, real *d__, real *e,
-      real * z__, integer *ldz, real *work, integer *info);
-
-  /* Subroutine */int sstevd_(char *jobz, integer *n, real *d__, real *e,
-      real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int sstevr_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
-      real * work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int sstevx_(char *jobz, char *range, integer *n, real *d__,
-      real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
-      integer *m, real *w, real *z__, integer *ldz, real *work, integer * iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int ssycon_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *anorm, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int ssyequb_(char *uplo, integer *n, real *a, integer *lda,
-      real *s, real *scond, real *amax, real *work, integer *info);
-
-  /* Subroutine */int ssyev_(char *jobz, char *uplo, integer *n, real *a,
-      integer *lda, real *w, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssyevd_(char *jobz, char *uplo, integer *n, real *a,
-      integer *lda, real *w, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssyevr_(char *jobz, char *range, char *uplo, integer *n,
-      real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
-      real *abstol, integer *m, real *w, real *z__, integer *ldz,
-      integer * isuppz, real *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ssyevx_(char *jobz, char *range, char *uplo, integer *n,
-      real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
-      real *abstol, integer *m, real *w, real *z__, integer *ldz, real * work,
-      integer *lwork, integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssygs2_(integer *itype, char *uplo, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ssygst_(integer *itype, char *uplo, integer *n, real *a,
-      integer *lda, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ssygv_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *w,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssygvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *w,
-      real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int ssygvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real * vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
-      real *w, real *z__, integer *ldz, real *work, integer *lwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int ssyrfs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real * work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int ssyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *s, real *b, integer *ldb, real *x, integer *ldx,
-      real *rcond, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
-      real * err_bnds_comp__, integer *nparams, real *params, real *work,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int ssysv_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, real *work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int ssysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
-      real *ferr, real *berr, real *work, integer *lwork, integer *iwork,
-      integer * info);
-
-  /* Subroutine */int ssysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, real *a, integer *lda, real *af, integer *ldaf,
-      integer *ipiv, char *equed, real *s, real *b, integer *ldb, real *x,
-      integer *ldx, real *rcond, real *rpvgrw, real *berr,
-      integer *n_err_bnds__, real * err_bnds_norm__, real *err_bnds_comp__,
-      integer *nparams, real * params, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int ssytd2_(char *uplo, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tau, integer *info);
-
-  /* Subroutine */int ssytf2_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int ssytrd_(char *uplo, integer *n, real *a, integer *lda,
-      real *d__, real *e, real *tau, real *work, integer *lwork,
-      integer * info);
-
-  /* Subroutine */int ssytrf_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ssytri_(char *uplo, integer *n, real *a, integer *lda,
-      integer *ipiv, real *work, integer *info);
-
-  /* Subroutine */int ssytrs_(char *uplo, integer *n, integer *nrhs, real *a,
-      integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int stbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, real *ab, integer *ldab, real *rcond, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int stbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
-      integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int stbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int stfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, real *alpha, real *a, real *b,
-      integer *ldb);
-
-  /* Subroutine */int stftri_(char *transr, char *uplo, char *diag, integer *n,
-      real *a, integer *info);
-
-  /* Subroutine */int stfttp_(char *transr, char *uplo, integer *n, real *arf,
-      real *ap, integer *info);
-
-  /* Subroutine */int stfttr_(char *transr, char *uplo, integer *n, real *arf,
-      real *a, integer *lda, integer *info);
-
-  /* Subroutine */int stgevc_(char *side, char *howmny, logical *select,
-      integer *n, real *s, integer *lds, real *p, integer *ldp, real *vl,
-      integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
-      real *work, integer *info);
-
-  /* Subroutine */int stgex2_(logical *wantq, logical *wantz, integer *n,
-      real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
-      real * z__, integer *ldz, integer *j1, integer *n1, integer *n2,
-      real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int stgexc_(logical *wantq, logical *wantz, integer *n,
-      real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
-      real * z__, integer *ldz, integer *ifst, integer *ilst, real *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int stgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, real *a, integer *lda, real *b,
-      integer * ldb, real *alphar, real *alphai, real *beta, real *q,
-      integer *ldq, real *z__, integer *ldz, integer *m, real *pl, real *pr,
-      real *dif, real *work, integer *lwork, integer *iwork, integer *liwork,
-      integer * info);
-
-  /* Subroutine */int stgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, real *a, integer *lda,
-      real *b, integer *ldb, real *tola, real *tolb, real *alpha, real * beta,
-      real *u, integer *ldu, real *v, integer *ldv, real *q, integer * ldq,
-      real *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int stgsna_(char *job, char *howmny, logical *select,
-      integer *n, real *a, integer *lda, real *b, integer *ldb, real *vl,
-      integer *ldvl, real *vr, integer *ldvr, real *s, real *dif, integer * mm,
-      integer *m, real *work, integer *lwork, integer *iwork, integer * info);
-
-  /* Subroutine */int stgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *c__,
-      integer * ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
-      integer *ldf, real *scale, real *rdsum, real *rdscal, integer *iwork,
-      integer *pq, integer *info);
-
-  /* Subroutine */int stgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, real *a, integer *lda, real *b, integer *ldb, real *c__,
-      integer * ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
-      integer *ldf, real *scale, real *dif, real *work, integer *lwork,
-      integer * iwork, integer *info);
-
-  /* Subroutine */int stpcon_(char *norm, char *uplo, char *diag, integer *n,
-      real *ap, real *rcond, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int stprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *ap, real *b, integer *ldb, real *x, integer *ldx,
-      real *ferr, real *berr, real *work, integer *iwork, integer *info);
-
-  /* Subroutine */int stptri_(char *uplo, char *diag, integer *n, real *ap,
-      integer *info);
-
-  /* Subroutine */int stptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *ap, real *b, integer *ldb, integer *info);
-
-  /* Subroutine */int stpttf_(char *transr, char *uplo, integer *n, real *ap,
-      real *arf, integer *info);
-
-  /* Subroutine */int stpttr_(char *uplo, integer *n, real *ap, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strcon_(char *norm, char *uplo, char *diag, integer *n,
-      real *a, integer *lda, real *rcond, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int strevc_(char *side, char *howmny, logical *select,
-      integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, integer *mm, integer *m, real *work, integer *info);
-
-  /* Subroutine */int strexc_(char *compq, integer *n, real *t, integer *ldt,
-      real *q, integer *ldq, integer *ifst, integer *ilst, real *work,
-      integer *info);
-
-  /* Subroutine */int strrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *x,
-      integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
-      integer *info);
-
-  /* Subroutine */int strsen_(char *job, char *compq, logical *select,
-      integer *n, real *t, integer *ldt, real *q, integer *ldq, real *wr,
-      real *wi, integer *m, real *s, real *sep, real *work, integer *lwork,
-      integer * iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int strsna_(char *job, char *howmny, logical *select,
-      integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
-      integer *ldvr, real *s, real *sep, integer *mm, integer *m, real * work,
-      integer *ldwork, integer *iwork, integer *info);
-
-  /* Subroutine */int strsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, real *a, integer *lda, real *b, integer *ldb,
-      real * c__, integer *ldc, real *scale, integer *info);
-
-  /* Subroutine */int strti2_(char *uplo, char *diag, integer *n, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strtri_(char *uplo, char *diag, integer *n, real *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int strtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, real *a, integer *lda, real *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int strttf_(char *transr, char *uplo, integer *n, real *a,
-      integer *lda, real *arf, integer *info);
-
-  /* Subroutine */int strttp_(char *uplo, integer *n, real *a, integer *lda,
-      real *ap, integer *info);
-
-  /* Subroutine */int stzrqf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, integer *info);
-
-  /* Subroutine */int stzrzf_(integer *m, integer *n, real *a, integer *lda,
-      real *tau, real *work, integer *lwork, integer *info);
-
-  /* Subroutine */int xerbla_(char *srname, integer *info);
-
-  /* Subroutine */int xerbla_array__(char *srname_array__,
-      integer * srname_len__, integer *info, ftnlen srname_array_len);
-
-  /* Subroutine */int zbdsqr_(char *uplo, integer *n, integer *ncvt,
-      integer * nru, integer *ncc, doublereal *d__, doublereal *e,
-      doublecomplex *vt, integer *ldvt, doublecomplex *u, integer *ldu,
-      doublecomplex *c__, integer *ldc, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zcgesv_(integer *n, integer *nrhs, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
-      doublereal *rwork, integer *iter, integer *info);
-
-  /* Subroutine */int zcposv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
-      doublereal *rwork, integer *iter, integer *info);
-
-  /* Subroutine */int zdrscl_(integer *n, doublereal *sa, doublecomplex *sx,
-      integer *incx);
-
-  /* Subroutine */int zgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
-      integer *kl, integer *ku, doublecomplex *ab, integer *ldab,
-      doublereal *d__, doublereal *e, doublecomplex *q, integer *ldq,
-      doublecomplex *pt, integer *ldpt, doublecomplex *c__, integer *ldc,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbcon_(char *norm, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, doublereal *anorm,
-      doublereal *rcond, doublecomplex *work, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zgbequ_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer * info);
-
-  /* Subroutine */int zgbequb_(integer *m, integer *n, integer *kl,
-      integer * ku, doublecomplex *ab, integer *ldab, doublereal *r__,
-      doublereal * c__, doublereal *rowcnd, doublereal *colcnd,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int zgbrfs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex * afb, integer *ldafb, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbrfsx_(char *trans, char *equed, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublecomplex *ab,
-      integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
-      doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbsv_(integer *n, integer *kl, integer *ku,
-      integer * nrhs, doublecomplex *ab, integer *ldab, integer *ipiv,
-      doublecomplex * b, integer *ldb, integer *info);
-
-  /* Subroutine */int zgbsvx_(char *fact, char *trans, integer *n, integer *kl,
-      integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *afb, integer *ldafb, integer *ipiv, char *equed,
-      doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zgbsvxx_(char *fact, char *trans, integer *n,
-      integer * kl, integer *ku, integer *nrhs, doublecomplex *ab,
-      integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
-      char *equed, doublereal *r__, doublereal *c__, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgbtrs_(char *trans, integer *n, integer *kl,
-      integer * ku, integer *nrhs, doublecomplex *ab, integer *ldab,
-      integer *ipiv, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zgebak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *scale, integer *m, doublecomplex *v,
-      integer *ldv, integer *info);
-
-  /* Subroutine */int zgebal_(char *job, integer *n, doublecomplex *a,
-      integer *lda, integer *ilo, integer *ihi, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int zgebd2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
-      doublecomplex *taup, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgebrd_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
-      doublecomplex *taup, doublecomplex *work, integer *lwork, integer * info);
-
-  /* Subroutine */int zgecon_(char *norm, integer *n, doublecomplex *a,
-      integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeequ_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
-
-  /* Subroutine */int zgeequb_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, integer *info);
-
-  /* Subroutine */int zgees_(char *jobvs, char *sort, L_fp select, integer *n,
-      doublecomplex *a, integer *lda, integer *sdim, doublecomplex *w,
-      doublecomplex *vs, integer *ldvs, doublecomplex *work, integer *lwork,
-      doublereal *rwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zgeesx_(char *jobvs, char *sort, L_fp select,
-      char * sense, integer *n, doublecomplex *a, integer *lda, integer *sdim,
-      doublecomplex *w, doublecomplex *vs, integer *ldvs, doublereal * rconde,
-      doublereal *rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zgeev_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *w, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
-      doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
-      doublecomplex *work, integer * lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgegs_(char *jobvsl, char *jobvsr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vsl,
-      integer *ldvsl, doublecomplex *vsr, integer *ldvsr, doublecomplex * work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgegv_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgehd2_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zgehrd_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zgelq2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgelqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgels_(char *trans, integer *m, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgelsd_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zgelss_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgelsx_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgelsy_(integer *m, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeql2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgeqlf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgeqp3_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeqpf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgeqr2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgeqrf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgerfs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgerfsx_(char *trans, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
-      doublecomplex * b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgerq2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgerqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zgesc2_(integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
-
-  /* Subroutine */int zgesdd_(char *jobz, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
-      integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zgesv_(integer *n, integer *nrhs, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer * info);
-
-  /* Subroutine */int zgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
-      integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgesvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgesvxx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *r__,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgetc2_(integer *n, doublecomplex *a, integer *lda,
-      integer *ipiv, integer *jpiv, integer *info);
-
-  /* Subroutine */int zgetf2_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgetrf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zgetri_(integer *n, doublecomplex *a, integer *lda,
-      integer *ipiv, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgetrs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int zggbak_(char *job, char *side, integer *n, integer *ilo,
-      integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
-      doublecomplex *v, integer *ldv, integer *info);
-
-  /* Subroutine */int zggbal_(char *job, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, integer *ilo, integer *ihi,
-      doublereal *lscale, doublereal *rscale, doublereal *work, integer * info);
-
-  /* Subroutine */int zgges_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, integer *sdim, doublecomplex *alpha, doublecomplex * beta,
-      doublecomplex *vsl, integer *ldvsl, doublecomplex *vsr, integer *ldvsr,
-      doublecomplex *work, integer *lwork, doublereal *rwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int zggesx_(char *jobvsl, char *jobvsr, char *sort,
-      L_fp selctg, char *sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, integer *sdim, doublecomplex *alpha,
-      doublecomplex *beta, doublecomplex *vsl, integer *ldvsl,
-      doublecomplex *vsr, integer *ldvsr, doublereal *rconde,
-      doublereal * rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *iwork, integer *liwork, logical *bwork,
-      integer *info);
-
-  /* Subroutine */int zggev_(char *jobvl, char *jobvr, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zggevx_(char *balanc, char *jobvl, char *jobvr,
-      char * sense, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *alpha, doublecomplex *beta,
-      doublecomplex *vl, integer *ldvl, doublecomplex *vr, integer *ldvr,
-      integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
-      doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
-      doublereal * rcondv, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *iwork, logical *bwork, integer *info);
-
-  /* Subroutine */int zggglm_(integer *n, integer *m, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *d__, doublecomplex *x, doublecomplex *y,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zgghrd_(char *compq, char *compz, integer *n,
-      integer * ilo, integer *ihi, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *q, integer *ldq,
-      doublecomplex *z__, integer *ldz, integer *info);
-
-  /* Subroutine */int zgglse_(integer *m, integer *n, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *c__, doublecomplex *d__, doublecomplex *x,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zggqrf_(integer *n, integer *m, integer *p,
-      doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
-      integer *ldb, doublecomplex *taub, doublecomplex *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int zggrqf_(integer *m, integer *p, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
-      integer *ldb, doublecomplex *taub, doublecomplex *work, integer * lwork,
-      integer *info);
-
-  /* Subroutine */int zggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *n, integer *p, integer *k, integer *l, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublereal *alpha,
-      doublereal *beta, doublecomplex *u, integer *ldu, doublecomplex *v,
-      integer *ldv, doublecomplex *q, integer *ldq, doublecomplex *work,
-      doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
-      doublecomplex *u, integer *ldu, doublecomplex *v, integer *ldv,
-      doublecomplex *q, integer *ldq, integer *iwork, doublereal * rwork,
-      doublecomplex *tau, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgtcon_(char *norm, integer *n, doublecomplex *dl,
-      doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer * ipiv,
-      doublereal *anorm, doublereal *rcond, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zgtrfs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zgtsv_(integer *n, integer *nrhs, doublecomplex *dl,
-      doublecomplex *d__, doublecomplex *du, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zgtsvx_(char *fact, char *trans, integer *n,
-      integer * nrhs, doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zgttrf_(integer *n, doublecomplex *dl,
-      doublecomplex * d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
-      integer * info);
-
-  /* Subroutine */int zgttrs_(char *trans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zgtts2_(integer *itrans, integer *n, integer *nrhs,
-      doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
-      doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zhbev_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbevd_(char *jobz, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *lrwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhbevx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *kd, doublecomplex *ab, integer *ldab, doublecomplex *q,
-      integer *ldq, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int zhbgst_(char *vect, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublecomplex *x, integer *ldx, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbgv_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
-      integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
-      integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, integer *lwork, doublereal *rwork, integer * lrwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhbgvx_(char *jobz, char *range, char *uplo, integer *n,
-      integer *ka, integer *kb, doublecomplex *ab, integer *ldab,
-      doublecomplex *bb, integer *ldbb, doublecomplex *q, integer *ldq,
-      doublereal *vl, doublereal *vu, integer *il, integer *iu,
-      doublereal * abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer * ifail, integer *info);
-
-  /* Subroutine */int zhbtrd_(char *vect, char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *d__, doublereal *e,
-      doublecomplex *q, integer *ldq, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhecon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zheequb_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zheev_(char *jobz, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zheevd_(char *jobz, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zheevr_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal * w,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublecomplex * work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer * iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zheevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal * w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer * lwork,
-      doublereal *rwork, integer *iwork, integer *ifail, integer * info);
-
-  /* Subroutine */int zhegs2_(integer *itype, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhegst_(integer *itype, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhegv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhegvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
-      doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int zhegvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer * iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int zherfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zherfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhesv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zhesvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zhesvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *s,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhetd2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
-      integer *info);
-
-  /* Subroutine */int zhetf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zhetrd_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
-      doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zhetrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zhetri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhetrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int zhfrk_(char *transr, char *uplo, char *trans, integer *n,
-      integer *k, doublereal *alpha, doublecomplex *a, integer *lda,
-      doublereal *beta, doublecomplex *c__);
-
-  /* Subroutine */int zhgeqz_(char *job, char *compq, char *compz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *t, integer *ldt, doublecomplex *alpha,
-      doublecomplex * beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
-      integer * ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zhpcon_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zhpev_(char *jobz, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhpevd_(char *jobz, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
-      doublecomplex *work, integer *lwork, doublereal *rwork, integer * lrwork,
-      integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zhpevx_(char *jobz, char *range, char *uplo, integer *n,
-      doublecomplex *ap, doublereal *vl, doublereal *vu, integer *il,
-      integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal * rwork,
-      integer *iwork, integer *ifail, integer *info);
-
-  /* Subroutine */int zhpgst_(integer *itype, char *uplo, integer *n,
-      doublecomplex *ap, doublecomplex *bp, integer *info);
-
-  /* Subroutine */int zhpgv_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
-      integer * info);
-
-  /* Subroutine */int zhpgvd_(integer *itype, char *jobz, char *uplo,
-      integer * n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
-      doublereal * rwork, integer *lrwork, integer *iwork, integer *liwork,
-      integer * info);
-
-  /* Subroutine */int zhpgvx_(integer *itype, char *jobz, char *range,
-      char * uplo, integer *n, doublecomplex *ap, doublecomplex *bp,
-      doublereal * vl, doublereal *vu, integer *il, integer *iu,
-      doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
-      integer * ifail, integer *info);
-
-  /* Subroutine */int zhprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex * b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zhpsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhpsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zhptrd_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *d__, doublereal *e, doublecomplex *tau, integer *info);
-
-  /* Subroutine */int zhptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int zhptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zhptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zhsein_(char *side, char *eigsrc, char *initv,
-      logical * select, integer *n, doublecomplex *h__, integer *ldh,
-      doublecomplex * w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer *ldvr, integer *mm, integer *m, doublecomplex *work,
-      doublereal *rwork, integer *ifaill, integer *ifailr, integer *info);
-
-  /* Subroutine */int zhseqr_(char *job, char *compz, integer *n, integer *ilo,
-      integer *ihi, doublecomplex *h__, integer *ldh, doublecomplex *w,
-      doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zla_gbamv__(integer *trans, integer *m, integer *n,
-      integer *kl, integer *ku, doublereal *alpha, doublecomplex *ab,
-      integer *ldab, doublecomplex *x, integer *incx, doublereal *beta,
-      doublereal *y, integer *incy);
-
-  doublereal zla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
-      integer *ipiv, doublereal *c__, logical *capply, integer *info,
-      doublecomplex *work, doublereal *rwork, ftnlen trans_len);
-
-  doublereal zla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
-      integer *ipiv, doublecomplex *x, integer *info, doublecomplex *work,
-      doublereal *rwork, ftnlen trans_len);
-
-  /* Subroutine */int zla_gbrfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *kl, integer *ku,
-      integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
-      doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
-      doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical *ignore_cwise__, integer *info);
-
-  doublereal zla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
-      integer * ncols, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer * ldafb);
-
-  /* Subroutine */int zla_geamv__(integer *trans, integer *m, integer *n,
-      doublereal *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
-      integer *incx, doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_gercond_c__(char *trans, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal * c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen trans_len);
-
-  doublereal zla_gercond_x__(char *trans, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen trans_len);
-
-  /* Subroutine */int zla_gerfsx_extended__(integer *prec_type__,
-      integer * trans_type__, integer *n, integer *nrhs, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      logical *colequ, doublereal *c__, doublecomplex *b, integer *ldb,
-      doublecomplex *y, integer *ldy, doublereal *berr_out__,
-      integer *n_norms__, doublereal * errs_n__, doublereal *errs_c__,
-      doublecomplex *res, doublereal *ayb, doublecomplex *dy,
-      doublecomplex *y_tail__, doublereal *rcond, integer *ithresh,
-      doublereal *rthresh, doublereal *dz_ub__, logical * ignore_cwise__,
-      integer *info);
-
-  /* Subroutine */int zla_heamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_hercond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal *c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen uplo_len);
-
-  doublereal zla_hercond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int zla_herfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
-      integer *ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal * errs_n__, doublereal *errs_c__, doublecomplex *res,
-      doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical * ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal zla_herpvgrw__(char *uplo, integer *n, integer *info,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int zla_lin_berr__(integer *n, integer *nz, integer *nrhs,
-      doublecomplex *res, doublereal *ayb, doublereal *berr);
-
-  doublereal zla_porcond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, doublereal *c__,
-      logical * capply, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  doublereal zla_porcond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, doublecomplex *x,
-      integer * info, doublecomplex *work, doublereal *rwork, ftnlen uplo_len);
-
-  /* Subroutine */int zla_porfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, logical *colequ, doublereal *c__,
-      doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
-      doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
-      doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
-      doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
-      integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
-      logical * ignore_cwise__, integer *info, ftnlen uplo_len);
-
-  doublereal zla_porpvgrw__(char *uplo, integer *ncols, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf, doublereal *work,
-      ftnlen uplo_len);
-
-  doublereal zla_rpvgrw__(integer *n, integer *ncols, doublecomplex *a,
-      integer *lda, doublecomplex *af, integer *ldaf);
-
-  /* Subroutine */int zla_syamv__(integer *uplo, integer *n, doublereal *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublereal *beta, doublereal *y, integer *incy);
-
-  doublereal zla_syrcond_c__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublereal *c__, logical *capply, integer *info, doublecomplex *work,
-      doublereal * rwork, ftnlen uplo_len);
-
-  doublereal zla_syrcond_x__(char *uplo, integer *n, doublecomplex *a,
-      integer * lda, doublecomplex *af, integer *ldaf, integer *ipiv,
-      doublecomplex * x, integer *info, doublecomplex *work, doublereal *rwork,
-      ftnlen uplo_len);
-
-  /* Subroutine */int zla_syrfsx_extended__(integer *prec_type__, char *uplo,
-      integer *n, integer *nrhs, doublecomplex *a, integer *lda,
-      doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
-      doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
-      integer *ldy, doublereal *berr_out__, integer *n_norms__,
-      doublereal * errs_n__, doublereal *errs_c__, doublecomplex *res,
-      doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
-      doublereal *rcond, integer *ithresh, doublereal *rthresh,
-      doublereal *dz_ub__, logical * ignore_cwise__, integer *info,
-      ftnlen uplo_len);
-
-  doublereal zla_syrpvgrw__(char *uplo, integer *n, integer *info,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublereal *work, ftnlen uplo_len);
-
-  /* Subroutine */int zla_wwaddw__(integer *n, doublecomplex *x,
-      doublecomplex *y, doublecomplex *w);
-
-  /* Subroutine */int zlabrd_(integer *m, integer *n, integer *nb,
-      doublecomplex *a, integer *lda, doublereal *d__, doublereal *e,
-      doublecomplex *tauq, doublecomplex *taup, doublecomplex *x, integer * ldx,
-      doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlacgv_(integer *n, doublecomplex *x, integer *incx);
-
-  /* Subroutine */int zlacn2_(integer *n, doublecomplex *v, doublecomplex *x,
-      doublereal *est, integer *kase, integer *isave);
-
-  /* Subroutine */int zlacon_(integer *n, doublecomplex *v, doublecomplex *x,
-      doublereal *est, integer *kase);
-
-  /* Subroutine */int zlacp2_(char *uplo, integer *m, integer *n,
-      doublereal * a, integer *lda, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlacpy_(char *uplo, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlacrm_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *b, integer *ldb, doublecomplex *c__,
-      integer *ldc, doublereal *rwork);
-
-  /* Subroutine */int zlacrt_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublecomplex *c__, doublecomplex * s);
-
-  /* Double Complex */VOID zladiv_(doublecomplex * ret_val, doublecomplex *x,
-      doublecomplex *y);
-
-  /* Subroutine */int zlaed0_(integer *qsiz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *q, integer *ldq, doublecomplex *qstore,
-      integer *ldqs, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zlaed7_(integer *n, integer *cutpnt, integer *qsiz,
-      integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
-      doublecomplex *q, integer *ldq, doublereal *rho, integer *indxq,
-      doublereal *qstore, integer *qptr, integer *prmptr, integer *perm,
-      integer *givptr, integer *givcol, doublereal *givnum,
-      doublecomplex * work, doublereal *rwork, integer *iwork, integer *info);
-
-  /* Subroutine */int zlaed8_(integer *k, integer *n, integer *qsiz,
-      doublecomplex *q, integer *ldq, doublereal *d__, doublereal *rho,
-      integer *cutpnt, doublereal *z__, doublereal *dlamda, doublecomplex * q2,
-      integer *ldq2, doublereal *w, integer *indxp, integer *indx,
-      integer *indxq, integer *perm, integer *givptr, integer *givcol,
-      doublereal *givnum, integer *info);
-
-  /* Subroutine */int zlaein_(logical *rightv, logical *noinit, integer *n,
-      doublecomplex *h__, integer *ldh, doublecomplex *w, doublecomplex *v,
-      doublecomplex *b, integer *ldb, doublereal *rwork, doublereal *eps3,
-      doublereal *smlnum, integer *info);
-
-  /* Subroutine */int zlaesy_(doublecomplex *a, doublecomplex *b,
-      doublecomplex *c__, doublecomplex *rt1, doublecomplex *rt2,
-      doublecomplex *evscal, doublecomplex *cs1, doublecomplex *sn1);
-
-  /* Subroutine */int zlaev2_(doublecomplex *a, doublecomplex *b,
-      doublecomplex *c__, doublereal *rt1, doublereal *rt2, doublereal *cs1,
-      doublecomplex *sn1);
-
-  /* Subroutine */int zlag2c_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, complex *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int zlags2_(logical *upper, doublereal *a1,
-      doublecomplex * a2, doublereal *a3, doublereal *b1, doublecomplex *b2,
-      doublereal *b3, doublereal *csu, doublecomplex *snu, doublereal *csv,
-      doublecomplex * snv, doublereal *csq, doublecomplex *snq);
-
-  /* Subroutine */int zlagtm_(char *trans, integer *n, integer *nrhs,
-      doublereal *alpha, doublecomplex *dl, doublecomplex *d__,
-      doublecomplex *du, doublecomplex *x, integer *ldx, doublereal *beta,
-      doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zlahef_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
-      integer *ldw, integer *info);
-
-  /* Subroutine */int zlahqr_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *info);
-
-  /* Subroutine */int zlahr2_(integer *n, integer *k, integer *nb,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
-      integer *ldt, doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlahrd_(integer *n, integer *k, integer *nb,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
-      integer *ldt, doublecomplex *y, integer *ldy);
-
-  /* Subroutine */int zlaic1_(integer *job, integer *j, doublecomplex *x,
-      doublereal *sest, doublecomplex *w, doublecomplex *gamma,
-      doublereal * sestpr, doublecomplex *s, doublecomplex *c__);
-
-  /* Subroutine */int zlals0_(integer *icompq, integer *nl, integer *nr,
-      integer *sqre, integer *nrhs, doublecomplex *b, integer *ldb,
-      doublecomplex *bx, integer *ldbx, integer *perm, integer *givptr,
-      integer *givcol, integer *ldgcol, doublereal *givnum, integer *ldgnum,
-      doublereal *poles, doublereal *difl, doublereal *difr, doublereal * z__,
-      integer *k, doublereal *c__, doublereal *s, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zlalsa_(integer *icompq, integer *smlsiz, integer *n,
-      integer *nrhs, doublecomplex *b, integer *ldb, doublecomplex *bx,
-      integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer * k,
-      doublereal *difl, doublereal *difr, doublereal *z__, doublereal * poles,
-      integer *givptr, integer *givcol, integer *ldgcol, integer * perm,
-      doublereal *givnum, doublereal *c__, doublereal *s, doublereal * rwork,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int zlalsd_(char *uplo, integer *smlsiz, integer *n,
-      integer *nrhs, doublereal *d__, doublereal *e, doublecomplex *b,
-      integer *ldb, doublereal *rcond, integer *rank, doublecomplex *work,
-      doublereal * rwork, integer *iwork, integer *info);
-
-  doublereal zlangb_(char *norm, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlange_(char *norm, integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlangt_(char *norm, integer *n, doublecomplex *dl,
-      doublecomplex * d__, doublecomplex *du);
-
-  doublereal zlanhb_(char *norm, char *uplo, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlanhf_(char *norm, char *transr, char *uplo, integer *n,
-      doublecomplex *a, doublereal *work);
-
-  doublereal zlanhp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
-      doublereal *work);
-
-  doublereal zlanhs_(char *norm, integer *n, doublecomplex *a, integer *lda,
-      doublereal *work);
-
-  doublereal zlanht_(char *norm, integer *n, doublereal *d__, doublecomplex *e);
-
-  doublereal zlansb_(char *norm, char *uplo, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlansp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
-      doublereal *work);
-
-  doublereal zlansy_(char *norm, char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *work);
-
-  doublereal zlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
-      doublecomplex *ab, integer *ldab, doublereal *work);
-
-  doublereal zlantp_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *ap, doublereal *work);
-
-  doublereal zlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
-      doublecomplex *a, integer *lda, doublereal *work);
-
-  /* Subroutine */int zlapll_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *ssmin);
-
-  /* Subroutine */int zlapmt_(logical *forwrd, integer *m, integer *n,
-      doublecomplex *x, integer *ldx, integer *k);
-
-  /* Subroutine */int zlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
-      doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
-      doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqge_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
-      doublereal *colcnd, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqhb_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqhe_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int zlaqhp_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqp2_(integer *m, integer *n, integer *offset,
-      doublecomplex *a, integer *lda, integer *jpvt, doublecomplex *tau,
-      doublereal *vn1, doublereal *vn2, doublecomplex *work);
-
-  /* Subroutine */int zlaqps_(integer *m, integer *n, integer *offset,
-      integer *nb, integer *kb, doublecomplex *a, integer *lda, integer *jpvt,
-      doublecomplex *tau, doublereal *vn1, doublereal *vn2,
-      doublecomplex * auxv, doublecomplex *f, integer *ldf);
-
-  /* Subroutine */int zlaqr0_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zlaqr1_(integer *n, doublecomplex *h__, integer *ldh,
-      doublecomplex *s1, doublecomplex *s2, doublecomplex *v);
-
-  /* Subroutine */int zlaqr2_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
-      integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
-      doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
-      integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
-      doublecomplex *work, integer *lwork);
-
-  /* Subroutine */int zlaqr3_(logical *wantt, logical *wantz, integer *n,
-      integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
-      integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
-      doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
-      integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
-      doublecomplex *work, integer *lwork);
-
-  /* Subroutine */int zlaqr4_(logical *wantt, logical *wantz, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
-      doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
-      integer *ldz, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
-      integer *n, integer *ktop, integer *kbot, integer *nshfts,
-      doublecomplex *s, doublecomplex *h__, integer *ldh, integer *iloz,
-      integer *ihiz, doublecomplex *z__, integer *ldz, doublecomplex *v,
-      integer *ldv, doublecomplex *u, integer *ldu, integer *nv,
-      doublecomplex *wv, integer *ldwv, integer *nh, doublecomplex *wh,
-      integer *ldwh);
-
-  /* Subroutine */int zlaqsb_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqsp_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, char *equed);
-
-  /* Subroutine */int zlaqsy_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      char *equed);
-
-  /* Subroutine */int zlar1v_(integer *n, integer *b1, integer *bn,
-      doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
-      doublereal * lld, doublereal *pivmin, doublereal *gaptol,
-      doublecomplex *z__, logical *wantnc, integer *negcnt, doublereal *ztz,
-      doublereal *mingma, integer *r__, integer *isuppz, doublereal *nrminv,
-      doublereal *resid, doublereal *rqcorr, doublereal *work);
-
-  /* Subroutine */int zlar2v_(integer *n, doublecomplex *x, doublecomplex *y,
-      doublecomplex *z__, integer *incx, doublereal *c__, doublecomplex *s,
-      integer *incc);
-
-  /* Subroutine */int zlarcm_(integer *m, integer *n, doublereal *a,
-      integer * lda, doublecomplex *b, integer *ldb, doublecomplex *c__,
-      integer *ldc, doublereal *rwork);
-
-  /* Subroutine */int zlarf_(char *side, integer *m, integer *n,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
-      integer * ldc, doublecomplex *work);
-
-  /* Subroutine */int zlarfb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, doublecomplex *v,
-      integer *ldv, doublecomplex *t, integer *ldt, doublecomplex *c__,
-      integer * ldc, doublecomplex *work, integer *ldwork);
-
-  /* Subroutine */int zlarfg_(integer *n, doublecomplex *alpha,
-      doublecomplex * x, integer *incx, doublecomplex *tau);
-
-  /* Subroutine */int zlarfp_(integer *n, doublecomplex *alpha,
-      doublecomplex * x, integer *incx, doublecomplex *tau);
-
-  /* Subroutine */int zlarft_(char *direct, char *storev, integer *n,
-      integer * k, doublecomplex *v, integer *ldv, doublecomplex *tau,
-      doublecomplex * t, integer *ldt);
-
-  /* Subroutine */int zlarfx_(char *side, integer *m, integer *n,
-      doublecomplex *v, doublecomplex *tau, doublecomplex *c__, integer * ldc,
-      doublecomplex *work);
-
-  /* Subroutine */int zlargv_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *c__, integer *incc);
-
-  /* Subroutine */int zlarnv_(integer *idist, integer *iseed, integer *n,
-      doublecomplex *x);
-
-  /* Subroutine */int zlarrv_(integer *n, doublereal *vl, doublereal *vu,
-      doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
-      integer *m, integer *dol, integer *dou, doublereal *minrgp,
-      doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
-      doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *iwork, integer *info);
-
-  /* Subroutine */int zlarscl2_(integer *m, integer *n, doublereal *d__,
-      doublecomplex *x, integer *ldx);
-
-  /* Subroutine */int zlartg_(doublecomplex *f, doublecomplex *g,
-      doublereal * cs, doublecomplex *sn, doublecomplex *r__);
-
-  /* Subroutine */int zlartv_(integer *n, doublecomplex *x, integer *incx,
-      doublecomplex *y, integer *incy, doublereal *c__, doublecomplex *s,
-      integer *incc);
-
-  /* Subroutine */int zlarz_(char *side, integer *m, integer *n, integer *l,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex * c__,
-      integer *ldc, doublecomplex *work);
-
-  /* Subroutine */int zlarzb_(char *side, char *trans, char *direct,
-      char * storev, integer *m, integer *n, integer *k, integer *l,
-      doublecomplex *v, integer *ldv, doublecomplex *t, integer *ldt,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *ldwork);
-
-  /* Subroutine */int zlarzt_(char *direct, char *storev, integer *n,
-      integer * k, doublecomplex *v, integer *ldv, doublecomplex *tau,
-      doublecomplex * t, integer *ldt);
-
-  /* Subroutine */int zlascl_(char *type__, integer *kl, integer *ku,
-      doublereal *cfrom, doublereal *cto, integer *m, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int zlascl2_(integer *m, integer *n, doublereal *d__,
-      doublecomplex *x, integer *ldx);
-
-  /* Subroutine */int zlaset_(char *uplo, integer *m, integer *n,
-      doublecomplex *alpha, doublecomplex *beta, doublecomplex *a,
-      integer * lda);
-
-  /* Subroutine */int zlasr_(char *side, char *pivot, char *direct, integer *m,
-      integer *n, doublereal *c__, doublereal *s, doublecomplex *a,
-      integer *lda);
-
-  /* Subroutine */int zlassq_(integer *n, doublecomplex *x, integer *incx,
-      doublereal *scale, doublereal *sumsq);
-
-  /* Subroutine */int zlaswp_(integer *n, doublecomplex *a, integer *lda,
-      integer *k1, integer *k2, integer *ipiv, integer *incx);
-
-  /* Subroutine */int zlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
-      integer *ldw, integer *info);
-
-  /* Subroutine */int zlat2c_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, complex *sa, integer *ldsa, integer *info);
-
-  /* Subroutine */int zlatbs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, integer *kd, doublecomplex *ab, integer *ldab,
-      doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatdf_(integer *ijob, integer *n, doublecomplex *z__,
-      integer *ldz, doublecomplex *rhs, doublereal *rdsum, doublereal * rdscal,
-      integer *ipiv, integer *jpiv);
-
-  /* Subroutine */int zlatps_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublecomplex *ap, doublecomplex *x,
-      doublereal * scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatrd_(char *uplo, integer *n, integer *nb,
-      doublecomplex *a, integer *lda, doublereal *e, doublecomplex *tau,
-      doublecomplex *w, integer *ldw);
-
-  /* Subroutine */int zlatrs_(char *uplo, char *trans, char *diag,
-      char * normin, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
-
-  /* Subroutine */int zlatrz_(integer *m, integer *n, integer *l,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work);
-
-  /* Subroutine */int zlatzm_(char *side, integer *m, integer *n,
-      doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex * c1,
-      doublecomplex *c2, integer *ldc, doublecomplex *work);
-
-  /* Subroutine */int zlauu2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zlauum_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpbcon_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *anorm, doublereal * rcond,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpbequ_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
-      doublereal *amax, integer *info);
-
-  /* Subroutine */int zpbrfs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer * ldafb, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zpbstf_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbsv_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
-      integer * ldb, integer *info);
-
-  /* Subroutine */int zpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
-      integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
-      integer *ldafb, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal * ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpbtf2_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbtrf_(char *uplo, integer *n, integer *kd,
-      doublecomplex *ab, integer *ldab, integer *info);
-
-  /* Subroutine */int zpbtrs_(char *uplo, integer *n, integer *kd,
-      integer * nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
-      integer * ldb, integer *info);
-
-  /* Subroutine */int zpftrf_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int zpftri_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int zpftrs_(char *transr, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zpocon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpoequ_(integer *n, doublecomplex *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zpoequb_(integer *n, doublecomplex *a, integer *lda,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zporfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zporfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, doublereal *s, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
-      integer * n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zposv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zposvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer * info);
-
-  /* Subroutine */int zposvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, char *equed, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
-      doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
-      integer *nparams, doublereal *params, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpotf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *info);
-
-  /* Subroutine */int zpotrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zppcon_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *anorm, doublereal *rcond, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zppequ_(char *uplo, integer *n, doublecomplex *ap,
-      doublereal *s, doublereal *scond, doublereal *amax, integer *info);
-
-  /* Subroutine */int zpprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zppsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zppsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, char *equed,
-      doublereal * s, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *info);
-
-  /* Subroutine */int zpptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *info);
-
-  /* Subroutine */int zpptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zpstf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int zpstrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *piv, integer *rank, doublereal *tol,
-      doublereal *work, integer *info);
-
-  /* Subroutine */int zptcon_(integer *n, doublereal *d__, doublecomplex *e,
-      doublereal *anorm, doublereal *rcond, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zpteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int zptrfs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int zptsv_(integer *n, integer *nrhs, doublereal *d__,
-      doublecomplex *e, doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int zptsvx_(char *fact, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zpttrf_(integer *n, doublereal *d__, doublecomplex *e,
-      integer *info);
-
-  /* Subroutine */int zpttrs_(char *uplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zptts2_(integer *iuplo, integer *n, integer *nrhs,
-      doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int zrot_(integer *n, doublecomplex *cx, integer *incx,
-      doublecomplex *cy, integer *incy, doublereal *c__, doublecomplex *s);
-
-  /* Subroutine */int zspcon_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zspmv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex * beta,
-      doublecomplex *y, integer *incy);
-
-  /* Subroutine */int zspr_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *ap);
-
-  /* Subroutine */int zsprfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex * b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int zspsv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zspsvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *ferr, doublereal *berr,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsptrf_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, integer *info);
-
-  /* Subroutine */int zsptri_(char *uplo, integer *n, doublecomplex *ap,
-      integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsptrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int zstedc_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublecomplex *work,
-      integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int zstegr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
-      doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
-      integer *lwork, integer *iwork, integer *liwork, integer *info);
-
-  /* Subroutine */int zstein_(integer *n, doublereal *d__, doublereal *e,
-      integer *m, doublereal *w, integer *iblock, integer *isplit,
-      doublecomplex *z__, integer *ldz, doublereal *work, integer *iwork,
-      integer *ifail, integer *info);
-
-  /* Subroutine */int zstemr_(char *jobz, char *range, integer *n,
-      doublereal * d__, doublereal *e, doublereal *vl, doublereal *vu,
-      integer *il, integer *iu, integer *m, doublereal *w, doublecomplex *z__,
-      integer * ldz, integer *nzc, integer *isuppz, logical *tryrac,
-      doublereal *work, integer *lwork, integer *iwork, integer *liwork,
-      integer *info);
-
-  /* Subroutine */int zsteqr_(char *compz, integer *n, doublereal *d__,
-      doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
-      integer *info);
-
-  /* Subroutine */int zsycon_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsyequb_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
-      doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsymv_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
-      doublecomplex *beta, doublecomplex *y, integer *incy);
-
-  /* Subroutine */int zsyr_(char *uplo, integer *n, doublecomplex *alpha,
-      doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
-
-  /* Subroutine */int zsyrfs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
-      integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
-      integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsyrfsx_(char *uplo, char *equed, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
-      doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal * err_bnds_comp__, integer *nparams, doublereal *params,
-      doublecomplex * work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsysv_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int zsysvx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
-      integer *info);
-
-  /* Subroutine */int zsysvxx_(char *fact, char *uplo, integer *n,
-      integer * nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
-      integer * ldaf, integer *ipiv, char *equed, doublereal *s,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
-      integer *n_err_bnds__, doublereal *err_bnds_norm__,
-      doublereal *err_bnds_comp__, integer * nparams, doublereal *params,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int zsytf2_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, integer *info);
-
-  /* Subroutine */int zsytrf_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zsytri_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, integer *ipiv, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zsytrs_(char *uplo, integer *n, integer *nrhs,
-      doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int ztbcon_(char *norm, char *uplo, char *diag, integer *n,
-      integer *kd, doublecomplex *ab, integer *ldab, doublereal *rcond,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztbrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
-      doublereal *ferr, doublereal *berr, doublecomplex *work,
-      doublereal * rwork, integer *info);
-
-  /* Subroutine */int ztbtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
-      doublecomplex *b, integer *ldb, integer *info);
-
-  /* Subroutine */int ztfsm_(char *transr, char *side, char *uplo, char *trans,
-      char *diag, integer *m, integer *n, doublecomplex *alpha,
-      doublecomplex *a, doublecomplex *b, integer *ldb);
-
-  /* Subroutine */int ztftri_(char *transr, char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *info);
-
-  /* Subroutine */int ztfttp_(char *transr, char *uplo, integer *n,
-      doublecomplex *arf, doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztfttr_(char *transr, char *uplo, integer *n,
-      doublecomplex *arf, doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztgevc_(char *side, char *howmny, logical *select,
-      integer *n, doublecomplex *s, integer *lds, doublecomplex *p,
-      integer *ldp, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer * ldvr, integer *mm, integer *m, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztgex2_(logical *wantq, logical *wantz, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
-      integer *j1, integer *info);
-
-  /* Subroutine */int ztgexc_(logical *wantq, logical *wantz, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
-      doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
-      integer *ifst, integer *ilst, integer *info);
-
-  /* Subroutine */int ztgsen_(integer *ijob, logical *wantq, logical *wantz,
-      logical *select, integer *n, doublecomplex *a, integer *lda,
-      doublecomplex *b, integer *ldb, doublecomplex *alpha,
-      doublecomplex * beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
-      integer * ldz, integer *m, doublereal *pl, doublereal *pr,
-      doublereal *dif, doublecomplex *work, integer *lwork, integer *iwork,
-      integer *liwork, integer *info);
-
-  /* Subroutine */int ztgsja_(char *jobu, char *jobv, char *jobq, integer *m,
-      integer *p, integer *n, integer *k, integer *l, doublecomplex *a,
-      integer *lda, doublecomplex *b, integer *ldb, doublereal *tola,
-      doublereal *tolb, doublereal *alpha, doublereal *beta, doublecomplex * u,
-      integer *ldu, doublecomplex *v, integer *ldv, doublecomplex *q,
-      integer *ldq, doublecomplex *work, integer *ncycle, integer *info);
-
-  /* Subroutine */int ztgsna_(char *job, char *howmny, logical *select,
-      integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
-      integer * ldvr, doublereal *s, doublereal *dif, integer *mm, integer *m,
-      doublecomplex *work, integer *lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int ztgsy2_(char *trans, integer *ijob, integer *m,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
-      integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
-      integer *ldf, doublereal *scale, doublereal *rdsum, doublereal *rdscal,
-      integer * info);
-
-  /* Subroutine */int ztgsyl_(char *trans, integer *ijob, integer *m,
-      integer * n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
-      integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
-      integer *ldf, doublereal *scale, doublereal *dif, doublecomplex *work,
-      integer * lwork, integer *iwork, integer *info);
-
-  /* Subroutine */int ztpcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *ap, doublereal *rcond, doublecomplex *work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztprfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
-      doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztptri_(char *uplo, char *diag, integer *n,
-      doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztptrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
-      integer *info);
-
-  /* Subroutine */int ztpttf_(char *transr, char *uplo, integer *n,
-      doublecomplex *ap, doublecomplex *arf, integer *info);
-
-  /* Subroutine */int ztpttr_(char *uplo, integer *n, doublecomplex *ap,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrcon_(char *norm, char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, doublereal *rcond, doublecomplex * work,
-      doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrevc_(char *side, char *howmny, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, integer *mm, integer *m,
-      doublecomplex *work, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrexc_(char *compq, integer *n, doublecomplex *t,
-      integer *ldt, doublecomplex *q, integer *ldq, integer *ifst,
-      integer * ilst, integer *info);
-
-  /* Subroutine */int ztrrfs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
-      doublereal *berr, doublecomplex *work, doublereal *rwork, integer * info);
-
-  /* Subroutine */int ztrsen_(char *job, char *compq, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *q,
-      integer *ldq, doublecomplex *w, integer *m, doublereal *s,
-      doublereal *sep, doublecomplex *work, integer *lwork, integer *info);
-
-  /* Subroutine */int ztrsna_(char *job, char *howmny, logical *select,
-      integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
-      integer *ldvl, doublecomplex *vr, integer *ldvr, doublereal *s,
-      doublereal *sep, integer *mm, integer *m, doublecomplex *work,
-      integer *ldwork, doublereal *rwork, integer *info);
-
-  /* Subroutine */int ztrsyl_(char *trana, char *tranb, integer *isgn,
-      integer *m, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, doublecomplex *c__, integer *ldc, doublereal *scale,
-      integer *info);
-
-  /* Subroutine */int ztrti2_(char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrtri_(char *uplo, char *diag, integer *n,
-      doublecomplex *a, integer *lda, integer *info);
-
-  /* Subroutine */int ztrtrs_(char *uplo, char *trans, char *diag, integer *n,
-      integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
-      integer *ldb, integer *info);
-
-  /* Subroutine */int ztrttf_(char *transr, char *uplo, integer *n,
-      doublecomplex *a, integer *lda, doublecomplex *arf, integer *info);
-
-  /* Subroutine */int ztrttp_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *ap, integer *info);
-
-  /* Subroutine */int ztzrqf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, integer *info);
-
-  /* Subroutine */int ztzrzf_(integer *m, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zung2l_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zung2r_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zungbr_(char *vect, integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zunghr_(integer *n, integer *ilo, integer *ihi,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungl2_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zunglq_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungql_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungqr_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungr2_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zungrq_(integer *m, integer *n, integer *k,
-      doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex * work,
-      integer *lwork, integer *info);
-
-  /* Subroutine */int zungtr_(char *uplo, integer *n, doublecomplex *a,
-      integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunm2l_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunm2r_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmbr_(char *vect, char *side, char *trans, integer *m,
-      integer *n, integer *k, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int zunmhr_(char *side, char *trans, integer *m, integer *n,
-      integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc,
-      doublecomplex * work, integer *lwork, integer *info);
-
-  /* Subroutine */int zunml2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmlq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmql_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmqr_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmr2_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int zunmr3_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * info);
-
-  /* Subroutine */int zunmrq_(char *side, char *trans, integer *m, integer *n,
-      integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zunmrz_(char *side, char *trans, integer *m, integer *n,
-      integer *k, integer *l, doublecomplex *a, integer *lda,
-      doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
-      integer * lwork, integer *info);
-
-  /* Subroutine */int zunmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublecomplex *a, integer *lda, doublecomplex *tau,
-      doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
-      integer *info);
-
-  /* Subroutine */int zupgtr_(char *uplo, integer *n, doublecomplex *ap,
-      doublecomplex *tau, doublecomplex *q, integer *ldq, doublecomplex * work,
-      integer *info);
-
-  /* Subroutine */int zupmtr_(char *side, char *uplo, char *trans, integer *m,
-      integer *n, doublecomplex *ap, doublecomplex *tau, doublecomplex *c__,
-      integer *ldc, doublecomplex *work, integer *info);
-
-  /* Subroutine */int dlamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  doublereal dsecnd_();
-
-  /* Subroutine */int ilaver_(integer *vers_major__, integer *vers_minor__,
-      integer *vers_patch__);
-
-  logical lsame_(char *ca, char *cb);
-
-  doublereal second_();
-
-  doublereal slamch_(char *cmach);
-
-  /* Subroutine */int slamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  /* Subroutine */int slamc2_(integer *beta, integer *t, logical *rnd,
-      real * eps, integer *emin, real *rmin, integer *emax, real *rmax);
-
-  doublereal slamc3_(real *a, real *b);
-
-  /* Subroutine */int slamc4_(integer *emin, real *start, integer *base);
-
-  /* Subroutine */int slamc5_(integer *beta, integer *p, integer *emin,
-      logical *ieee, integer *emax, real *rmax);
-
-  doublereal dlamch_(char *cmach);
-
-  /* Subroutine */int dlamc1_(integer *beta, integer *t, logical *rnd,
-      logical *ieee1);
-
-  /* Subroutine */int dlamc2_(integer *beta, integer *t, logical *rnd,
-      doublereal *eps, integer *emin, doublereal *rmin, integer *emax,
-      doublereal *rmax);
-
-  doublereal dlamc3_(doublereal *a, doublereal *b);
-
-  /* Subroutine */int dlamc4_(integer *emin, doublereal *start, integer *base);
-
-  /* Subroutine */int dlamc5_(integer *beta, integer *p, integer *emin,
-      logical *ieee, integer *emax, doublereal *rmax);
-
-  integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
-      integer *n2, integer *n3, integer *n4);
+/* Subroutine */ int dgerq2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *info);
+
+/* Subroutine */ int dgerqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesc2_(integer *n, doublereal *a, integer *lda,
+                             doublereal *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
+
+/* Subroutine */ int dgesdd_(char *jobz, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgesv_(integer *n, integer *nrhs, doublereal *a,
+                            integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
+                             doublereal *vt, integer *ldvt, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesvj_(char *joba, char *jobu, char *jobv, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *sva, integer *mv,
+                             doublereal *v, integer *ldv, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                             doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                              doublereal *c__, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dgetc2_(integer *n, doublereal *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
+
+/* Subroutine */ int dgetf2_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgetrf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgetri_(integer *n, doublereal *a, integer *lda,
+                             integer *ipiv, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dgetrs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
+                             doublereal *v, integer *ldv, integer *info);
+
+/* Subroutine */ int dggbal_(char *job, integer *n, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, integer *ilo, integer *ihi,
+                             doublereal *lscale, doublereal *rscale, doublereal *work, integer *info);
+
+/* Subroutine */ int dgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, integer *sdim, doublereal *alphar, doublereal *alphai,
+                            doublereal *beta, doublereal *vsl, integer *ldvsl, doublereal *vsr,
+                            integer *ldvsr, doublereal *work, integer *lwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int dggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, doublereal *a, integer *lda,
+                             doublereal *b, integer *ldb, integer *sdim, doublereal *alphar,
+                             doublereal *alphai, doublereal *beta, doublereal *vsl, integer *ldvsl,
+                             doublereal *vsr, integer *ldvsr, doublereal *rconde, doublereal *rcondv,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int dggev_(char *jobvl, char *jobvr, integer *n,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *alphar, doublereal *alphai, doublereal *beta, doublereal *vl,
+                            integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int dggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                             integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
+                             doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
+                             doublereal *rcondv, doublereal *work, integer *lwork, integer *iwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int dggglm_(integer *n, integer *m, integer *p,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *d__, doublereal *x, doublereal *y, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
+                             integer *info);
+
+/* Subroutine */ int dgglse_(integer *m, integer *n, integer *p,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, doublereal *d__, doublereal *x, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dggqrf_(integer *n, integer *m, integer *p,
+                             doublereal *a, integer *lda, doublereal *taua, doublereal *b,
+                             integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dggrqf_(integer *m, integer *p, integer *n,
+                             doublereal *a, integer *lda, doublereal *taua, doublereal *b,
+                             integer *ldb, doublereal *taub, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, doublereal *alpha,
+                             doublereal *beta, doublereal *u, integer *ldu, doublereal *v,
+                             integer *ldv, doublereal *q, integer *ldq, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
+                             doublereal *u, integer *ldu, doublereal *v, integer *ldv, doublereal *q,
+                             integer *ldq, integer *iwork, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dgsvj0_(char *jobv, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
+                             integer *mv, doublereal *v, integer *ldv, doublereal *eps,
+                             doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *sva,
+                             integer *mv, doublereal *v, integer *ldv, doublereal *eps,
+                             doublereal *sfmin, doublereal *tol, integer *nsweep, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dgtcon_(char *norm, integer *n, doublereal *dl,
+                             doublereal *d__, doublereal *du, doublereal *du2, integer *ipiv,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dgtrfs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *dlf,
+                             doublereal *df, doublereal *duf, doublereal *du2, integer *ipiv,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dgtsv_(integer *n, integer *nrhs, doublereal *dl,
+                            doublereal *d__, doublereal *du, doublereal *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int dgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublereal *dl, doublereal *d__, doublereal *du,
+                             doublereal *dlf, doublereal *df, doublereal *duf, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dgttrf_(integer *n, doublereal *dl, doublereal *d__,
+                             doublereal *du, doublereal *du2, integer *ipiv, integer *info);
+
+/* Subroutine */ int dgttrs_(char *trans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             doublereal *dl, doublereal *d__, doublereal *du, doublereal *du2,
+                             integer *ipiv, doublereal *b, integer *ldb);
+
+/* Subroutine */ int dhgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *t,
+                             integer *ldt, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *q, integer *ldq, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dhsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, doublereal *h__, integer *ldh,
+                             doublereal *wr, doublereal *wi, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
+                             integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int dhseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *info);
+
+logical disnan_(doublereal *din);
+
+/* Subroutine */ int dla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, doublereal *alpha, doublereal *ab,
+                                 integer *ldab, doublereal *x, integer *incx, doublereal *beta,
+                                 doublereal *y, integer *incy);
+
+doublereal dla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
+                         doublereal *ab, integer *ldab, doublereal *afb, integer *ldafb,
+                         integer *ipiv, integer *cmode, doublereal *c__, integer *info,
+                         doublereal *work, integer *iwork, ftnlen trans_len);
+
+/* Subroutine */ int dla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                                           integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublereal *b, integer *ldb, doublereal *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
+                                           doublereal *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
+
+doublereal dla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, doublereal *ab, integer *ldab, doublereal *afb,
+                          integer *ldafb);
+
+/* Subroutine */ int dla_geamv__(integer *trans, integer *m, integer *n,
+                                 doublereal *alpha, doublereal *a, integer *lda, doublereal *x,
+                                 integer *incx, doublereal *beta, doublereal *y, integer *incy);
+
+doublereal dla_gercond__(char *trans, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
+                         doublereal *c__, integer *info, doublereal *work, integer *iwork,
+                         ftnlen trans_len);
+
+/* Subroutine */ int dla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, doublereal *a,
+                                           integer *lda, doublereal *af, integer *ldaf, integer *ipiv,
+                                           logical *colequ, doublereal *c__, doublereal *b, integer *ldb,
+                                           doublereal *y, integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublereal *res,
+                                           doublereal *ayb, doublereal *dy, doublereal *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+/* Subroutine */ int dla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    doublereal *res, doublereal *ayb, doublereal *berr);
+
+doublereal dla_porcond__(char *uplo, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *cmode, doublereal *c__,
+                         integer *info, doublereal *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int dla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                                           integer *ldaf, logical *colequ, doublereal *c__, doublereal *b,
+                                           integer *ldb, doublereal *y, integer *ldy, doublereal *berr_out__,
+                                           integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
+                                           doublereal *res, doublereal *ayb, doublereal *dy, doublereal *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal dla_porpvgrw__(char *uplo, integer *ncols, doublereal *a,
+                          integer *lda, doublereal *af, integer *ldaf, doublereal *work,
+                          ftnlen uplo_len);
+
+doublereal dla_rpvgrw__(integer *n, integer *ncols, doublereal *a,
+                        integer *lda, doublereal *af, integer *ldaf);
+
+/* Subroutine */ int dla_syamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublereal *a, integer *lda, doublereal *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal dla_syrcond__(char *uplo, integer *n, doublereal *a, integer *lda,
+                         doublereal *af, integer *ldaf, integer *ipiv, integer *cmode,
+                         doublereal *c__, integer *info, doublereal *work, integer *iwork,
+                         ftnlen uplo_len);
+
+/* Subroutine */ int dla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublereal *b, integer *ldb, doublereal *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublereal *res, doublereal *ayb, doublereal *dy,
+                                           doublereal *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info, ftnlen uplo_len);
+
+doublereal dla_syrpvgrw__(char *uplo, integer *n, integer *info,
+                          doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int dla_wwaddw__(integer *n, doublereal *x, doublereal *y,
+                                  doublereal *w);
+
+/* Subroutine */ int dlabad_(doublereal *small, doublereal *large);
+
+/* Subroutine */ int dlabrd_(integer *m, integer *n, integer *nb,
+                             doublereal *a, integer *lda, doublereal *d__, doublereal *e,
+                             doublereal *tauq, doublereal *taup, doublereal *x, integer *ldx,
+                             doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlacn2_(integer *n, doublereal *v, doublereal *x,
+                             integer *isgn, doublereal *est, integer *kase, integer *isave);
+
+/* Subroutine */ int dlacon_(integer *n, doublereal *v, doublereal *x,
+                             integer *isgn, doublereal *est, integer *kase);
+
+/* Subroutine */ int dlacpy_(char *uplo, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb);
+
+/* Subroutine */ int dladiv_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *d__, doublereal *p, doublereal *q);
+
+/* Subroutine */ int dlae2_(doublereal *a, doublereal *b, doublereal *c__,
+                            doublereal *rt1, doublereal *rt2);
+
+/* Subroutine */ int dlaebz_(integer *ijob, integer *nitmax, integer *n,
+                             integer *mmax, integer *minp, integer *nbmin, doublereal *abstol,
+                             doublereal *reltol, doublereal *pivmin, doublereal *d__, doublereal *e,
+                             doublereal *e2, integer *nval, doublereal *ab, doublereal *c__,
+                             integer *mout, integer *nab, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlaed0_(integer *icompq, integer *qsiz, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *q, integer *ldq,
+                             doublereal *qstore, integer *ldqs, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlaed1_(integer *n, doublereal *d__, doublereal *q,
+                             integer *ldq, integer *indxq, doublereal *rho, integer *cutpnt,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlaed2_(integer *k, integer *n, integer *n1,
+                             doublereal *d__, doublereal *q, integer *ldq, integer *indxq,
+                             doublereal *rho, doublereal *z__, doublereal *dlamda, doublereal *w,
+                             doublereal *q2, integer *indx, integer *indxc, integer *indxp,
+                             integer *coltyp, integer *info);
+
+/* Subroutine */ int dlaed3_(integer *k, integer *n, integer *n1,
+                             doublereal *d__, doublereal *q, integer *ldq, doublereal *rho,
+                             doublereal *dlamda, doublereal *q2, integer *indx, integer *ctot,
+                             doublereal *w, doublereal *s, integer *info);
+
+/* Subroutine */ int dlaed4_(integer *n, integer *i__, doublereal *d__,
+                             doublereal *z__, doublereal *delta, doublereal *rho, doublereal *dlam,
+                             integer *info);
+
+/* Subroutine */ int dlaed5_(integer *i__, doublereal *d__, doublereal *z__,
+                             doublereal *delta, doublereal *rho, doublereal *dlam);
+
+/* Subroutine */ int dlaed6_(integer *kniter, logical *orgati,
+                             doublereal *rho, doublereal *d__, doublereal *z__, doublereal *finit,
+                             doublereal *tau, integer *info);
+
+/* Subroutine */ int dlaed7_(integer *icompq, integer *n, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
+                             doublereal *q, integer *ldq, integer *indxq, doublereal *rho,
+                             integer *cutpnt, doublereal *qstore, integer *qptr, integer *prmptr,
+                             integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlaed8_(integer *icompq, integer *k, integer *n,
+                             integer *qsiz, doublereal *d__, doublereal *q, integer *ldq,
+                             integer *indxq, doublereal *rho, integer *cutpnt, doublereal *z__,
+                             doublereal *dlamda, doublereal *q2, integer *ldq2, doublereal *w,
+                             integer *perm, integer *givptr, integer *givcol, doublereal *givnum,
+                             integer *indxp, integer *indx, integer *info);
+
+/* Subroutine */ int dlaed9_(integer *k, integer *kstart, integer *kstop,
+                             integer *n, doublereal *d__, doublereal *q, integer *ldq,
+                             doublereal *rho, doublereal *dlamda, doublereal *w, doublereal *s,
+                             integer *lds, integer *info);
+
+/* Subroutine */ int dlaeda_(integer *n, integer *tlvls, integer *curlvl,
+                             integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, doublereal *givnum, doublereal *q, integer *qptr,
+                             doublereal *z__, doublereal *ztemp, integer *info);
+
+/* Subroutine */ int dlaein_(logical *rightv, logical *noinit, integer *n,
+                             doublereal *h__, integer *ldh, doublereal *wr, doublereal *wi,
+                             doublereal *vr, doublereal *vi, doublereal *b, integer *ldb,
+                             doublereal *work, doublereal *eps3, doublereal *smlnum,
+                             doublereal *bignum, integer *info);
+
+/* Subroutine */ int dlaev2_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *rt1, doublereal *rt2, doublereal *cs1, doublereal *sn1);
+
+/* Subroutine */ int dlaexc_(logical *wantq, integer *n, doublereal *t,
+                             integer *ldt, doublereal *q, integer *ldq, integer *j1, integer *n1,
+                             integer *n2, doublereal *work, integer *info);
+
+/* Subroutine */ int dlag2_(doublereal *a, integer *lda, doublereal *b,
+                            integer *ldb, doublereal *safmin, doublereal *scale1, doublereal *scale2,
+                            doublereal *wr1, doublereal *wr2, doublereal *wi);
+
+/* Subroutine */ int dlag2s_(integer *m, integer *n, doublereal *a,
+                             integer *lda, real *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int dlags2_(logical *upper, doublereal *a1, doublereal *a2,
+                             doublereal *a3, doublereal *b1, doublereal *b2, doublereal *b3,
+                             doublereal *csu, doublereal *snu, doublereal *csv, doublereal *snv,
+                             doublereal *csq, doublereal *snq);
+
+/* Subroutine */ int dlagtf_(integer *n, doublereal *a, doublereal *lambda,
+                             doublereal *b, doublereal *c__, doublereal *tol, doublereal *d__,
+                             integer *in, integer *info);
+
+/* Subroutine */ int dlagtm_(char *trans, integer *n, integer *nrhs,
+                             doublereal *alpha, doublereal *dl, doublereal *d__, doublereal *du,
+                             doublereal *x, integer *ldx, doublereal *beta, doublereal *b,
+                             integer *ldb);
+
+/* Subroutine */ int dlagts_(integer *job, integer *n, doublereal *a,
+                             doublereal *b, doublereal *c__, doublereal *d__, integer *in,
+                             doublereal *y, doublereal *tol, integer *info);
+
+/* Subroutine */ int dlagv2_(doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *csl, doublereal *snl, doublereal *csr, doublereal *snr);
+
+/* Subroutine */ int dlahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, integer *info);
+
+/* Subroutine */ int dlahr2_(integer *n, integer *k, integer *nb,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *t,
+                             integer *ldt, doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlahrd_(integer *n, integer *k, integer *nb,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *t,
+                             integer *ldt, doublereal *y, integer *ldy);
+
+/* Subroutine */ int dlaic1_(integer *job, integer *j, doublereal *x,
+                             doublereal *sest, doublereal *w, doublereal *gamma, doublereal *sestpr,
+                             doublereal *s, doublereal *c__);
+
+logical dlaisnan_(doublereal *din1, doublereal *din2);
+
+/* Subroutine */ int dlaln2_(logical *ltrans, integer *na, integer *nw,
+                             doublereal *smin, doublereal *ca, doublereal *a, integer *lda,
+                             doublereal *d1, doublereal *d2, doublereal *b, integer *ldb,
+                             doublereal *wr, doublereal *wi, doublereal *x, integer *ldx,
+                             doublereal *scale, doublereal *xnorm, integer *info);
+
+/* Subroutine */ int dlals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, doublereal *givnum, integer *ldgnum, doublereal *poles,
+                             doublereal *difl, doublereal *difr, doublereal *z__, integer *k,
+                             doublereal *c__, doublereal *s, doublereal *work, integer *info);
+
+/* Subroutine */ int dlalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *b, integer *ldb, doublereal *bx,
+                             integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
+                             doublereal *difl, doublereal *difr, doublereal *z__, doublereal *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             doublereal *givnum, doublereal *c__, doublereal *s, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *d__, doublereal *e, doublereal *b,
+                             integer *ldb, doublereal *rcond, integer *rank, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlamrg_(integer *n1, integer *n2, doublereal *a,
+                             integer *dtrd1, integer *dtrd2, integer *index);
+
+integer dlaneg_(integer *n, doublereal *d__, doublereal *lld,
+                doublereal *sigma, doublereal *pivmin, integer *r__);
+
+doublereal dlangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlange_(char *norm, integer *m, integer *n, doublereal *a,
+                   integer *lda, doublereal *work);
+
+doublereal dlangt_(char *norm, integer *n, doublereal *dl, doublereal *d__,
+                   doublereal *du);
+
+doublereal dlanhs_(char *norm, integer *n, doublereal *a, integer *lda,
+                   doublereal *work);
+
+doublereal dlansb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlansf_(char *norm, char *transr, char *uplo, integer *n,
+                   doublereal *a, doublereal *work);
+
+doublereal dlansp_(char *norm, char *uplo, integer *n, doublereal *ap,
+                   doublereal *work);
+
+doublereal dlanst_(char *norm, integer *n, doublereal *d__, doublereal *e);
+
+doublereal dlansy_(char *norm, char *uplo, integer *n, doublereal *a,
+                   integer *lda, doublereal *work);
+
+doublereal dlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   doublereal *ab, integer *ldab, doublereal *work);
+
+doublereal dlantp_(char *norm, char *uplo, char *diag, integer *n,
+                   doublereal *ap, doublereal *work);
+
+doublereal dlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   doublereal *a, integer *lda, doublereal *work);
+
+/* Subroutine */ int dlanv2_(doublereal *a, doublereal *b, doublereal *c__,
+                             doublereal *d__, doublereal *rt1r, doublereal *rt1i, doublereal *rt2r,
+                             doublereal *rt2i, doublereal *cs, doublereal *sn);
+
+/* Subroutine */ int dlapll_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *ssmin);
+
+/* Subroutine */ int dlapmt_(logical *forwrd, integer *m, integer *n,
+                             doublereal *x, integer *ldx, integer *k);
+
+doublereal dlapy2_(doublereal *x, doublereal *y);
+
+doublereal dlapy3_(doublereal *x, doublereal *y, doublereal *z__);
+
+/* Subroutine */ int dlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublereal *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqge_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqp2_(integer *m, integer *n, integer *offset,
+                             doublereal *a, integer *lda, integer *jpvt, doublereal *tau,
+                             doublereal *vn1, doublereal *vn2, doublereal *work);
+
+/* Subroutine */ int dlaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, doublereal *a, integer *lda, integer *jpvt,
+                             doublereal *tau, doublereal *vn1, doublereal *vn2, doublereal *auxv,
+                             doublereal *f, integer *ldf);
+
+/* Subroutine */ int dlaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dlaqr1_(integer *n, doublereal *h__, integer *ldh,
+                             doublereal *sr1, doublereal *si1, doublereal *sr2, doublereal *si2,
+                             doublereal *v);
+
+/* Subroutine */ int dlaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
+                             integer *nd, doublereal *sr, doublereal *si, doublereal *v, integer *ldv,
+                             integer *nh, doublereal *t, integer *ldt, integer *nv, doublereal *wv,
+                             integer *ldwv, doublereal *work, integer *lwork);
+
+/* Subroutine */ int dlaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublereal *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, doublereal *z__, integer *ldz, integer *ns,
+                             integer *nd, doublereal *sr, doublereal *si, doublereal *v, integer *ldv,
+                             integer *nh, doublereal *t, integer *ldt, integer *nv, doublereal *wv,
+                             integer *ldwv, doublereal *work, integer *lwork);
+
+/* Subroutine */ int dlaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublereal *h__, integer *ldh, doublereal *wr,
+                             doublereal *wi, integer *iloz, integer *ihiz, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, doublereal *sr,
+                             doublereal *si, doublereal *h__, integer *ldh, integer *iloz,
+                             integer *ihiz, doublereal *z__, integer *ldz, doublereal *v,
+                             integer *ldv, doublereal *u, integer *ldu, integer *nv, doublereal *wv,
+                             integer *ldwv, integer *nh, doublereal *wh, integer *ldwh);
+
+/* Subroutine */ int dlaqsb_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqsp_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int dlaqsy_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int dlaqtr_(logical *ltran, logical *lreal, integer *n,
+                             doublereal *t, integer *ldt, doublereal *b, doublereal *w,
+                             doublereal *scale, doublereal *x, doublereal *work, integer *info);
+
+/* Subroutine */ int dlar1v_(integer *n, integer *b1, integer *bn,
+                             doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
+                             doublereal *lld, doublereal *pivmin, doublereal *gaptol, doublereal *z__,
+                             logical *wantnc, integer *negcnt, doublereal *ztz, doublereal *mingma,
+                             integer *r__, integer *isuppz, doublereal *nrminv, doublereal *resid,
+                             doublereal *rqcorr, doublereal *work);
+
+/* Subroutine */ int dlar2v_(integer *n, doublereal *x, doublereal *y,
+                             doublereal *z__, integer *incx, doublereal *c__, doublereal *s,
+                             integer *incc);
+
+/* Subroutine */ int dlarf_(char *side, integer *m, integer *n, doublereal *v,
+                            integer *incv, doublereal *tau, doublereal *c__, integer *ldc,
+                            doublereal *work);
+
+/* Subroutine */ int dlarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, doublereal *v,
+                             integer *ldv, doublereal *t, integer *ldt, doublereal *c__, integer *ldc,
+                             doublereal *work, integer *ldwork);
+
+/* Subroutine */ int dlarfg_(integer *n, doublereal *alpha, doublereal *x,
+                             integer *incx, doublereal *tau);
+
+/* Subroutine */ int dlarfp_(integer *n, doublereal *alpha, doublereal *x,
+                             integer *incx, doublereal *tau);
+
+/* Subroutine */ int dlarft_(char *direct, char *storev, integer *n,
+                             integer *k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
+                             integer *ldt);
+
+/* Subroutine */ int dlarfx_(char *side, integer *m, integer *n,
+                             doublereal *v, doublereal *tau, doublereal *c__, integer *ldc,
+                             doublereal *work);
+
+/* Subroutine */ int dlargv_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *c__, integer *incc);
+
+/* Subroutine */ int dlarnv_(integer *idist, integer *iseed, integer *n,
+                             doublereal *x);
+
+/* Subroutine */ int dlarra_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *spltol, doublereal *tnrm, integer *nsplit,
+                             integer *isplit, integer *info);
+
+/* Subroutine */ int dlarrb_(integer *n, doublereal *d__, doublereal *lld,
+                             integer *ifirst, integer *ilast, doublereal *rtol1, doublereal *rtol2,
+                             integer *offset, doublereal *w, doublereal *wgap, doublereal *werr,
+                             doublereal *work, integer *iwork, doublereal *pivmin, doublereal *spdiam,
+                             integer *twist, integer *info);
+
+/* Subroutine */ int dlarrc_(char *jobt, integer *n, doublereal *vl,
+                             doublereal *vu, doublereal *d__, doublereal *e, doublereal *pivmin,
+                             integer *eigcnt, integer *lcnt, integer *rcnt, integer *info);
+
+/* Subroutine */ int dlarrd_(char *range, char *order, integer *n,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *gers, doublereal *reltol, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *pivmin, integer *nsplit, integer *isplit,
+                             integer *m, doublereal *w, doublereal *werr, doublereal *wl,
+                             doublereal *wu, integer *iblock, integer *indexw, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlarre_(char *range, integer *n, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *d__, doublereal *e,
+                             doublereal *e2, doublereal *rtol1, doublereal *rtol2, doublereal *spltol,
+                             integer *nsplit, integer *isplit, integer *m, doublereal *w,
+                             doublereal *werr, doublereal *wgap, integer *iblock, integer *indexw,
+                             doublereal *gers, doublereal *pivmin, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlarrf_(integer *n, doublereal *d__, doublereal *l,
+                             doublereal *ld, integer *clstrt, integer *clend, doublereal *w,
+                             doublereal *wgap, doublereal *werr, doublereal *spdiam,
+                             doublereal *clgapl, doublereal *clgapr, doublereal *pivmin,
+                             doublereal *sigma, doublereal *dplus, doublereal *lplus, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlarrj_(integer *n, doublereal *d__, doublereal *e2,
+                             integer *ifirst, integer *ilast, doublereal *rtol, integer *offset,
+                             doublereal *w, doublereal *werr, doublereal *work, integer *iwork,
+                             doublereal *pivmin, doublereal *spdiam, integer *info);
+
+/* Subroutine */ int dlarrk_(integer *n, integer *iw, doublereal *gl,
+                             doublereal *gu, doublereal *d__, doublereal *e2, doublereal *pivmin,
+                             doublereal *reltol, doublereal *w, doublereal *werr, integer *info);
+
+/* Subroutine */ int dlarrr_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dlarrv_(integer *n, doublereal *vl, doublereal *vu,
+                             doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
+                             integer *m, integer *dol, integer *dou, doublereal *minrgp,
+                             doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
+                             doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dlarscl2_(integer *m, integer *n, doublereal *d__,
+                               doublereal *x, integer *ldx);
+
+/* Subroutine */ int dlartg_(doublereal *f, doublereal *g, doublereal *cs,
+                             doublereal *sn, doublereal *r__);
+
+/* Subroutine */ int dlartv_(integer *n, doublereal *x, integer *incx,
+                             doublereal *y, integer *incy, doublereal *c__, doublereal *s,
+                             integer *incc);
+
+/* Subroutine */ int dlaruv_(integer *iseed, integer *n, doublereal *x);
+
+/* Subroutine */ int dlarz_(char *side, integer *m, integer *n, integer *l,
+                            doublereal *v, integer *incv, doublereal *tau, doublereal *c__,
+                            integer *ldc, doublereal *work);
+
+/* Subroutine */ int dlarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l,
+                             doublereal *v, integer *ldv, doublereal *t, integer *ldt, doublereal *c__,
+                             integer *ldc, doublereal *work, integer *ldwork);
+
+/* Subroutine */ int dlarzt_(char *direct, char *storev, integer *n,
+                             integer *k, doublereal *v, integer *ldv, doublereal *tau, doublereal *t,
+                             integer *ldt);
+
+/* Subroutine */ int dlas2_(doublereal *f, doublereal *g, doublereal *h__,
+                            doublereal *ssmin, doublereal *ssmax);
+
+/* Subroutine */ int dlascl_(char *type__, integer *kl, integer *ku,
+                             doublereal *cfrom, doublereal *cto, integer *m, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dlascl2_(integer *m, integer *n, doublereal *d__,
+                              doublereal *x, integer *ldx);
+
+/* Subroutine */ int dlasd0_(integer *n, integer *sqre, doublereal *d__,
+                             doublereal *e, doublereal *u, integer *ldu, doublereal *vt,
+                             integer *ldvt, integer *smlsiz, integer *iwork, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlasd1_(integer *nl, integer *nr, integer *sqre,
+                             doublereal *d__, doublereal *alpha, doublereal *beta, doublereal *u,
+                             integer *ldu, doublereal *vt, integer *ldvt, integer *idxq,
+                             integer *iwork, doublereal *work, integer *info);
+
+/* Subroutine */ int dlasd2_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, doublereal *d__, doublereal *z__, doublereal *alpha,
+                             doublereal *beta, doublereal *u, integer *ldu, doublereal *vt,
+                             integer *ldvt, doublereal *dsigma, doublereal *u2, integer *ldu2,
+                             doublereal *vt2, integer *ldvt2, integer *idxp, integer *idx,
+                             integer *idxc, integer *idxq, integer *coltyp, integer *info);
+
+/* Subroutine */ int dlasd3_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, doublereal *d__, doublereal *q, integer *ldq,
+                             doublereal *dsigma, doublereal *u, integer *ldu, doublereal *u2,
+                             integer *ldu2, doublereal *vt, integer *ldvt, doublereal *vt2,
+                             integer *ldvt2, integer *idxc, integer *ctot, doublereal *z__,
+                             integer *info);
+
+/* Subroutine */ int dlasd4_(integer *n, integer *i__, doublereal *d__,
+                             doublereal *z__, doublereal *delta, doublereal *rho, doublereal *sigma,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dlasd5_(integer *i__, doublereal *d__, doublereal *z__,
+                             doublereal *delta, doublereal *rho, doublereal *dsigma,
+                             doublereal *work);
+
+/* Subroutine */ int dlasd6_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, doublereal *d__, doublereal *vf, doublereal *vl,
+                             doublereal *alpha, doublereal *beta, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
+                             integer *ldgnum, doublereal *poles, doublereal *difl, doublereal *difr,
+                             doublereal *z__, integer *k, doublereal *c__, doublereal *s,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dlasd7_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *k, doublereal *d__, doublereal *z__,
+                             doublereal *zw, doublereal *vf, doublereal *vfw, doublereal *vl,
+                             doublereal *vlw, doublereal *alpha, doublereal *beta, doublereal *dsigma,
+                             integer *idx, integer *idxp, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, doublereal *givnum,
+                             integer *ldgnum, doublereal *c__, doublereal *s, integer *info);
+
+/* Subroutine */ int dlasd8_(integer *icompq, integer *k, doublereal *d__,
+                             doublereal *z__, doublereal *vf, doublereal *vl, doublereal *difl,
+                             doublereal *difr, integer *lddifr, doublereal *dsigma, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dlasda_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *sqre, doublereal *d__, doublereal *e, doublereal *u,
+                             integer *ldu, doublereal *vt, integer *k, doublereal *difl,
+                             doublereal *difr, doublereal *z__, doublereal *poles, integer *givptr,
+                             integer *givcol, integer *ldgcol, integer *perm, doublereal *givnum,
+                             doublereal *c__, doublereal *s, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dlasdq_(char *uplo, integer *sqre, integer *n,
+                             integer *ncvt, integer *nru, integer *ncc, doublereal *d__,
+                             doublereal *e, doublereal *vt, integer *ldvt, doublereal *u, integer *ldu,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dlasdt_(integer *n, integer *lvl, integer *nd,
+                             integer *inode, integer *ndiml, integer *ndimr, integer *msub);
+
+/* Subroutine */ int dlaset_(char *uplo, integer *m, integer *n,
+                             doublereal *alpha, doublereal *beta, doublereal *a, integer *lda);
+
+/* Subroutine */ int dlasq1_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dlasq2_(integer *n, doublereal *z__, integer *info);
+
+/* Subroutine */ int dlasq3_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *dmin__, doublereal *sigma, doublereal *desig,
+                             doublereal *qmax, integer *nfail, integer *iter, integer *ndiv,
+                             logical *ieee, integer *ttype, doublereal *dmin1, doublereal *dmin2,
+                             doublereal *dn, doublereal *dn1, doublereal *dn2, doublereal *g,
+                             doublereal *tau);
+
+/* Subroutine */ int dlasq4_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, integer *n0in, doublereal *dmin__, doublereal *dmin1,
+                             doublereal *dmin2, doublereal *dn, doublereal *dn1, doublereal *dn2,
+                             doublereal *tau, integer *ttype, doublereal *g);
+
+/* Subroutine */ int dlasq5_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *tau, doublereal *dmin__, doublereal *dmin1,
+                             doublereal *dmin2, doublereal *dn, doublereal *dnm1, doublereal *dnm2,
+                             logical *ieee);
+
+/* Subroutine */ int dlasq6_(integer *i0, integer *n0, doublereal *z__,
+                             integer *pp, doublereal *dmin__, doublereal *dmin1, doublereal *dmin2,
+                             doublereal *dn, doublereal *dnm1, doublereal *dnm2);
+
+/* Subroutine */ int dlasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, doublereal *c__, doublereal *s, doublereal *a, integer *lda);
+
+/* Subroutine */ int dlasrt_(char *id, integer *n, doublereal *d__,
+                             integer *info);
+
+/* Subroutine */ int dlassq_(integer *n, doublereal *x, integer *incx,
+                             doublereal *scale, doublereal *sumsq);
+
+/* Subroutine */ int dlasv2_(doublereal *f, doublereal *g, doublereal *h__,
+                             doublereal *ssmin, doublereal *ssmax, doublereal *snr, doublereal *csr,
+                             doublereal *snl, doublereal *csl);
+
+/* Subroutine */ int dlaswp_(integer *n, doublereal *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int dlasy2_(logical *ltranl, logical *ltranr, integer *isgn,
+                             integer *n1, integer *n2, doublereal *tl, integer *ldtl, doublereal *tr,
+                             integer *ldtr, doublereal *b, integer *ldb, doublereal *scale,
+                             doublereal *x, integer *ldx, doublereal *xnorm, integer *info);
+
+/* Subroutine */ int dlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *w, integer *ldw,
+                             integer *info);
+
+/* Subroutine */ int dlat2s_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, real *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int dlatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, doublereal *ab, integer *ldab,
+                             doublereal *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatdf_(integer *ijob, integer *n, doublereal *z__,
+                             integer *ldz, doublereal *rhs, doublereal *rdsum, doublereal *rdscal,
+                             integer *ipiv, integer *jpiv);
+
+/* Subroutine */ int dlatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublereal *ap, doublereal *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatrd_(char *uplo, integer *n, integer *nb,
+                             doublereal *a, integer *lda, doublereal *e, doublereal *tau,
+                             doublereal *w, integer *ldw);
+
+/* Subroutine */ int dlatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublereal *a, integer *lda, doublereal *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int dlatrz_(integer *m, integer *n, integer *l,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work);
+
+/* Subroutine */ int dlatzm_(char *side, integer *m, integer *n,
+                             doublereal *v, integer *incv, doublereal *tau, doublereal *c1,
+                             doublereal *c2, integer *ldc, doublereal *work);
+
+/* Subroutine */ int dlauu2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dlauum_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dopgtr_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *tau, doublereal *q, integer *ldq, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dopmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublereal *ap, doublereal *tau, doublereal *c__,
+                             integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dorg2l_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorg2r_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorgbr_(char *vect, integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorghr_(integer *n, integer *ilo, integer *ihi,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgl2_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorglq_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgql_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgqr_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgr2_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dorgrq_(integer *m, integer *n, integer *k,
+                             doublereal *a, integer *lda, doublereal *tau, doublereal *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int dorgtr_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dorm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dorm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dorml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *info);
+
+/* Subroutine */ int dormrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dormtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *tau,
+                             doublereal *c__, integer *ldc, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dpbcon_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *anorm, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpbequ_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, integer *info);
+
+/* Subroutine */ int dpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                             integer *ldafb, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dpbstf_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int dpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *afb,
+                             integer *ldafb, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpbtf2_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbtrf_(char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int dpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int dpftrf_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dpftri_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dpocon_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dpoequ_(integer *n, doublereal *a, integer *lda,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dpoequb_(integer *n, doublereal *a, integer *lda,
+                              doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dporfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, doublereal *s, doublereal *b, integer *ldb, doublereal *x,
+                              integer *ldx, doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int dposv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, char *equed, doublereal *s, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *rpvgrw,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dpotf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotri_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int dpotrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dppcon_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dppequ_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int dpprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *afp, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dppsv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *ap, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *afp, char *equed,
+                             doublereal *s, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dpptrf_(char *uplo, integer *n, doublereal *ap,
+                             integer *info);
+
+/* Subroutine */ int dpptri_(char *uplo, integer *n, doublereal *ap,
+                             integer *info);
+
+/* Subroutine */ int dpptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dpstf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dpstrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dptcon_(integer *n, doublereal *d__, doublereal *e,
+                             doublereal *anorm, doublereal *rcond, doublereal *work, integer *info);
+
+/* Subroutine */ int dpteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dptrfs_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *df, doublereal *ef, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *info);
+
+/* Subroutine */ int dptsv_(integer *n, integer *nrhs, doublereal *d__,
+                            doublereal *e, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dptsvx_(char *fact, integer *n, integer *nrhs,
+                             doublereal *d__, doublereal *e, doublereal *df, doublereal *ef,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dpttrf_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dpttrs_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dptts2_(integer *n, integer *nrhs, doublereal *d__,
+                             doublereal *e, doublereal *b, integer *ldb);
+
+/* Subroutine */ int drscl_(integer *n, doublereal *sa, doublereal *sx,
+                            integer *incx);
+
+/* Subroutine */ int dsbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
+                            integer *ldz, doublereal *work, integer *info);
+
+/* Subroutine */ int dsbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dsbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, doublereal *ab, integer *ldab, doublereal *q, integer *ldq,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int dsbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *x, integer *ldx, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dsbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                            integer *ldbb, doublereal *w, doublereal *z__, integer *ldz,
+                            doublereal *work, integer *info);
+
+/* Subroutine */ int dsbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *w, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dsbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, doublereal *ab, integer *ldab, doublereal *bb,
+                             integer *ldbb, doublereal *q, integer *ldq, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
+                             doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             doublereal *ab, integer *ldab, doublereal *d__, doublereal *e,
+                             doublereal *q, integer *ldq, doublereal *work, integer *info);
+
+/* Subroutine */ int dsfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, doublereal *alpha, doublereal *a, integer *lda,
+                            doublereal *beta, doublereal *c__);
+
+/* Subroutine */ int dsgesv_(integer *n, integer *nrhs, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *work, real *swork, integer *iter,
+                             integer *info);
+
+/* Subroutine */ int dspcon_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dspev_(char *jobz, char *uplo, integer *n,
+                            doublereal *ap, doublereal *w, doublereal *z__, integer *ldz,
+                            doublereal *work, integer *info);
+
+/* Subroutine */ int dspevd_(char *jobz, char *uplo, integer *n,
+                             doublereal *ap, doublereal *w, doublereal *z__, integer *ldz,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dspevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *ap, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int dspgst_(integer *itype, char *uplo, integer *n,
+                             doublereal *ap, doublereal *bp, integer *info);
+
+/* Subroutine */ int dspgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublereal *ap, doublereal *bp, doublereal *w,
+                            doublereal *z__, integer *ldz, doublereal *work, integer *info);
+
+/* Subroutine */ int dspgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublereal *ap, doublereal *bp, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dspgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublereal *ap, doublereal *bp, doublereal *vl,
+                             doublereal *vu, integer *il, integer *iu, doublereal *abstol, integer *m,
+                             doublereal *w, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsposv_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *work, real *swork, integer *iter,
+                             integer *info);
+
+/* Subroutine */ int dsprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, doublereal *afp, integer *ipiv, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dspsv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int dspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *afp, integer *ipiv,
+                             doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dsptrd_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *d__, doublereal *e, doublereal *tau, integer *info);
+
+/* Subroutine */ int dsptrf_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int dsptri_(char *uplo, integer *n, doublereal *ap,
+                             integer *ipiv, doublereal *work, integer *info);
+
+/* Subroutine */ int dsptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *ap, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dstebz_(char *range, char *order, integer *n,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, doublereal *d__, doublereal *e, integer *m,
+                             integer *nsplit, doublereal *w, integer *iblock, integer *isplit,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dstedc_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstegr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstein_(integer *n, doublereal *d__, doublereal *e,
+                             integer *m, doublereal *w, integer *iblock, integer *isplit,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dstemr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int dsteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dsterf_(integer *n, doublereal *d__, doublereal *e,
+                             integer *info);
+
+/* Subroutine */ int dstev_(char *jobz, integer *n, doublereal *d__,
+                            doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                            integer *info);
+
+/* Subroutine */ int dstevd_(char *jobz, integer *n, doublereal *d__,
+                             doublereal *e, doublereal *z__, integer *ldz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstevr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dstevx_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dsycon_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dsyequb_(char *uplo, integer *n, doublereal *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublereal *work, integer *info);
+
+/* Subroutine */ int dsyev_(char *jobz, char *uplo, integer *n, doublereal *a,
+                            integer *lda, doublereal *w, doublereal *work, integer *lwork,
+                            integer *info);
+
+/* Subroutine */ int dsyevd_(char *jobz, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *w, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dsyevr_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dsyevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublereal *z__, integer *ldz, doublereal *work, integer *lwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int dsygs2_(integer *itype, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dsygst_(integer *itype, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, integer *info);
+
+/* Subroutine */ int dsygv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                            doublereal *w, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsygvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *w, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dsygvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublereal *z__,
+                             integer *ldz, doublereal *work, integer *lwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int dsyrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, doublereal *af, integer *ldaf,
+                             integer *ipiv, doublereal *b, integer *ldb, doublereal *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dsyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublereal *b, integer *ldb,
+                              doublereal *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dsysv_(char *uplo, integer *n, integer *nrhs,
+                            doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                            doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                             integer *ldaf, integer *ipiv, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int dsysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublereal *a, integer *lda, doublereal *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s, doublereal *b,
+                              integer *ldb, doublereal *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublereal *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int dsytd2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tau,
+                             integer *info);
+
+/* Subroutine */ int dsytf2_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int dsytrd_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublereal *tau,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dsytrf_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int dsytri_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, integer *ipiv, doublereal *work, integer *info);
+
+/* Subroutine */ int dsytrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, doublereal *ab, integer *ldab, doublereal *rcond,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, doublereal *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublereal *ab, integer *ldab, doublereal *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int dtfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, doublereal *alpha, doublereal *a,
+                            doublereal *b, integer *ldb);
+
+/* Subroutine */ int dtftri_(char *transr, char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *info);
+
+/* Subroutine */ int dtfttp_(char *transr, char *uplo, integer *n,
+                             doublereal *arf, doublereal *ap, integer *info);
+
+/* Subroutine */ int dtfttr_(char *transr, char *uplo, integer *n,
+                             doublereal *arf, doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtgevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublereal *s, integer *lds, doublereal *p, integer *ldp,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr, integer *mm,
+                             integer *m, doublereal *work, integer *info);
+
+/* Subroutine */ int dtgex2_(logical *wantq, logical *wantz, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *q,
+                             integer *ldq, doublereal *z__, integer *ldz, integer *j1, integer *n1,
+                             integer *n2, doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dtgexc_(logical *wantq, logical *wantz, integer *n,
+                             doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *q,
+                             integer *ldq, doublereal *z__, integer *ldz, integer *ifst, integer *ilst,
+                             doublereal *work, integer *lwork, integer *info);
+
+/* Subroutine */ int dtgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *alphar, doublereal *alphai, doublereal *beta,
+                             doublereal *q, integer *ldq, doublereal *z__, integer *ldz, integer *m,
+                             doublereal *pl, doublereal *pr, doublereal *dif, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int dtgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, doublereal *a,
+                             integer *lda, doublereal *b, integer *ldb, doublereal *tola,
+                             doublereal *tolb, doublereal *alpha, doublereal *beta, doublereal *u,
+                             integer *ldu, doublereal *v, integer *ldv, doublereal *q, integer *ldq,
+                             doublereal *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int dtgsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *vl, integer *ldvl, doublereal *vr, integer *ldvr,
+                             doublereal *s, doublereal *dif, integer *mm, integer *m,
+                             doublereal *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int dtgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
+                             doublereal *e, integer *lde, doublereal *f, integer *ldf,
+                             doublereal *scale, doublereal *rdsum, doublereal *rdscal, integer *iwork,
+                             integer *pq, integer *info);
+
+/* Subroutine */ int dtgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *c__, integer *ldc, doublereal *d__, integer *ldd,
+                             doublereal *e, integer *lde, doublereal *f, integer *ldf,
+                             doublereal *scale, doublereal *dif, doublereal *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublereal *ap, doublereal *rcond, doublereal *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int dtprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *b, integer *ldb, doublereal *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtptri_(char *uplo, char *diag, integer *n,
+                             doublereal *ap, integer *info);
+
+/* Subroutine */ int dtptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *ap, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtpttf_(char *transr, char *uplo, integer *n,
+                             doublereal *ap, doublereal *arf, integer *info);
+
+/* Subroutine */ int dtpttr_(char *uplo, integer *n, doublereal *ap,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, doublereal *rcond, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtrevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, integer *mm, integer *m, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int dtrexc_(char *compq, integer *n, doublereal *t,
+                             integer *ldt, doublereal *q, integer *ldq, integer *ifst, integer *ilst,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int dtrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             doublereal *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublereal *work, integer *iwork, integer *info);
+
+/* Subroutine */ int dtrsen_(char *job, char *compq, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *q, integer *ldq,
+                             doublereal *wr, doublereal *wi, integer *m, doublereal *s,
+                             doublereal *sep, doublereal *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int dtrsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublereal *t, integer *ldt, doublereal *vl, integer *ldvl,
+                             doublereal *vr, integer *ldvr, doublereal *s, doublereal *sep,
+                             integer *mm, integer *m, doublereal *work, integer *ldwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int dtrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, doublereal *a, integer *lda, doublereal *b,
+                             integer *ldb, doublereal *c__, integer *ldc, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int dtrti2_(char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrtri_(char *uplo, char *diag, integer *n,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int dtrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublereal *a, integer *lda, doublereal *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int dtrttf_(char *transr, char *uplo, integer *n,
+                             doublereal *a, integer *lda, doublereal *arf, integer *info);
+
+/* Subroutine */ int dtrttp_(char *uplo, integer *n, doublereal *a,
+                             integer *lda, doublereal *ap, integer *info);
+
+/* Subroutine */ int dtzrqf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, integer *info);
+
+/* Subroutine */ int dtzrzf_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublereal *tau, doublereal *work, integer *lwork,
+                             integer *info);
+
+doublereal dzsum1_(integer *n, doublecomplex *cx, integer *incx);
+
+integer icmax1_(integer *n, complex *cx, integer *incx);
+
+integer ieeeck_(integer *ispec, real *zero, real *one);
+
+integer ilaclc_(integer *m, integer *n, complex *a, integer *lda);
+
+integer ilaclr_(integer *m, integer *n, complex *a, integer *lda);
+
+integer iladiag_(char *diag);
+
+integer iladlc_(integer *m, integer *n, doublereal *a, integer *lda);
+
+integer iladlr_(integer *m, integer *n, doublereal *a, integer *lda);
+
+integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
+                integer *n2, integer *n3, integer *n4);
+
+integer ilaprec_(char *prec);
+
+integer ilaslc_(integer *m, integer *n, real *a, integer *lda);
+
+integer ilaslr_(integer *m, integer *n, real *a, integer *lda);
+
+integer ilatrans_(char *trans);
+
+integer ilauplo_(char *uplo);
+
+/* Subroutine */ int ilaver_(integer *vers_major__, integer *vers_minor__,
+                             integer *vers_patch__);
+
+integer ilazlc_(integer *m, integer *n, doublecomplex *a, integer *lda);
+
+integer ilazlr_(integer *m, integer *n, doublecomplex *a, integer *lda);
+
+integer iparmq_(integer *ispec, char *name__, char *opts, integer *n,
+                integer *ilo, integer *ihi, integer *lwork);
+
+integer izmax1_(integer *n, doublecomplex *cx, integer *incx);
+
+logical lsamen_(integer *n, char *ca, char *cb);
+
+integer smaxloc_(real *a, integer *dimm);
+
+/* Subroutine */ int sbdsdc_(char *uplo, char *compq, integer *n, real *d__,
+                             real *e, real *u, integer *ldu, real *vt, integer *ldvt, real *q,
+                             integer *iq, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, real *d__, real *e, real *vt, integer *ldvt,
+                             real *u, integer *ldu, real *c__, integer *ldc, real *work,
+                             integer *info);
+
+doublereal scsum1_(integer *n, complex *cx, integer *incx);
+
+/* Subroutine */ int sdisna_(char *job, integer *m, integer *n, real *d__,
+                             real *sep, integer *info);
+
+/* Subroutine */ int sgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, real *ab, integer *ldab, real *d__, real *e,
+                             real *q, integer *ldq, real *pt, integer *ldpt, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, real *anorm, real *rcond,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, integer *info);
+
+/* Subroutine */ int sgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                              real *colcnd, real *amax, integer *info);
+
+/* Subroutine */ int sgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
+                             integer *ldafb, integer *ipiv, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
+                              real *afb, integer *ldafb, integer *ipiv, real *r__, real *c__, real *b,
+                              integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, real *ab, integer *ldab, integer *ipiv, real *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int sgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, real *afb,
+                             integer *ldafb, integer *ipiv, char *equed, real *r__, real *c__, real *b,
+                             integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, real *ab, integer *ldab,
+                              real *afb, integer *ldafb, integer *ipiv, char *equed, real *r__,
+                              real *c__, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
+                              real *rpvgrw, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, real *work,
+                              integer *iwork, integer *info);
+
+/* Subroutine */ int sgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, real *ab, integer *ldab, integer *ipiv,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *scale, integer *m, real *v, integer *ldv,
+                             integer *info);
+
+/* Subroutine */ int sgebal_(char *job, integer *n, real *a, integer *lda,
+                             integer *ilo, integer *ihi, real *scale, integer *info);
+
+/* Subroutine */ int sgebd2_(integer *m, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tauq, real *taup, real *work, integer *info);
+
+/* Subroutine */ int sgebrd_(integer *m, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tauq, real *taup, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int sgecon_(char *norm, integer *n, real *a, integer *lda,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgeequ_(integer *m, integer *n, real *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             integer *info);
+
+/* Subroutine */ int sgeequb_(integer *m, integer *n, real *a, integer *lda,
+                              real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                              integer *info);
+
+/* Subroutine */ int sgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            real *a, integer *lda, integer *sdim, real *wr, real *wi, real *vs,
+                            integer *ldvs, real *work, integer *lwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int sgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, real *a, integer *lda, integer *sdim, real *wr,
+                             real *wi, real *vs, integer *ldvs, real *rconde, real *rcondv,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             logical *bwork, integer *info);
+
+/* Subroutine */ int sgeev_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *wr, real *wi, real *vl, integer *ldvl, real *vr,
+                            integer *ldvr, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, real *a, integer *lda, real *wr, real *wi,
+                             real *vl, integer *ldvl, real *vr, integer *ldvr, integer *ilo,
+                             integer *ihi, real *scale, real *abnrm, real *rconde, real *rcondv,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgegs_(char *jobvsl, char *jobvsr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vsl, integer *ldvsl, real *vsr, integer *ldvsr,
+                            real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgegv_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sgehd2_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgehrd_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgejsv_(char *joba, char *jobu, char *jobv, char *jobr,
+                             char *jobt, char *jobp, integer *m, integer *n, real *a, integer *lda,
+                             real *sva, real *u, integer *ldu, real *v, integer *ldv, real *work,
+                             integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgelq2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgelqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sgelsd_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, real *s, real *rcond, integer *rank,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgelss_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, real *s, real *rcond, integer *rank,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgelsx_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
+                             integer *rank, real *work, integer *info);
+
+/* Subroutine */ int sgelsy_(integer *m, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *jpvt, real *rcond,
+                             integer *rank, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeql2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqlf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeqp3_(integer *m, integer *n, real *a, integer *lda,
+                             integer *jpvt, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgeqpf_(integer *m, integer *n, real *a, integer *lda,
+                             integer *jpvt, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqr2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgeqrf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgerfs_(char *trans, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, real *r__, real *c__, real *b, integer *ldb, real *x,
+                              integer *ldx, real *rcond, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgerq2_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *info);
+
+/* Subroutine */ int sgerqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesc2_(integer *n, real *a, integer *lda, real *rhs,
+                             integer *ipiv, integer *jpiv, real *scale);
+
+/* Subroutine */ int sgesdd_(char *jobz, integer *m, integer *n, real *a,
+                             integer *lda, real *s, real *u, integer *ldu, real *vt, integer *ldvt,
+                             real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int sgesv_(integer *n, integer *nrhs, real *a, integer *lda,
+                            integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             real *a, integer *lda, real *s, real *u, integer *ldu, real *vt,
+                             integer *ldvt, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesvj_(char *joba, char *jobu, char *jobv, integer *m,
+                             integer *n, real *a, integer *lda, real *sva, integer *mv, real *v,
+                             integer *ldv, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
+                             real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *r__, real *c__, real *b, integer *ldb,
+                              real *x, integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sgetc2_(integer *n, real *a, integer *lda, integer *ipiv,
+                             integer *jpiv, integer *info);
+
+/* Subroutine */ int sgetf2_(integer *m, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int sgetrf_(integer *m, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int sgetri_(integer *n, real *a, integer *lda, integer *ipiv,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgetrs_(char *trans, integer *n, integer *nrhs, real *a,
+                             integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, real *lscale, real *rscale, integer *m, real *v,
+                             integer *ldv, integer *info);
+
+/* Subroutine */ int sggbal_(char *job, integer *n, real *a, integer *lda,
+                             real *b, integer *ldb, integer *ilo, integer *ihi, real *lscale,
+                             real *rscale, real *work, integer *info);
+
+/* Subroutine */ int sgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                            integer *sdim, real *alphar, real *alphai, real *beta, real *vsl,
+                            integer *ldvsl, real *vsr, integer *ldvsr, real *work, integer *lwork,
+                            logical *bwork, integer *info);
+
+/* Subroutine */ int sggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, real *a, integer *lda, real *b,
+                             integer *ldb, integer *sdim, real *alphar, real *alphai, real *beta,
+                             real *vsl, integer *ldvsl, real *vsr, integer *ldvsr, real *rconde,
+                             real *rcondv, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, logical *bwork, integer *info);
+
+/* Subroutine */ int sggev_(char *jobvl, char *jobvr, integer *n, real *a,
+                            integer *lda, real *b, integer *ldb, real *alphar, real *alphai,
+                            real *beta, real *vl, integer *ldvl, real *vr, integer *ldvr, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int sggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *alphar, real *alphai, real *beta, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, real *lscale, real *rscale,
+                             real *abnrm, real *bbnrm, real *rconde, real *rcondv, real *work,
+                             integer *lwork, integer *iwork, logical *bwork, integer *info);
+
+/* Subroutine */ int sggglm_(integer *n, integer *m, integer *p, real *a,
+                             integer *lda, real *b, integer *ldb, real *d__, real *x, real *y,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, real *a, integer *lda, real *b, integer *ldb,
+                             real *q, integer *ldq, real *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int sgglse_(integer *m, integer *n, integer *p, real *a,
+                             integer *lda, real *b, integer *ldb, real *c__, real *d__, real *x,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sggqrf_(integer *n, integer *m, integer *p, real *a,
+                             integer *lda, real *taua, real *b, integer *ldb, real *taub, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sggrqf_(integer *m, integer *p, integer *n, real *a,
+                             integer *lda, real *taua, real *b, integer *ldb, real *taub, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, real *a, integer *lda,
+                             real *b, integer *ldb, real *alpha, real *beta, real *u, integer *ldu,
+                             real *v, integer *ldv, real *q, integer *ldq, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *tola, real *tolb, integer *k, integer *l, real *u, integer *ldu,
+                             real *v, integer *ldv, real *q, integer *ldq, integer *iwork, real *tau,
+                             real *work, integer *info);
+
+/* Subroutine */ int sgsvj0_(char *jobv, integer *m, integer *n, real *a,
+                             integer *lda, real *d__, real *sva, integer *mv, real *v, integer *ldv,
+                             real *eps, real *sfmin, real *tol, integer *nsweep, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int sgsvj1_(char *jobv, integer *m, integer *n, integer *n1,
+                             real *a, integer *lda, real *d__, real *sva, integer *mv, real *v,
+                             integer *ldv, real *eps, real *sfmin, real *tol, integer *nsweep,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sgtcon_(char *norm, integer *n, real *dl, real *d__,
+                             real *du, real *du2, integer *ipiv, real *anorm, real *rcond, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgtrfs_(char *trans, integer *n, integer *nrhs, real *dl,
+                             real *d__, real *du, real *dlf, real *df, real *duf, real *du2,
+                             integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
+                             real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sgtsv_(integer *n, integer *nrhs, real *dl, real *d__,
+                            real *du, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, real *dl, real *d__, real *du, real *dlf, real *df,
+                             real *duf, real *du2, integer *ipiv, real *b, integer *ldb, real *x,
+                             integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int sgttrf_(integer *n, real *dl, real *d__, real *du,
+                             real *du2, integer *ipiv, integer *info);
+
+/* Subroutine */ int sgttrs_(char *trans, integer *n, integer *nrhs, real *dl,
+                             real *d__, real *du, real *du2, integer *ipiv, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int sgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             real *dl, real *d__, real *du, real *du2, integer *ipiv, real *b,
+                             integer *ldb);
+
+/* Subroutine */ int shgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *t,
+                             integer *ldt, real *alphar, real *alphai, real *beta, real *q,
+                             integer *ldq, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int shsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, real *h__, integer *ldh, real *wr, real *wi,
+                             real *vl, integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
+                             real *work, integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int shseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, real *h__, integer *ldh, real *wr, real *wi, real *z__,
+                             integer *ldz, real *work, integer *lwork, integer *info);
+
+logical sisnan_(real *sin__);
+
+/* Subroutine */ int sla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, real *alpha, real *ab, integer *ldab, real *x,
+                                 integer *incx, real *beta, real *y, integer *incy);
+
+doublereal sla_gbrcond__(char *trans, integer *n, integer *kl, integer *ku,
+                         real *ab, integer *ldab, real *afb, integer *ldafb, integer *ipiv,
+                         integer *cmode, real *c__, integer *info, real *work, integer *iwork,
+                         ftnlen trans_len);
+
+/* Subroutine */ int sla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                                           integer *ipiv, logical *colequ, real *c__, real *b, integer *ldb, real *y,
+                                           integer *ldy, real *berr_out__, integer *n_norms__, real *errs_n__,
+                                           real *errs_c__, real *res, real *ayb, real *dy, real *y_tail__,
+                                           real *rcond, integer *ithresh, real *rthresh, real *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+doublereal sla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, real *ab, integer *ldab, real *afb, integer *ldafb);
+
+/* Subroutine */ int sla_geamv__(integer *trans, integer *m, integer *n,
+                                 real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta,
+                                 real *y, integer *incy);
+
+doublereal sla_gercond__(char *trans, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
+                         integer *info, real *work, integer *iwork, ftnlen trans_len);
+
+/* Subroutine */ int sla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, real *a, integer *lda,
+                                           real *af, integer *ldaf, integer *ipiv, logical *colequ, real *c__,
+                                           real *b, integer *ldb, real *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
+                                           real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info);
+
+/* Subroutine */ int sla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    real *res, real *ayb, real *berr);
+
+doublereal sla_porcond__(char *uplo, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *cmode, real *c__, integer *info,
+                         real *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int sla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, real *a, integer *lda, real *af,
+                                           integer *ldaf, logical *colequ, real *c__, real *b, integer *ldb,
+                                           real *y, integer *ldy, real *berr_out__, integer *n_norms__,
+                                           real *errs_n__, real *errs_c__, real *res, real *ayb, real *dy,
+                                           real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal sla_porpvgrw__(char *uplo, integer *ncols, real *a, integer *lda,
+                          real *af, integer *ldaf, real *work, ftnlen uplo_len);
+
+doublereal sla_rpvgrw__(integer *n, integer *ncols, real *a, integer *lda,
+                        real *af, integer *ldaf);
+
+/* Subroutine */ int sla_syamv__(integer *uplo, integer *n, real *alpha,
+                                 real *a, integer *lda, real *x, integer *incx, real *beta, real *y,
+                                 integer *incy);
+
+doublereal sla_syrcond__(char *uplo, integer *n, real *a, integer *lda,
+                         real *af, integer *ldaf, integer *ipiv, integer *cmode, real *c__,
+                         integer *info, real *work, integer *iwork, ftnlen uplo_len);
+
+/* Subroutine */ int sla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, real *a, integer *lda, real *af,
+                                           integer *ldaf, integer *ipiv, logical *colequ, real *c__, real *b,
+                                           integer *ldb, real *y, integer *ldy, real *berr_out__,
+                                           integer *n_norms__, real *errs_n__, real *errs_c__, real *res, real *ayb,
+                                           real *dy, real *y_tail__, real *rcond, integer *ithresh, real *rthresh,
+                                           real *dz_ub__, logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal sla_syrpvgrw__(char *uplo, integer *n, integer *info, real *a,
+                          integer *lda, real *af, integer *ldaf, integer *ipiv, real *work,
+                          ftnlen uplo_len);
+
+/* Subroutine */ int sla_wwaddw__(integer *n, real *x, real *y, real *w);
+
+/* Subroutine */ int slabad_(real *small, real *large);
+
+/* Subroutine */ int slabrd_(integer *m, integer *n, integer *nb, real *a,
+                             integer *lda, real *d__, real *e, real *tauq, real *taup, real *x,
+                             integer *ldx, real *y, integer *ldy);
+
+/* Subroutine */ int slacn2_(integer *n, real *v, real *x, integer *isgn,
+                             real *est, integer *kase, integer *isave);
+
+/* Subroutine */ int slacon_(integer *n, real *v, real *x, integer *isgn,
+                             real *est, integer *kase);
+
+/* Subroutine */ int slacpy_(char *uplo, integer *m, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb);
+
+/* Subroutine */ int sladiv_(real *a, real *b, real *c__, real *d__, real *p,
+                             real *q);
+
+/* Subroutine */ int slae2_(real *a, real *b, real *c__, real *rt1, real *rt2);
+
+/* Subroutine */ int slaebz_(integer *ijob, integer *nitmax, integer *n,
+                             integer *mmax, integer *minp, integer *nbmin, real *abstol, real *reltol,
+                             real *pivmin, real *d__, real *e, real *e2, integer *nval, real *ab,
+                             real *c__, integer *mout, integer *nab, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slaed0_(integer *icompq, integer *qsiz, integer *n,
+                             real *d__, real *e, real *q, integer *ldq, real *qstore, integer *ldqs,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slaed1_(integer *n, real *d__, real *q, integer *ldq,
+                             integer *indxq, real *rho, integer *cutpnt, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slaed2_(integer *k, integer *n, integer *n1, real *d__,
+                             real *q, integer *ldq, integer *indxq, real *rho, real *z__,
+                             real *dlamda, real *w, real *q2, integer *indx, integer *indxc,
+                             integer *indxp, integer *coltyp, integer *info);
+
+/* Subroutine */ int slaed3_(integer *k, integer *n, integer *n1, real *d__,
+                             real *q, integer *ldq, real *rho, real *dlamda, real *q2, integer *indx,
+                             integer *ctot, real *w, real *s, integer *info);
+
+/* Subroutine */ int slaed4_(integer *n, integer *i__, real *d__, real *z__,
+                             real *delta, real *rho, real *dlam, integer *info);
+
+/* Subroutine */ int slaed5_(integer *i__, real *d__, real *z__, real *delta,
+                             real *rho, real *dlam);
+
+/* Subroutine */ int slaed6_(integer *kniter, logical *orgati, real *rho,
+                             real *d__, real *z__, real *finit, real *tau, integer *info);
+
+/* Subroutine */ int slaed7_(integer *icompq, integer *n, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, real *d__, real *q,
+                             integer *ldq, integer *indxq, real *rho, integer *cutpnt, real *qstore,
+                             integer *qptr, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, real *givnum, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slaed8_(integer *icompq, integer *k, integer *n,
+                             integer *qsiz, real *d__, real *q, integer *ldq, integer *indxq,
+                             real *rho, integer *cutpnt, real *z__, real *dlamda, real *q2,
+                             integer *ldq2, real *w, integer *perm, integer *givptr, integer *givcol,
+                             real *givnum, integer *indxp, integer *indx, integer *info);
+
+/* Subroutine */ int slaed9_(integer *k, integer *kstart, integer *kstop,
+                             integer *n, real *d__, real *q, integer *ldq, real *rho, real *dlamda,
+                             real *w, real *s, integer *lds, integer *info);
+
+/* Subroutine */ int slaeda_(integer *n, integer *tlvls, integer *curlvl,
+                             integer *curpbm, integer *prmptr, integer *perm, integer *givptr,
+                             integer *givcol, real *givnum, real *q, integer *qptr, real *z__,
+                             real *ztemp, integer *info);
+
+/* Subroutine */ int slaein_(logical *rightv, logical *noinit, integer *n,
+                             real *h__, integer *ldh, real *wr, real *wi, real *vr, real *vi, real *b,
+                             integer *ldb, real *work, real *eps3, real *smlnum, real *bignum,
+                             integer *info);
+
+/* Subroutine */ int slaev2_(real *a, real *b, real *c__, real *rt1,
+                             real *rt2, real *cs1, real *sn1);
+
+/* Subroutine */ int slaexc_(logical *wantq, integer *n, real *t,
+                             integer *ldt, real *q, integer *ldq, integer *j1, integer *n1,
+                             integer *n2, real *work, integer *info);
+
+/* Subroutine */ int slag2_(real *a, integer *lda, real *b, integer *ldb,
+                            real *safmin, real *scale1, real *scale2, real *wr1, real *wr2,
+                            real *wi);
+
+/* Subroutine */ int slag2d_(integer *m, integer *n, real *sa, integer *ldsa,
+                             doublereal *a, integer *lda, integer *info);
+
+/* Subroutine */ int slags2_(logical *upper, real *a1, real *a2, real *a3,
+                             real *b1, real *b2, real *b3, real *csu, real *snu, real *csv, real *snv,
+                             real *csq, real *snq);
+
+/* Subroutine */ int slagtf_(integer *n, real *a, real *lambda, real *b,
+                             real *c__, real *tol, real *d__, integer *in, integer *info);
+
+/* Subroutine */ int slagtm_(char *trans, integer *n, integer *nrhs,
+                             real *alpha, real *dl, real *d__, real *du, real *x, integer *ldx,
+                             real *beta, real *b, integer *ldb);
+
+/* Subroutine */ int slagts_(integer *job, integer *n, real *a, real *b,
+                             real *c__, real *d__, integer *in, real *y, real *tol, integer *info);
+
+/* Subroutine */ int slagv2_(real *a, integer *lda, real *b, integer *ldb,
+                             real *alphar, real *alphai, real *beta, real *csl, real *snl, real *csr,
+                             real *snr);
+
+/* Subroutine */ int slahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int slahr2_(integer *n, integer *k, integer *nb, real *a,
+                             integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
+
+/* Subroutine */ int slahrd_(integer *n, integer *k, integer *nb, real *a,
+                             integer *lda, real *tau, real *t, integer *ldt, real *y, integer *ldy);
+
+/* Subroutine */ int slaic1_(integer *job, integer *j, real *x, real *sest,
+                             real *w, real *gamma, real *sestpr, real *s, real *c__);
+
+logical slaisnan_(real *sin1, real *sin2);
+
+/* Subroutine */ int slaln2_(logical *ltrans, integer *na, integer *nw,
+                             real *smin, real *ca, real *a, integer *lda, real *d1, real *d2, real *b,
+                             integer *ldb, real *wr, real *wi, real *x, integer *ldx, real *scale,
+                             real *xnorm, integer *info);
+
+/* Subroutine */ int slals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, real *b, integer *ldb, real *bx,
+                             integer *ldbx, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *work,
+                             integer *info);
+
+/* Subroutine */ int slalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, real *b, integer *ldb, real *bx, integer *ldbx, real *u,
+                             integer *ldu, real *vt, integer *k, real *difl, real *difr, real *z__,
+                             real *poles, integer *givptr, integer *givcol, integer *ldgcol,
+                             integer *perm, real *givnum, real *c__, real *s, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int slalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, real *d__, real *e, real *b, integer *ldb, real *rcond,
+                             integer *rank, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slamrg_(integer *n1, integer *n2, real *a,
+                             integer *strd1, integer *strd2, integer *index);
+
+integer slaneg_(integer *n, real *d__, real *lld, real *sigma, real *pivmin,
+                integer *r__);
+
+doublereal slangb_(char *norm, integer *n, integer *kl, integer *ku, real *ab,
+                   integer *ldab, real *work);
+
+doublereal slange_(char *norm, integer *m, integer *n, real *a, integer *lda,
+                   real *work);
+
+doublereal slangt_(char *norm, integer *n, real *dl, real *d__, real *du);
+
+doublereal slanhs_(char *norm, integer *n, real *a, integer *lda, real *work);
+
+doublereal slansb_(char *norm, char *uplo, integer *n, integer *k, real *ab,
+                   integer *ldab, real *work);
+
+doublereal slansf_(char *norm, char *transr, char *uplo, integer *n, real *a,
+                   real *work);
+
+doublereal slansp_(char *norm, char *uplo, integer *n, real *ap, real *work);
+
+doublereal slanst_(char *norm, integer *n, real *d__, real *e);
+
+doublereal slansy_(char *norm, char *uplo, integer *n, real *a, integer *lda,
+                   real *work);
+
+doublereal slantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   real *ab, integer *ldab, real *work);
+
+doublereal slantp_(char *norm, char *uplo, char *diag, integer *n, real *ap,
+                   real *work);
+
+doublereal slantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   real *a, integer *lda, real *work);
+
+/* Subroutine */ int slanv2_(real *a, real *b, real *c__, real *d__,
+                             real *rt1r, real *rt1i, real *rt2r, real *rt2i, real *cs, real *sn);
+
+/* Subroutine */ int slapll_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *ssmin);
+
+/* Subroutine */ int slapmt_(logical *forwrd, integer *m, integer *n, real *x,
+                             integer *ldx, integer *k);
+
+doublereal slapy2_(real *x, real *y);
+
+doublereal slapy3_(real *x, real *y, real *z__);
+
+/* Subroutine */ int slaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             real *ab, integer *ldab, real *r__, real *c__, real *rowcnd,
+                             real *colcnd, real *amax, char *equed);
+
+/* Subroutine */ int slaqge_(integer *m, integer *n, real *a, integer *lda,
+                             real *r__, real *c__, real *rowcnd, real *colcnd, real *amax,
+                             char *equed);
+
+/* Subroutine */ int slaqp2_(integer *m, integer *n, integer *offset, real *a,
+                             integer *lda, integer *jpvt, real *tau, real *vn1, real *vn2,
+                             real *work);
+
+/* Subroutine */ int slaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, real *a, integer *lda, integer *jpvt, real *tau,
+                             real *vn1, real *vn2, real *auxv, real *f, integer *ldf);
+
+/* Subroutine */ int slaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int slaqr1_(integer *n, real *h__, integer *ldh, real *sr1,
+                             real *si1, real *sr2, real *si2, real *v);
+
+/* Subroutine */ int slaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
+                             integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
+                             real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real *work,
+                             integer *lwork);
+
+/* Subroutine */ int slaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, real *h__, integer *ldh,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, integer *ns,
+                             integer *nd, real *sr, real *si, real *v, integer *ldv, integer *nh,
+                             real *t, integer *ldt, integer *nv, real *wv, integer *ldwv, real *work,
+                             integer *lwork);
+
+/* Subroutine */ int slaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, real *h__, integer *ldh, real *wr, real *wi,
+                             integer *iloz, integer *ihiz, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int slaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts, real *sr,
+                             real *si, real *h__, integer *ldh, integer *iloz, integer *ihiz,
+                             real *z__, integer *ldz, real *v, integer *ldv, real *u, integer *ldu,
+                             integer *nv, real *wv, integer *ldwv, integer *nh, real *wh,
+                             integer *ldwh);
+
+/* Subroutine */ int slaqsb_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *s, real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqsp_(char *uplo, integer *n, real *ap, real *s,
+                             real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqsy_(char *uplo, integer *n, real *a, integer *lda,
+                             real *s, real *scond, real *amax, char *equed);
+
+/* Subroutine */ int slaqtr_(logical *ltran, logical *lreal, integer *n,
+                             real *t, integer *ldt, real *b, real *w, real *scale, real *x, real *work,
+                             integer *info);
+
+/* Subroutine */ int slar1v_(integer *n, integer *b1, integer *bn,
+                             real *lambda, real *d__, real *l, real *ld, real *lld, real *pivmin,
+                             real *gaptol, real *z__, logical *wantnc, integer *negcnt, real *ztz,
+                             real *mingma, integer *r__, integer *isuppz, real *nrminv, real *resid,
+                             real *rqcorr, real *work);
+
+/* Subroutine */ int slar2v_(integer *n, real *x, real *y, real *z__,
+                             integer *incx, real *c__, real *s, integer *incc);
+
+/* Subroutine */ int slarf_(char *side, integer *m, integer *n, real *v,
+                            integer *incv, real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, real *v, integer *ldv,
+                             real *t, integer *ldt, real *c__, integer *ldc, real *work,
+                             integer *ldwork);
+
+/* Subroutine */ int slarfg_(integer *n, real *alpha, real *x, integer *incx,
+                             real *tau);
+
+/* Subroutine */ int slarfp_(integer *n, real *alpha, real *x, integer *incx,
+                             real *tau);
+
+/* Subroutine */ int slarft_(char *direct, char *storev, integer *n,
+                             integer *k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
+
+/* Subroutine */ int slarfx_(char *side, integer *m, integer *n, real *v,
+                             real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slargv_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *c__, integer *incc);
+
+/* Subroutine */ int slarnv_(integer *idist, integer *iseed, integer *n,
+                             real *x);
+
+/* Subroutine */ int slarra_(integer *n, real *d__, real *e, real *e2,
+                             real *spltol, real *tnrm, integer *nsplit, integer *isplit,
+                             integer *info);
+
+/* Subroutine */ int slarrb_(integer *n, real *d__, real *lld,
+                             integer *ifirst, integer *ilast, real *rtol1, real *rtol2,
+                             integer *offset, real *w, real *wgap, real *werr, real *work,
+                             integer *iwork, real *pivmin, real *spdiam, integer *twist,
+                             integer *info);
+
+/* Subroutine */ int slarrc_(char *jobt, integer *n, real *vl, real *vu,
+                             real *d__, real *e, real *pivmin, integer *eigcnt, integer *lcnt,
+                             integer *rcnt, integer *info);
+
+/* Subroutine */ int slarrd_(char *range, char *order, integer *n, real *vl,
+                             real *vu, integer *il, integer *iu, real *gers, real *reltol, real *d__,
+                             real *e, real *e2, real *pivmin, integer *nsplit, integer *isplit,
+                             integer *m, real *w, real *werr, real *wl, real *wu, integer *iblock,
+                             integer *indexw, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slarre_(char *range, integer *n, real *vl, real *vu,
+                             integer *il, integer *iu, real *d__, real *e, real *e2, real *rtol1,
+                             real *rtol2, real *spltol, integer *nsplit, integer *isplit, integer *m,
+                             real *w, real *werr, real *wgap, integer *iblock, integer *indexw,
+                             real *gers, real *pivmin, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int slarrf_(integer *n, real *d__, real *l, real *ld,
+                             integer *clstrt, integer *clend, real *w, real *wgap, real *werr,
+                             real *spdiam, real *clgapl, real *clgapr, real *pivmin, real *sigma,
+                             real *dplus, real *lplus, real *work, integer *info);
+
+/* Subroutine */ int slarrj_(integer *n, real *d__, real *e2, integer *ifirst,
+                             integer *ilast, real *rtol, integer *offset, real *w, real *werr,
+                             real *work, integer *iwork, real *pivmin, real *spdiam, integer *info);
+
+/* Subroutine */ int slarrk_(integer *n, integer *iw, real *gl, real *gu,
+                             real *d__, real *e2, real *pivmin, real *reltol, real *w, real *werr,
+                             integer *info);
+
+/* Subroutine */ int slarrr_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int slarrv_(integer *n, real *vl, real *vu, real *d__,
+                             real *l, real *pivmin, integer *isplit, integer *m, integer *dol,
+                             integer *dou, real *minrgp, real *rtol1, real *rtol2, real *w,
+                             real *werr, real *wgap, integer *iblock, integer *indexw, real *gers,
+                             real *z__, integer *ldz, integer *isuppz, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slarscl2_(integer *m, integer *n, real *d__, real *x,
+                               integer *ldx);
+
+/* Subroutine */ int slartg_(real *f, real *g, real *cs, real *sn, real *r__);
+
+/* Subroutine */ int slartv_(integer *n, real *x, integer *incx, real *y,
+                             integer *incy, real *c__, real *s, integer *incc);
+
+/* Subroutine */ int slaruv_(integer *iseed, integer *n, real *x);
+
+/* Subroutine */ int slarz_(char *side, integer *m, integer *n, integer *l,
+                            real *v, integer *incv, real *tau, real *c__, integer *ldc, real *work);
+
+/* Subroutine */ int slarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l, real *v,
+                             integer *ldv, real *t, integer *ldt, real *c__, integer *ldc, real *work,
+                             integer *ldwork);
+
+/* Subroutine */ int slarzt_(char *direct, char *storev, integer *n,
+                             integer *k, real *v, integer *ldv, real *tau, real *t, integer *ldt);
+
+/* Subroutine */ int slas2_(real *f, real *g, real *h__, real *ssmin,
+                            real *ssmax);
+
+/* Subroutine */ int slascl_(char *type__, integer *kl, integer *ku,
+                             real *cfrom, real *cto, integer *m, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int slascl2_(integer *m, integer *n, real *d__, real *x,
+                              integer *ldx);
+
+/* Subroutine */ int slasd0_(integer *n, integer *sqre, real *d__, real *e,
+                             real *u, integer *ldu, real *vt, integer *ldvt, integer *smlsiz,
+                             integer *iwork, real *work, integer *info);
+
+/* Subroutine */ int slasd1_(integer *nl, integer *nr, integer *sqre,
+                             real *d__, real *alpha, real *beta, real *u, integer *ldu, real *vt,
+                             integer *ldvt, integer *idxq, integer *iwork, real *work, integer *info);
+
+/* Subroutine */ int slasd2_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, real *d__, real *z__, real *alpha, real *beta, real *u,
+                             integer *ldu, real *vt, integer *ldvt, real *dsigma, real *u2,
+                             integer *ldu2, real *vt2, integer *ldvt2, integer *idxp, integer *idx,
+                             integer *idxc, integer *idxq, integer *coltyp, integer *info);
+
+/* Subroutine */ int slasd3_(integer *nl, integer *nr, integer *sqre,
+                             integer *k, real *d__, real *q, integer *ldq, real *dsigma, real *u,
+                             integer *ldu, real *u2, integer *ldu2, real *vt, integer *ldvt,
+                             real *vt2, integer *ldvt2, integer *idxc, integer *ctot, real *z__,
+                             integer *info);
+
+/* Subroutine */ int slasd4_(integer *n, integer *i__, real *d__, real *z__,
+                             real *delta, real *rho, real *sigma, real *work, integer *info);
+
+/* Subroutine */ int slasd5_(integer *i__, real *d__, real *z__, real *delta,
+                             real *rho, real *dsigma, real *work);
+
+/* Subroutine */ int slasd6_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, real *d__, real *vf, real *vl, real *alpha, real *beta,
+                             integer *idxq, integer *perm, integer *givptr, integer *givcol,
+                             integer *ldgcol, real *givnum, integer *ldgnum, real *poles, real *difl,
+                             real *difr, real *z__, integer *k, real *c__, real *s, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int slasd7_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *k, real *d__, real *z__, real *zw, real *vf,
+                             real *vfw, real *vl, real *vlw, real *alpha, real *beta, real *dsigma,
+                             integer *idx, integer *idxp, integer *idxq, integer *perm,
+                             integer *givptr, integer *givcol, integer *ldgcol, real *givnum,
+                             integer *ldgnum, real *c__, real *s, integer *info);
+
+/* Subroutine */ int slasd8_(integer *icompq, integer *k, real *d__,
+                             real *z__, real *vf, real *vl, real *difl, real *difr, integer *lddifr,
+                             real *dsigma, real *work, integer *info);
+
+/* Subroutine */ int slasda_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *sqre, real *d__, real *e, real *u, integer *ldu, real *vt,
+                             integer *k, real *difl, real *difr, real *z__, real *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             real *givnum, real *c__, real *s, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int slasdq_(char *uplo, integer *sqre, integer *n,
+                             integer *ncvt, integer *nru, integer *ncc, real *d__, real *e, real *vt,
+                             integer *ldvt, real *u, integer *ldu, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int slasdt_(integer *n, integer *lvl, integer *nd,
+                             integer *inode, integer *ndiml, integer *ndimr, integer *msub);
+
+/* Subroutine */ int slaset_(char *uplo, integer *m, integer *n, real *alpha,
+                             real *beta, real *a, integer *lda);
+
+/* Subroutine */ int slasq1_(integer *n, real *d__, real *e, real *work,
+                             integer *info);
+
+/* Subroutine */ int slasq2_(integer *n, real *z__, integer *info);
+
+/* Subroutine */ int slasq3_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *dmin__, real *sigma, real *desig, real *qmax, integer *nfail,
+                             integer *iter, integer *ndiv, logical *ieee, integer *ttype, real *dmin1,
+                             real *dmin2, real *dn, real *dn1, real *dn2, real *g, real *tau);
+
+/* Subroutine */ int slasq4_(integer *i0, integer *n0, real *z__, integer *pp,
+                             integer *n0in, real *dmin__, real *dmin1, real *dmin2, real *dn,
+                             real *dn1, real *dn2, real *tau, integer *ttype, real *g);
+
+/* Subroutine */ int slasq5_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *tau, real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
+                             real *dnm2, logical *ieee);
+
+/* Subroutine */ int slasq6_(integer *i0, integer *n0, real *z__, integer *pp,
+                             real *dmin__, real *dmin1, real *dmin2, real *dn, real *dnm1,
+                             real *dnm2);
+
+/* Subroutine */ int slasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, real *c__, real *s, real *a, integer *lda);
+
+/* Subroutine */ int slasrt_(char *id, integer *n, real *d__, integer *info);
+
+/* Subroutine */ int slassq_(integer *n, real *x, integer *incx, real *scale,
+                             real *sumsq);
+
+/* Subroutine */ int slasv2_(real *f, real *g, real *h__, real *ssmin,
+                             real *ssmax, real *snr, real *csr, real *snl, real *csl);
+
+/* Subroutine */ int slaswp_(integer *n, real *a, integer *lda, integer *k1,
+                             integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int slasy2_(logical *ltranl, logical *ltranr, integer *isgn,
+                             integer *n1, integer *n2, real *tl, integer *ldtl, real *tr,
+                             integer *ldtr, real *b, integer *ldb, real *scale, real *x, integer *ldx,
+                             real *xnorm, integer *info);
+
+/* Subroutine */ int slasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             real *a, integer *lda, integer *ipiv, real *w, integer *ldw,
+                             integer *info);
+
+/* Subroutine */ int slatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, real *ab, integer *ldab, real *x,
+                             real *scale, real *cnorm, integer *info);
+
+/* Subroutine */ int slatdf_(integer *ijob, integer *n, real *z__,
+                             integer *ldz, real *rhs, real *rdsum, real *rdscal, integer *ipiv,
+                             integer *jpiv);
+
+/* Subroutine */ int slatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, real *ap, real *x, real *scale, real *cnorm,
+                             integer *info);
+
+/* Subroutine */ int slatrd_(char *uplo, integer *n, integer *nb, real *a,
+                             integer *lda, real *e, real *tau, real *w, integer *ldw);
+
+/* Subroutine */ int slatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, real *a, integer *lda, real *x, real *scale,
+                             real *cnorm, integer *info);
+
+/* Subroutine */ int slatrz_(integer *m, integer *n, integer *l, real *a,
+                             integer *lda, real *tau, real *work);
+
+/* Subroutine */ int slatzm_(char *side, integer *m, integer *n, real *v,
+                             integer *incv, real *tau, real *c1, real *c2, integer *ldc, real *work);
+
+/* Subroutine */ int slauu2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int slauum_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int sopgtr_(char *uplo, integer *n, real *ap, real *tau,
+                             real *q, integer *ldq, real *work, integer *info);
+
+/* Subroutine */ int sopmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, real *ap, real *tau, real *c__, integer *ldc, real *work,
+                             integer *info);
+
+/* Subroutine */ int sorg2l_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorg2r_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorgbr_(char *vect, integer *m, integer *n, integer *k,
+                             real *a, integer *lda, real *tau, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int sorghr_(integer *n, integer *ilo, integer *ihi, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgl2_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorglq_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgql_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgqr_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgr2_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *info);
+
+/* Subroutine */ int sorgrq_(integer *m, integer *n, integer *k, real *a,
+                             integer *lda, real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorgtr_(char *uplo, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sorm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sorml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *info);
+
+/* Subroutine */ int sormr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *info);
+
+/* Subroutine */ int sormrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, real *a, integer *lda, real *tau, real *c__,
+                             integer *ldc, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int sormtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, real *a, integer *lda, real *tau, real *c__, integer *ldc,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int spbcon_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *anorm, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int spbequ_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, real *s, real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                             real *b, integer *ldb, real *x, integer *ldx, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spbstf_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, real *ab, integer *ldab, real *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int spbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *afb, integer *ldafb,
+                             char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int spbtf2_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbtrf_(char *uplo, integer *n, integer *kd, real *ab,
+                             integer *ldab, integer *info);
+
+/* Subroutine */ int spbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, real *ab, integer *ldab, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int spftrf_(char *transr, char *uplo, integer *n, real *a,
+                             integer *info);
+
+/* Subroutine */ int spftri_(char *transr, char *uplo, integer *n, real *a,
+                             integer *info);
+
+/* Subroutine */ int spftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, real *a, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int spocon_(char *uplo, integer *n, real *a, integer *lda,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spoequ_(integer *n, real *a, integer *lda, real *s,
+                             real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spoequb_(integer *n, real *a, integer *lda, real *s,
+                              real *scond, real *amax, integer *info);
+
+/* Subroutine */ int sporfs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf, real *s,
+                              real *b, integer *ldb, real *x, integer *ldx, real *rcond, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int sposv_(char *uplo, integer *n, integer *nrhs, real *a,
+                            integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int sposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              char *equed, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                              real *rcond, real *rpvgrw, real *berr, integer *n_err_bnds__,
+                              real *err_bnds_norm__, real *err_bnds_comp__, integer *nparams,
+                              real *params, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spotf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotri_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *info);
+
+/* Subroutine */ int spotrs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sppcon_(char *uplo, integer *n, real *ap, real *anorm,
+                             real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sppequ_(char *uplo, integer *n, real *ap, real *s,
+                             real *scond, real *amax, integer *info);
+
+/* Subroutine */ int spprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *afp, real *b, integer *ldb, real *x, integer *ldx, real *ferr,
+                             real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sppsv_(char *uplo, integer *n, integer *nrhs, real *ap,
+                            real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *ap, real *afp, char *equed, real *s, real *b,
+                             integer *ldb, real *x, integer *ldx, real *rcond, real *ferr, real *berr,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int spptrf_(char *uplo, integer *n, real *ap, integer *info);
+
+/* Subroutine */ int spptri_(char *uplo, integer *n, real *ap, integer *info);
+
+/* Subroutine */ int spptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int spstf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
+
+/* Subroutine */ int spstrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *piv, integer *rank, real *tol, real *work, integer *info);
+
+/* Subroutine */ int sptcon_(integer *n, real *d__, real *e, real *anorm,
+                             real *rcond, real *work, integer *info);
+
+/* Subroutine */ int spteqr_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sptrfs_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *info);
+
+/* Subroutine */ int sptsv_(integer *n, integer *nrhs, real *d__, real *e,
+                            real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sptsvx_(char *fact, integer *n, integer *nrhs, real *d__,
+                             real *e, real *df, real *ef, real *b, integer *ldb, real *x, integer *ldx,
+                             real *rcond, real *ferr, real *berr, real *work, integer *info);
+
+/* Subroutine */ int spttrf_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int spttrs_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sptts2_(integer *n, integer *nrhs, real *d__, real *e,
+                             real *b, integer *ldb);
+
+/* Subroutine */ int srscl_(integer *n, real *sa, real *sx, integer *incx);
+
+/* Subroutine */ int ssbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
+                            integer *info);
+
+/* Subroutine */ int ssbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             real *ab, integer *ldab, real *w, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int ssbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, real *ab, integer *ldab, real *q, integer *ldq, real *vl,
+                             real *vu, integer *il, integer *iu, real *abstol, integer *m, real *w,
+                             real *z__, integer *ldz, real *work, integer *iwork, integer *ifail,
+                             integer *info);
+
+/* Subroutine */ int ssbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *x,
+                             integer *ldx, real *work, integer *info);
+
+/* Subroutine */ int ssbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *w,
+                            real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int ssbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, real *ab, integer *ldab, real *bb, integer *ldbb, real *w,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, real *ab, integer *ldab, real *bb,
+                             integer *ldbb, real *q, integer *ldq, real *vl, real *vu, integer *il,
+                             integer *iu, real *abstol, integer *m, real *w, real *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             real *ab, integer *ldab, real *d__, real *e, real *q, integer *ldq,
+                             real *work, integer *info);
+
+/* Subroutine */ int ssfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, real *alpha, real *a, integer *lda, real *beta, real *c__);
+
+/* Subroutine */ int sspcon_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             real *anorm, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sspev_(char *jobz, char *uplo, integer *n, real *ap,
+                            real *w, real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sspevd_(char *jobz, char *uplo, integer *n, real *ap,
+                             real *w, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int sspevx_(char *jobz, char *range, char *uplo, integer *n,
+                             real *ap, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, real *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int sspgst_(integer *itype, char *uplo, integer *n, real *ap,
+                             real *bp, integer *info);
+
+/* Subroutine */ int sspgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, real *ap, real *bp, real *w, real *z__, integer *ldz,
+                            real *work, integer *info);
+
+/* Subroutine */ int sspgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, real *ap, real *bp, real *w, real *z__, integer *ldz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sspgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, real *ap, real *bp, real *vl, real *vu,
+                             integer *il, integer *iu, real *abstol, integer *m, real *w, real *z__,
+                             integer *ldz, real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssprfs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             real *afp, integer *ipiv, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sspsv_(char *uplo, integer *n, integer *nrhs, real *ap,
+                            integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *ap, real *afp, integer *ipiv, real *b, integer *ldb,
+                             real *x, integer *ldx, real *rcond, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int ssptrd_(char *uplo, integer *n, real *ap, real *d__,
+                             real *e, real *tau, integer *info);
+
+/* Subroutine */ int ssptrf_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             integer *info);
+
+/* Subroutine */ int ssptri_(char *uplo, integer *n, real *ap, integer *ipiv,
+                             real *work, integer *info);
+
+/* Subroutine */ int ssptrs_(char *uplo, integer *n, integer *nrhs, real *ap,
+                             integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int sstebz_(char *range, char *order, integer *n, real *vl,
+                             real *vu, integer *il, integer *iu, real *abstol, real *d__, real *e,
+                             integer *m, integer *nsplit, real *w, integer *iblock, integer *isplit,
+                             real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int sstedc_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int sstegr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sstein_(integer *n, real *d__, real *e, integer *m,
+                             real *w, integer *iblock, integer *isplit, real *z__, integer *ldz,
+                             real *work, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int sstemr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, integer *m,
+                             real *w, real *z__, integer *ldz, integer *nzc, integer *isuppz,
+                             logical *tryrac, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssteqr_(char *compz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int ssterf_(integer *n, real *d__, real *e, integer *info);
+
+/* Subroutine */ int sstev_(char *jobz, integer *n, real *d__, real *e,
+                            real *z__, integer *ldz, real *work, integer *info);
+
+/* Subroutine */ int sstevd_(char *jobz, integer *n, real *d__, real *e,
+                             real *z__, integer *ldz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int sstevr_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, integer *isuppz,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int sstevx_(char *jobz, char *range, integer *n, real *d__,
+                             real *e, real *vl, real *vu, integer *il, integer *iu, real *abstol,
+                             integer *m, real *w, real *z__, integer *ldz, real *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int ssycon_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *anorm, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int ssyequb_(char *uplo, integer *n, real *a, integer *lda,
+                              real *s, real *scond, real *amax, real *work, integer *info);
+
+/* Subroutine */ int ssyev_(char *jobz, char *uplo, integer *n, real *a,
+                            integer *lda, real *w, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssyevd_(char *jobz, char *uplo, integer *n, real *a,
+                             integer *lda, real *w, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssyevr_(char *jobz, char *range, char *uplo, integer *n,
+                             real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, real *z__, integer *ldz,
+                             integer *isuppz, real *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ssyevx_(char *jobz, char *range, char *uplo, integer *n,
+                             real *a, integer *lda, real *vl, real *vu, integer *il, integer *iu,
+                             real *abstol, integer *m, real *w, real *z__, integer *ldz, real *work,
+                             integer *lwork, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssygs2_(integer *itype, char *uplo, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ssygst_(integer *itype, char *uplo, integer *n, real *a,
+                             integer *lda, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ssygv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, real *a, integer *lda, real *b, integer *ldb, real *w,
+                            real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssygvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *w,
+                             real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int ssygvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *vl, real *vu, integer *il, integer *iu, real *abstol, integer *m,
+                             real *w, real *z__, integer *ldz, real *work, integer *lwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int ssyrfs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, real *af, integer *ldaf, integer *ipiv, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int ssyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, real *s, real *b, integer *ldb, real *x, integer *ldx,
+                              real *rcond, real *berr, integer *n_err_bnds__, real *err_bnds_norm__,
+                              real *err_bnds_comp__, integer *nparams, real *params, real *work,
+                              integer *iwork, integer *info);
+
+/* Subroutine */ int ssysv_(char *uplo, integer *n, integer *nrhs, real *a,
+                            integer *lda, integer *ipiv, real *b, integer *ldb, real *work,
+                            integer *lwork, integer *info);
+
+/* Subroutine */ int ssysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                             integer *ipiv, real *b, integer *ldb, real *x, integer *ldx, real *rcond,
+                             real *ferr, real *berr, real *work, integer *lwork, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int ssysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, real *a, integer *lda, real *af, integer *ldaf,
+                              integer *ipiv, char *equed, real *s, real *b, integer *ldb, real *x,
+                              integer *ldx, real *rcond, real *rpvgrw, real *berr,
+                              integer *n_err_bnds__, real *err_bnds_norm__, real *err_bnds_comp__,
+                              integer *nparams, real *params, real *work, integer *iwork,
+                              integer *info);
+
+/* Subroutine */ int ssytd2_(char *uplo, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tau, integer *info);
+
+/* Subroutine */ int ssytf2_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int ssytrd_(char *uplo, integer *n, real *a, integer *lda,
+                             real *d__, real *e, real *tau, real *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int ssytrf_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ssytri_(char *uplo, integer *n, real *a, integer *lda,
+                             integer *ipiv, real *work, integer *info);
+
+/* Subroutine */ int ssytrs_(char *uplo, integer *n, integer *nrhs, real *a,
+                             integer *lda, integer *ipiv, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int stbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, real *ab, integer *ldab, real *rcond, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
+                             integer *ldb, real *x, integer *ldx, real *ferr, real *berr, real *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, real *ab, integer *ldab, real *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int stfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, real *alpha, real *a, real *b,
+                            integer *ldb);
+
+/* Subroutine */ int stftri_(char *transr, char *uplo, char *diag, integer *n,
+                             real *a, integer *info);
+
+/* Subroutine */ int stfttp_(char *transr, char *uplo, integer *n, real *arf,
+                             real *ap, integer *info);
+
+/* Subroutine */ int stfttr_(char *transr, char *uplo, integer *n, real *arf,
+                             real *a, integer *lda, integer *info);
+
+/* Subroutine */ int stgevc_(char *side, char *howmny, logical *select,
+                             integer *n, real *s, integer *lds, real *p, integer *ldp, real *vl,
+                             integer *ldvl, real *vr, integer *ldvr, integer *mm, integer *m,
+                             real *work, integer *info);
+
+/* Subroutine */ int stgex2_(logical *wantq, logical *wantz, integer *n,
+                             real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
+                             real *z__, integer *ldz, integer *j1, integer *n1, integer *n2,
+                             real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int stgexc_(logical *wantq, logical *wantz, integer *n,
+                             real *a, integer *lda, real *b, integer *ldb, real *q, integer *ldq,
+                             real *z__, integer *ldz, integer *ifst, integer *ilst, real *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int stgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, real *a, integer *lda, real *b,
+                             integer *ldb, real *alphar, real *alphai, real *beta, real *q,
+                             integer *ldq, real *z__, integer *ldz, integer *m, real *pl, real *pr,
+                             real *dif, real *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int stgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, real *a, integer *lda,
+                             real *b, integer *ldb, real *tola, real *tolb, real *alpha, real *beta,
+                             real *u, integer *ldu, real *v, integer *ldv, real *q, integer *ldq,
+                             real *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int stgsna_(char *job, char *howmny, logical *select,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *vl,
+                             integer *ldvl, real *vr, integer *ldvr, real *s, real *dif, integer *mm,
+                             integer *m, real *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int stgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *c__,
+                             integer *ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
+                             integer *ldf, real *scale, real *rdsum, real *rdscal, integer *iwork,
+                             integer *pq, integer *info);
+
+/* Subroutine */ int stgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, real *a, integer *lda, real *b, integer *ldb, real *c__,
+                             integer *ldc, real *d__, integer *ldd, real *e, integer *lde, real *f,
+                             integer *ldf, real *scale, real *dif, real *work, integer *lwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int stpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             real *ap, real *rcond, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int stprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *ap, real *b, integer *ldb, real *x, integer *ldx,
+                             real *ferr, real *berr, real *work, integer *iwork, integer *info);
+
+/* Subroutine */ int stptri_(char *uplo, char *diag, integer *n, real *ap,
+                             integer *info);
+
+/* Subroutine */ int stptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *ap, real *b, integer *ldb, integer *info);
+
+/* Subroutine */ int stpttf_(char *transr, char *uplo, integer *n, real *ap,
+                             real *arf, integer *info);
+
+/* Subroutine */ int stpttr_(char *uplo, integer *n, real *ap, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strcon_(char *norm, char *uplo, char *diag, integer *n,
+                             real *a, integer *lda, real *rcond, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int strevc_(char *side, char *howmny, logical *select,
+                             integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, integer *mm, integer *m, real *work, integer *info);
+
+/* Subroutine */ int strexc_(char *compq, integer *n, real *t, integer *ldt,
+                             real *q, integer *ldq, integer *ifst, integer *ilst, real *work,
+                             integer *info);
+
+/* Subroutine */ int strrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *b, integer *ldb, real *x,
+                             integer *ldx, real *ferr, real *berr, real *work, integer *iwork,
+                             integer *info);
+
+/* Subroutine */ int strsen_(char *job, char *compq, logical *select,
+                             integer *n, real *t, integer *ldt, real *q, integer *ldq, real *wr,
+                             real *wi, integer *m, real *s, real *sep, real *work, integer *lwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int strsna_(char *job, char *howmny, logical *select,
+                             integer *n, real *t, integer *ldt, real *vl, integer *ldvl, real *vr,
+                             integer *ldvr, real *s, real *sep, integer *mm, integer *m, real *work,
+                             integer *ldwork, integer *iwork, integer *info);
+
+/* Subroutine */ int strsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, real *a, integer *lda, real *b, integer *ldb,
+                             real *c__, integer *ldc, real *scale, integer *info);
+
+/* Subroutine */ int strti2_(char *uplo, char *diag, integer *n, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strtri_(char *uplo, char *diag, integer *n, real *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int strtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, real *a, integer *lda, real *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int strttf_(char *transr, char *uplo, integer *n, real *a,
+                             integer *lda, real *arf, integer *info);
+
+/* Subroutine */ int strttp_(char *uplo, integer *n, real *a, integer *lda,
+                             real *ap, integer *info);
+
+/* Subroutine */ int stzrqf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, integer *info);
+
+/* Subroutine */ int stzrzf_(integer *m, integer *n, real *a, integer *lda,
+                             real *tau, real *work, integer *lwork, integer *info);
+
+/* Subroutine */ int xerbla_(char *srname, integer *info);
+
+/* Subroutine */ int xerbla_array__(char *srname_array__,
+                                    integer *srname_len__, integer *info, ftnlen srname_array_len);
+
+/* Subroutine */ int zbdsqr_(char *uplo, integer *n, integer *ncvt,
+                             integer *nru, integer *ncc, doublereal *d__, doublereal *e,
+                             doublecomplex *vt, integer *ldvt, doublecomplex *u, integer *ldu,
+                             doublecomplex *c__, integer *ldc, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zcgesv_(integer *n, integer *nrhs, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
+                             doublereal *rwork, integer *iter, integer *info);
+
+/* Subroutine */ int zcposv_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublecomplex *work, complex *swork,
+                             doublereal *rwork, integer *iter, integer *info);
+
+/* Subroutine */ int zdrscl_(integer *n, doublereal *sa, doublecomplex *sx,
+                             integer *incx);
+
+/* Subroutine */ int zgbbrd_(char *vect, integer *m, integer *n, integer *ncc,
+                             integer *kl, integer *ku, doublecomplex *ab, integer *ldab,
+                             doublereal *d__, doublereal *e, doublecomplex *q, integer *ldq,
+                             doublecomplex *pt, integer *ldpt, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbcon_(char *norm, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, doublereal *anorm,
+                             doublereal *rcond, doublecomplex *work, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zgbequ_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgbequb_(integer *m, integer *n, integer *kl,
+                              integer *ku, doublecomplex *ab, integer *ldab, doublereal *r__,
+                              doublereal *c__, doublereal *rowcnd, doublereal *colcnd,
+                              doublereal *amax, integer *info);
+
+/* Subroutine */ int zgbrfs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *afb, integer *ldafb, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbrfsx_(char *trans, char *equed, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublecomplex *ab,
+                              integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
+                              doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
+                              doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbsv_(integer *n, integer *kl, integer *ku,
+                            integer *nrhs, doublecomplex *ab, integer *ldab, integer *ipiv,
+                            doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zgbsvx_(char *fact, char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *afb, integer *ldafb, integer *ipiv, char *equed,
+                             doublereal *r__, doublereal *c__, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbsvxx_(char *fact, char *trans, integer *n,
+                              integer *kl, integer *ku, integer *nrhs, doublecomplex *ab,
+                              integer *ldab, doublecomplex *afb, integer *ldafb, integer *ipiv,
+                              char *equed, doublereal *r__, doublereal *c__, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgbtf2_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgbtrf_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgbtrs_(char *trans, integer *n, integer *kl,
+                             integer *ku, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             integer *ipiv, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zgebak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *scale, integer *m, doublecomplex *v,
+                             integer *ldv, integer *info);
+
+/* Subroutine */ int zgebal_(char *job, integer *n, doublecomplex *a,
+                             integer *lda, integer *ilo, integer *ihi, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int zgebd2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
+                             doublecomplex *taup, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgebrd_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tauq,
+                             doublecomplex *taup, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgecon_(char *norm, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeequ_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgeequb_(integer *m, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                              doublereal *colcnd, doublereal *amax, integer *info);
+
+/* Subroutine */ int zgees_(char *jobvs, char *sort, L_fp select, integer *n,
+                            doublecomplex *a, integer *lda, integer *sdim, doublecomplex *w,
+                            doublecomplex *vs, integer *ldvs, doublecomplex *work, integer *lwork,
+                            doublereal *rwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zgeesx_(char *jobvs, char *sort, L_fp select,
+                             char *sense, integer *n, doublecomplex *a, integer *lda, integer *sdim,
+                             doublecomplex *w, doublecomplex *vs, integer *ldvs, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zgeev_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *w, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *ilo, integer *ihi, doublereal *scale,
+                             doublereal *abnrm, doublereal *rconde, doublereal *rcondv,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgegs_(char *jobvsl, char *jobvsr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vsl,
+                            integer *ldvsl, doublecomplex *vsr, integer *ldvsr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgegv_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgehd2_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zgehrd_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zgelq2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgelqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgels_(char *trans, integer *m, integer *n,
+                            integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgelsd_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zgelss_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublereal *s, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgelsx_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgelsy_(integer *m, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *jpvt, doublereal *rcond, integer *rank, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeql2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgeqlf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgeqp3_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeqpf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *jpvt, doublecomplex *tau, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgeqr2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgeqrf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgerfs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgerfsx_(char *trans, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *r__, doublereal *c__,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgerq2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgerqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zgesc2_(integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *rhs, integer *ipiv, integer *jpiv, doublereal *scale);
+
+/* Subroutine */ int zgesdd_(char *jobz, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
+                             integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zgesv_(integer *n, integer *nrhs, doublecomplex *a,
+                            integer *lda, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zgesvd_(char *jobu, char *jobvt, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *s, doublecomplex *u,
+                             integer *ldu, doublecomplex *vt, integer *ldvt, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgesvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                             doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgesvxx_(char *fact, char *trans, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *r__,
+                              doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *x,
+                              integer *ldx, doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgetc2_(integer *n, doublecomplex *a, integer *lda,
+                             integer *ipiv, integer *jpiv, integer *info);
+
+/* Subroutine */ int zgetf2_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgetrf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zgetri_(integer *n, doublecomplex *a, integer *lda,
+                             integer *ipiv, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgetrs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zggbak_(char *job, char *side, integer *n, integer *ilo,
+                             integer *ihi, doublereal *lscale, doublereal *rscale, integer *m,
+                             doublecomplex *v, integer *ldv, integer *info);
+
+/* Subroutine */ int zggbal_(char *job, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, integer *ilo, integer *ihi,
+                             doublereal *lscale, doublereal *rscale, doublereal *work, integer *info);
+
+/* Subroutine */ int zgges_(char *jobvsl, char *jobvsr, char *sort,
+                            L_fp selctg, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, integer *sdim, doublecomplex *alpha, doublecomplex *beta,
+                            doublecomplex *vsl, integer *ldvsl, doublecomplex *vsr, integer *ldvsr,
+                            doublecomplex *work, integer *lwork, doublereal *rwork, logical *bwork,
+                            integer *info);
+
+/* Subroutine */ int zggesx_(char *jobvsl, char *jobvsr, char *sort,
+                             L_fp selctg, char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, integer *sdim, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *vsl, integer *ldvsl,
+                             doublecomplex *vsr, integer *ldvsr, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, integer *liwork, logical *bwork,
+                             integer *info);
+
+/* Subroutine */ int zggev_(char *jobvl, char *jobvr, integer *n,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            doublecomplex *alpha, doublecomplex *beta, doublecomplex *vl,
+                            integer *ldvl, doublecomplex *vr, integer *ldvr, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zggevx_(char *balanc, char *jobvl, char *jobvr,
+                             char *sense, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *alpha, doublecomplex *beta,
+                             doublecomplex *vl, integer *ldvl, doublecomplex *vr, integer *ldvr,
+                             integer *ilo, integer *ihi, doublereal *lscale, doublereal *rscale,
+                             doublereal *abnrm, doublereal *bbnrm, doublereal *rconde,
+                             doublereal *rcondv, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, logical *bwork, integer *info);
+
+/* Subroutine */ int zggglm_(integer *n, integer *m, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *d__, doublecomplex *x, doublecomplex *y,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zgghrd_(char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *q, integer *ldq,
+                             doublecomplex *z__, integer *ldz, integer *info);
+
+/* Subroutine */ int zgglse_(integer *m, integer *n, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *c__, doublecomplex *d__, doublecomplex *x,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zggqrf_(integer *n, integer *m, integer *p,
+                             doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
+                             integer *ldb, doublecomplex *taub, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zggrqf_(integer *m, integer *p, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *taua, doublecomplex *b,
+                             integer *ldb, doublecomplex *taub, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zggsvd_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *n, integer *p, integer *k, integer *l, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublereal *alpha,
+                             doublereal *beta, doublecomplex *u, integer *ldu, doublecomplex *v,
+                             integer *ldv, doublecomplex *q, integer *ldq, doublecomplex *work,
+                             doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zggsvp_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *tola, doublereal *tolb, integer *k, integer *l,
+                             doublecomplex *u, integer *ldu, doublecomplex *v, integer *ldv,
+                             doublecomplex *q, integer *ldq, integer *iwork, doublereal *rwork,
+                             doublecomplex *tau, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgtcon_(char *norm, integer *n, doublecomplex *dl,
+                             doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
+                             doublereal *anorm, doublereal *rcond, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zgtrfs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgtsv_(integer *n, integer *nrhs, doublecomplex *dl,
+                            doublecomplex *d__, doublecomplex *du, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zgtsvx_(char *fact, char *trans, integer *n,
+                             integer *nrhs, doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *dlf, doublecomplex *df, doublecomplex *duf,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zgttrf_(integer *n, doublecomplex *dl,
+                             doublecomplex *d__, doublecomplex *du, doublecomplex *du2, integer *ipiv,
+                             integer *info);
+
+/* Subroutine */ int zgttrs_(char *trans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zgtts2_(integer *itrans, integer *n, integer *nrhs,
+                             doublecomplex *dl, doublecomplex *d__, doublecomplex *du,
+                             doublecomplex *du2, integer *ipiv, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zhbev_(char *jobz, char *uplo, integer *n, integer *kd,
+                            doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
+                            integer *ldz, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbevd_(char *jobz, char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *lrwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhbevx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *kd, doublecomplex *ab, integer *ldab, doublecomplex *q,
+                             integer *ldq, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhbgst_(char *vect, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                             integer *ldbb, doublecomplex *x, integer *ldx, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbgv_(char *jobz, char *uplo, integer *n, integer *ka,
+                            integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                            integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
+                            doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhbgvd_(char *jobz, char *uplo, integer *n, integer *ka,
+                             integer *kb, doublecomplex *ab, integer *ldab, doublecomplex *bb,
+                             integer *ldbb, doublereal *w, doublecomplex *z__, integer *ldz,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhbgvx_(char *jobz, char *range, char *uplo, integer *n,
+                             integer *ka, integer *kb, doublecomplex *ab, integer *ldab,
+                             doublecomplex *bb, integer *ldbb, doublecomplex *q, integer *ldq,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhbtrd_(char *vect, char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *d__, doublereal *e,
+                             doublecomplex *q, integer *ldq, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhecon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, integer *info);
+
+/* Subroutine */ int zheequb_(char *uplo, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublecomplex *work, integer *info);
+
+/* Subroutine */ int zheev_(char *jobz, char *uplo, integer *n,
+                            doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
+                            integer *lwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zheevd_(char *jobz, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *w, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zheevr_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zheevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zhegs2_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhegst_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhegv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                            integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
+                            doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhegvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *w, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zhegvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zherfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zherfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhesv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zhesvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zhesvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhetd2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
+                             integer *info);
+
+/* Subroutine */ int zhetf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zhetrd_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *d__, doublereal *e, doublecomplex *tau,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zhetrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zhetri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhetrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zhfrk_(char *transr, char *uplo, char *trans, integer *n,
+                            integer *k, doublereal *alpha, doublecomplex *a, integer *lda,
+                            doublereal *beta, doublecomplex *c__);
+
+/* Subroutine */ int zhgeqz_(char *job, char *compq, char *compz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *t, integer *ldt, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zhpcon_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zhpev_(char *jobz, char *uplo, integer *n,
+                            doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
+                            doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhpevd_(char *jobz, char *uplo, integer *n,
+                             doublecomplex *ap, doublereal *w, doublecomplex *z__, integer *ldz,
+                             doublecomplex *work, integer *lwork, doublereal *rwork, integer *lrwork,
+                             integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zhpevx_(char *jobz, char *range, char *uplo, integer *n,
+                             doublecomplex *ap, doublereal *vl, doublereal *vu, integer *il,
+                             integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
+                             integer *iwork, integer *ifail, integer *info);
+
+/* Subroutine */ int zhpgst_(integer *itype, char *uplo, integer *n,
+                             doublecomplex *ap, doublecomplex *bp, integer *info);
+
+/* Subroutine */ int zhpgv_(integer *itype, char *jobz, char *uplo,
+                            integer *n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
+                            doublecomplex *z__, integer *ldz, doublecomplex *work, doublereal *rwork,
+                            integer *info);
+
+/* Subroutine */ int zhpgvd_(integer *itype, char *jobz, char *uplo,
+                             integer *n, doublecomplex *ap, doublecomplex *bp, doublereal *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             doublereal *rwork, integer *lrwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zhpgvx_(integer *itype, char *jobz, char *range,
+                             char *uplo, integer *n, doublecomplex *ap, doublecomplex *bp,
+                             doublereal *vl, doublereal *vu, integer *il, integer *iu,
+                             doublereal *abstol, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, doublereal *rwork, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zhprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhpsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zhpsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zhptrd_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *d__, doublereal *e, doublecomplex *tau, integer *info);
+
+/* Subroutine */ int zhptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int zhptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zhptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zhsein_(char *side, char *eigsrc, char *initv,
+                             logical *select, integer *n, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *mm, integer *m, doublecomplex *work,
+                             doublereal *rwork, integer *ifaill, integer *ifailr, integer *info);
+
+/* Subroutine */ int zhseqr_(char *job, char *compz, integer *n, integer *ilo,
+                             integer *ihi, doublecomplex *h__, integer *ldh, doublecomplex *w,
+                             doublecomplex *z__, integer *ldz, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zla_gbamv__(integer *trans, integer *m, integer *n,
+                                 integer *kl, integer *ku, doublereal *alpha, doublecomplex *ab,
+                                 integer *ldab, doublecomplex *x, integer *incx, doublereal *beta,
+                                 doublereal *y, integer *incy);
+
+doublereal zla_gbrcond_c__(char *trans, integer *n, integer *kl, integer *ku,
+                           doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
+                           integer *ipiv, doublereal *c__, logical *capply, integer *info,
+                           doublecomplex *work, doublereal *rwork, ftnlen trans_len);
+
+doublereal zla_gbrcond_x__(char *trans, integer *n, integer *kl, integer *ku,
+                           doublecomplex *ab, integer *ldab, doublecomplex *afb, integer *ldafb,
+                           integer *ipiv, doublecomplex *x, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen trans_len);
+
+/* Subroutine */ int zla_gbrfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *kl, integer *ku,
+                                           integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                                           integer *ldafb, integer *ipiv, logical *colequ, doublereal *c__,
+                                           doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
+                                           doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info);
+
+doublereal zla_gbrpvgrw__(integer *n, integer *kl, integer *ku,
+                          integer *ncols, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                          integer *ldafb);
+
+/* Subroutine */ int zla_geamv__(integer *trans, integer *m, integer *n,
+                                 doublereal *alpha, doublecomplex *a, integer *lda, doublecomplex *x,
+                                 integer *incx, doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_gercond_c__(char *trans, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen trans_len);
+
+doublereal zla_gercond_x__(char *trans, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen trans_len);
+
+/* Subroutine */ int zla_gerfsx_extended__(integer *prec_type__,
+                                           integer *trans_type__, integer *n, integer *nrhs, doublecomplex *a,
+                                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                                           logical *colequ, doublereal *c__, doublecomplex *b, integer *ldb,
+                                           doublecomplex *y, integer *ldy, doublereal *berr_out__,
+                                           integer *n_norms__, doublereal *errs_n__, doublereal *errs_c__,
+                                           doublecomplex *res, doublereal *ayb, doublecomplex *dy,
+                                           doublecomplex *y_tail__, doublereal *rcond, integer *ithresh,
+                                           doublereal *rthresh, doublereal *dz_ub__, logical *ignore_cwise__,
+                                           integer *info);
+
+/* Subroutine */ int zla_heamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_hercond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen uplo_len);
+
+doublereal zla_hercond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+/* Subroutine */ int zla_herfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
+                                           integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublecomplex *res,
+                                           doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal zla_herpvgrw__(char *uplo, integer *n, integer *info,
+                          doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int zla_lin_berr__(integer *n, integer *nz, integer *nrhs,
+                                    doublecomplex *res, doublereal *ayb, doublereal *berr);
+
+doublereal zla_porcond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, doublereal *c__,
+                           logical *capply, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+doublereal zla_porcond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, doublecomplex *x,
+                           integer *info, doublecomplex *work, doublereal *rwork, ftnlen uplo_len);
+
+/* Subroutine */ int zla_porfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, logical *colequ, doublereal *c__,
+                                           doublecomplex *b, integer *ldb, doublecomplex *y, integer *ldy,
+                                           doublereal *berr_out__, integer *n_norms__, doublereal *errs_n__,
+                                           doublereal *errs_c__, doublecomplex *res, doublereal *ayb,
+                                           doublecomplex *dy, doublecomplex *y_tail__, doublereal *rcond,
+                                           integer *ithresh, doublereal *rthresh, doublereal *dz_ub__,
+                                           logical *ignore_cwise__, integer *info, ftnlen uplo_len);
+
+doublereal zla_porpvgrw__(char *uplo, integer *ncols, doublecomplex *a,
+                          integer *lda, doublecomplex *af, integer *ldaf, doublereal *work,
+                          ftnlen uplo_len);
+
+doublereal zla_rpvgrw__(integer *n, integer *ncols, doublecomplex *a,
+                        integer *lda, doublecomplex *af, integer *ldaf);
+
+/* Subroutine */ int zla_syamv__(integer *uplo, integer *n, doublereal *alpha,
+                                 doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                                 doublereal *beta, doublereal *y, integer *incy);
+
+doublereal zla_syrcond_c__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublereal *c__, logical *capply, integer *info, doublecomplex *work,
+                           doublereal *rwork, ftnlen uplo_len);
+
+doublereal zla_syrcond_x__(char *uplo, integer *n, doublecomplex *a,
+                           integer *lda, doublecomplex *af, integer *ldaf, integer *ipiv,
+                           doublecomplex *x, integer *info, doublecomplex *work, doublereal *rwork,
+                           ftnlen uplo_len);
+
+/* Subroutine */ int zla_syrfsx_extended__(integer *prec_type__, char *uplo,
+                                           integer *n, integer *nrhs, doublecomplex *a, integer *lda,
+                                           doublecomplex *af, integer *ldaf, integer *ipiv, logical *colequ,
+                                           doublereal *c__, doublecomplex *b, integer *ldb, doublecomplex *y,
+                                           integer *ldy, doublereal *berr_out__, integer *n_norms__,
+                                           doublereal *errs_n__, doublereal *errs_c__, doublecomplex *res,
+                                           doublereal *ayb, doublecomplex *dy, doublecomplex *y_tail__,
+                                           doublereal *rcond, integer *ithresh, doublereal *rthresh,
+                                           doublereal *dz_ub__, logical *ignore_cwise__, integer *info,
+                                           ftnlen uplo_len);
+
+doublereal zla_syrpvgrw__(char *uplo, integer *n, integer *info,
+                          doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                          integer *ipiv, doublereal *work, ftnlen uplo_len);
+
+/* Subroutine */ int zla_wwaddw__(integer *n, doublecomplex *x,
+                                  doublecomplex *y, doublecomplex *w);
+
+/* Subroutine */ int zlabrd_(integer *m, integer *n, integer *nb,
+                             doublecomplex *a, integer *lda, doublereal *d__, doublereal *e,
+                             doublecomplex *tauq, doublecomplex *taup, doublecomplex *x, integer *ldx,
+                             doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlacgv_(integer *n, doublecomplex *x, integer *incx);
+
+/* Subroutine */ int zlacn2_(integer *n, doublecomplex *v, doublecomplex *x,
+                             doublereal *est, integer *kase, integer *isave);
+
+/* Subroutine */ int zlacon_(integer *n, doublecomplex *v, doublecomplex *x,
+                             doublereal *est, integer *kase);
+
+/* Subroutine */ int zlacp2_(char *uplo, integer *m, integer *n,
+                             doublereal *a, integer *lda, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlacpy_(char *uplo, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlacrm_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *b, integer *ldb, doublecomplex *c__,
+                             integer *ldc, doublereal *rwork);
+
+/* Subroutine */ int zlacrt_(integer *n, doublecomplex *cx, integer *incx,
+                             doublecomplex *cy, integer *incy, doublecomplex *c__, doublecomplex *s);
+
+/* Double Complex */ VOID zladiv_(doublecomplex *ret_val, doublecomplex *x,
+                                  doublecomplex *y);
+
+/* Subroutine */ int zlaed0_(integer *qsiz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *q, integer *ldq, doublecomplex *qstore,
+                             integer *ldqs, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zlaed7_(integer *n, integer *cutpnt, integer *qsiz,
+                             integer *tlvls, integer *curlvl, integer *curpbm, doublereal *d__,
+                             doublecomplex *q, integer *ldq, doublereal *rho, integer *indxq,
+                             doublereal *qstore, integer *qptr, integer *prmptr, integer *perm,
+                             integer *givptr, integer *givcol, doublereal *givnum,
+                             doublecomplex *work, doublereal *rwork, integer *iwork, integer *info);
+
+/* Subroutine */ int zlaed8_(integer *k, integer *n, integer *qsiz,
+                             doublecomplex *q, integer *ldq, doublereal *d__, doublereal *rho,
+                             integer *cutpnt, doublereal *z__, doublereal *dlamda, doublecomplex *q2,
+                             integer *ldq2, doublereal *w, integer *indxp, integer *indx,
+                             integer *indxq, integer *perm, integer *givptr, integer *givcol,
+                             doublereal *givnum, integer *info);
+
+/* Subroutine */ int zlaein_(logical *rightv, logical *noinit, integer *n,
+                             doublecomplex *h__, integer *ldh, doublecomplex *w, doublecomplex *v,
+                             doublecomplex *b, integer *ldb, doublereal *rwork, doublereal *eps3,
+                             doublereal *smlnum, integer *info);
+
+/* Subroutine */ int zlaesy_(doublecomplex *a, doublecomplex *b,
+                             doublecomplex *c__, doublecomplex *rt1, doublecomplex *rt2,
+                             doublecomplex *evscal, doublecomplex *cs1, doublecomplex *sn1);
+
+/* Subroutine */ int zlaev2_(doublecomplex *a, doublecomplex *b,
+                             doublecomplex *c__, doublereal *rt1, doublereal *rt2, doublereal *cs1,
+                             doublecomplex *sn1);
+
+/* Subroutine */ int zlag2c_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, complex *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int zlags2_(logical *upper, doublereal *a1,
+                             doublecomplex *a2, doublereal *a3, doublereal *b1, doublecomplex *b2,
+                             doublereal *b3, doublereal *csu, doublecomplex *snu, doublereal *csv,
+                             doublecomplex *snv, doublereal *csq, doublecomplex *snq);
+
+/* Subroutine */ int zlagtm_(char *trans, integer *n, integer *nrhs,
+                             doublereal *alpha, doublecomplex *dl, doublecomplex *d__,
+                             doublecomplex *du, doublecomplex *x, integer *ldx, doublereal *beta,
+                             doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zlahef_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
+                             integer *ldw, integer *info);
+
+/* Subroutine */ int zlahqr_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *info);
+
+/* Subroutine */ int zlahr2_(integer *n, integer *k, integer *nb,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
+                             integer *ldt, doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlahrd_(integer *n, integer *k, integer *nb,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *t,
+                             integer *ldt, doublecomplex *y, integer *ldy);
+
+/* Subroutine */ int zlaic1_(integer *job, integer *j, doublecomplex *x,
+                             doublereal *sest, doublecomplex *w, doublecomplex *gamma,
+                             doublereal *sestpr, doublecomplex *s, doublecomplex *c__);
+
+/* Subroutine */ int zlals0_(integer *icompq, integer *nl, integer *nr,
+                             integer *sqre, integer *nrhs, doublecomplex *b, integer *ldb,
+                             doublecomplex *bx, integer *ldbx, integer *perm, integer *givptr,
+                             integer *givcol, integer *ldgcol, doublereal *givnum, integer *ldgnum,
+                             doublereal *poles, doublereal *difl, doublereal *difr, doublereal *z__,
+                             integer *k, doublereal *c__, doublereal *s, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zlalsa_(integer *icompq, integer *smlsiz, integer *n,
+                             integer *nrhs, doublecomplex *b, integer *ldb, doublecomplex *bx,
+                             integer *ldbx, doublereal *u, integer *ldu, doublereal *vt, integer *k,
+                             doublereal *difl, doublereal *difr, doublereal *z__, doublereal *poles,
+                             integer *givptr, integer *givcol, integer *ldgcol, integer *perm,
+                             doublereal *givnum, doublereal *c__, doublereal *s, doublereal *rwork,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int zlalsd_(char *uplo, integer *smlsiz, integer *n,
+                             integer *nrhs, doublereal *d__, doublereal *e, doublecomplex *b,
+                             integer *ldb, doublereal *rcond, integer *rank, doublecomplex *work,
+                             doublereal *rwork, integer *iwork, integer *info);
+
+doublereal zlangb_(char *norm, integer *n, integer *kl, integer *ku,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlange_(char *norm, integer *m, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlangt_(char *norm, integer *n, doublecomplex *dl,
+                   doublecomplex *d__, doublecomplex *du);
+
+doublereal zlanhb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlanhe_(char *norm, char *uplo, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlanhf_(char *norm, char *transr, char *uplo, integer *n,
+                   doublecomplex *a, doublereal *work);
+
+doublereal zlanhp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
+                   doublereal *work);
+
+doublereal zlanhs_(char *norm, integer *n, doublecomplex *a, integer *lda,
+                   doublereal *work);
+
+doublereal zlanht_(char *norm, integer *n, doublereal *d__, doublecomplex *e);
+
+doublereal zlansb_(char *norm, char *uplo, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlansp_(char *norm, char *uplo, integer *n, doublecomplex *ap,
+                   doublereal *work);
+
+doublereal zlansy_(char *norm, char *uplo, integer *n, doublecomplex *a,
+                   integer *lda, doublereal *work);
+
+doublereal zlantb_(char *norm, char *uplo, char *diag, integer *n, integer *k,
+                   doublecomplex *ab, integer *ldab, doublereal *work);
+
+doublereal zlantp_(char *norm, char *uplo, char *diag, integer *n,
+                   doublecomplex *ap, doublereal *work);
+
+doublereal zlantr_(char *norm, char *uplo, char *diag, integer *m, integer *n,
+                   doublecomplex *a, integer *lda, doublereal *work);
+
+/* Subroutine */ int zlapll_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *ssmin);
+
+/* Subroutine */ int zlapmt_(logical *forwrd, integer *m, integer *n,
+                             doublecomplex *x, integer *ldx, integer *k);
+
+/* Subroutine */ int zlaqgb_(integer *m, integer *n, integer *kl, integer *ku,
+                             doublecomplex *ab, integer *ldab, doublereal *r__, doublereal *c__,
+                             doublereal *rowcnd, doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqge_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *r__, doublereal *c__, doublereal *rowcnd,
+                             doublereal *colcnd, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqhb_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqhe_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int zlaqhp_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqp2_(integer *m, integer *n, integer *offset,
+                             doublecomplex *a, integer *lda, integer *jpvt, doublecomplex *tau,
+                             doublereal *vn1, doublereal *vn2, doublecomplex *work);
+
+/* Subroutine */ int zlaqps_(integer *m, integer *n, integer *offset,
+                             integer *nb, integer *kb, doublecomplex *a, integer *lda, integer *jpvt,
+                             doublecomplex *tau, doublereal *vn1, doublereal *vn2,
+                             doublecomplex *auxv, doublecomplex *f, integer *ldf);
+
+/* Subroutine */ int zlaqr0_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zlaqr1_(integer *n, doublecomplex *h__, integer *ldh,
+                             doublecomplex *s1, doublecomplex *s2, doublecomplex *v);
+
+/* Subroutine */ int zlaqr2_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
+                             integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
+                             doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
+                             integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
+                             doublecomplex *work, integer *lwork);
+
+/* Subroutine */ int zlaqr3_(logical *wantt, logical *wantz, integer *n,
+                             integer *ktop, integer *kbot, integer *nw, doublecomplex *h__,
+                             integer *ldh, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, integer *ns, integer *nd, doublecomplex *sh,
+                             doublecomplex *v, integer *ldv, integer *nh, doublecomplex *t,
+                             integer *ldt, integer *nv, doublecomplex *wv, integer *ldwv,
+                             doublecomplex *work, integer *lwork);
+
+/* Subroutine */ int zlaqr4_(logical *wantt, logical *wantz, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *h__, integer *ldh,
+                             doublecomplex *w, integer *iloz, integer *ihiz, doublecomplex *z__,
+                             integer *ldz, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zlaqr5_(logical *wantt, logical *wantz, integer *kacc22,
+                             integer *n, integer *ktop, integer *kbot, integer *nshfts,
+                             doublecomplex *s, doublecomplex *h__, integer *ldh, integer *iloz,
+                             integer *ihiz, doublecomplex *z__, integer *ldz, doublecomplex *v,
+                             integer *ldv, doublecomplex *u, integer *ldu, integer *nv,
+                             doublecomplex *wv, integer *ldwv, integer *nh, doublecomplex *wh,
+                             integer *ldwh);
+
+/* Subroutine */ int zlaqsb_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqsp_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, char *equed);
+
+/* Subroutine */ int zlaqsy_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                             char *equed);
+
+/* Subroutine */ int zlar1v_(integer *n, integer *b1, integer *bn,
+                             doublereal *lambda, doublereal *d__, doublereal *l, doublereal *ld,
+                             doublereal *lld, doublereal *pivmin, doublereal *gaptol,
+                             doublecomplex *z__, logical *wantnc, integer *negcnt, doublereal *ztz,
+                             doublereal *mingma, integer *r__, integer *isuppz, doublereal *nrminv,
+                             doublereal *resid, doublereal *rqcorr, doublereal *work);
+
+/* Subroutine */ int zlar2v_(integer *n, doublecomplex *x, doublecomplex *y,
+                             doublecomplex *z__, integer *incx, doublereal *c__, doublecomplex *s,
+                             integer *incc);
+
+/* Subroutine */ int zlarcm_(integer *m, integer *n, doublereal *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublecomplex *c__,
+                             integer *ldc, doublereal *rwork);
+
+/* Subroutine */ int zlarf_(char *side, integer *m, integer *n,
+                            doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
+                            integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlarfb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, doublecomplex *v,
+                             integer *ldv, doublecomplex *t, integer *ldt, doublecomplex *c__,
+                             integer *ldc, doublecomplex *work, integer *ldwork);
+
+/* Subroutine */ int zlarfg_(integer *n, doublecomplex *alpha,
+                             doublecomplex *x, integer *incx, doublecomplex *tau);
+
+/* Subroutine */ int zlarfp_(integer *n, doublecomplex *alpha,
+                             doublecomplex *x, integer *incx, doublecomplex *tau);
+
+/* Subroutine */ int zlarft_(char *direct, char *storev, integer *n,
+                             integer *k, doublecomplex *v, integer *ldv, doublecomplex *tau,
+                             doublecomplex *t, integer *ldt);
+
+/* Subroutine */ int zlarfx_(char *side, integer *m, integer *n,
+                             doublecomplex *v, doublecomplex *tau, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work);
+
+/* Subroutine */ int zlargv_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *c__, integer *incc);
+
+/* Subroutine */ int zlarnv_(integer *idist, integer *iseed, integer *n,
+                             doublecomplex *x);
+
+/* Subroutine */ int zlarrv_(integer *n, doublereal *vl, doublereal *vu,
+                             doublereal *d__, doublereal *l, doublereal *pivmin, integer *isplit,
+                             integer *m, integer *dol, integer *dou, doublereal *minrgp,
+                             doublereal *rtol1, doublereal *rtol2, doublereal *w, doublereal *werr,
+                             doublereal *wgap, integer *iblock, integer *indexw, doublereal *gers,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *iwork, integer *info);
+
+/* Subroutine */ int zlarscl2_(integer *m, integer *n, doublereal *d__,
+                               doublecomplex *x, integer *ldx);
+
+/* Subroutine */ int zlartg_(doublecomplex *f, doublecomplex *g,
+                             doublereal *cs, doublecomplex *sn, doublecomplex *r__);
+
+/* Subroutine */ int zlartv_(integer *n, doublecomplex *x, integer *incx,
+                             doublecomplex *y, integer *incy, doublereal *c__, doublecomplex *s,
+                             integer *incc);
+
+/* Subroutine */ int zlarz_(char *side, integer *m, integer *n, integer *l,
+                            doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c__,
+                            integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlarzb_(char *side, char *trans, char *direct,
+                             char *storev, integer *m, integer *n, integer *k, integer *l,
+                             doublecomplex *v, integer *ldv, doublecomplex *t, integer *ldt,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *ldwork);
+
+/* Subroutine */ int zlarzt_(char *direct, char *storev, integer *n,
+                             integer *k, doublecomplex *v, integer *ldv, doublecomplex *tau,
+                             doublecomplex *t, integer *ldt);
+
+/* Subroutine */ int zlascl_(char *type__, integer *kl, integer *ku,
+                             doublereal *cfrom, doublereal *cto, integer *m, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int zlascl2_(integer *m, integer *n, doublereal *d__,
+                              doublecomplex *x, integer *ldx);
+
+/* Subroutine */ int zlaset_(char *uplo, integer *m, integer *n,
+                             doublecomplex *alpha, doublecomplex *beta, doublecomplex *a,
+                             integer *lda);
+
+/* Subroutine */ int zlasr_(char *side, char *pivot, char *direct, integer *m,
+                            integer *n, doublereal *c__, doublereal *s, doublecomplex *a,
+                            integer *lda);
+
+/* Subroutine */ int zlassq_(integer *n, doublecomplex *x, integer *incx,
+                             doublereal *scale, doublereal *sumsq);
+
+/* Subroutine */ int zlaswp_(integer *n, doublecomplex *a, integer *lda,
+                             integer *k1, integer *k2, integer *ipiv, integer *incx);
+
+/* Subroutine */ int zlasyf_(char *uplo, integer *n, integer *nb, integer *kb,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *w,
+                             integer *ldw, integer *info);
+
+/* Subroutine */ int zlat2c_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, complex *sa, integer *ldsa, integer *info);
+
+/* Subroutine */ int zlatbs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, integer *kd, doublecomplex *ab, integer *ldab,
+                             doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatdf_(integer *ijob, integer *n, doublecomplex *z__,
+                             integer *ldz, doublecomplex *rhs, doublereal *rdsum, doublereal *rdscal,
+                             integer *ipiv, integer *jpiv);
+
+/* Subroutine */ int zlatps_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublecomplex *ap, doublecomplex *x,
+                             doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatrd_(char *uplo, integer *n, integer *nb,
+                             doublecomplex *a, integer *lda, doublereal *e, doublecomplex *tau,
+                             doublecomplex *w, integer *ldw);
+
+/* Subroutine */ int zlatrs_(char *uplo, char *trans, char *diag,
+                             char *normin, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *x, doublereal *scale, doublereal *cnorm, integer *info);
+
+/* Subroutine */ int zlatrz_(integer *m, integer *n, integer *l,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work);
+
+/* Subroutine */ int zlatzm_(char *side, integer *m, integer *n,
+                             doublecomplex *v, integer *incv, doublecomplex *tau, doublecomplex *c1,
+                             doublecomplex *c2, integer *ldc, doublecomplex *work);
+
+/* Subroutine */ int zlauu2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zlauum_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpbcon_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbequ_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, doublereal *s, doublereal *scond,
+                             doublereal *amax, integer *info);
+
+/* Subroutine */ int zpbrfs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                             integer *ldafb, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbstf_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbsv_(char *uplo, integer *n, integer *kd,
+                            integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
+                            integer *ldb, integer *info);
+
+/* Subroutine */ int zpbsvx_(char *fact, char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *afb,
+                             integer *ldafb, char *equed, doublereal *s, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpbtf2_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbtrf_(char *uplo, integer *n, integer *kd,
+                             doublecomplex *ab, integer *ldab, integer *info);
+
+/* Subroutine */ int zpbtrs_(char *uplo, integer *n, integer *kd,
+                             integer *nrhs, doublecomplex *ab, integer *ldab, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int zpftrf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int zpftri_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int zpftrs_(char *transr, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zpocon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpoequ_(integer *n, doublecomplex *a, integer *lda,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zpoequb_(integer *n, doublecomplex *a, integer *lda,
+                              doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zporfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zporfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, doublereal *s, doublecomplex *b, integer *ldb,
+                              doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zposv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zposvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, char *equed, doublereal *s, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zposvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, char *equed, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *rpvgrw, doublereal *berr, integer *n_err_bnds__,
+                              doublereal *err_bnds_norm__, doublereal *err_bnds_comp__,
+                              integer *nparams, doublereal *params, doublecomplex *work,
+                              doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpotf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *info);
+
+/* Subroutine */ int zpotrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zppcon_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zppequ_(char *uplo, integer *n, doublecomplex *ap,
+                             doublereal *s, doublereal *scond, doublereal *amax, integer *info);
+
+/* Subroutine */ int zpprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zppsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zppsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, char *equed,
+                             doublereal *s, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *info);
+
+/* Subroutine */ int zpptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *info);
+
+/* Subroutine */ int zpptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zpstf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int zpstrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *piv, integer *rank, doublereal *tol,
+                             doublereal *work, integer *info);
+
+/* Subroutine */ int zptcon_(integer *n, doublereal *d__, doublecomplex *e,
+                             doublereal *anorm, doublereal *rcond, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int zptrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zptsv_(integer *n, integer *nrhs, doublereal *d__,
+                            doublecomplex *e, doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int zptsvx_(char *fact, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublereal *df, doublecomplex *ef,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zpttrf_(integer *n, doublereal *d__, doublecomplex *e,
+                             integer *info);
+
+/* Subroutine */ int zpttrs_(char *uplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zptts2_(integer *iuplo, integer *n, integer *nrhs,
+                             doublereal *d__, doublecomplex *e, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int zrot_(integer *n, doublecomplex *cx, integer *incx,
+                           doublecomplex *cy, integer *incy, doublereal *c__, doublecomplex *s);
+
+/* Subroutine */ int zspcon_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublereal *anorm, doublereal *rcond, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zspmv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta,
+                            doublecomplex *y, integer *incy);
+
+/* Subroutine */ int zspr_(char *uplo, integer *n, doublecomplex *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *ap);
+
+/* Subroutine */ int zsprfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, doublecomplex *afp, integer *ipiv, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zspsv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                            integer *info);
+
+/* Subroutine */ int zspsvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *afp, integer *ipiv,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *rcond, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsptrf_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, integer *info);
+
+/* Subroutine */ int zsptri_(char *uplo, integer *n, doublecomplex *ap,
+                             integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsptrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *ap, integer *ipiv, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int zstedc_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublecomplex *work,
+                             integer *lwork, doublereal *rwork, integer *lrwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int zstegr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, doublereal *abstol, integer *m, doublereal *w,
+                             doublecomplex *z__, integer *ldz, integer *isuppz, doublereal *work,
+                             integer *lwork, integer *iwork, integer *liwork, integer *info);
+
+/* Subroutine */ int zstein_(integer *n, doublereal *d__, doublereal *e,
+                             integer *m, doublereal *w, integer *iblock, integer *isplit,
+                             doublecomplex *z__, integer *ldz, doublereal *work, integer *iwork,
+                             integer *ifail, integer *info);
+
+/* Subroutine */ int zstemr_(char *jobz, char *range, integer *n,
+                             doublereal *d__, doublereal *e, doublereal *vl, doublereal *vu,
+                             integer *il, integer *iu, integer *m, doublereal *w, doublecomplex *z__,
+                             integer *ldz, integer *nzc, integer *isuppz, logical *tryrac,
+                             doublereal *work, integer *lwork, integer *iwork, integer *liwork,
+                             integer *info);
+
+/* Subroutine */ int zsteqr_(char *compz, integer *n, doublereal *d__,
+                             doublereal *e, doublecomplex *z__, integer *ldz, doublereal *work,
+                             integer *info);
+
+/* Subroutine */ int zsycon_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublereal *anorm, doublereal *rcond,
+                             doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsyequb_(char *uplo, integer *n, doublecomplex *a,
+                              integer *lda, doublereal *s, doublereal *scond, doublereal *amax,
+                              doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsymv_(char *uplo, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, integer *lda, doublecomplex *x, integer *incx,
+                            doublecomplex *beta, doublecomplex *y, integer *incy);
+
+/* Subroutine */ int zsyr_(char *uplo, integer *n, doublecomplex *alpha,
+                           doublecomplex *x, integer *incx, doublecomplex *a, integer *lda);
+
+/* Subroutine */ int zsyrfs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, doublecomplex *af, integer *ldaf,
+                             integer *ipiv, doublecomplex *b, integer *ldb, doublecomplex *x,
+                             integer *ldx, doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsyrfsx_(char *uplo, char *equed, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, doublereal *s, doublecomplex *b,
+                              integer *ldb, doublecomplex *x, integer *ldx, doublereal *rcond,
+                              doublereal *berr, integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsysv_(char *uplo, integer *n, integer *nrhs,
+                            doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                            integer *ldb, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zsysvx_(char *fact, char *uplo, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                             integer *ldaf, integer *ipiv, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *rcond, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, integer *lwork, doublereal *rwork,
+                             integer *info);
+
+/* Subroutine */ int zsysvxx_(char *fact, char *uplo, integer *n,
+                              integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *af,
+                              integer *ldaf, integer *ipiv, char *equed, doublereal *s,
+                              doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                              doublereal *rcond, doublereal *rpvgrw, doublereal *berr,
+                              integer *n_err_bnds__, doublereal *err_bnds_norm__,
+                              doublereal *err_bnds_comp__, integer *nparams, doublereal *params,
+                              doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int zsytf2_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, integer *info);
+
+/* Subroutine */ int zsytrf_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zsytri_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, integer *ipiv, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zsytrs_(char *uplo, integer *n, integer *nrhs,
+                             doublecomplex *a, integer *lda, integer *ipiv, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int ztbcon_(char *norm, char *uplo, char *diag, integer *n,
+                             integer *kd, doublecomplex *ab, integer *ldab, doublereal *rcond,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztbrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *b, integer *ldb, doublecomplex *x, integer *ldx,
+                             doublereal *ferr, doublereal *berr, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztbtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *kd, integer *nrhs, doublecomplex *ab, integer *ldab,
+                             doublecomplex *b, integer *ldb, integer *info);
+
+/* Subroutine */ int ztfsm_(char *transr, char *side, char *uplo, char *trans,
+                            char *diag, integer *m, integer *n, doublecomplex *alpha,
+                            doublecomplex *a, doublecomplex *b, integer *ldb);
+
+/* Subroutine */ int ztftri_(char *transr, char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *info);
+
+/* Subroutine */ int ztfttp_(char *transr, char *uplo, integer *n,
+                             doublecomplex *arf, doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztfttr_(char *transr, char *uplo, integer *n,
+                             doublecomplex *arf, doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztgevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublecomplex *s, integer *lds, doublecomplex *p,
+                             integer *ldp, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, integer *mm, integer *m, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztgex2_(logical *wantq, logical *wantz, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
+                             integer *j1, integer *info);
+
+/* Subroutine */ int ztgexc_(logical *wantq, logical *wantz, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *b, integer *ldb,
+                             doublecomplex *q, integer *ldq, doublecomplex *z__, integer *ldz,
+                             integer *ifst, integer *ilst, integer *info);
+
+/* Subroutine */ int ztgsen_(integer *ijob, logical *wantq, logical *wantz,
+                             logical *select, integer *n, doublecomplex *a, integer *lda,
+                             doublecomplex *b, integer *ldb, doublecomplex *alpha,
+                             doublecomplex *beta, doublecomplex *q, integer *ldq, doublecomplex *z__,
+                             integer *ldz, integer *m, doublereal *pl, doublereal *pr,
+                             doublereal *dif, doublecomplex *work, integer *lwork, integer *iwork,
+                             integer *liwork, integer *info);
+
+/* Subroutine */ int ztgsja_(char *jobu, char *jobv, char *jobq, integer *m,
+                             integer *p, integer *n, integer *k, integer *l, doublecomplex *a,
+                             integer *lda, doublecomplex *b, integer *ldb, doublereal *tola,
+                             doublereal *tolb, doublereal *alpha, doublereal *beta, doublecomplex *u,
+                             integer *ldu, doublecomplex *v, integer *ldv, doublecomplex *q,
+                             integer *ldq, doublecomplex *work, integer *ncycle, integer *info);
+
+/* Subroutine */ int ztgsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *vl, integer *ldvl, doublecomplex *vr,
+                             integer *ldvr, doublereal *s, doublereal *dif, integer *mm, integer *m,
+                             doublecomplex *work, integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int ztgsy2_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
+                             integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
+                             integer *ldf, doublereal *scale, doublereal *rdsum, doublereal *rdscal,
+                             integer *info);
+
+/* Subroutine */ int ztgsyl_(char *trans, integer *ijob, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublecomplex *d__,
+                             integer *ldd, doublecomplex *e, integer *lde, doublecomplex *f,
+                             integer *ldf, doublereal *scale, doublereal *dif, doublecomplex *work,
+                             integer *lwork, integer *iwork, integer *info);
+
+/* Subroutine */ int ztpcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublecomplex *ap, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztprfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
+                             doublecomplex *x, integer *ldx, doublereal *ferr, doublereal *berr,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztptri_(char *uplo, char *diag, integer *n,
+                             doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztptrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *ap, doublecomplex *b, integer *ldb,
+                             integer *info);
+
+/* Subroutine */ int ztpttf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *ap, doublecomplex *arf, integer *info);
+
+/* Subroutine */ int ztpttr_(char *uplo, integer *n, doublecomplex *ap,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrcon_(char *norm, char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, doublereal *rcond, doublecomplex *work,
+                             doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrevc_(char *side, char *howmny, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
+                             integer *ldvl, doublecomplex *vr, integer *ldvr, integer *mm, integer *m,
+                             doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrexc_(char *compq, integer *n, doublecomplex *t,
+                             integer *ldt, doublecomplex *q, integer *ldq, integer *ifst,
+                             integer *ilst, integer *info);
+
+/* Subroutine */ int ztrrfs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *x, integer *ldx, doublereal *ferr,
+                             doublereal *berr, doublecomplex *work, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrsen_(char *job, char *compq, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *q,
+                             integer *ldq, doublecomplex *w, integer *m, doublereal *s,
+                             doublereal *sep, doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int ztrsna_(char *job, char *howmny, logical *select,
+                             integer *n, doublecomplex *t, integer *ldt, doublecomplex *vl,
+                             integer *ldvl, doublecomplex *vr, integer *ldvr, doublereal *s,
+                             doublereal *sep, integer *mm, integer *m, doublecomplex *work,
+                             integer *ldwork, doublereal *rwork, integer *info);
+
+/* Subroutine */ int ztrsyl_(char *trana, char *tranb, integer *isgn,
+                             integer *m, integer *n, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, doublecomplex *c__, integer *ldc, doublereal *scale,
+                             integer *info);
+
+/* Subroutine */ int ztrti2_(char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrtri_(char *uplo, char *diag, integer *n,
+                             doublecomplex *a, integer *lda, integer *info);
+
+/* Subroutine */ int ztrtrs_(char *uplo, char *trans, char *diag, integer *n,
+                             integer *nrhs, doublecomplex *a, integer *lda, doublecomplex *b,
+                             integer *ldb, integer *info);
+
+/* Subroutine */ int ztrttf_(char *transr, char *uplo, integer *n,
+                             doublecomplex *a, integer *lda, doublecomplex *arf, integer *info);
+
+/* Subroutine */ int ztrttp_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *ap, integer *info);
+
+/* Subroutine */ int ztzrqf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, integer *info);
+
+/* Subroutine */ int ztzrzf_(integer *m, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zung2l_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zung2r_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zungbr_(char *vect, integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunghr_(integer *n, integer *ilo, integer *ihi,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungl2_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zunglq_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungql_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungqr_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungr2_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zungrq_(integer *m, integer *n, integer *k,
+                             doublecomplex *a, integer *lda, doublecomplex *tau, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zungtr_(char *uplo, integer *n, doublecomplex *a,
+                             integer *lda, doublecomplex *tau, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunm2l_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunm2r_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmbr_(char *vect, char *side, char *trans, integer *m,
+                             integer *n, integer *k, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunmhr_(char *side, char *trans, integer *m, integer *n,
+                             integer *ilo, integer *ihi, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc,
+                             doublecomplex *work, integer *lwork, integer *info);
+
+/* Subroutine */ int zunml2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmlq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmql_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmqr_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmr2_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int zunmr3_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zunmrq_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zunmrz_(char *side, char *trans, integer *m, integer *n,
+                             integer *k, integer *l, doublecomplex *a, integer *lda,
+                             doublecomplex *tau, doublecomplex *c__, integer *ldc, doublecomplex *work,
+                             integer *lwork, integer *info);
+
+/* Subroutine */ int zunmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublecomplex *a, integer *lda, doublecomplex *tau,
+                             doublecomplex *c__, integer *ldc, doublecomplex *work, integer *lwork,
+                             integer *info);
+
+/* Subroutine */ int zupgtr_(char *uplo, integer *n, doublecomplex *ap,
+                             doublecomplex *tau, doublecomplex *q, integer *ldq, doublecomplex *work,
+                             integer *info);
+
+/* Subroutine */ int zupmtr_(char *side, char *uplo, char *trans, integer *m,
+                             integer *n, doublecomplex *ap, doublecomplex *tau, doublecomplex *c__,
+                             integer *ldc, doublecomplex *work, integer *info);
+
+/* Subroutine */ int dlamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+doublereal dsecnd_();
+
+/* Subroutine */ int ilaver_(integer *vers_major__, integer *vers_minor__,
+                             integer *vers_patch__);
+
+logical lsame_(char *ca, char *cb);
+
+doublereal second_();
+
+doublereal slamch_(char *cmach);
+
+/* Subroutine */ int slamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+/* Subroutine */ int slamc2_(integer *beta, integer *t, logical *rnd,
+                             real *eps, integer *emin, real *rmin, integer *emax, real *rmax);
+
+doublereal slamc3_(real *a, real *b);
+
+/* Subroutine */ int slamc4_(integer *emin, real *start, integer *base);
+
+/* Subroutine */ int slamc5_(integer *beta, integer *p, integer *emin,
+                             logical *ieee, integer *emax, real *rmax);
+
+doublereal dlamch_(char *cmach);
+
+/* Subroutine */ int dlamc1_(integer *beta, integer *t, logical *rnd,
+                             logical *ieee1);
+
+/* Subroutine */ int dlamc2_(integer *beta, integer *t, logical *rnd,
+                             doublereal *eps, integer *emin, doublereal *rmin, integer *emax,
+                             doublereal *rmax);
+
+doublereal dlamc3_(doublereal *a, doublereal *b);
+
+/* Subroutine */ int dlamc4_(integer *emin, doublereal *start, integer *base);
+
+/* Subroutine */ int dlamc5_(integer *beta, integer *p, integer *emin,
+                             logical *ieee, integer *emax, doublereal *rmax);
+
+integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
+                integer *n2, integer *n3, integer *n4);
 
 #ifdef __cplusplus
 }

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -34,46 +34,46 @@
 #ifndef EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLBASESTATESPACE_H_
 #define EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLBASESTATESPACE_H_
 
-#include <ompl/base/StateSpace.h>
-#include "exotica/Problems/SamplingProblem.h"
-#include <ompl/base/StateValidityChecker.h>
-#include <ompl/base/SpaceInformation.h>
 #include <ompl/base/ProjectionEvaluator.h>
+#include <ompl/base/SpaceInformation.h>
+#include <ompl/base/StateSpace.h>
+#include <ompl/base/StateValidityChecker.h>
 #include <ompl_solver/OMPLsolverInitializer.h>
+#include "exotica/Problems/SamplingProblem.h"
 
 namespace ob = ompl::base;
 namespace exotica
 {
+class OMPLBaseStateSpace : public ompl::base::CompoundStateSpace
+{
+public:
+    OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
 
-  class OMPLBaseStateSpace: public ompl::base::CompoundStateSpace
-  {
-    public:
-      OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
+    virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
+                                    ompl::base::State *state) const = 0;
+    virtual void OMPLToExoticaState(const ompl::base::State *state,
+                                    Eigen::VectorXd &q) const = 0;
 
-      virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
-          ompl::base::State *state) const = 0;
-      virtual void OMPLToExoticaState(const ompl::base::State *state,
-          Eigen::VectorXd &q) const = 0;
+    virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const = 0;
+    virtual void stateDebug(const Eigen::VectorXd &q) const = 0;
 
-      virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const = 0;
-      virtual void stateDebug(const Eigen::VectorXd &q) const = 0;
-    protected:
-      SamplingProblem_ptr prob_;
-  };
+protected:
+    SamplingProblem_ptr prob_;
+};
 
-  class OMPLStateValidityChecker: public ompl::base::StateValidityChecker
-  {
-    public:
-      OMPLStateValidityChecker(const ob::SpaceInformationPtr &si,
-          const SamplingProblem_ptr &prob, OMPLsolverInitializer init);
+class OMPLStateValidityChecker : public ompl::base::StateValidityChecker
+{
+public:
+    OMPLStateValidityChecker(const ob::SpaceInformationPtr &si,
+                             const SamplingProblem_ptr &prob, OMPLsolverInitializer init);
 
-      virtual bool isValid(const ompl::base::State *state) const;
+    virtual bool isValid(const ompl::base::State *state) const;
 
-      virtual bool isValid(const ompl::base::State *state, double &dist) const;
+    virtual bool isValid(const ompl::base::State *state, double &dist) const;
 
-    protected:
-      SamplingProblem_ptr prob_;
-  };
+protected:
+    SamplingProblem_ptr prob_;
+};
 
 } /* namespace exotica */
 

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
@@ -34,87 +34,89 @@
 #ifndef EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLIMPSOLVER_H_
 #define EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLIMPSOLVER_H_
 
-#include "ompl_solver/OMPLBaseSolver.h"
+#include <exotica/Property.h>
+#include <pluginlib/class_loader.h>
 #include "ompl_imp_solver/OMPLRNStateSpace.h"
 #include "ompl_imp_solver/OMPLSE3RNStateSpace.h"
-#include <pluginlib/class_loader.h>
-#include <exotica/Property.h>
+#include "ompl_solver/OMPLBaseSolver.h"
 
 namespace exotica
 {
-  /*
+/*
    * The implementation of basic EXOTica-OMPL solver
    */
-  class OMPLImpSolver: public OMPLBaseSolver
-  {
-    public:
-      /*
+class OMPLImpSolver : public OMPLBaseSolver
+{
+public:
+    /*
        * \brief Default constructor
        */
-      OMPLImpSolver();
+    OMPLImpSolver();
 
-      virtual void initialiseSolver(Initializer& init);
+    virtual void initialiseSolver(Initializer &init);
 
-      /*
+    /*
        * \brief Solve function
        * @param x0      start configuration
        * @param sol     Solution
        */
-      virtual bool solve(Eigen::VectorXdRefConst x0, Eigen::MatrixXd &sol);
+    virtual bool solve(Eigen::VectorXdRefConst x0, Eigen::MatrixXd &sol);
 
-      /*
+    /*
        * \brief Set goal state to the sampled state space
        * @param qT      Goal state in sampled state space
        * @param eps     Numerical tolerance
        */
-      virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon());
+    virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon());
 
-      /*
+    /*
        * \brief Get the planner's name
        * @return  Planner's name
        */
-      virtual std::string getPlannerName();
+    virtual std::string getPlannerName();
 
-      /*
+    /*
        * \brief Assign exotica problem to this solver
        * @param prob    EXOTica Planning Problem pointer
        */
-      virtual void specifyProblem(const SamplingProblem_ptr &prob);
-    protected:
-      /*
+    virtual void specifyProblem(const SamplingProblem_ptr &prob);
+
+protected:
+    /*
        * \brief Register default ompl planning algorithms
        */
-      virtual void registerDefaultPlanners();
+    virtual void registerDefaultPlanners();
 
-      /*
+    /*
        * \brief Allocate state space sampler
        */
-      ompl::base::StateSamplerPtr allocStateSampler(const ompl::base::StateSpace *ss);
+    ompl::base::StateSamplerPtr allocStateSampler(const ompl::base::StateSpace *ss);
 
-      /*
+    /*
        * \biref Converts OMPL trajectory into Eigen Matrix
        * @param pg      OMPL trajectory
        * @param traj    Eigen Matrix trajectory
        */
-      virtual void convertPath(const og::PathGeometric &pg, Eigen::MatrixXd & traj);
+    virtual void convertPath(const og::PathGeometric &pg, Eigen::MatrixXd &traj);
 
-      /*
+    /*
        * \brief Simplifying the trajectory
        * @param pg      OMPL geometric path
        * @param
        */
-      virtual void getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd & traj, ob::PlannerTerminationCondition &ptc);
-      virtual ompl::base::GoalPtr constructGoal();
-      std::string algorithm_;
-      std::string range_;
-      std::string object_name_;
-      Eigen::VectorXd qT_;
-      int min_traj_length_;
+    virtual void getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd &traj, ob::PlannerTerminationCondition &ptc);
+    virtual ompl::base::GoalPtr constructGoal();
+    std::string algorithm_;
+    std::string range_;
+    std::string object_name_;
+    Eigen::VectorXd qT_;
+    int min_traj_length_;
 
-      OMPLsolverInitializer init_;
-    private:
-      BASE_TYPE BaseType;
-  };
+    OMPLsolverInitializer init_;
+
+private:
+    BASE_TYPE BaseType;
+};
 }
 
 #endif /* EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLIMPSOLVER_H_ */

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLRNStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLRNStateSpace.h
@@ -34,81 +34,79 @@
 #ifndef EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLRNSTATESPACE_H_
 #define EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLRNSTATESPACE_H_
 
-#include "ompl_imp_solver/OMPLBaseStateSpace.h"
-#include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/base/SpaceInformation.h>
+#include <ompl/base/spaces/RealVectorStateSpace.h>
+#include "ompl_imp_solver/OMPLBaseStateSpace.h"
 
 namespace exotica
 {
-  class OMPLRNStateSpace: public OMPLBaseStateSpace
-  {
+class OMPLRNStateSpace : public OMPLBaseStateSpace
+{
+public:
+    class StateType : public ob::CompoundStateSpace::StateType
+    {
     public:
-      class StateType: public ob::CompoundStateSpace::StateType
-      {
-        public:
-          StateType()
-              : CompoundStateSpace::StateType()
-          {
+        StateType()
+            : CompoundStateSpace::StateType()
+        {
+        }
 
-          }
-
-          const ob::RealVectorStateSpace::StateType & getRNSpace() const
-          {
+        const ob::RealVectorStateSpace::StateType &getRNSpace() const
+        {
             return *as<ob::RealVectorStateSpace::StateType>(0);
-          }
+        }
 
-          ob::RealVectorStateSpace::StateType & getRNSpace()
-          {
+        ob::RealVectorStateSpace::StateType &getRNSpace()
+        {
             return *as<ob::RealVectorStateSpace::StateType>(0);
-          }
-      };
-      OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
+        }
+    };
+    OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
 
-      virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
-      virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
-          ompl::base::State *state) const;
-      virtual void OMPLToExoticaState(const ompl::base::State *state,
-          Eigen::VectorXd &q) const;
-      virtual void stateDebug(const Eigen::VectorXd &q) const;
-  };
+    virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
+    virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
+                                    ompl::base::State *state) const;
+    virtual void OMPLToExoticaState(const ompl::base::State *state,
+                                    Eigen::VectorXd &q) const;
+    virtual void stateDebug(const Eigen::VectorXd &q) const;
+};
 
-  class OMPLRNProjection: public ompl::base::ProjectionEvaluator
-  {
-    public:
-      OMPLRNProjection(const ompl::base::StateSpacePtr &space,
-          const std::vector<int> & vars)
-          : ompl::base::ProjectionEvaluator(space), variables_(vars)
-      {
+class OMPLRNProjection : public ompl::base::ProjectionEvaluator
+{
+public:
+    OMPLRNProjection(const ompl::base::StateSpacePtr &space,
+                     const std::vector<int> &vars)
+        : ompl::base::ProjectionEvaluator(space), variables_(vars)
+    {
+    }
 
-      }
-
-      ~OMPLRNProjection()
-      {
+    ~OMPLRNProjection()
+    {
         //TODO
-      }
+    }
 
-      virtual unsigned int getDimension(void) const
-      {
+    virtual unsigned int getDimension(void) const
+    {
         return variables_.size();
-      }
+    }
 
-      virtual void defaultCellSizes()
-      {
+    virtual void defaultCellSizes()
+    {
         cellSizes_.clear();
         cellSizes_.resize(variables_.size(), 0.1);
-      }
+    }
 
-      virtual void project(const ompl::base::State *state,
-          ompl::base::EuclideanProjection &projection) const
-      {
+    virtual void project(const ompl::base::State *state,
+                         ompl::base::EuclideanProjection &projection) const
+    {
         for (std::size_t i = 0; i < variables_.size(); ++i)
-          projection(i) =
-              state->as<exotica::OMPLRNStateSpace::StateType>()->getRNSpace().values[variables_[i]];
-      }
+            projection(i) =
+                state->as<exotica::OMPLRNStateSpace::StateType>()->getRNSpace().values[variables_[i]];
+    }
 
-    private:
-      std::vector<int> variables_;
-  };
+private:
+    std::vector<int> variables_;
+};
 }
 
 #endif /* EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLRNSTATESPACE_H_ */

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLSE3RNStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLSE3RNStateSpace.h
@@ -34,136 +34,135 @@
 #ifndef EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLSE3RNSTATESPACE_H_
 #define EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLSE3RNSTATESPACE_H_
 
-#include "ompl_imp_solver/OMPLBaseStateSpace.h"
 #include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/base/spaces/SE3StateSpace.h>
 #include <ompl_solver/OMPLsolverInitializer.h>
+#include "ompl_imp_solver/OMPLBaseStateSpace.h"
 
 namespace exotica
 {
-  class OMPLSE3RNStateSpace: public OMPLBaseStateSpace
-  {
+class OMPLSE3RNStateSpace : public OMPLBaseStateSpace
+{
+public:
+    class StateType : public ob::CompoundStateSpace::StateType
+    {
     public:
-      class StateType: public ob::CompoundStateSpace::StateType
-      {
-        public:
-          StateType()
-              : CompoundStateSpace::StateType()
-          {
+        StateType()
+            : CompoundStateSpace::StateType()
+        {
+        }
 
-          }
-
-          const ob::RealVectorStateSpace::StateType & RealVectorStateSpace() const
-          {
+        const ob::RealVectorStateSpace::StateType &RealVectorStateSpace() const
+        {
             return *as<ob::RealVectorStateSpace::StateType>(1);
-          }
+        }
 
-          ob::RealVectorStateSpace::StateType & RealVectorStateSpace()
-          {
+        ob::RealVectorStateSpace::StateType &RealVectorStateSpace()
+        {
             return *as<ob::RealVectorStateSpace::StateType>(1);
-          }
+        }
 
-          const ob::SE3StateSpace::StateType & SE3StateSpace() const
-          {
+        const ob::SE3StateSpace::StateType &SE3StateSpace() const
+        {
             return *as<ob::SE3StateSpace::StateType>(0);
-          }
-          ob::SE3StateSpace::StateType & SE3StateSpace()
-          {
+        }
+        ob::SE3StateSpace::StateType &SE3StateSpace()
+        {
             return *as<ob::SE3StateSpace::StateType>(0);
-          }
-      };
+        }
+    };
 
-      OMPLSE3RNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
-      virtual unsigned int getDimension() const;
-      virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
-      virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
-          ompl::base::State *state) const;
-      virtual void OMPLToExoticaState(const ompl::base::State *state,
-          Eigen::VectorXd &q) const;
-      virtual void stateDebug(const Eigen::VectorXd &q) const;
-      /*
+    OMPLSE3RNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init);
+    virtual unsigned int getDimension() const;
+    virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
+    virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
+                                    ompl::base::State *state) const;
+    virtual void OMPLToExoticaState(const ompl::base::State *state,
+                                    Eigen::VectorXd &q) const;
+    virtual void stateDebug(const Eigen::VectorXd &q) const;
+    /*
        * \brief	Set the bounds for upper body configuration
        * @param	bounds		Real vector bounds for upper body
        */
-      void setRealVectorStateSpaceBounds(const ob::RealVectorBounds &bounds);
-      const ob::RealVectorBounds & getRealVectorStateSpaceBounds() const;
+    void setRealVectorStateSpaceBounds(const ob::RealVectorBounds &bounds);
+    const ob::RealVectorBounds &getRealVectorStateSpaceBounds() const;
 
-      /*
+    /*
        * \brief	Set the bounds for pelvis
        * @param	xyz			Pelvis XYZ position bounds
        * @param	dist		Pelvis maximum allowed angle from z-axis
        */
-      void setSE3StateSpaceBounds(const ob::RealVectorBounds &xyz, double dist =
-          0);
-      const ob::RealVectorBounds & getSE3StateSpaceBounds() const;
-      const double getSE3StateSpaceRobotationBound() const;
-      void setStart(const Eigen::VectorXd &start);
-      void setGoal(const Eigen::VectorXd &goal);
-      Eigen::VectorXd start_;
-      Eigen::VectorXd goal_;
-      double base_dist_;
-      Eigen::VectorXd weights_;
-      double rn_bias_percentage_;
-      ob::RealVectorBounds SO3Bounds_;
-      bool useGoal_;
-    private:
-      int realvectordim_;
-  };
+    void setSE3StateSpaceBounds(const ob::RealVectorBounds &xyz, double dist =
+                                                                     0);
+    const ob::RealVectorBounds &getSE3StateSpaceBounds() const;
+    const double getSE3StateSpaceRobotationBound() const;
+    void setStart(const Eigen::VectorXd &start);
+    void setGoal(const Eigen::VectorXd &goal);
+    Eigen::VectorXd start_;
+    Eigen::VectorXd goal_;
+    double base_dist_;
+    Eigen::VectorXd weights_;
+    double rn_bias_percentage_;
+    ob::RealVectorBounds SO3Bounds_;
+    bool useGoal_;
 
-  class OMPLSE3RNStateSampler: public ob::StateSampler
-  {
-    public:
-      OMPLSE3RNStateSampler(const ob::StateSpace *space)
-          : ob::StateSampler(space)
-      {
+private:
+    int realvectordim_;
+};
+
+class OMPLSE3RNStateSampler : public ob::StateSampler
+{
+public:
+    OMPLSE3RNStateSampler(const ob::StateSpace *space)
+        : ob::StateSampler(space)
+    {
         weightImportance_ = space->as<OMPLSE3RNStateSpace>()->weights_;
-        weightImportance_ = weightImportance_/weightImportance_.sum();
-      }
-      virtual void sampleUniform(ob::State *state);
-      virtual void sampleUniformNear(ob::State *state, const ob::State *near,
-          const double distance);
-      virtual void sampleGaussian(ob::State *state, const ob::State * mean,
-          const double stdDev);
-      Eigen::VectorXd weightImportance_;
-  };
+        weightImportance_ = weightImportance_ / weightImportance_.sum();
+    }
+    virtual void sampleUniform(ob::State *state);
+    virtual void sampleUniformNear(ob::State *state, const ob::State *near,
+                                   const double distance);
+    virtual void sampleGaussian(ob::State *state, const ob::State *mean,
+                                const double stdDev);
+    Eigen::VectorXd weightImportance_;
+};
 
-  class OMPLSE3RNProjection: public ompl::base::ProjectionEvaluator
-  {
-    public:
-      OMPLSE3RNProjection(const ompl::base::StateSpacePtr &space,
-          const std::vector<int> & vars)
-          : ompl::base::ProjectionEvaluator(space), variables_(vars)
-      {
+class OMPLSE3RNProjection : public ompl::base::ProjectionEvaluator
+{
+public:
+    OMPLSE3RNProjection(const ompl::base::StateSpacePtr &space,
+                        const std::vector<int> &vars)
+        : ompl::base::ProjectionEvaluator(space), variables_(vars)
+    {
+    }
 
-      }
-
-      ~OMPLSE3RNProjection()
-      {
+    ~OMPLSE3RNProjection()
+    {
         //TODO
-      }
+    }
 
-      virtual unsigned int getDimension(void) const
-      {
+    virtual unsigned int getDimension(void) const
+    {
         return variables_.size();
-      }
+    }
 
-      virtual void defaultCellSizes()
-      {
+    virtual void defaultCellSizes()
+    {
         cellSizes_.clear();
         cellSizes_.resize(variables_.size(), 0.1);
-      }
+    }
 
-      virtual void project(const ompl::base::State *state,
-          ompl::base::EuclideanProjection &projection) const
-      {
+    virtual void project(const ompl::base::State *state,
+                         ompl::base::EuclideanProjection &projection) const
+    {
         for (std::size_t i = 0; i < variables_.size(); ++i)
-          projection(i) =
-              state->as<exotica::OMPLSE3RNStateSpace::StateType>()->RealVectorStateSpace().values[variables_[i]];
-      }
+            projection(i) =
+                state->as<exotica::OMPLSE3RNStateSpace::StateType>()->RealVectorStateSpace().values[variables_[i]];
+    }
 
-    private:
-      std::vector<int> variables_;
-  };
+private:
+    std::vector<int> variables_;
+};
 }
 //	Namespace exotica
 

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -35,41 +35,38 @@
 
 namespace exotica
 {
-  OMPLBaseStateSpace::OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
-      : ob::CompoundStateSpace(), prob_(prob)
-  {
-  }
+OMPLBaseStateSpace::OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
+    : ob::CompoundStateSpace(), prob_(prob)
+{
+}
 
-  OMPLStateValidityChecker::OMPLStateValidityChecker(const ob::SpaceInformationPtr &si, const SamplingProblem_ptr &prob, OMPLsolverInitializer init)
-      : ob::StateValidityChecker(si), prob_(prob)
-  {
+OMPLStateValidityChecker::OMPLStateValidityChecker(const ob::SpaceInformationPtr &si, const SamplingProblem_ptr &prob, OMPLsolverInitializer init)
+    : ob::StateValidityChecker(si), prob_(prob)
+{
     Server_ptr server = Server::Instance();
-  }
+}
 
-  bool OMPLStateValidityChecker::isValid(const ompl::base::State *state) const
-  {
+bool OMPLStateValidityChecker::isValid(const ompl::base::State *state) const
+{
     double tmp;
     return isValid(state, tmp);
-  }
+}
 
-  bool OMPLStateValidityChecker::isValid(const ompl::base::State *state,
-      double &dist) const
-  {
+bool OMPLStateValidityChecker::isValid(const ompl::base::State *state,
+                                       double &dist) const
+{
     Eigen::VectorXd q(prob_->N);
 #ifdef ROS_INDIGO
-    boost::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(
-        state, q);
+    boost::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q);
 #elif ROS_KINETIC
-    std::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(
-        state, q);
+    std::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q);
 #endif
 
     if (!prob_->isValid(q))
     {
-      dist = -1;
-      return false;
+        dist = -1;
+        return false;
     }
     return true;
-  }
 }
-
+}

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
@@ -34,27 +34,27 @@
 #include "ompl_imp_solver/OMPLImpSolver.h"
 #include <pluginlib/class_list_macros.h>
 
-#include <ompl/geometric/planners/rrt/RRT.h>
-#include <ompl/geometric/planners/rrt/pRRT.h>
-#include <ompl/geometric/planners/rrt/RRTConnect.h>
-#include <ompl/geometric/planners/rrt/TRRT.h>
-#include <ompl/geometric/planners/rrt/LazyRRT.h>
 #include <ompl/geometric/planners/est/EST.h>
-#include <ompl/geometric/planners/sbl/SBL.h>
-#include <ompl/geometric/planners/sbl/pSBL.h>
-#include <ompl/geometric/planners/kpiece/KPIECE1.h>
 #include <ompl/geometric/planners/kpiece/BKPIECE1.h>
+#include <ompl/geometric/planners/kpiece/KPIECE1.h>
 #include <ompl/geometric/planners/kpiece/LBKPIECE1.h>
-#include <ompl/geometric/planners/rrt/RRTstar.h>
-#include <ompl/geometric/planners/prm/PRM.h>
-#include <ompl/geometric/planners/prm/PRMstar.h>
 #include <ompl/geometric/planners/pdst/PDST.h>
 #include <ompl/geometric/planners/prm/LazyPRM.h>
+#include <ompl/geometric/planners/prm/PRM.h>
+#include <ompl/geometric/planners/prm/PRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
 #include <ompl/geometric/planners/prm/SPARStwo.h>
 #include <ompl/geometric/planners/rrt/LBTRRT.h>
+#include <ompl/geometric/planners/rrt/LazyRRT.h>
+#include <ompl/geometric/planners/rrt/RRT.h>
+#include <ompl/geometric/planners/rrt/RRTConnect.h>
 #include <ompl/geometric/planners/rrt/RRTstar.h>
+#include <ompl/geometric/planners/rrt/RRTstar.h>
+#include <ompl/geometric/planners/rrt/TRRT.h>
 #include <ompl/geometric/planners/rrt/pRRT.h>
+#include <ompl/geometric/planners/rrt/pRRT.h>
+#include <ompl/geometric/planners/sbl/SBL.h>
+#include <ompl/geometric/planners/sbl/pSBL.h>
 #include <ompl/geometric/planners/stride/STRIDE.h>
 #include <ompl_solver/OMPLsolverInitializer.h>
 
@@ -62,62 +62,62 @@ PLUGINLIB_EXPORT_CLASS(exotica::OMPLImpSolver, exotica::OMPLBaseSolver)
 
 namespace exotica
 {
-  OMPLImpSolver::OMPLImpSolver() : OMPLBaseSolver("OMPLImpSolver"), algorithm_("geometric::RRTConnect")
-  {
-    object_name_=algorithm_;
-  }
+OMPLImpSolver::OMPLImpSolver() : OMPLBaseSolver("OMPLImpSolver"), algorithm_("geometric::RRTConnect")
+{
+    object_name_ = algorithm_;
+}
 
-  void OMPLImpSolver::initialiseSolver(Initializer& init)
-  {
-      init_ = OMPLsolverInitializer(init);
-      range_ = init_.Range;
-      if(init_.Algorithm!="")
-      {
-        algorithm_ = "geometric::"+init_.Algorithm;
-      }
-      object_name_=algorithm_;
+void OMPLImpSolver::initialiseSolver(Initializer &init)
+{
+    init_ = OMPLsolverInitializer(init);
+    range_ = init_.Range;
+    if (init_.Algorithm != "")
+    {
+        algorithm_ = "geometric::" + init_.Algorithm;
+    }
+    object_name_ = algorithm_;
 
-      if (known_algorithms_.find(algorithm_) != known_algorithms_.end())
-      {
-        HIGHLIGHT("Using planning algorithm "<<algorithm_);
-      }
-      else
-      {
-        ERROR("Unknown planning algorithm "<<algorithm_<<".");
+    if (known_algorithms_.find(algorithm_) != known_algorithms_.end())
+    {
+        HIGHLIGHT("Using planning algorithm " << algorithm_);
+    }
+    else
+    {
+        ERROR("Unknown planning algorithm " << algorithm_ << ".");
         ERROR("Available algorithms: ");
         for (auto &it : known_algorithms_)
-          ERROR(it.first);
-      }
-      timeout_ = init_.Timeout;
-      HIGHLIGHT("Planning timeout: " << timeout_);
-  }
+            ERROR(it.first);
+    }
+    timeout_ = init_.Timeout;
+    HIGHLIGHT("Planning timeout: " << timeout_);
+}
 
-  void OMPLImpSolver::specifyProblem(const SamplingProblem_ptr &prob)
-  {
+void OMPLImpSolver::specifyProblem(const SamplingProblem_ptr &prob)
+{
     prob_ = prob;
     BaseType = prob_->getScene()->getBaseType();
     if (BaseType == BASE_TYPE::FIXED)
-      state_space_.reset(new OMPLRNStateSpace(prob_->N, prob_, init_));
+        state_space_.reset(new OMPLRNStateSpace(prob_->N, prob_, init_));
     else if (BaseType == BASE_TYPE::FLOATING)
-      state_space_.reset(new OMPLSE3RNStateSpace(prob_->N - 6, prob_, init_));
+        state_space_.reset(new OMPLSE3RNStateSpace(prob_->N - 6, prob_, init_));
 
     ompl_simple_setup_.reset(new og::SimpleSetup(state_space_));
     ompl_simple_setup_->setStateValidityChecker(ob::StateValidityCheckerPtr(new OMPLStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_, init_)));
     ompl_simple_setup_->setPlannerAllocator(boost::bind(known_algorithms_[algorithm_], _1, "Exotica_" + algorithm_));
 
-    std::vector<int> project_vars = { 0, 1 };
+    std::vector<int> project_vars = {0, 1};
     if (BaseType == BASE_TYPE::FIXED)
-      ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ob::ProjectionEvaluatorPtr(new OMPLRNProjection(state_space_, project_vars)));
+        ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ob::ProjectionEvaluatorPtr(new OMPLRNProjection(state_space_, project_vars)));
     else if (BaseType == BASE_TYPE::FLOATING)
-      ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ob::ProjectionEvaluatorPtr(new OMPLSE3RNProjection(state_space_, project_vars)));
+        ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ob::ProjectionEvaluatorPtr(new OMPLSE3RNProjection(state_space_, project_vars)));
     ompl_simple_setup_->getSpaceInformation()->setup();
     ompl_simple_setup_->setup();
     if (ompl_simple_setup_->getPlanner()->params().hasParam("range"))
-      ompl_simple_setup_->getPlanner()->params().setParam("range", range_);
-  }
+        ompl_simple_setup_->getPlanner()->params().setParam("range", range_);
+}
 
-  bool OMPLImpSolver::solve(Eigen::VectorXdRefConst &x0, Eigen::MatrixXd &sol)
-  {
+bool OMPLImpSolver::solve(Eigen::VectorXdRefConst &x0, Eigen::MatrixXd &sol)
+{
     Timer timer;
     finishedSolving_ = false;
     ompl::base::ScopedState<> ompl_start_state(state_space_);
@@ -130,42 +130,42 @@ namespace exotica
 
     if (ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION)
     {
-      unregisterTerminationCondition();
+        unregisterTerminationCondition();
 
-      finishedSolving_ = true;
+        finishedSolving_ = true;
 
-      if (!ompl_simple_setup_->haveSolutionPath()) return false;
-      planning_time_ = timer.getDuration();
-      getSimplifiedPath(ompl_simple_setup_->getSolutionPath(), sol, ptc);
-      planning_time_ = timer.getDuration();
-      postSolve();
-      prob_->Update(Eigen::VectorXd(sol.row(sol.rows() - 1)));
-      prob_->getScene()->publishScene();
-      return true;
+        if (!ompl_simple_setup_->haveSolutionPath()) return false;
+        planning_time_ = timer.getDuration();
+        getSimplifiedPath(ompl_simple_setup_->getSolutionPath(), sol, ptc);
+        planning_time_ = timer.getDuration();
+        postSolve();
+        prob_->Update(Eigen::VectorXd(sol.row(sol.rows() - 1)));
+        prob_->getScene()->publishScene();
+        return true;
     }
     else
     {
-      finishedSolving_ = true;
-      planning_time_ = timer.getDuration();
-      postSolve();
-      return false;
+        finishedSolving_ = true;
+        planning_time_ = timer.getDuration();
+        postSolve();
+        return false;
     }
-  }
+}
 
-  void OMPLImpSolver::convertPath(const og::PathGeometric &pg, Eigen::MatrixXd & traj)
-  {
+void OMPLImpSolver::convertPath(const og::PathGeometric &pg, Eigen::MatrixXd &traj)
+{
     traj.resize(pg.getStateCount(), prob_->getSpaceDim());
     Eigen::VectorXd tmp(prob_->getSpaceDim());
 
-    for (int i = 0; i < (int) pg.getStateCount(); ++i)
+    for (int i = 0; i < (int)pg.getStateCount(); ++i)
     {
-      state_space_->as<OMPLBaseStateSpace>()->OMPLToExoticaState(pg.getState(i), tmp);
-      traj.row(i) = tmp;
+        state_space_->as<OMPLBaseStateSpace>()->OMPLToExoticaState(pg.getState(i), tmp);
+        traj.row(i) = tmp;
     }
-  }
+}
 
-  void OMPLImpSolver::getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd & traj, ob::PlannerTerminationCondition &ptc)
-  {
+void OMPLImpSolver::getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd &traj, ob::PlannerTerminationCondition &ptc)
+{
     Timer timer;
 
     og::PathSimplifierPtr psf_ = ompl_simple_setup_->getPathSimplifier();
@@ -177,46 +177,46 @@ namespace exotica
     int times = 0;
     while (times < 10 && tryMore && ptc == false)
     {
-      tryMore = psf_->reduceVertices(pg);
-      times++;
+        tryMore = psf_->reduceVertices(pg);
+        times++;
     }
     if (si->getStateSpace()->isMetricSpace())
     {
-      if (ptc == false)
-        tryMore = psf_->shortcutPath(pg);
-      else
-        tryMore = false;
-      while (times < 10 && tryMore && ptc == false)
-      {
-        tryMore = psf_->shortcutPath(pg);
-        times++;
-      }
+        if (ptc == false)
+            tryMore = psf_->shortcutPath(pg);
+        else
+            tryMore = false;
+        while (times < 10 && tryMore && ptc == false)
+        {
+            tryMore = psf_->shortcutPath(pg);
+            times++;
+        }
     }
 
-    std::vector<ob::State*> &states = pg.getStates();
+    std::vector<ob::State *> &states = pg.getStates();
     //  Calculate number of states required
     unsigned int length = 0;
     const int n1 = states.size() - 1;
     for (int i = 0; i < n1; ++i)
-      length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
+        length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
     //  unsigned int length = 50;
     pg.interpolate(length);
     convertPath(pg, traj);
-    HIGHLIGHT("Trajectory simplification took "<<timer.getDuration()<<" sec. Trajectory length after interpolation = "<<length);
-  }
+    HIGHLIGHT("Trajectory simplification took " << timer.getDuration() << " sec. Trajectory length after interpolation = " << length);
+}
 
-  ompl::base::GoalPtr OMPLImpSolver::constructGoal()
-  {
+ompl::base::GoalPtr OMPLImpSolver::constructGoal()
+{
     return NULL;
-  }
+}
 
-  std::string OMPLImpSolver::getPlannerName()
-  {
+std::string OMPLImpSolver::getPlannerName()
+{
     return planner_name_;
-  }
+}
 
-  void OMPLImpSolver::setGoalState(Eigen::VectorXdRefConst qT, const double eps)
-  {
+void OMPLImpSolver::setGoalState(Eigen::VectorXdRefConst qT, const double eps)
+{
     ompl::base::ScopedState<> gs(state_space_);
     state_space_->as<OMPLBaseStateSpace>()->ExoticaToOMPLState(qT, gs.get());
     if (!ompl_simple_setup_->getStateValidityChecker()->isValid(gs.get()))
@@ -226,65 +226,64 @@ namespace exotica
 
     if (!ompl_simple_setup_->getSpaceInformation()->satisfiesBounds(gs.get()))
     {
-      state_space_->as<OMPLBaseStateSpace>()->stateDebug(qT);
+        state_space_->as<OMPLBaseStateSpace>()->stateDebug(qT);
 
-      // Debug state and bounds
-      std::string out_of_bounds_joint_ids = "";
-      for (int i = 0; i < qT.rows(); i++)
-        if (qT(i) < prob_->getBounds()[i] ||
-            qT(i) > prob_->getBounds()[i + qT.rows()])
-          out_of_bounds_joint_ids +=
-              "[j" + std::to_string(i) + "=" + std::to_string(qT(i)) + ", ll=" +
-              std::to_string(prob_->getBounds()[i]) + ", ul=" +
-              std::to_string(prob_->getBounds()[i + qT.rows()]) + "]\n";
+        // Debug state and bounds
+        std::string out_of_bounds_joint_ids = "";
+        for (int i = 0; i < qT.rows(); i++)
+            if (qT(i) < prob_->getBounds()[i] ||
+                qT(i) > prob_->getBounds()[i + qT.rows()])
+                out_of_bounds_joint_ids +=
+                    "[j" + std::to_string(i) + "=" + std::to_string(qT(i)) + ", ll=" +
+                    std::to_string(prob_->getBounds()[i]) + ", ul=" +
+                    std::to_string(prob_->getBounds()[i + qT.rows()]) + "]\n";
 
-      throw_named(
-          "Invalid goal state [Invalid joint bounds for joint indices: \n"
-          << out_of_bounds_joint_ids << "]");
+        throw_named(
+            "Invalid goal state [Invalid joint bounds for joint indices: \n"
+            << out_of_bounds_joint_ids << "]");
     }
     ompl_simple_setup_->setGoalState(gs, eps);
-  }
-
-  void OMPLImpSolver::registerDefaultPlanners()
-  {
-    registerPlannerAllocator("geometric::RRT",
-        boost::bind(&allocatePlanner<og::RRT>, _1, _2));
-    registerPlannerAllocator("geometric::pRRT",
-        boost::bind(&allocatePlanner<og::pRRT>, _1, _2));
-    registerPlannerAllocator("geometric::RRTConnect",
-        boost::bind(&allocatePlanner<og::RRTConnect>, _1, _2));
-    registerPlannerAllocator("geometric::LazyRRT",
-        boost::bind(&allocatePlanner<og::LazyRRT>, _1, _2));
-//    registerPlannerAllocator("geometric::TRRT",
-//        boost::bind(&allocatePlanner<og::TRRT>, _1, _2));
-    registerPlannerAllocator("geometric::EST",
-        boost::bind(&allocatePlanner<og::EST>, _1, _2));
-    registerPlannerAllocator("geometric::SBL",
-        boost::bind(&allocatePlanner<og::SBL>, _1, _2));
-    registerPlannerAllocator("geometric::KPIECE",
-        boost::bind(&allocatePlanner<og::KPIECE1>, _1, _2));
-    registerPlannerAllocator("geometric::BKPIECE",
-        boost::bind(&allocatePlanner<og::BKPIECE1>, _1, _2));
-    registerPlannerAllocator("geometric::LBKPIECE",
-        boost::bind(&allocatePlanner<og::LBKPIECE1>, _1, _2));
-    registerPlannerAllocator("geometric::RRTStar",
-        boost::bind(&allocatePlanner<og::RRTstar>, _1, _2));
-    registerPlannerAllocator("geometric::PRM",
-        boost::bind(&allocatePlanner<og::PRM>, _1, _2));
-    registerPlannerAllocator("geometric::PRMstar",
-        boost::bind(&allocatePlanner<og::PRMstar>, _1, _2));
-    registerPlannerAllocator("geometric::PDST",
-        boost::bind(&allocatePlanner<og::PDST>, _1, _2));
-    registerPlannerAllocator("geometric::LazyPRM",
-        boost::bind(&allocatePlanner<og::LazyPRM>, _1, _2));
-    registerPlannerAllocator("geometric::SPARS",
-        boost::bind(&allocatePlanner<og::SPARS>, _1, _2));
-    registerPlannerAllocator("geometric::SPARStwo",
-        boost::bind(&allocatePlanner<og::SPARStwo>, _1, _2));
-    registerPlannerAllocator("geometric::LBTRRT",
-        boost::bind(&allocatePlanner<og::LBTRRT>, _1, _2));
-    registerPlannerAllocator("geometric::STRIDE",
-        boost::bind(&allocatePlanner<og::STRIDE>, _1, _2));
-  }
 }
 
+void OMPLImpSolver::registerDefaultPlanners()
+{
+    registerPlannerAllocator("geometric::RRT",
+                             boost::bind(&allocatePlanner<og::RRT>, _1, _2));
+    registerPlannerAllocator("geometric::pRRT",
+                             boost::bind(&allocatePlanner<og::pRRT>, _1, _2));
+    registerPlannerAllocator("geometric::RRTConnect",
+                             boost::bind(&allocatePlanner<og::RRTConnect>, _1, _2));
+    registerPlannerAllocator("geometric::LazyRRT",
+                             boost::bind(&allocatePlanner<og::LazyRRT>, _1, _2));
+    //    registerPlannerAllocator("geometric::TRRT",
+    //        boost::bind(&allocatePlanner<og::TRRT>, _1, _2));
+    registerPlannerAllocator("geometric::EST",
+                             boost::bind(&allocatePlanner<og::EST>, _1, _2));
+    registerPlannerAllocator("geometric::SBL",
+                             boost::bind(&allocatePlanner<og::SBL>, _1, _2));
+    registerPlannerAllocator("geometric::KPIECE",
+                             boost::bind(&allocatePlanner<og::KPIECE1>, _1, _2));
+    registerPlannerAllocator("geometric::BKPIECE",
+                             boost::bind(&allocatePlanner<og::BKPIECE1>, _1, _2));
+    registerPlannerAllocator("geometric::LBKPIECE",
+                             boost::bind(&allocatePlanner<og::LBKPIECE1>, _1, _2));
+    registerPlannerAllocator("geometric::RRTStar",
+                             boost::bind(&allocatePlanner<og::RRTstar>, _1, _2));
+    registerPlannerAllocator("geometric::PRM",
+                             boost::bind(&allocatePlanner<og::PRM>, _1, _2));
+    registerPlannerAllocator("geometric::PRMstar",
+                             boost::bind(&allocatePlanner<og::PRMstar>, _1, _2));
+    registerPlannerAllocator("geometric::PDST",
+                             boost::bind(&allocatePlanner<og::PDST>, _1, _2));
+    registerPlannerAllocator("geometric::LazyPRM",
+                             boost::bind(&allocatePlanner<og::LazyPRM>, _1, _2));
+    registerPlannerAllocator("geometric::SPARS",
+                             boost::bind(&allocatePlanner<og::SPARS>, _1, _2));
+    registerPlannerAllocator("geometric::SPARStwo",
+                             boost::bind(&allocatePlanner<og::SPARStwo>, _1, _2));
+    registerPlannerAllocator("geometric::LBTRRT",
+                             boost::bind(&allocatePlanner<og::LBTRRT>, _1, _2));
+    registerPlannerAllocator("geometric::STRIDE",
+                             boost::bind(&allocatePlanner<og::STRIDE>, _1, _2));
+}
+}

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLRNStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLRNStateSpace.cpp
@@ -35,9 +35,9 @@
 
 namespace exotica
 {
-  OMPLRNStateSpace::OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
-      : OMPLBaseStateSpace(dim, prob, init)
-  {
+OMPLRNStateSpace::OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
+    : OMPLBaseStateSpace(dim, prob, init)
+{
     setName("OMPLRNStateSpace");
     addSubspace(
         ompl::base::StateSpacePtr(new ompl::base::RealVectorStateSpace(dim)),
@@ -45,50 +45,49 @@ namespace exotica
     ompl::base::RealVectorBounds bounds(dim);
     for (int i = 0; i < dim; i++)
     {
-      bounds.setHigh(i, prob->getBounds()[i + dim]);
-      bounds.setLow(i, prob->getBounds()[i]);
+        bounds.setHigh(i, prob->getBounds()[i + dim]);
+        bounds.setLow(i, prob->getBounds()[i]);
     }
     getSubspace(0)->as<ob::RealVectorStateSpace>()->setBounds(bounds);
     lock();
-  }
-
-  ompl::base::StateSamplerPtr OMPLRNStateSpace::allocDefaultStateSampler() const
-  {
-    return CompoundStateSpace::allocDefaultStateSampler();
-  }
-
-  void OMPLRNStateSpace::ExoticaToOMPLState(const Eigen::VectorXd &q,
-      ompl::base::State *state) const
-  {
-    if (!state)
-    {
-      throw_pretty("Invalid state!");
-    }
-    if (q.rows() != (int) getDimension())
-    {
-      throw_pretty(
-          "State vector ("<<q.rows()<<") and internal state ("<<(int)getDimension()<<") dimension disagree");
-    }
-    memcpy(state->as<OMPLRNStateSpace::StateType>()->getRNSpace().values,
-        q.data(), sizeof(double) * q.rows());
-  }
-
-  void OMPLRNStateSpace::OMPLToExoticaState(const ompl::base::State *state,
-      Eigen::VectorXd &q) const
-  {
-    if (!state)
-    {
-      throw_pretty("Invalid state!");
-    }
-    if (q.rows() != (int) getDimension()) q.resize((int) getDimension());
-    memcpy(q.data(),
-        state->as<OMPLRNStateSpace::StateType>()->getRNSpace().values,
-        sizeof(double) * q.rows());
-  }
-
-  void OMPLRNStateSpace::stateDebug(const Eigen::VectorXd &q) const
-  {
-    //  TODO
-  }
 }
 
+ompl::base::StateSamplerPtr OMPLRNStateSpace::allocDefaultStateSampler() const
+{
+    return CompoundStateSpace::allocDefaultStateSampler();
+}
+
+void OMPLRNStateSpace::ExoticaToOMPLState(const Eigen::VectorXd &q,
+                                          ompl::base::State *state) const
+{
+    if (!state)
+    {
+        throw_pretty("Invalid state!");
+    }
+    if (q.rows() != (int)getDimension())
+    {
+        throw_pretty(
+            "State vector (" << q.rows() << ") and internal state (" << (int)getDimension() << ") dimension disagree");
+    }
+    memcpy(state->as<OMPLRNStateSpace::StateType>()->getRNSpace().values,
+           q.data(), sizeof(double) * q.rows());
+}
+
+void OMPLRNStateSpace::OMPLToExoticaState(const ompl::base::State *state,
+                                          Eigen::VectorXd &q) const
+{
+    if (!state)
+    {
+        throw_pretty("Invalid state!");
+    }
+    if (q.rows() != (int)getDimension()) q.resize((int)getDimension());
+    memcpy(q.data(),
+           state->as<OMPLRNStateSpace::StateType>()->getRNSpace().values,
+           sizeof(double) * q.rows());
+}
+
+void OMPLRNStateSpace::stateDebug(const Eigen::VectorXd &q) const
+{
+    //  TODO
+}
+}

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLSE3RNStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLSE3RNStateSpace.cpp
@@ -34,9 +34,9 @@
 #include <ompl_imp_solver/OMPLSE3RNStateSpace.h>
 namespace exotica
 {
-  OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
-      : OMPLBaseStateSpace(dim, prob, init), realvectordim_(dim), SO3Bounds_(3)
-  {
+OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLsolverInitializer init)
+    : OMPLBaseStateSpace(dim, prob, init), realvectordim_(dim), SO3Bounds_(3)
+{
     setName("OMPLSE3RNCompoundStateSpace");
     addSubspace(ob::StateSpacePtr(new ob::SE3StateSpace()), 10.0);
     addSubspace(ob::StateSpacePtr(new ob::RealVectorStateSpace(dim)), 1.0);
@@ -46,218 +46,210 @@ namespace exotica
     unsigned int n = dim + 6;
     if (prob->getBounds().size() == 2 * n)
     {
-      ompl::base::RealVectorBounds RNbounds(dim);
-      ompl::base::RealVectorBounds SE3bounds(3);
+        ompl::base::RealVectorBounds RNbounds(dim);
+        ompl::base::RealVectorBounds SE3bounds(3);
 
-      for (int i = 0; i < 3; i++)
-      {
-        SE3bounds.setHigh(i, prob->getBounds()[i + n]);
-        SE3bounds.setLow(i, prob->getBounds()[i]);
-      }
-      SO3Bounds_.resize(3);
-      for (int i = 3; i < 6; i++)
-        SO3Bounds_.low[i - 3] = prob->getBounds()[i];
-      for (int i = 3; i < 6; i++)
-        SO3Bounds_.high[i - 3] = prob->getBounds()[i + n];
-      setSE3StateSpaceBounds(SE3bounds);
-      for (int i = 6; i < n; i++)
-      {
-        RNbounds.setHigh(i - 6, prob->getBounds()[i + n]);
-        RNbounds.setLow(i - 6, prob->getBounds()[i]);
-      }
-      setRealVectorStateSpaceBounds(RNbounds);
+        for (int i = 0; i < 3; i++)
+        {
+            SE3bounds.setHigh(i, prob->getBounds()[i + n]);
+            SE3bounds.setLow(i, prob->getBounds()[i]);
+        }
+        SO3Bounds_.resize(3);
+        for (int i = 3; i < 6; i++)
+            SO3Bounds_.low[i - 3] = prob->getBounds()[i];
+        for (int i = 3; i < 6; i++)
+            SO3Bounds_.high[i - 3] = prob->getBounds()[i + n];
+        setSE3StateSpaceBounds(SE3bounds);
+        for (int i = 6; i < n; i++)
+        {
+            RNbounds.setHigh(i - 6, prob->getBounds()[i + n]);
+            RNbounds.setLow(i - 6, prob->getBounds()[i]);
+        }
+        setRealVectorStateSpaceBounds(RNbounds);
     }
     else
     {
-      ERROR(
-          "State space bounds were not specified!\n"<< prob->getBounds().size() << " " << n);
+        ERROR(
+            "State space bounds were not specified!\n"
+            << prob->getBounds().size() << " " << n);
     }
     lock();
-  }
+}
 
-  ob::StateSamplerPtr OMPLSE3RNStateSpace::allocDefaultStateSampler() const
-  {
+ob::StateSamplerPtr OMPLSE3RNStateSpace::allocDefaultStateSampler() const
+{
     OMPLSE3RNStateSampler *state_sampler = new OMPLSE3RNStateSampler(this);
     return ob::StateSamplerPtr(state_sampler);
-  }
+}
 
-  void OMPLSE3RNStateSpace::stateDebug(const Eigen::VectorXd &q) const
-  {
+void OMPLSE3RNStateSpace::stateDebug(const Eigen::VectorXd &q) const
+{
     //  TODO
-  }
+}
 
-  unsigned int OMPLSE3RNStateSpace::getDimension() const
-  {
+unsigned int OMPLSE3RNStateSpace::getDimension() const
+{
     return realvectordim_ + 6;
-  }
+}
 
-  void OMPLSE3RNStateSpace::setRealVectorStateSpaceBounds(
-      const ob::RealVectorBounds &bounds)
-  {
+void OMPLSE3RNStateSpace::setRealVectorStateSpaceBounds(
+    const ob::RealVectorBounds &bounds)
+{
     bounds.check();
     getSubspace(1)->as<ob::RealVectorStateSpace>()->setBounds(bounds);
-  }
+}
 
-  const ob::RealVectorBounds & OMPLSE3RNStateSpace::getRealVectorStateSpaceBounds() const
-  {
+const ob::RealVectorBounds &OMPLSE3RNStateSpace::getRealVectorStateSpaceBounds() const
+{
     return getSubspace(1)->as<ob::RealVectorStateSpace>()->getBounds();
-  }
+}
 
-  void OMPLSE3RNStateSpace::setSE3StateSpaceBounds(
-      const ob::RealVectorBounds &xyz, const double dist)
-  {
+void OMPLSE3RNStateSpace::setSE3StateSpaceBounds(
+    const ob::RealVectorBounds &xyz, const double dist)
+{
     xyz.check();
     getSubspace(0)->as<ob::SE3StateSpace>()->setBounds(xyz);
-  }
+}
 
-  const ob::RealVectorBounds & OMPLSE3RNStateSpace::getSE3StateSpaceBounds() const
-  {
+const ob::RealVectorBounds &OMPLSE3RNStateSpace::getSE3StateSpaceBounds() const
+{
     return getSubspace(0)->as<ob::SE3StateSpace>()->getBounds();
-  }
+}
 
-  void OMPLSE3RNStateSpace::setStart(const Eigen::VectorXd &start)
-  {
+void OMPLSE3RNStateSpace::setStart(const Eigen::VectorXd &start)
+{
     start_ = start;
     base_dist_ = (goal_.segment(0, 2) - start_.segment(0, 2)).norm();
-  }
+}
 
-  void OMPLSE3RNStateSpace::setGoal(const Eigen::VectorXd &goal)
-  {
+void OMPLSE3RNStateSpace::setGoal(const Eigen::VectorXd &goal)
+{
     if (goal.rows() == realvectordim_ + 6)
     {
-      goal_ = goal;
+        goal_ = goal;
     }
-  }
-  void OMPLSE3RNStateSampler::sampleUniform(ob::State *state)
-  {
+}
+void OMPLSE3RNStateSampler::sampleUniform(ob::State *state)
+{
     OMPLSE3RNStateSpace::StateType *rstate =
-        static_cast<OMPLSE3RNStateSpace::StateType*>(state);
+        static_cast<OMPLSE3RNStateSpace::StateType *>(state);
 
     //	Sample for the SE3 space
-    const OMPLSE3RNStateSpace* space =
-        static_cast<const OMPLSE3RNStateSpace*>(space_);
+    const OMPLSE3RNStateSpace *space =
+        static_cast<const OMPLSE3RNStateSpace *>(space_);
     const ob::RealVectorBounds &se3_bounds =
-        static_cast<const OMPLSE3RNStateSpace*>(space_)->getSE3StateSpaceBounds();
+        static_cast<const OMPLSE3RNStateSpace *>(space_)->getSE3StateSpaceBounds();
     ob::RealVectorBounds so3_bounds =
-        static_cast<const OMPLSE3RNStateSpace*>(space_)->SO3Bounds_;
+        static_cast<const OMPLSE3RNStateSpace *>(space_)->SO3Bounds_;
     rstate->SE3StateSpace().setXYZ(
         rng_.uniformReal(se3_bounds.low[0], se3_bounds.high[0]),
         rng_.uniformReal(se3_bounds.low[1], se3_bounds.high[1]),
         rng_.uniformReal(se3_bounds.low[2], se3_bounds.high[2]));
     //	Only rotates along Z, for base movement
     rstate->SE3StateSpace().rotation().setAxisAngle(0, 0, 1,
-        rng_.uniformReal(so3_bounds.low[0], so3_bounds.high[0]));
+                                                    rng_.uniformReal(so3_bounds.low[0], so3_bounds.high[0]));
     rstate->SE3StateSpace().rotation().setAxisAngle(0, 1, 0,
-        rng_.uniformReal(so3_bounds.low[1], so3_bounds.high[1]));
+                                                    rng_.uniformReal(so3_bounds.low[1], so3_bounds.high[1]));
     rstate->SE3StateSpace().rotation().setAxisAngle(1, 0, 0,
-        rng_.uniformReal(so3_bounds.low[2], so3_bounds.high[2]));
+                                                    rng_.uniformReal(so3_bounds.low[2], so3_bounds.high[2]));
     //	Sample for the RN space
     const ob::RealVectorBounds &realvector_bounds =
-        static_cast<const OMPLSE3RNStateSpace*>(space_)->getRealVectorStateSpaceBounds();
+        static_cast<const OMPLSE3RNStateSpace *>(space_)->getRealVectorStateSpaceBounds();
     const unsigned int dim = realvector_bounds.high.size();
     if (space->useGoal_)
     {
-      Eigen::VectorXd tmp(2);
-      tmp << rstate->SE3StateSpace().getX(), rstate->SE3StateSpace().getY();
-      double percentage = (space->goal_.segment(0, 2) - tmp).norm()
-          / space->base_dist_;
-      if (percentage < space->rn_bias_percentage_)
-      {
-        for (unsigned int i = 0; i < dim; ++i)
-          rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
-              realvector_bounds.low[i], realvector_bounds.high[i]);
-      }
-      else
-        for (unsigned int i = 0; i < dim; ++i)
-          rstate->RealVectorStateSpace().values[i] = space->start_(i + 6);
+        Eigen::VectorXd tmp(2);
+        tmp << rstate->SE3StateSpace().getX(), rstate->SE3StateSpace().getY();
+        double percentage = (space->goal_.segment(0, 2) - tmp).norm() / space->base_dist_;
+        if (percentage < space->rn_bias_percentage_)
+        {
+            for (unsigned int i = 0; i < dim; ++i)
+                rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
+                    realvector_bounds.low[i], realvector_bounds.high[i]);
+        }
+        else
+            for (unsigned int i = 0; i < dim; ++i)
+                rstate->RealVectorStateSpace().values[i] = space->start_(i + 6);
     }
     else
-      for (unsigned int i = 0; i < dim; ++i)
-        rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
-            realvector_bounds.low[i], realvector_bounds.high[i]);
-  }
+        for (unsigned int i = 0; i < dim; ++i)
+            rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
+                realvector_bounds.low[i], realvector_bounds.high[i]);
+}
 
-  void OMPLSE3RNStateSampler::sampleUniformNear(ob::State *state,
-      const ob::State *near, const double distance)
-  {
+void OMPLSE3RNStateSampler::sampleUniformNear(ob::State *state,
+                                              const ob::State *near, const double distance)
+{
     //	First sample for the upper body
     OMPLSE3RNStateSpace::StateType *rstate =
-        static_cast<OMPLSE3RNStateSpace::StateType*>(state);
+        static_cast<OMPLSE3RNStateSpace::StateType *>(state);
     const OMPLSE3RNStateSpace::StateType *nstate =
-        static_cast<const OMPLSE3RNStateSpace::StateType*>(near);
+        static_cast<const OMPLSE3RNStateSpace::StateType *>(near);
     const ob::RealVectorBounds &realvector_bounds =
-        static_cast<const OMPLSE3RNStateSpace*>(space_)->getRealVectorStateSpaceBounds();
+        static_cast<const OMPLSE3RNStateSpace *>(space_)->getRealVectorStateSpaceBounds();
     const unsigned int dim = realvector_bounds.high.size();
     for (unsigned int i = 0; i < dim; ++i)
-      rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
-          std::max(realvector_bounds.low[i],
-              nstate->RealVectorStateSpace().values[i]
-                  - distance * weightImportance_[i + 6]),
-          std::min(realvector_bounds.high[i],
-              nstate->RealVectorStateSpace().values[i]
-                  + distance * weightImportance_[i + 6]));
+        rstate->RealVectorStateSpace().values[i] = rng_.uniformReal(
+            std::max(realvector_bounds.low[i],
+                     nstate->RealVectorStateSpace().values[i] - distance * weightImportance_[i + 6]),
+            std::min(realvector_bounds.high[i],
+                     nstate->RealVectorStateSpace().values[i] + distance * weightImportance_[i + 6]));
     //	Now sample for the SE3 space
     const ob::RealVectorBounds &se3_bounds =
-        static_cast<const OMPLSE3RNStateSpace*>(space_)->getSE3StateSpaceBounds();
+        static_cast<const OMPLSE3RNStateSpace *>(space_)->getSE3StateSpaceBounds();
     rstate->SE3StateSpace().setX(
         rng_.uniformReal(
             std::max(se3_bounds.low[0],
-                nstate->SE3StateSpace().getX()
-                    - distance * weightImportance_[0]),
+                     nstate->SE3StateSpace().getX() - distance * weightImportance_[0]),
             std::min(se3_bounds.high[0],
-                nstate->SE3StateSpace().getX()
-                    + distance * weightImportance_[0])));
+                     nstate->SE3StateSpace().getX() + distance * weightImportance_[0])));
     rstate->SE3StateSpace().setY(
         rng_.uniformReal(
             std::max(se3_bounds.low[1],
-                nstate->SE3StateSpace().getY()
-                    - distance * weightImportance_[1]),
+                     nstate->SE3StateSpace().getY() - distance * weightImportance_[1]),
             std::min(se3_bounds.high[1],
-                nstate->SE3StateSpace().getY()
-                    + distance * weightImportance_[1])));
+                     nstate->SE3StateSpace().getY() + distance * weightImportance_[1])));
     rstate->SE3StateSpace().setZ(
         rng_.uniformReal(
             std::max(se3_bounds.low[2],
-                nstate->SE3StateSpace().getZ()
-                    - distance * weightImportance_[2]),
+                     nstate->SE3StateSpace().getZ() - distance * weightImportance_[2]),
             std::min(se3_bounds.high[2],
-                nstate->SE3StateSpace().getZ()
-                    + distance * weightImportance_[2])));
+                     nstate->SE3StateSpace().getZ() + distance * weightImportance_[2])));
     rstate->SE3StateSpace().rotation().setAxisAngle(0, 0, 1,
-        rng_.uniformReal(-1.57, 1.57));
-  }
+                                                    rng_.uniformReal(-1.57, 1.57));
+}
 
-  void OMPLSE3RNStateSampler::sampleGaussian(ob::State *state,
-      const ob::State * mean, const double stdDev)
-  {
+void OMPLSE3RNStateSampler::sampleGaussian(ob::State *state,
+                                           const ob::State *mean, const double stdDev)
+{
     WARNING_NAMED("OMPLFullBodyStateSampler", "sampleGaussian not implemented");
-  }
+}
 
-  void OMPLSE3RNStateSpace::ExoticaToOMPLState(const Eigen::VectorXd &q,
-      ompl::base::State *state) const
-  {
+void OMPLSE3RNStateSpace::ExoticaToOMPLState(const Eigen::VectorXd &q,
+                                             ompl::base::State *state) const
+{
     OMPLSE3RNStateSpace::StateType *statetype =
-        static_cast<OMPLSE3RNStateSpace::StateType*>(state);
+        static_cast<OMPLSE3RNStateSpace::StateType *>(state);
     statetype->SE3StateSpace().setXYZ(q(0), q(1), q(2));
     KDL::Rotation tmp = KDL::Rotation::EulerZYX(q(3), q(4), q(5));
     tmp.GetQuaternion(statetype->SE3StateSpace().rotation().x,
-        statetype->SE3StateSpace().rotation().y,
-        statetype->SE3StateSpace().rotation().z,
-        statetype->SE3StateSpace().rotation().w);
+                      statetype->SE3StateSpace().rotation().y,
+                      statetype->SE3StateSpace().rotation().z,
+                      statetype->SE3StateSpace().rotation().w);
 
     memcpy(statetype->RealVectorStateSpace().values,
-        q.segment(6, q.rows() - 6).data(), sizeof(double) * (q.rows() - 6));
-  }
+           q.segment(6, q.rows() - 6).data(), sizeof(double) * (q.rows() - 6));
+}
 
-  void OMPLSE3RNStateSpace::OMPLToExoticaState(
-      const ompl::base::State *state, Eigen::VectorXd &q) const
-  {
+void OMPLSE3RNStateSpace::OMPLToExoticaState(
+    const ompl::base::State *state, Eigen::VectorXd &q) const
+{
     q.setZero(getDimension());
     const OMPLSE3RNStateSpace::StateType *statetype =
-        static_cast<const OMPLSE3RNStateSpace::StateType*>(state);
+        static_cast<const OMPLSE3RNStateSpace::StateType *>(state);
     memcpy(q.segment(6, q.rows() - 6).data(),
-        statetype->RealVectorStateSpace().values,
-        sizeof(double) * (q.rows() - 6));
+           statetype->RealVectorStateSpace().values,
+           sizeof(double) * (q.rows() - 6));
     q(0) = statetype->SE3StateSpace().getX();
     q(1) = statetype->SE3StateSpace().getY();
     q(2) = statetype->SE3StateSpace().getZ();
@@ -268,6 +260,5 @@ namespace exotica
         statetype->SE3StateSpace().rotation().z,
         statetype->SE3StateSpace().rotation().w);
     tmp.GetEulerZYX(q(3), q(4), q(5));
-  }
 }
-
+}

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
@@ -34,123 +34,124 @@
 #ifndef EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLBASESOLVER_H_
 #define EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLBASESOLVER_H_
 
+#include <exotica/Property.h>
+#include <ompl/base/DiscreteMotionValidator.h>
+#include <ompl/geometric/PathSimplifier.h>
+#include <pluginlib/class_loader.h>
 #include "exotica/Problems/SamplingProblem.h"
 #include "ompl_solver/common.h"
-#include <ompl/geometric/PathSimplifier.h>
-#include <ompl/base/DiscreteMotionValidator.h>
-#include <pluginlib/class_loader.h>
-#include <exotica/Property.h>
 
 namespace exotica
 {
-  namespace ob = ompl::base;
-  namespace og = ompl::geometric;
-  class OMPLBaseSolver
-  {
-    public:
-      virtual ~OMPLBaseSolver();
+namespace ob = ompl::base;
+namespace og = ompl::geometric;
+class OMPLBaseSolver
+{
+public:
+    virtual ~OMPLBaseSolver();
 
-      void initialiseBaseSolver(Initializer& init);
-      virtual void initialiseSolver(Initializer& init) = 0;
+    void initialiseBaseSolver(Initializer &init);
+    virtual void initialiseSolver(Initializer &init) = 0;
 
-      virtual bool solve(Eigen::VectorXdRefConst x0, Eigen::MatrixXd &sol) = 0;
-      virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon()) = 0;
+    virtual bool solve(Eigen::VectorXdRefConst x0, Eigen::MatrixXd &sol) = 0;
+    virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon()) = 0;
 
-      virtual std::string getPlannerName() = 0;
-      double getPlanningTime();
+    virtual std::string getPlannerName() = 0;
+    double getPlanningTime();
 
-      const og::SimpleSetupPtr getOMPLSimpleSetup() const;
+    const og::SimpleSetupPtr getOMPLSimpleSetup() const;
 
-      virtual void specifyProblem(const SamplingProblem_ptr &prob) = 0;
+    virtual void specifyProblem(const SamplingProblem_ptr &prob) = 0;
 
-      static pluginlib::ClassLoader<exotica::OMPLBaseSolver> base_solver_loader;
-    protected:
-      OMPLBaseSolver(const std::string planner_name);
-      void registerPlannerAllocator(const std::string &planner_id, const ConfiguredPlannerAllocator &pa)
-      {
+    static pluginlib::ClassLoader<exotica::OMPLBaseSolver> base_solver_loader;
+
+protected:
+    OMPLBaseSolver(const std::string planner_name);
+    void registerPlannerAllocator(const std::string &planner_id, const ConfiguredPlannerAllocator &pa)
+    {
         known_algorithms_[planner_id] = pa;
-      }
+    }
 
-      template<typename T> static ob::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr &si, const std::string &new_name)
-      {
+    template <typename T>
+    static ob::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr &si, const std::string &new_name)
+    {
         ompl::base::PlannerPtr planner(new T(si));
         if (!new_name.empty()) planner->setName(new_name);
         return planner;
-      }
+    }
 
-      std::map<std::string, ConfiguredPlannerAllocator> known_algorithms_;
-      std::string planner_name_;
+    std::map<std::string, ConfiguredPlannerAllocator> known_algorithms_;
+    std::string planner_name_;
 
-      virtual void registerDefaultPlanners() = 0;
-      /**
+    virtual void registerDefaultPlanners() = 0;
+    /**
        * \biref Converts OMPL trajectory into Eigen Matrix
        * @param pg OMPL trajectory
        * @param traj Eigen Matrix trajectory
        * @return Indicates success
        */
-      virtual void convertPath(const og::PathGeometric &pg, Eigen::MatrixXd & traj) = 0;
+    virtual void convertPath(const og::PathGeometric &pg, Eigen::MatrixXd &traj) = 0;
 
-      virtual void getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd & traj, ob::PlannerTerminationCondition &ptc) = 0;
-      /**
+    virtual void getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd &traj, ob::PlannerTerminationCondition &ptc) = 0;
+    /**
        * \brief Registers trajectory termination condition
        * @param ptc Termination criteria
        */
-      void registerTerminationCondition(const ob::PlannerTerminationCondition &ptc);
+    void registerTerminationCondition(const ob::PlannerTerminationCondition &ptc);
 
-      /**
+    /**
        * \brief Unregisters trajectory termination condition
        */
-      void unregisterTerminationCondition();
+    void unregisterTerminationCondition();
 
-      /**
+    /**
        * \brief Executes pre solve steps
        */
-      bool virtual preSolve();
-      /**
+    bool virtual preSolve();
+    /**
        * \brief Executes post solve steps
        */
-      bool virtual postSolve();
+    bool virtual postSolve();
 
-      /**
+    /**
        * Constructs goal representation
        */
-      virtual ompl::base::GoalPtr constructGoal() = 0;
+    virtual ompl::base::GoalPtr constructGoal() = 0;
 
-      /**
+    /**
        * \brief Record data for analysis
        */
-      void recordData();
+    void recordData();
 
-      SamplingProblem_ptr prob_; //!< Shared pointer to the planning problem.
+    SamplingProblem_ptr prob_;  //!< Shared pointer to the planning problem.
 
-      /// The OMPL planning context; this contains the problem definition and the planner used
-      og::SimpleSetupPtr ompl_simple_setup_;
+    /// The OMPL planning context; this contains the problem definition and the planner used
+    og::SimpleSetupPtr ompl_simple_setup_;
 
-      /// \brief OMPL state space specification
-      ompl::base::StateSpacePtr state_space_;
+    /// \brief OMPL state space specification
+    ompl::base::StateSpacePtr state_space_;
 
-      /// \brief Maximum allowed time for planning
-      double timeout_;
+    /// \brief Maximum allowed time for planning
+    double timeout_;
 
-      /// \brief Planner termination criteria
-      const ob::PlannerTerminationCondition *ptc_;
+    /// \brief Planner termination criteria
+    const ob::PlannerTerminationCondition *ptc_;
 
-      /// \bierf True when the solver finished its work and background threads need to finish.
-      bool finishedSolving_;
+    /// \bierf True when the solver finished its work and background threads need to finish.
+    bool finishedSolving_;
 
-      // \brief Max number of attempts at sampling the goal region
-      int goal_sampling_max_attempts_;
+    // \brief Max number of attempts at sampling the goal region
+    int goal_sampling_max_attempts_;
 
-      /// \brief  Porjection type
-      std::string projector_;
+    /// \brief  Porjection type
+    std::string projector_;
 
-      /// \brief  Projection components
-      std::vector<std::string> projection_components_;
+    /// \brief  Projection components
+    std::vector<std::string> projection_components_;
 
-      double planning_time_;
-
-  };
-  typedef std::shared_ptr<exotica::OMPLBaseSolver> OMPLBaseSolver_ptr;
+    double planning_time_;
+};
+typedef std::shared_ptr<exotica::OMPLBaseSolver> OMPLBaseSolver_ptr;
 }
 
 #endif /* EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLBASESOLVER_H_ */

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
@@ -36,68 +36,69 @@
 
 #include <exotica/MotionSolver.h>
 #include <ompl_solver/OMPLsolverInitializer.h>
-#include "ompl_solver/OMPLBaseSolver.h"
 #include <ros/package.h>
 #include <fstream>
+#include "ompl_solver/OMPLBaseSolver.h"
 
 #define REGISTER_OMPL_SOLVER_TYPE(TYPE, DERIV) EXOTICA_REGISTER(std::string, exotica::MotionSolver, TYPE, DERIV)
 
 namespace exotica
 {
-  class OMPLsolver: public MotionSolver, Instantiable<OMPLsolverInitializer>
-  {
-    public:
-      OMPLsolver();
+class OMPLsolver : public MotionSolver, Instantiable<OMPLsolverInitializer>
+{
+public:
+    OMPLsolver();
 
-      virtual void Instantiate(OMPLsolverInitializer& init);
+    virtual void Instantiate(OMPLsolverInitializer& init);
 
-      /*
+    /*
        * \breif Default destructor
        */
-      virtual ~OMPLsolver();
+    virtual ~OMPLsolver();
 
-      /**
+    /**
        * \brief Binds the solver to a specific problem which must be pre-initalised
        * @param pointer Shared pointer to the motion planning problem
        * @return        Successful if the problem is a valid AICOProblem
        */
-      virtual void specifyProblem(PlanningProblem_ptr pointer);
+    virtual void specifyProblem(PlanningProblem_ptr pointer);
 
-      void Solve(Eigen::MatrixXd & solution);
+    void Solve(Eigen::MatrixXd& solution);
 
-      /*
+    /*
        * \brief Get planning problem
        */
-      const SamplingProblem_ptr getProblem() const
-      {
+    const SamplingProblem_ptr getProblem() const
+    {
         return prob_;
-      }
+    }
 
-      /*
+    /*
        * \brief Get planning algorithm
        */
-      const std::string getAlgorithm()
-      {
+    const std::string getAlgorithm()
+    {
         return base_solver_->getPlannerName();
-      }
+    }
 
-      const OMPLBaseSolver_ptr getOMPLSolver()
-      {
+    const OMPLBaseSolver_ptr getOMPLSolver()
+    {
         return base_solver_;
-      }
+    }
 
-      virtual std::string print(std::string prepend);
+    virtual std::string print(std::string prepend);
 
-      virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon());
-    private:
-      SamplingProblem_ptr prob_; //!< Shared pointer to the planning problem.
+    virtual void setGoalState(Eigen::VectorXdRefConst qT, const double eps = std::numeric_limits<double>::epsilon());
 
-      OMPLBaseSolver_ptr base_solver_;
+private:
+    SamplingProblem_ptr prob_;  //!< Shared pointer to the planning problem.
 
-      OMPLsolverInitializer parameters_;
-  };
+    OMPLBaseSolver_ptr base_solver_;
 
-  typedef std::shared_ptr<exotica::OMPLsolver> OMPLsolver_ptr;
+    OMPLsolverInitializer parameters_;
+};
+
+typedef std::shared_ptr<exotica::OMPLsolver> OMPLsolver_ptr;
 
 } /* namespace exotica */
 

--- a/exotations/solvers/ompl_solver/include/ompl_solver/common.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/common.h
@@ -34,20 +34,18 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
+#include <ompl/base/StateStorage.h>
 #include <ompl/geometric/SimpleSetup.h>
 #include <ompl/tools/benchmark/Benchmark.h>
 #include <ompl/tools/multiplan/ParallelPlan.h>
-#include <ompl/base/StateStorage.h>
 
 namespace exotica
 {
+namespace ob = ompl::base;
+namespace og = ompl::geometric;
+namespace ot = ompl::tools;
 
-  namespace ob = ompl::base;
-  namespace og = ompl::geometric;
-  namespace ot = ompl::tools;
-
-  typedef boost::function<ob::PlannerPtr(const ob::SpaceInformationPtr &si, const std::string &name)> ConfiguredPlannerAllocator;
-
+typedef boost::function<ob::PlannerPtr(const ob::SpaceInformationPtr &si, const std::string &name)> ConfiguredPlannerAllocator;
 }
 
 #endif /* COMMON_H_ */

--- a/exotations/solvers/ompl_solver/include/projections/DMeshProjection.h
+++ b/exotations/solvers/ompl_solver/include/projections/DMeshProjection.h
@@ -40,61 +40,56 @@
 
 namespace exotica
 {
-  class DMeshProjection: public ompl::base::ProjectionEvaluator
-  {
-    public:
-      DMeshProjection(const ompl::base::StateSpacePtr &space,
-          const std::vector<std::string> & links,
-          std::vector<std::pair<int, int> > dist_index, Scene_ptr & scene)
-          : ompl::base::ProjectionEvaluator(space), links_(links), dist_index_(
-              dist_index), scene_(scene), space_(space)
-      {
+class DMeshProjection : public ompl::base::ProjectionEvaluator
+{
+public:
+    DMeshProjection(const ompl::base::StateSpacePtr &space,
+                    const std::vector<std::string> &links,
+                    std::vector<std::pair<int, int> > dist_index, Scene_ptr &scene)
+        : ompl::base::ProjectionEvaluator(space), links_(links), dist_index_(dist_index), scene_(scene), space_(space)
+    {
         std::string str = space_->getName();
         if (str.compare("OMPLSE3RNCompoundStateSpace") == 0)
-          compound_ = true;
+            compound_ = true;
         else
-          compound_ = false;
-      }
+            compound_ = false;
+    }
 
-      ~DMeshProjection()
-      {
+    ~DMeshProjection()
+    {
         //TODO
-      }
+    }
 
-      virtual unsigned int getDimension(void) const
-      {
+    virtual unsigned int getDimension(void) const
+    {
         return dist_index_.size();
-      }
+    }
 
-      virtual void defaultCellSizes()
-      {
+    virtual void defaultCellSizes()
+    {
         cellSizes_.clear();
         cellSizes_.resize(dist_index_.size(), 0.1);
-      }
+    }
 
-      virtual void project(const ompl::base::State *state,
-          ompl::base::EuclideanProjection &projection) const
-      {
-//				HIGHLIGHT_NAMED("DMeshProjection", "Calling project");
+    virtual void project(const ompl::base::State *state,
+                         ompl::base::EuclideanProjection &projection) const
+    {
+        //				HIGHLIGHT_NAMED("DMeshProjection", "Calling project");
         Eigen::VectorXd q(space_->getDimension());
-        compound_ ?
-            space_->as<OMPLSE3RNStateSpace>()->OMPLStateToEigen(state,
-                q) :
-            space_->as<OMPLStateSpace>()->copyFromOMPLState(state, q);
+        compound_ ? space_->as<OMPLSE3RNStateSpace>()->OMPLStateToEigen(state, q) : space_->as<OMPLStateSpace>()->copyFromOMPLState(state, q);
         scene_->Update(q);
         ArrayFrame poses = scene_->getSolver().Solution->Phi;
         for (std::size_t i = 0; i < dist_index_.size(); ++i)
-          projection(i) = (poses(dist_index_[i].second).p
-              - poses(dist_index_[i].first).p).Norm();
-      }
+            projection(i) = (poses(dist_index_[i].second).p - poses(dist_index_[i].first).p).Norm();
+    }
 
-    private:
-      std::vector<std::string> links_;
-      std::vector<std::pair<int, int> > dist_index_;
-      Scene_ptr scene_;
-      ob::StateSpacePtr space_;
-      bool compound_;
-  };
+private:
+    std::vector<std::string> links_;
+    std::vector<std::pair<int, int> > dist_index_;
+    Scene_ptr scene_;
+    ob::StateSpacePtr space_;
+    bool compound_;
+};
 }
 
 #endif /* EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_PROJECTIONS_DMESHPROJECTION_H_ */

--- a/exotations/solvers/ompl_solver/include/projections/OMPLProjection.h
+++ b/exotations/solvers/ompl_solver/include/projections/OMPLProjection.h
@@ -39,42 +39,41 @@
 ///	Implementation of OMPL EXOTica Projection (Testing)
 namespace exotica
 {
-  class OMPLProjection: public ompl::base::ProjectionEvaluator
-  {
-    public:
-      OMPLProjection(const ompl::base::StateSpacePtr &space,
-          const std::vector<int> & vars)
-          : ompl::base::ProjectionEvaluator(space), variables_(vars)
-      {
+class OMPLProjection : public ompl::base::ProjectionEvaluator
+{
+public:
+    OMPLProjection(const ompl::base::StateSpacePtr &space,
+                   const std::vector<int> &vars)
+        : ompl::base::ProjectionEvaluator(space), variables_(vars)
+    {
+    }
 
-      }
-
-      ~OMPLProjection()
-      {
+    ~OMPLProjection()
+    {
         //TODO
-      }
+    }
 
-      virtual unsigned int getDimension(void) const
-      {
+    virtual unsigned int getDimension(void) const
+    {
         return variables_.size();
-      }
+    }
 
-      virtual void defaultCellSizes()
-      {
+    virtual void defaultCellSizes()
+    {
         cellSizes_.clear();
         cellSizes_.resize(variables_.size(), 0.1);
-      }
+    }
 
-      virtual void project(const ompl::base::State *state,
-          ompl::base::EuclideanProjection &projection) const
-      {
+    virtual void project(const ompl::base::State *state,
+                         ompl::base::EuclideanProjection &projection) const
+    {
         for (std::size_t i = 0; i < variables_.size(); ++i)
-          projection(i) =
-              state->as<exotica::OMPLStateSpace::StateType>()->values[variables_[i]];
-      }
+            projection(i) =
+                state->as<exotica::OMPLStateSpace::StateType>()->values[variables_[i]];
+    }
 
-    private:
-      std::vector<int> variables_;
-  };
+private:
+    std::vector<int> variables_;
+};
 }
 #endif /* EXOTICA_EXOTATIONS_SOLVERS_OMPL_SOLVER_INCLUDE_OMPL_SOLVER_OMPLPROJECTION_H_ */

--- a/exotations/solvers/ompl_solver/src/OMPLBaseSolver.cpp
+++ b/exotations/solvers/ompl_solver/src/OMPLBaseSolver.cpp
@@ -9,78 +9,76 @@
 
 namespace exotica
 {
-  pluginlib::ClassLoader<exotica::OMPLBaseSolver> OMPLBaseSolver::base_solver_loader("ompl_solver","exotica::OMPLBaseSolver");
+pluginlib::ClassLoader<exotica::OMPLBaseSolver> OMPLBaseSolver::base_solver_loader("ompl_solver", "exotica::OMPLBaseSolver");
 
-  OMPLBaseSolver::OMPLBaseSolver(const std::string planner_name)
-      : timeout_(600.0), finishedSolving_(false), planner_name_(planner_name)
-  {
+OMPLBaseSolver::OMPLBaseSolver(const std::string planner_name)
+    : timeout_(600.0), finishedSolving_(false), planner_name_(planner_name)
+{
+}
+OMPLBaseSolver::~OMPLBaseSolver()
+{
+}
 
-  }
-  OMPLBaseSolver::~OMPLBaseSolver()
-  {
+void OMPLBaseSolver::initialiseBaseSolver(Initializer& init)
+{
+    registerDefaultPlanners();
+    initialiseSolver(init);
+}
 
-  }
-
-  void OMPLBaseSolver::initialiseBaseSolver(Initializer& init)
-  {
-      registerDefaultPlanners();
-      initialiseSolver(init);
-  }
-
-  void OMPLBaseSolver::recordData()
-  {
+void OMPLBaseSolver::recordData()
+{
     ompl::base::PlannerData data(ompl_simple_setup_->getSpaceInformation());
     ompl_simple_setup_->getPlanner()->getPlannerData(data);
-  }
+}
 
-  double OMPLBaseSolver::getPlanningTime()
-  {
+double OMPLBaseSolver::getPlanningTime()
+{
     return planning_time_;
-  }
+}
 
-  bool OMPLBaseSolver::preSolve()
-  {
+bool OMPLBaseSolver::preSolve()
+{
     // clear previously computed solutions
     ompl_simple_setup_->getProblemDefinition()->clearSolutionPaths();
     const ob::PlannerPtr planner = ompl_simple_setup_->getPlanner();
     if (planner)
     {
-      planner->clear();
+        planner->clear();
     }
     else
     {
-      ERROR("Planner not found");
-      return false;
+        ERROR("Planner not found");
+        return false;
     }
     ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->resetMotionCounter();
     ompl_simple_setup_->getPlanner()->setProblemDefinition(ompl_simple_setup_->getProblemDefinition());
     return true;
-  }
+}
 
-  bool OMPLBaseSolver::postSolve()
-  {
+bool OMPLBaseSolver::postSolve()
+{
     ompl_simple_setup_->clearStartStates();
     int v = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getValidMotionCount();
     int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
     logDebug("There were %d valid motions and %d invalid motions.", v, iv);
 
     if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-      logWarn("Computed solution is approximate");
+        logWarn("Computed solution is approximate");
     return true;
-  }
+}
 
-  void OMPLBaseSolver::registerTerminationCondition(const ob::PlannerTerminationCondition &ptc)
-  {
+void OMPLBaseSolver::registerTerminationCondition(const ob::PlannerTerminationCondition& ptc)
+{
     ptc_ = &ptc;
-  }
+}
 
-  void OMPLBaseSolver::unregisterTerminationCondition()
-  {
+void OMPLBaseSolver::unregisterTerminationCondition()
+{
     ptc_ = NULL;
-  }
+}
 
-  const og::SimpleSetupPtr OMPLBaseSolver::getOMPLSimpleSetup() const
-  {
+const og::SimpleSetupPtr OMPLBaseSolver::getOMPLSimpleSetup() const
+{
     return ompl_simple_setup_;
-  }
+}
 }

--- a/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
+++ b/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
@@ -38,74 +38,75 @@ REGISTER_MOTIONSOLVER_TYPE("OMPLsolver", exotica::OMPLsolver)
 
 namespace exotica
 {
-  OMPLsolver::OMPLsolver()
-  {
+OMPLsolver::OMPLsolver()
+{
+}
 
-  }
-
-  void OMPLsolver::Instantiate(OMPLsolverInitializer& init)
-  {
-      parameters_ = init;
-      try
-      {
-        HIGHLIGHT_NAMED(object_name_,"Using ["<<parameters_.Solver<<"]");
+void OMPLsolver::Instantiate(OMPLsolverInitializer& init)
+{
+    parameters_ = init;
+    try
+    {
+        HIGHLIGHT_NAMED(object_name_, "Using [" << parameters_.Solver << "]");
         base_solver_ = to_std_ptr(OMPLBaseSolver::base_solver_loader.createInstance("ompl_solver/" + parameters_.Solver));
-      } catch (pluginlib::PluginlibException& ex)
-      {
-        throw_named("EXOTica-OMPL plugin failed to load solver "<<parameters_.Solver<<"!\nError: " << ex.what());
-      }
-      Initializer baseInit = (Initializer)init;
-      base_solver_->initialiseBaseSolver(baseInit);
-  }
+    }
+    catch (pluginlib::PluginlibException& ex)
+    {
+        throw_named("EXOTica-OMPL plugin failed to load solver " << parameters_.Solver << "!\nError: " << ex.what());
+    }
+    Initializer baseInit = (Initializer)init;
+    base_solver_->initialiseBaseSolver(baseInit);
+}
 
-  OMPLsolver::~OMPLsolver()
-  {
+OMPLsolver::~OMPLsolver()
+{
     // If this is not empty, your code is bad and you should feel bad!
     // Whoop whoop whoop whoop ...
-  }
+}
 
-  std::string OMPLsolver::print(std::string prepend)
-  {
+std::string OMPLsolver::print(std::string prepend)
+{
     std::string ret = Object::print(prepend);
     ret += "\n" + prepend + "  Goal:";
     if (prob_) ret += "\n" + prob_->print(prepend + "    ");
     return ret;
-  }
+}
 
-  void OMPLsolver::Solve(Eigen::MatrixXd & solution)
-  {
+void OMPLsolver::Solve(Eigen::MatrixXd& solution)
+{
     prob_->preupdate();
     Eigen::VectorXd q0 = prob_->applyStartState();
     setGoalState(prob_->goal_);
     if (base_solver_->solve(q0, solution))
     {
-      HIGHLIGHT("OMPL solving succeeded, planning time "<<base_solver_->getPlanningTime()<<"sec");
+        HIGHLIGHT("OMPL solving succeeded, planning time " << base_solver_->getPlanningTime() << "sec");
     }
     else
     {
-      throw_solve("OMPL solving failed");
+        throw_solve("OMPL solving failed");
     }
-  }
+}
 
-  void OMPLsolver::specifyProblem(PlanningProblem_ptr pointer)
+void OMPLsolver::specifyProblem(PlanningProblem_ptr pointer)
 
-  {
+{
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<SamplingProblem>(pointer);
     base_solver_->specifyProblem(prob_);
-  }
+}
 
-  template<typename T> static ompl::base::PlannerPtr allocatePlanner(
-      const ob::SpaceInformationPtr &si, const std::string &new_name)
-  {
+template <typename T>
+static ompl::base::PlannerPtr allocatePlanner(
+    const ob::SpaceInformationPtr& si, const std::string& new_name)
+{
     ompl::base::PlannerPtr planner(new T(si));
     if (!new_name.empty()) planner->setName(new_name);
     planner->setup();
     return planner;
-  }
+}
 
-  void OMPLsolver::setGoalState(Eigen::VectorXdRefConst qT, const double eps)
-  {
+void OMPLsolver::setGoalState(Eigen::VectorXdRefConst qT, const double eps)
+{
     base_solver_->setGoalState(qT, eps);
-  }
+}
 } /* namespace exotica */

--- a/exotations/task_maps/dmesh_ros/include/dmesh_ros/GraphManager.h
+++ b/exotations/task_maps/dmesh_ros/include/dmesh_ros/GraphManager.h
@@ -33,68 +33,68 @@
 #ifndef GRAPHMANAGER_H_
 #define GRAPHMANAGER_H_
 
-#include <ros/ros.h>
-#include <exotica/Exotica.h>
-#include <dmesh_ros/MeshGraph.h>
 #include <dmesh_ros/DMeshVertexInitializer.h>
+#include <dmesh_ros/MeshGraph.h>
+#include <exotica/Exotica.h>
+#include <ros/ros.h>
 
 namespace exotica
 {
-  /**
+/**
    * \brief	The graph manager manages the graph (environment).
    * The manager handles external objects I/O,
    * i.e. receives objects information from outside, processes them and then send out to dmesh.
    */
-  class GraphManager
-  {
-    public:
-      /**
+class GraphManager
+{
+public:
+    /**
        * \brief	Default constructor
        */
-      GraphManager();
+    GraphManager();
 
-      /**
+    /**
        * \brief	Default destructor
        */
-      ~GraphManager();
+    ~GraphManager();
 
-      /**
+    /**
        * \brief	Initialise the manager
        * @param	links		All the robot links
        * @param	link_types	Link types, real or dummy
        * @param	size		Maximum graph size
        * @return	True if succeeded, false otherwise
        */
-      void initialisation(std::vector<DMeshVertexInitializer>& verts, int size);
+    void initialisation(std::vector<DMeshVertexInitializer>& verts, int size);
 
-      /*
+    /*
        * \brief	Get the graph pointer
        * @return	MeshGraph pointer
        */
-      MeshGraphPtr getGraph();
+    MeshGraphPtr getGraph();
 
-    private:
-      //	The mesh graph
-      MeshGraphPtr graph_;
+private:
+    //	The mesh graph
+    MeshGraphPtr graph_;
 
-      //	Initialisation flag
-      bool initialised_;
+    //	Initialisation flag
+    bool initialised_;
 
-      //	For ROS
-      //	External object callback
-      void extCallback(const exotica::MeshVertexConstPtr & ext);
-      void extArrCallback(const exotica::MeshVertexArrayConstPtr & ext);
+    //	For ROS
+    //	External object callback
+    void extCallback(const exotica::MeshVertexConstPtr& ext);
+    void extArrCallback(const exotica::MeshVertexArrayConstPtr& ext);
 
-      ros::Timer vel_timer_;
-      void velTimeCallback(const ros::TimerEvent&);
+    ros::Timer vel_timer_;
+    void velTimeCallback(const ros::TimerEvent&);
 
-      //	Private node handle
-      ros::NodeHandle nh_;
+    //	Private node handle
+    ros::NodeHandle nh_;
 
-      //	External object subscriber
-      ros::Subscriber ext_sub_;
-      ros::Subscriber ext_arr_sub_;
-  };
-}	//namespace exotica
+    //	External object subscriber
+    ros::Subscriber ext_sub_;
+    ros::Subscriber ext_arr_sub_;
+};
+}  //namespace exotica
 
 #endif /* GRAPHMANAGER_H_ */

--- a/exotations/task_maps/dmesh_ros/include/dmesh_ros/MeshGraph.h
+++ b/exotations/task_maps/dmesh_ros/include/dmesh_ros/MeshGraph.h
@@ -33,22 +33,22 @@
 #ifndef MESHGRAPH_H_
 #define MESHGRAPH_H_
 
-#include <string>
+#include <dmesh_ros/DMeshVertexInitializer.h>
 #include <eigen_conversions/eigen_msg.h>
-#include <exotica/Tools.h>
-#include <exotica/MeshVertexArray.h>
-#include <exotica/MeshVertex.h>
-#include <exotica/StringList.h>
 #include <exotica/BoolList.h>
+#include <exotica/MeshVertex.h>
+#include <exotica/MeshVertexArray.h>
+#include <exotica/StringList.h>
+#include <exotica/Tools.h>
 #include <exotica/Vector.h>
 #include <ros/ros.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <dmesh_ros/DMeshVertexInitializer.h>
+#include <string>
 
 namespace exotica
 {
-  enum VERTEX_TYPE
-  {
+enum VERTEX_TYPE
+{
     LINK = 0,
     DUMMY_LINK = 5,
     GOAL = 10,
@@ -56,215 +56,214 @@ namespace exotica
     OBSTACLE_TO_ALL = 30,
     IGNORE = 40,
     NONE = 255
-  };
+};
 
 //	\brief	The vertex
-  class Vertex
-  {
-    public:
-      /**
+class Vertex
+{
+public:
+    /**
        * \briref	Default constructor
        * @param	name		The vertex name
        */
-      Vertex(const std::string & name = "UNKNOWN");
-      Vertex(const std::string & name, const Eigen::Vector3d & position, double r, const std::vector<std::string> & tolinks, VERTEX_TYPE type, double w = 1.0);
+    Vertex(const std::string &name = "UNKNOWN");
+    Vertex(const std::string &name, const Eigen::Vector3d &position, double r, const std::vector<std::string> &tolinks, VERTEX_TYPE type, double w = 1.0);
 
-      /**
+    /**
        * \brief	Set this vertex as robot link
        * @param	name		The vertex name
        * @param	real_link	Whether this is a real link or dummy link
        * @param	position	The position of this vertex
        * @return	True is succeed, false if something goes wrong
        */
-      bool setAsLink(const std::string & name, bool real_link,
-          const Eigen::Vector3d & position, double r);
-      bool setAsLink(const std::string & name, bool real_link,
-          const geometry_msgs::Point & position, double r);
+    bool setAsLink(const std::string &name, bool real_link,
+                   const Eigen::Vector3d &position, double r);
+    bool setAsLink(const std::string &name, bool real_link,
+                   const geometry_msgs::Point &position, double r);
 
-      bool setToDummy()
-      {
+    bool setToDummy()
+    {
         type_ = VERTEX_TYPE::DUMMY_LINK;
         return true;
-      }
-      /**
+    }
+    /**
        * \brief	Set this vertex as goal
        * @param	name		The vertex name
        * @param	position	The position of this vertex
        * @param	tolinks		The interacting links
        * @return	True is succeed, false if something goes wrong
        */
-      bool setAsGoal(const std::string & name, const Eigen::Vector3d & position,
-          double r, const std::vector<std::string> & tolinks, double w);
-      bool setAsGoal(const std::string & name,
-          const geometry_msgs::Point & position, double r,
-          const std::vector<std::string> & tolinks, double w);
+    bool setAsGoal(const std::string &name, const Eigen::Vector3d &position,
+                   double r, const std::vector<std::string> &tolinks, double w);
+    bool setAsGoal(const std::string &name,
+                   const geometry_msgs::Point &position, double r,
+                   const std::vector<std::string> &tolinks, double w);
 
-      /**
+    /**
        * \brief	Set this vertex as obstacle
        * @param	name		The vertex name
        * @param	position	The position of this vertex
        * @param	tolinks		The interacting links
        * @return	True is succeeded, false if something goes wrong
        */
-      bool setAsObstacle(const std::string & name,
-          const Eigen::Vector3d & position, double r);
-      bool setAsObstacle(const std::string & name,
-          const geometry_msgs::Point & position, double r);
-      bool setAsObstacle(const std::string & name,
-          const Eigen::Vector3d & position, double r,
-          const std::vector<std::string> & tolinks);
-      bool setAsObstacle(const std::string & name,
-          const geometry_msgs::Point & position, double r,
-          const std::vector<std::string> & tolinks);
+    bool setAsObstacle(const std::string &name,
+                       const Eigen::Vector3d &position, double r);
+    bool setAsObstacle(const std::string &name,
+                       const geometry_msgs::Point &position, double r);
+    bool setAsObstacle(const std::string &name,
+                       const Eigen::Vector3d &position, double r,
+                       const std::vector<std::string> &tolinks);
+    bool setAsObstacle(const std::string &name,
+                       const geometry_msgs::Point &position, double r,
+                       const std::vector<std::string> &tolinks);
 
-      /**
+    /**
        * \brief	Activate this vertex
        * @return	True if succeeded, false otherwise
        */
-      bool activate();
+    bool activate();
 
-      /**
+    /**
        * \brief	Deactivate this vertex
        * @return	True if succeeded, false otherwise
        */
-      bool deactivate();
+    bool deactivate();
 
-      /**
+    /**
        * \brief	Check if the vertex is activated
        * @return	True if the vertex is activated, false otherwise
        */
-      bool isActive();
+    bool isActive();
 
-      /**
+    /**
        * \brief	Invalidate this vertex
        */
-      void invalidate();
+    void invalidate();
 
-      /**
+    /**
        * \brief	Get the distance to another vertex or position
        * @param	other	Other vertex or position
        * @return	Distance between two vertex, -1 if something wrong
        */
-      double distance(const Vertex & other);
-      double distance(const std::shared_ptr<Vertex> & other);
-      double distance(const Eigen::Vector3d & other);
+    double distance(const Vertex &other);
+    double distance(const std::shared_ptr<Vertex> &other);
+    double distance(const Eigen::Vector3d &other);
 
-      /**
+    /**
        * \brief	Check whether another link is in the interaction list
        * @param	link		The other link's name
        * @return	True if in the list, false otherwise
        */
-      bool checkList(const std::string & link);
+    bool checkList(const std::string &link);
 
-      /**
+    /**
        * \brief	Get the name of the vertex
        * @return	The name of this vertex
        */
-      std::string getName();
+    std::string getName();
 
-      /**
+    /**
        * \brief	Get he radius of the vertex
        * @return	The radius of this vertex
        */
-      double getRadius();
+    double getRadius();
 
-      /**
+    /**
        * \brief Get the type of the vertex
        * @return The type of this vertex
        */
-      VERTEX_TYPE getType();
+    VERTEX_TYPE getType();
 
-      //	The pose of the vertex (for now, just consider the position)
-      Eigen::Vector3d position_;
+    //	The pose of the vertex (for now, just consider the position)
+    Eigen::Vector3d position_;
 
-      //	The list of which robot links this vertex is interacting with
-      std::vector<std::string> toLinks_;
+    //	The list of which robot links this vertex is interacting with
+    std::vector<std::string> toLinks_;
 
-      //	The radius of this vertex
-      double radius_;
+    //	The radius of this vertex
+    double radius_;
 
-      //	The weighting factor
-      double w_;
-    private:
-      //	The name of this vertex
-      std::string name_;
+    //	The weighting factor
+    double w_;
 
-      //	The type of the vertex
-      VERTEX_TYPE type_;
+private:
+    //	The name of this vertex
+    std::string name_;
 
-      //	Flag indicates weather this vertex has been activated
-      bool isActive_;
+    //	The type of the vertex
+    VERTEX_TYPE type_;
 
-  };
+    //	Flag indicates weather this vertex has been activated
+    bool isActive_;
+};
 
 //	Vertex smart pointer
-  typedef std::shared_ptr<Vertex> VertexPtr;
+typedef std::shared_ptr<Vertex> VertexPtr;
 
 //	Graph initialiser
-  struct GraphProperties
-  {
-      //	The maximum size
-      int size;
+struct GraphProperties
+{
+    //	The maximum size
+    int size;
 
-      //	List of all robot links in the graph
-      std::vector<std::string> & link_names;
+    //	List of all robot links in the graph
+    std::vector<std::string> &link_names;
 
-      //	Interactive range
-      //	i.e. Object within this range will be considered to interact with
-      double interact_range_;
+    //	Interactive range
+    //	i.e. Object within this range will be considered to interact with
+    double interact_range_;
 
-      //	Safety threshold
-      double eps;
-
-  };
-  /**
+    //	Safety threshold
+    double eps;
+};
+/**
    * \brief	MeshGraph contains all the information of the vertices
    */
-  class MeshGraph
-  {
-    public:
-      /**
+class MeshGraph
+{
+public:
+    /**
        * \brief	Constructor
        * @param	name		The name of the graph
        */
-      MeshGraph(const std::string & name = "MeshGraph");
+    MeshGraph(const std::string &name = "MeshGraph");
 
-      /**
+    /**
        * \brief	Check whether the graph was initialised
        * @return	True if initialised, false otherwise
        */
-      bool isInitialised();
+    bool isInitialised();
 
-      /**
+    /**
        * \brief	Get the name of this graph
        * @return	The name of this graph
        */
-      std::string getName();
+    std::string getName();
 
-      /**
+    /**
        * \brief	Get the maximum size of this graph
        * @param	size		The maximum size of this graph
        * @return	True if succeeded, false otherwise
        */
-      bool getGraphSize(int size);
-      int getGraphSize();
+    bool getGraphSize(int size);
+    int getGraphSize();
 
-      /**
+    /**
        * \brief	Get the robot link size of this graph
        * @param	size		The robot link size of this graph
        * @return	True if succeeded, false otherwise
        */
-      bool getRobotSize(int robot_size);
-      int getRobotSize();
+    bool getRobotSize(int robot_size);
+    int getRobotSize();
 
-      /**
+    /**
        * \brief	Get vertex pointer
        * @prarm	index	The vertex index
        * @return	Vertex pointer
        */
-      VertexPtr getVertex(const int index);
+    VertexPtr getVertex(const int index);
 
-      /**
+    /**
        * \brief	Initalise the graph
        * @param	size		The maximum graph size
        * @param	link_names	The names of robot links
@@ -274,174 +273,174 @@ namespace exotica
        * @param	dummy_table	Flag indicate if use the dummy table obstacle
        * @return	True if succeeded, false otherwise
        */
-      void initialisation(const int size,
-          std::vector<DMeshVertexInitializer>& verts, const double i_range,
-          const double eps, const bool dummy_table);
+    void initialisation(const int size,
+                        std::vector<DMeshVertexInitializer> &verts, const double i_range,
+                        const double eps, const bool dummy_table);
 
-      /**
+    /**
        * \brief	Update robot links
        * @param	link_poses	Links' position that needs to be updated
        * @return	True if succeeded, false otherwise
        */
-      bool updateLinksRef(Eigen::VectorXdRefConst link_poses);
-      bool updateLinks(const Eigen::MatrixX3d & link_poses);
+    bool updateLinksRef(Eigen::VectorXdRefConst link_poses);
+    bool updateLinks(const Eigen::MatrixX3d &link_poses);
 
-      /**
+    /**
        * \brief	Update individual link
        * @param	name		Link name
        * @param	pose		Link pose
        * @return	True if succeeded, false otherwise
        */
-      bool updateLink(const std::string & name, const Eigen::Vector3d & pose);
+    bool updateLink(const std::string &name, const Eigen::Vector3d &pose);
 
-      /**
+    /**
        * \brief	Update external vertices
        * @param	ext			external objects
        * @return	True if succeeded, false otherwise
        */
-      bool updateExternal(const exotica::MeshVertex & ext);
-      bool updateExternal(const exotica::MeshVertexConstPtr & ext);
+    bool updateExternal(const exotica::MeshVertex &ext);
+    bool updateExternal(const exotica::MeshVertexConstPtr &ext);
 
-      /**
+    /**
        * \brief	Remove vertex from graph
        * @param	name		Vertex name
        * @return	True if succeeded, false otherwise
        */
-      bool removeVertex(const std::string & name);
+    bool removeVertex(const std::string &name);
 
-      /**
+    /**
        * \brief	Connect the external vertex from the graph
        * @param	name		The name of the external vertex
        * @return	True if succeeded, false otherwise
        */
-      bool connect(const std::string & name);
+    bool connect(const std::string &name);
 
-      /**
+    /**
        * \brief	Disconnect the vertex from the graph
        * @param	name		The name of the vertex
        * @return	True if succeeded, false otherwise
        */
-      bool disconnect(const std::string & name);
+    bool disconnect(const std::string &name);
 
-      /**
+    /**
        * \brief	Check if the vertex is in the graph
        * @param	name		The name of the vertex
        * @return	True if the vertex exist, false otherwise
        */
-      bool hasVertex(const std::string & name);
+    bool hasVertex(const std::string &name);
 
-      /**
+    /**
        * \brief	Get GOAL vertices and distances in Eigen format
        * @param	dist		Distance matrix
        * @return	True if succeeded, false otherwise
        */
-      bool getGoalDistanceEigen(Eigen::MatrixXd & dist);
+    bool getGoalDistanceEigen(Eigen::MatrixXd &dist);
 
-      /**
+    /**
        * \brief	Get	ACTUAL vertices and distances in Eigen format
        * @param	dist		Distance matrix
        * @return	True if succeeded, false otherwise
        */
-      bool getAcutalDistanceEigen(Eigen::MatrixXd & dist);
+    bool getAcutalDistanceEigen(Eigen::MatrixXd &dist);
 
-      /**
+    /**
        * \brief	Get interact range
        * @return	Interact range
        */
-      double getInteractRange();
+    double getInteractRange();
 
-      /**
+    /**
        * \brief	Get safety threshold
        * @return	Safety threshold
        */
-      double getEps();
+    double getEps();
 
-      /*
+    /*
        * \brief	Check whether another vertex is close
        * @param	j,l		Vertex indexes
        * @param	d		Distance between vertices j and l
        * @param	bound	Bound
        * @return	True if yes, false otherwise
        */
-      bool checkClose(const int j, const int l, double &d, double &bound);
+    bool checkClose(const int j, const int l, double &d, double &bound);
 
-      /**
+    /**
        * \brief	Get currently activated graph size
        * @return	Current size, -1 if not initialised
        */
-      double getCurrentSize();
+    double getCurrentSize();
 
-      /*
+    /*
        * \brief	Compute distance velocity. This is called by a ROS timer callback function
        * @return	True if succeeded, false otherwise
        */
-      bool computeVelocity();
+    bool computeVelocity();
 
-      Eigen::MatrixXd getVelocity();
+    Eigen::MatrixXd getVelocity();
 
-      /**
+    /**
        * \brief	Check if currently there are any close obstacles
        * return	True if yes, false otherwise
        */
-      bool hasActiveObstacle();
+    bool hasActiveObstacle();
 
-      //	Print the graph
-      void printGraph();
+    //	Print the graph
+    void printGraph();
 
-      void publishEdges();
-    private:
+    void publishEdges();
 
-      /*
+private:
+    /*
        * \brief	Check if a vertex needs to be activated
        * @param	ext		The new external object
        */
-      void checkActivation(const VertexPtr & ext);
+    void checkActivation(const VertexPtr &ext);
 
-      Eigen::MatrixXd groundTruthDistance();
+    Eigen::MatrixXd groundTruthDistance();
 
-      //	Name of the graph, usually wont be used, but...why not
-      std::string name_;
+    //	Name of the graph, usually wont be used, but...why not
+    std::string name_;
 
-      //	Size of the graph, i.e. number of vertices
-      int size_;
+    //	Size of the graph, i.e. number of vertices
+    int size_;
 
-      //	Size of robot link size
-      int robot_size_;
+    //	Size of robot link size
+    int robot_size_;
 
-      //	Interactive range
-      //	i.e. Object within this range will be considered to interact with
-      double interact_range_;
+    //	Interactive range
+    //	i.e. Object within this range will be considered to interact with
+    double interact_range_;
 
-      //	Safety threshold
-      double eps_;
+    //	Safety threshold
+    double eps_;
 
-      //	Vertices
-      std::vector<VertexPtr> vertices_;
+    //	Vertices
+    std::vector<VertexPtr> vertices_;
 
-      //	Vertex map
-      std::map<std::string, int> vertex_map_;
+    //	Vertex map
+    std::map<std::string, int> vertex_map_;
 
-      //	Link names
-      std::vector<std::string> link_names_;
+    //	Link names
+    std::vector<std::string> link_names_;
 
-      //	Initialisation flag
-      bool initialised_;
+    //	Initialisation flag
+    bool initialised_;
 
-      //	True if use dummy table obstacle
-      bool dummy_table_;
+    //	True if use dummy table obstacle
+    bool dummy_table_;
 
-      ros::NodeHandle nh_;
-      std::vector<ros::Publisher> pubs_;
-      std::vector<visualization_msgs::Marker> edges_;
+    ros::NodeHandle nh_;
+    std::vector<ros::Publisher> pubs_;
+    std::vector<visualization_msgs::Marker> edges_;
 
-      bool first_time_;
-      Eigen::MatrixXd old_dist_;
-      Eigen::MatrixXd dist_;
-      Eigen::MatrixXd vel_;
-  };
+    bool first_time_;
+    Eigen::MatrixXd old_dist_;
+    Eigen::MatrixXd dist_;
+    Eigen::MatrixXd vel_;
+};
 
 //	Graph smart pointer
-  typedef std::shared_ptr<MeshGraph> MeshGraphPtr;
-}	//namespace exotica
+typedef std::shared_ptr<MeshGraph> MeshGraphPtr;
+}  //namespace exotica
 
 #endif /* MESHGRAPH_H_ */

--- a/exotations/task_maps/dmesh_ros/include/dmesh_ros/VertexGeometry.h
+++ b/exotations/task_maps/dmesh_ros/include/dmesh_ros/VertexGeometry.h
@@ -35,43 +35,45 @@
 
 namespace exotica
 {
-  enum VERTEX_GEO_TYPE
-  {
-    UNKNOWN = 0, SPHERE = 10, CAPSULE = 20, PLANE = 30
-  };
+enum VERTEX_GEO_TYPE
+{
+    UNKNOWN = 0,
+    SPHERE = 10,
+    CAPSULE = 20,
+    PLANE = 30
+};
 //	\brief	Implementation of graph vertex geometry properties
-  class VertexGeometry
-  {
-    public:
-      /**
+class VertexGeometry
+{
+public:
+    /**
        * \brief	Constructor
        */
-      VertexGeometry();
+    VertexGeometry();
 
-      /**
+    /**
        * \brief	Destructor
        */
-      ~VertexGeometry();
+    ~VertexGeometry();
 
-      /**
+    /**
        * \brief	Initialise to sphere
        * @param	r		Radius
        */
-      bool initSphere(const double & r);
+    bool initSphere(const double& r);
 
-      /**
+    /**
        * \brief	Initialise to capsule
        * @param	l		Height of the cylindrical part
        * @param	r		Radius
        */
-      bool initCapsule(const double & l, const double & r);
+    bool initCapsule(const double& l, const double& r);
 
-      /**
+    /**
        * \brief	Initialise to plane
        *
        */
-
-  };
+};
 }
 
 #endif /* VERTEXGEOMETRY_H_ */

--- a/exotations/task_maps/dmesh_ros/include/dmesh_ros/dmesh_ros.h
+++ b/exotations/task_maps/dmesh_ros/include/dmesh_ros/dmesh_ros.h
@@ -34,145 +34,142 @@
 #define DMESH_ROS_H_
 
 //EXOTica and SYSTEM packages
+#include <dmesh_ros/GraphManager.h>
 #include <exotica/Exotica.h>
 #include <exotica/KinematicTree.h>
-#include <dmesh_ros/GraphManager.h>
-#include <tf/transform_listener.h>
 #include <exotica/Problems/UnconstrainedEndPoseProblem.h>
+#include <tf/transform_listener.h>
 //ROS packages
-#include <ros/ros.h>
 #include <geometry_msgs/PoseArray.h>
+#include <ros/ros.h>
 
 #include <dmesh_ros/DMeshROSInitializer.h>
 
 namespace exotica
 {
-  /**
+/**
    * \brief	Implementation of distance mesh task map with ROS.
    * Apart from dMesh task map, this task map use exotica and ROS node, msgs, etc.
    * The main improvement is now dMeshROS taking computation, visualisation, and robust into consideration
    * L(d_jl)=K*||p_j-p_l||, K(gain)={PoseGain(kp),ObstacleGain(ko),GoalGain(kg)}
    */
-  class DMeshROS: public TaskMap, public Instantiable<DMeshROSInitializer>
-  {
-    public:
+class DMeshROS : public TaskMap, public Instantiable<DMeshROSInitializer>
+{
+public:
+    DMeshROS();
 
-      DMeshROS();
+    ~DMeshROS();
 
-      ~DMeshROS();
+    virtual void Instantiate(DMeshROSInitializer& init);
 
-      virtual void Instantiate(DMeshROSInitializer& init);
+    virtual void assignScene(Scene_ptr scene);
 
-      virtual void assignScene(Scene_ptr scene);
+    void Initialize();
 
-      void Initialize();
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual int taskSpaceDim();
 
-      virtual int taskSpaceDim();
-
-      /**
+    /**
        * \brief	Get the goal laplace
        * @param	goal	Goal laplace
        */
-      Eigen::VectorXd getGoalLaplace();
+    Eigen::VectorXd getGoalLaplace();
 
-      /**
+    /**
        * \brief	Update external objects
        */
-      void updateExternal(const exotica::MeshVertex & ext);
-      void updateExternal(const exotica::MeshVertexArray & ext);
+    void updateExternal(const exotica::MeshVertex& ext);
+    void updateExternal(const exotica::MeshVertexArray& ext);
 
-      void removeVertex(const std::string & name);
+    void removeVertex(const std::string& name);
 
-      bool hasActiveObstacle();
+    bool hasActiveObstacle();
 
-      //	Graph Manager
-      GraphManager gManager_;
+    //	Graph Manager
+    GraphManager gManager_;
 
-    private:
-      /**
+private:
+    /**
        * \brief	Compute Laplace
        */
-      Eigen::VectorXd computeLaplace();
+    Eigen::VectorXd computeLaplace();
 
-      /**
+    /**
        * \brief	Compute Jacobian
        */
-      Eigen::MatrixXd computeJacobian();
+    Eigen::MatrixXd computeJacobian();
 
-      /**
+    /**
        * \brief	Update the graph from kinematic scene
        */
-      void updateGraphFromKS();
+    void updateGraphFromKS();
 
-      /**
+    /**
        * \brief	Update the graph externally
        * @param	name		Vertex name
        * @param	pose		Vertex position
        */
-      void updateGraphFromExternal(const std::string & name, const Eigen::Vector3d & pose);
+    void updateGraphFromExternal(const std::string& name, const Eigen::Vector3d& pose);
 
-      /**
+    /**
        * \brief	Update the graph from real transform
        */
-      void updateGraphFromTF();
-      /**
+    void updateGraphFromTF();
+    /**
        * \brief	Update the graph from given poses
        * @param	V		The given links' poses
        */
-      void updateGraphFromPoses(const Eigen::Matrix3Xd & V);
+    void updateGraphFromPoses(const Eigen::Matrix3Xd& V);
 
-      std::vector<std::string> links_;
-      std::vector<bool> link_types_;
-      Eigen::VectorXd radius_;
+    std::vector<std::string> links_;
+    std::vector<bool> link_types_;
+    Eigen::VectorXd radius_;
 
-      //	If we want to get real joint state
-      tf::TransformListener listener_;
+    //	If we want to get real joint state
+    tf::TransformListener listener_;
 
-      tf::StampedTransform transform_;
+    tf::StampedTransform transform_;
 
-      //	Maximum graph size
-      int size_;
+    //	Maximum graph size
+    int size_;
 
-      //	Robot links size
-      int robot_size_;
+    //	Robot links size
+    int robot_size_;
 
-      //	External objects size
-      int ext_size_;
+    //	External objects size
+    int ext_size_;
 
-      //	Task space size
-      int task_size_;
+    //	Task space size
+    int task_size_;
 
-      //	Configuration size
-      int q_size_;
+    //	Configuration size
+    int q_size_;
 
-      double kp_;
-      double ko_;
-      double kg_;
+    double kp_;
+    double ko_;
+    double kg_;
 
-      //	Distance matrix
-      Eigen::MatrixXd dist_;
+    //	Distance matrix
+    Eigen::MatrixXd dist_;
 
-      //	True if the obstacle is close
-      std::vector<bool> obs_close_;
+    //	True if the obstacle is close
+    std::vector<bool> obs_close_;
 
-      //	Interact Range
-      double ir_;
+    //	Interact Range
+    double ir_;
 
-      double wo_;
-      double wg_;
+    double wo_;
+    double wg_;
 
-      bool usePose_;
+    bool usePose_;
 
-      DMeshROSInitializer init_;
-      Scene_ptr scene_;
-
-
-  };
-  typedef std::shared_ptr<DMeshROS> DMeshROS_Ptr;
-} //namespace exotica
+    DMeshROSInitializer init_;
+    Scene_ptr scene_;
+};
+typedef std::shared_ptr<DMeshROS> DMeshROS_Ptr;
+}  //namespace exotica
 
 #endif /* DMESH_ROS_H_ */

--- a/exotations/task_maps/dmesh_ros/src/GraphManager.cpp
+++ b/exotations/task_maps/dmesh_ros/src/GraphManager.cpp
@@ -34,20 +34,19 @@
 
 namespace exotica
 {
-  GraphManager::GraphManager()
-      : initialised_(false), nh_("/MeshGraphManager"), graph_(
-          new MeshGraph("MESH_GRAPH"))
-  {
+GraphManager::GraphManager()
+    : initialised_(false), nh_("/MeshGraphManager"), graph_(new MeshGraph("MESH_GRAPH"))
+{
     //TODO
-  }
+}
 
-  GraphManager::~GraphManager()
-  {
+GraphManager::~GraphManager()
+{
     //TODO
-  }
+}
 
-  void GraphManager::initialisation(std::vector<DMeshVertexInitializer>& verts, int size)
-  {
+void GraphManager::initialisation(std::vector<DMeshVertexInitializer>& verts, int size)
+{
     if (verts.size() == 0 || size < verts.size())
     {
         throw_pretty("Mesh Graph Manager: wrong size(link size=" << verts.size() << ", size=" << size << ")\n");
@@ -55,13 +54,13 @@ namespace exotica
     double i_range;
     if (!nh_.getParam("/MeshGraphManager/InteractRange", i_range))
     {
-      throw_pretty("Parameter '/MeshGraphManager/InteractRange' not set!");
+        throw_pretty("Parameter '/MeshGraphManager/InteractRange' not set!");
     }
 
     double eps;
     if (!nh_.getParam("/MeshGraphManager/SafetyThreshold", eps))
     {
-      throw_pretty("Parameter '/MeshGraphManager/SafetyThreshold' not set!");
+        throw_pretty("Parameter '/MeshGraphManager/SafetyThreshold' not set!");
     }
     bool dummy_table = false;
     nh_.getParam("/MeshGraphManager/DummyTable", dummy_table);
@@ -71,38 +70,38 @@ namespace exotica
     std::string topic;
     if (!nh_.getParam("/MeshGraphManager/ExternalTopic", topic))
     {
-      throw_pretty("Parameter '/MeshGraphManager/ExternalTopic' not set!");
+        throw_pretty("Parameter '/MeshGraphManager/ExternalTopic' not set!");
     }
-//		ext_sub_ =
-//				nh_.subscribe<exotica::MeshVertex>(topic, 10, boost::bind(&exotica::GraphManager::extCallback, this, _1));
+    //		ext_sub_ =
+    //				nh_.subscribe<exotica::MeshVertex>(topic, 10, boost::bind(&exotica::GraphManager::extCallback, this, _1));
     ext_arr_sub_ = nh_.subscribe<exotica::MeshVertexArray>(topic, 10,
-        boost::bind(&exotica::GraphManager::extArrCallback, this, _1));
-//		vel_timer_ =
-//				nh_.createTimer(ros::Duration(0.05), boost::bind(&exotica::GraphManager::velTimeCallback, this, _1));
+                                                           boost::bind(&exotica::GraphManager::extArrCallback, this, _1));
+    //		vel_timer_ =
+    //				nh_.createTimer(ros::Duration(0.05), boost::bind(&exotica::GraphManager::velTimeCallback, this, _1));
 
     ROS_INFO("Mesh Graph Manager has been initialised");
     initialised_ = true;
-  }
+}
 
-  MeshGraphPtr GraphManager::getGraph()
-  {
+MeshGraphPtr GraphManager::getGraph()
+{
     return graph_;
-  }
+}
 
-  void GraphManager::extCallback(const exotica::MeshVertexConstPtr & ext)
-  {
+void GraphManager::extCallback(const exotica::MeshVertexConstPtr& ext)
+{
     graph_->updateExternal(ext);
-  }
+}
 
-  void GraphManager::extArrCallback(
-      const exotica::MeshVertexArrayConstPtr & ext)
-  {
+void GraphManager::extArrCallback(
+    const exotica::MeshVertexArrayConstPtr& ext)
+{
     for (int i = 0; i < ext->vertices.size(); i++)
-      graph_->updateExternal(ext->vertices[i]);
-  }
+        graph_->updateExternal(ext->vertices[i]);
+}
 
-  void GraphManager::velTimeCallback(const ros::TimerEvent&)
-  {
+void GraphManager::velTimeCallback(const ros::TimerEvent&)
+{
     graph_->computeVelocity();
-  }
-}	//namespace exotica
+}
+}  //namespace exotica

--- a/exotations/task_maps/dmesh_ros/src/MeshGraph.cpp
+++ b/exotations/task_maps/dmesh_ros/src/MeshGraph.cpp
@@ -35,30 +35,30 @@
 namespace exotica
 {
 //	Functions of Vertex
-  Vertex::Vertex(const std::string & name)
-      : name_(name), type_(NONE), isActive_(false), radius_(0)
-  {
+Vertex::Vertex(const std::string &name)
+    : name_(name), type_(NONE), isActive_(false), radius_(0)
+{
     position_.setZero();
-  }
+}
 
-  Vertex::Vertex(const std::string & name, const Eigen::Vector3d & position, double r, const std::vector<std::string> & tolinks, VERTEX_TYPE type, double w)
-  {
-      name_ = name;
-      type_ = type;
-      position_ = position;
-      radius_ = r;
-      isActive_ = true;
-      w_ = w;
-      toLinks_ = tolinks;
-  }
+Vertex::Vertex(const std::string &name, const Eigen::Vector3d &position, double r, const std::vector<std::string> &tolinks, VERTEX_TYPE type, double w)
+{
+    name_ = name;
+    type_ = type;
+    position_ = position;
+    radius_ = r;
+    isActive_ = true;
+    w_ = w;
+    toLinks_ = tolinks;
+}
 
-  bool Vertex::setAsLink(const std::string & name, bool real_link,
-      const Eigen::Vector3d & position, double r)
-  {
+bool Vertex::setAsLink(const std::string &name, bool real_link,
+                       const Eigen::Vector3d &position, double r)
+{
     if (name.compare("") == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     name_ = name;
     type_ = LINK;
@@ -67,23 +67,23 @@ namespace exotica
     isActive_ = true;
     w_ = 1;
     return true;
-  }
+}
 
-  bool Vertex::setAsLink(const std::string & name, bool real_link,
-      const geometry_msgs::Point & position, double r)
-  {
+bool Vertex::setAsLink(const std::string &name, bool real_link,
+                       const geometry_msgs::Point &position, double r)
+{
     position_ << position.x, position.y, position.z;
     return setAsLink(name, real_link, position_, r);
-  }
+}
 
-  bool Vertex::setAsGoal(const std::string & name,
-      const Eigen::Vector3d & position, double r,
-      const std::vector<std::string> & tolinks, double w)
-  {
+bool Vertex::setAsGoal(const std::string &name,
+                       const Eigen::Vector3d &position, double r,
+                       const std::vector<std::string> &tolinks, double w)
+{
     if (name.compare("") == 0 || tolinks.size() == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     name_ = name;
     type_ = GOAL;
@@ -93,46 +93,46 @@ namespace exotica
     radius_ = r;
     w_ = w;
     return true;
-  }
+}
 
-  bool Vertex::setAsGoal(const std::string & name,
-      const geometry_msgs::Point & position, double r,
-      const std::vector<std::string> & tolinks, double w)
-  {
+bool Vertex::setAsGoal(const std::string &name,
+                       const geometry_msgs::Point &position, double r,
+                       const std::vector<std::string> &tolinks, double w)
+{
     position_ << position.x, position.y, position.z;
     return setAsGoal(name, position_, r, tolinks, w);
-  }
+}
 
-  bool Vertex::setAsObstacle(const std::string & name,
-      const Eigen::Vector3d & position, double r)
-  {
+bool Vertex::setAsObstacle(const std::string &name,
+                           const Eigen::Vector3d &position, double r)
+{
     if (name.compare("") == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     name_ = name;
     type_ = OBSTACLE_TO_ALL;
     position_ = position;
     radius_ = r;
     return true;
-  }
+}
 
-  bool Vertex::setAsObstacle(const std::string & name,
-      const geometry_msgs::Point & position, double r)
-  {
+bool Vertex::setAsObstacle(const std::string &name,
+                           const geometry_msgs::Point &position, double r)
+{
     position_ << position.x, position.y, position.z;
     return setAsObstacle(name, position_, r);
-  }
+}
 
-  bool Vertex::setAsObstacle(const std::string & name,
-      const Eigen::Vector3d & position, double r,
-      const std::vector<std::string> & tolinks)
-  {
+bool Vertex::setAsObstacle(const std::string &name,
+                           const Eigen::Vector3d &position, double r,
+                           const std::vector<std::string> &tolinks)
+{
     if (name.compare("") == 0 || tolinks.size() == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     name_ = name;
     type_ = OBSTACLE;
@@ -140,162 +140,160 @@ namespace exotica
     toLinks_ = tolinks;
     radius_ = r;
     return true;
-  }
+}
 
-  bool Vertex::setAsObstacle(const std::string & name,
-      const geometry_msgs::Point & position, double r,
-      const std::vector<std::string> & tolinks)
-  {
+bool Vertex::setAsObstacle(const std::string &name,
+                           const geometry_msgs::Point &position, double r,
+                           const std::vector<std::string> &tolinks)
+{
     position_ << position.x, position.y, position.z;
     return setAsObstacle(name, position_, r, tolinks);
-  }
+}
 
-  void Vertex::invalidate()
-  {
+void Vertex::invalidate()
+{
     name_ = "UNKNOWN";
     position_.setZero();
     type_ = NONE;
     toLinks_.clear();
-  }
+}
 
-  bool Vertex::activate()
-  {
+bool Vertex::activate()
+{
     if (type_ == NONE)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
 
     return isActive_ = true;
-  }
+}
 
-  bool Vertex::deactivate()
-  {
+bool Vertex::deactivate()
+{
     if (type_ == NONE)
     {
-      WARNING("The vertex has not been initialised yet "<<name_);
-      return true;
+        WARNING("The vertex has not been initialised yet " << name_);
+        return true;
     }
     isActive_ = false;
     return true;
-  }
+}
 
-  bool Vertex::isActive()
-  {
+bool Vertex::isActive()
+{
     return isActive_;
-  }
+}
 
-  double Vertex::distance(const Eigen::Vector3d & other)
-  {
+double Vertex::distance(const Eigen::Vector3d &other)
+{
     return (other - position_).norm();
-  }
+}
 
-  double Vertex::distance(const Vertex & other)
-  {
+double Vertex::distance(const Vertex &other)
+{
     return distance(other.position_);
-  }
+}
 
-  double Vertex::distance(const VertexPtr & other)
-  {
+double Vertex::distance(const VertexPtr &other)
+{
     return distance(other->position_);
-  }
+}
 
-  bool Vertex::checkList(const std::string & link)
-  {
+bool Vertex::checkList(const std::string &link)
+{
     for (int i = 0; i < toLinks_.size(); i++)
     {
-      if (toLinks_[i].compare(link) == 0) return true;
+        if (toLinks_[i].compare(link) == 0) return true;
     }
     return false;
-  }
+}
 
-  std::string Vertex::getName()
-  {
+std::string Vertex::getName()
+{
     return name_;
-  }
+}
 
-  double Vertex::getRadius()
-  {
+double Vertex::getRadius()
+{
     return radius_;
-  }
-  VERTEX_TYPE Vertex::getType()
-  {
+}
+VERTEX_TYPE Vertex::getType()
+{
     return type_;
-  }
+}
 
 //	Functions of MeshGarph
-  MeshGraph::MeshGraph(const std::string & name)
-      : name_(name), size_(0), robot_size_(0), initialised_(false), interact_range_(
-          1.0), eps_(0.05), nh_("/DMeshGraph")
-  {
+MeshGraph::MeshGraph(const std::string &name)
+    : name_(name), size_(0), robot_size_(0), initialised_(false), interact_range_(1.0), eps_(0.05), nh_("/DMeshGraph")
+{
     //TODO
-  }
+}
 
-  std::string MeshGraph::getName()
-  {
+std::string MeshGraph::getName()
+{
     return name_;
-  }
+}
 
-  bool MeshGraph::getGraphSize(int size)
-  {
+bool MeshGraph::getGraphSize(int size)
+{
     if (!initialised_)
     {
-      INDICATE_FAILURE
-      size = -1;
-      return false;
+        INDICATE_FAILURE
+        size = -1;
+        return false;
     }
     size = size_;
     return true;
-  }
+}
 
-  int MeshGraph::getGraphSize()
-  {
+int MeshGraph::getGraphSize()
+{
     if (!initialised_) return -1;
     return size_;
-  }
+}
 
-  bool MeshGraph::getRobotSize(int robot_size)
-  {
+bool MeshGraph::getRobotSize(int robot_size)
+{
     if (!initialised_)
     {
-      INDICATE_FAILURE
-      robot_size = -1;
-      return false;
+        INDICATE_FAILURE
+        robot_size = -1;
+        return false;
     }
     robot_size = robot_size_;
     return true;
-  }
+}
 
-  int MeshGraph::getRobotSize()
-  {
+int MeshGraph::getRobotSize()
+{
     if (!initialised_) return -1;
     return robot_size_;
-  }
+}
 
-  VertexPtr MeshGraph::getVertex(const int index)
-  {
+VertexPtr MeshGraph::getVertex(const int index)
+{
     if (index >= vertices_.size())
     {
-      if (!initialised_)
-        std::cout << "Graph not initialised" << std::endl;
-      else
-        std::cout << "You are querying the vertex with index " << index
-            << ", but the graph current only contains " << vertices_.size()
-            << " vertices" << std::endl;
-      INDICATE_FAILURE
-      return VertexPtr(new Vertex);
+        if (!initialised_)
+            std::cout << "Graph not initialised" << std::endl;
+        else
+            std::cout << "You are querying the vertex with index " << index
+                      << ", but the graph current only contains " << vertices_.size()
+                      << " vertices" << std::endl;
+        INDICATE_FAILURE
+        return VertexPtr(new Vertex);
     }
     return vertices_[index];
-  }
+}
 
-  void MeshGraph::initialisation(const int size,
-      std::vector<DMeshVertexInitializer>& verts, const double i_range,
-      const double eps, const bool dummy_table)
-  {
-    if (initialised_ || verts.size() == 0 || size < verts.size()
-        || i_range < 0 || eps < 0)
+void MeshGraph::initialisation(const int size,
+                               std::vector<DMeshVertexInitializer> &verts, const double i_range,
+                               const double eps, const bool dummy_table)
+{
+    if (initialised_ || verts.size() == 0 || size < verts.size() || i_range < 0 || eps < 0)
     {
-      throw_pretty("Wrong graph parameter sizes!");
+        throw_pretty("Wrong graph parameter sizes!");
     }
     size_ = size;
     robot_size_ = verts.size();
@@ -304,45 +302,45 @@ namespace exotica
     vertices_.resize(size_);
     for (int i = 0; i < robot_size_; i++)
     {
-      if (vertex_map_.find(verts[i].Name) != vertex_map_.end())
-      {
-        throw_pretty("Trying to add an already existing vertex '"<<verts[i].Name<<"'");
-      }
-      Eigen::Vector3d pos = verts[i].LinkOffset.head(3);
-      VERTEX_TYPE type;
-      if(verts[i].LinkType == "LINK")
-        type = LINK;
-      else if(verts[i].LinkType == "DUMMY_LINK")
-        type = DUMMY_LINK;
-      else if(verts[i].LinkType == "GOAL")
-        type = GOAL;
-      else if(verts[i].LinkType == "OBSTACLE")
-        type = OBSTACLE;
-      else if(verts[i].LinkType == "OBSTACLE_TO_ALL")
-        type = OBSTACLE_TO_ALL;
-      else if(verts[i].LinkType == "IGNORE")
-        type = IGNORE;
-      else
-        type = NONE;
-      vertices_[i].reset(new Vertex(verts[i].Name, pos, verts[i].Radius, verts[i].ConnectTo, type, verts[i].W));
-      vertex_map_[verts[i].Name] = i;
+        if (vertex_map_.find(verts[i].Name) != vertex_map_.end())
+        {
+            throw_pretty("Trying to add an already existing vertex '" << verts[i].Name << "'");
+        }
+        Eigen::Vector3d pos = verts[i].LinkOffset.head(3);
+        VERTEX_TYPE type;
+        if (verts[i].LinkType == "LINK")
+            type = LINK;
+        else if (verts[i].LinkType == "DUMMY_LINK")
+            type = DUMMY_LINK;
+        else if (verts[i].LinkType == "GOAL")
+            type = GOAL;
+        else if (verts[i].LinkType == "OBSTACLE")
+            type = OBSTACLE;
+        else if (verts[i].LinkType == "OBSTACLE_TO_ALL")
+            type = OBSTACLE_TO_ALL;
+        else if (verts[i].LinkType == "IGNORE")
+            type = IGNORE;
+        else
+            type = NONE;
+        vertices_[i].reset(new Vertex(verts[i].Name, pos, verts[i].Radius, verts[i].ConnectTo, type, verts[i].W));
+        vertex_map_[verts[i].Name] = i;
     }
     for (int j = robot_size_; j < size_; j++)
-      vertices_[j].reset(new Vertex);
+        vertices_[j].reset(new Vertex);
 
     dummy_table_ = dummy_table;
     if (dummy_table_)
     {
-      //	Let's create a dummy table for end-effector
-      vertex_map_["DummyTable_link6"] = robot_size_;
-      std::vector<std::string> eff;
-      vertices_[vertex_map_.at("DummyTable_link6")]->setAsObstacle(
-          "DummyTable_link6", Eigen::Vector3d::Zero(), 0.06,
-          { "lwr_arm_6_link" });
+        //	Let's create a dummy table for end-effector
+        vertex_map_["DummyTable_link6"] = robot_size_;
+        std::vector<std::string> eff;
+        vertices_[vertex_map_.at("DummyTable_link6")]->setAsObstacle(
+            "DummyTable_link6", Eigen::Vector3d::Zero(), 0.06,
+            {"lwr_arm_6_link"});
 
-//			vertex_map_["DummyTable_tip"] = robot_size_ + 1;
-//			vertices_[vertex_map_.at("DummyTable_tip")]->setAsObstacle("DummyTable_tip", Eigen::Vector3d::Zero(), 0.06, {
-//					"pen_tip_link" });
+        //			vertex_map_["DummyTable_tip"] = robot_size_ + 1;
+        //			vertices_[vertex_map_.at("DummyTable_tip")]->setAsObstacle("DummyTable_tip", Eigen::Vector3d::Zero(), 0.06, {
+        //					"pen_tip_link" });
     }
 
     pubs_.resize(5);
@@ -354,11 +352,10 @@ namespace exotica
     //	4.	Non-active obstacle in current mesh
     for (int i = 0; i < 5; i++)
     {
-      pubs_[i] = nh_.advertise<visualization_msgs::Marker>(
-          "DMeshEdges" + std::to_string(i), 100);
-      edges_[i].type = visualization_msgs::Marker::LINE_LIST;
-      edges_[i].header.frame_id = "/base";
-
+        pubs_[i] = nh_.advertise<visualization_msgs::Marker>(
+            "DMeshEdges" + std::to_string(i), 100);
+        edges_[i].type = visualization_msgs::Marker::LINE_LIST;
+        edges_[i].header.frame_id = "/base";
     }
 
     edges_[0].scale.x = 0.002;
@@ -393,78 +390,78 @@ namespace exotica
     edges_[4].color.a = 1;
 
     initialised_ = true;
-  }
+}
 
-  bool MeshGraph::isInitialised()
-  {
+bool MeshGraph::isInitialised()
+{
     return initialised_;
-  }
+}
 
-  bool MeshGraph::updateLinksRef(Eigen::VectorXdRefConst link_poses)
-  {
+bool MeshGraph::updateLinksRef(Eigen::VectorXdRefConst link_poses)
+{
     //	Check size, assume they are in correct order
     if (robot_size_ != link_poses.rows() / 3 || link_poses.rows() % 3 != 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
 
     for (int i = 0; i < robot_size_; i++)
-      vertices_[i]->position_ = Eigen::Vector3d(link_poses.segment(3 * i, 3));
+        vertices_[i]->position_ = Eigen::Vector3d(link_poses.segment(3 * i, 3));
 
     if (dummy_table_)
     {
-      //	When we update the links, dummy table should also be updated
-      vertices_[vertex_map_.at("DummyTable_link6")]->position_ =
-          vertices_[vertex_map_.at("lwr_arm_6_link")]->position_;
-      vertices_[vertex_map_.at("DummyTable_link6")]->position_(2) = 0;
-      checkActivation(vertices_[vertex_map_.at("DummyTable_link6")]);
+        //	When we update the links, dummy table should also be updated
+        vertices_[vertex_map_.at("DummyTable_link6")]->position_ =
+            vertices_[vertex_map_.at("lwr_arm_6_link")]->position_;
+        vertices_[vertex_map_.at("DummyTable_link6")]->position_(2) = 0;
+        checkActivation(vertices_[vertex_map_.at("DummyTable_link6")]);
 
-//			vertices_[vertex_map_.at("DummyTable_tip")]->position_ =
-//					vertices_[vertex_map_.at("pen_tip_link")]->position_;
-//			vertices_[vertex_map_.at("DummyTable_tip")]->position_(2) = 0;
-//			checkActivation(vertices_[vertex_map_.at("DummyTable_tip")]);
+        //			vertices_[vertex_map_.at("DummyTable_tip")]->position_ =
+        //					vertices_[vertex_map_.at("pen_tip_link")]->position_;
+        //			vertices_[vertex_map_.at("DummyTable_tip")]->position_(2) = 0;
+        //			checkActivation(vertices_[vertex_map_.at("DummyTable_tip")]);
     }
     return true;
-  }
+}
 
-  bool MeshGraph::updateLinks(const Eigen::MatrixX3d & link_poses)
-  {
+bool MeshGraph::updateLinks(const Eigen::MatrixX3d &link_poses)
+{
     //	Check size, assume they are in correct order
     if (robot_size_ != link_poses.cols())
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
 
     for (int i = 0; i < robot_size_; i++)
-      vertices_[i]->position_ = Eigen::Vector3d(link_poses.row(i));
+        vertices_[i]->position_ = Eigen::Vector3d(link_poses.row(i));
     return true;
-  }
+}
 
-  bool MeshGraph::updateLink(const std::string & name,
-      const Eigen::Vector3d & pose)
-  {
+bool MeshGraph::updateLink(const std::string &name,
+                           const Eigen::Vector3d &pose)
+{
     if (vertex_map_.find(name) == vertex_map_.end())
     {
-      std::cout << "Link " << name << " does not exist" << std::endl;
-      return false;
+        std::cout << "Link " << name << " does not exist" << std::endl;
+        return false;
     }
     vertices_[vertex_map_.at(name)]->position_ = pose;
     return true;
-  }
+}
 
-  bool MeshGraph::updateExternal(const exotica::MeshVertex & ext)
-  {
+bool MeshGraph::updateExternal(const exotica::MeshVertex &ext)
+{
     //	If it's already in the list, just change position
     if (vertex_map_.find(ext.name) != vertex_map_.end())
     {
-      vertices_[vertex_map_.at(ext.name)]->position_(0) = ext.position.x;
-      vertices_[vertex_map_.at(ext.name)]->position_(1) = ext.position.y;
-      vertices_[vertex_map_.at(ext.name)]->position_(2) = ext.position.z;
-      vertices_[vertex_map_.at(ext.name)]->radius_ = ext.radius;
-      vertices_[vertex_map_.at(ext.name)]->w_ = ext.w;
-      return true;
+        vertices_[vertex_map_.at(ext.name)]->position_(0) = ext.position.x;
+        vertices_[vertex_map_.at(ext.name)]->position_(1) = ext.position.y;
+        vertices_[vertex_map_.at(ext.name)]->position_(2) = ext.position.z;
+        vertices_[vertex_map_.at(ext.name)]->radius_ = ext.radius;
+        vertices_[vertex_map_.at(ext.name)]->w_ = ext.w;
+        return true;
     }
 
     //	If not, then we need to add a new object
@@ -472,212 +469,209 @@ namespace exotica
     VertexPtr newvertex(new Vertex);
     switch (ext.type)
     {
-    case exotica::MeshVertex::GOAL:
-      if (newvertex->setAsGoal(ext.name, ext.position, ext.radius, ext.toLinks,
-          ext.w)) success = true;
-      break;
-    case exotica::MeshVertex::OBSTACLE_TO_ALL:
-      if (newvertex->setAsObstacle(ext.name, ext.position, ext.radius))
-        success = true;
-      break;
-    case exotica::MeshVertex::OBSTACLE:
-      if (newvertex->setAsObstacle(ext.name, ext.position, ext.radius,
-          ext.toLinks)) success = true;
-      break;
-    default:
-      //	This function should not contain LINK, as it should be called from external subscriber callbacks
-      break;
+        case exotica::MeshVertex::GOAL:
+            if (newvertex->setAsGoal(ext.name, ext.position, ext.radius, ext.toLinks,
+                                     ext.w)) success = true;
+            break;
+        case exotica::MeshVertex::OBSTACLE_TO_ALL:
+            if (newvertex->setAsObstacle(ext.name, ext.position, ext.radius))
+                success = true;
+            break;
+        case exotica::MeshVertex::OBSTACLE:
+            if (newvertex->setAsObstacle(ext.name, ext.position, ext.radius,
+                                         ext.toLinks)) success = true;
+            break;
+        default:
+            //	This function should not contain LINK, as it should be called from external subscriber callbacks
+            break;
     }
     if (!success) return false;
     int tmpsize = vertex_map_.size();
     vertices_[tmpsize] = newvertex;
     vertex_map_[ext.name] = tmpsize;
     return true;
-  }
+}
 
-  bool MeshGraph::updateExternal(const exotica::MeshVertexConstPtr & ext)
-  {
-
+bool MeshGraph::updateExternal(const exotica::MeshVertexConstPtr &ext)
+{
     return updateExternal(*ext.get());
-  }
+}
 
-  bool MeshGraph::removeVertex(const std::string & name)
-  {
+bool MeshGraph::removeVertex(const std::string &name)
+{
     std::map<std::string, int>::iterator it = vertex_map_.find(name);
     if (it == vertex_map_.end())
     {
-      std::cout << "Link " << name << " does not exist" << std::endl;
-      return false;
+        std::cout << "Link " << name << " does not exist" << std::endl;
+        return false;
     }
     vertices_[it->second]->invalidate();
     vertex_map_.erase(it);
     return true;
-  }
-  void MeshGraph::checkActivation(const VertexPtr & ext)
-  {
+}
+void MeshGraph::checkActivation(const VertexPtr &ext)
+{
     double d = 999;
     bool found = false;
     switch (ext->getType())
     {
-    case OBSTACLE:
-      for (auto & it : vertex_map_)
-      {
-        if (ext->checkList(it.first))
-        {
-          d = ext->distance(vertices_[it.second]->position_);
+        case OBSTACLE:
+            for (auto &it : vertex_map_)
+            {
+                if (ext->checkList(it.first))
+                {
+                    d = ext->distance(vertices_[it.second]->position_);
 
-          if (d < interact_range_) //if (d < interact_range_)
-          {
+                    if (d < interact_range_)  //if (d < interact_range_)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            break;
+        case OBSTACLE_TO_ALL:
+            for (auto &it : vertex_map_)
+            {
+                if (vertices_[it.second]->getType() == LINK)
+                {
+                    d = ext->distance(vertices_[it.second]->position_);
+
+                    if (d < interact_range_)  //if (d < interact_range_)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            break;
+        case GOAL:
+            for (auto &it : vertex_map_)
+                if (ext->checkList(it.first))
+                {
+                    found = true;
+                    break;
+                }
+            break;
+        case LINK:
             found = true;
             break;
-          }
-        }
-      }
-      break;
-    case OBSTACLE_TO_ALL:
-      for (auto & it : vertex_map_)
-      {
-        if (vertices_[it.second]->getType() == LINK)
-        {
-          d = ext->distance(vertices_[it.second]->position_);
-
-          if (d < interact_range_) //if (d < interact_range_)
-          {
+        case DUMMY_LINK:
             found = true;
             break;
-          }
-        }
-      }
-      break;
-    case GOAL:
-      for (auto & it : vertex_map_)
-        if (ext->checkList(it.first))
-        {
-          found = true;
-          break;
-        }
-      break;
-    case LINK:
-      found = true;
-      break;
-    case DUMMY_LINK:
-      found = true;
-      break;
-    default:
-      break;
+        default:
+            break;
     }
     if (found)
     {
-      ext->activate();
+        ext->activate();
     }
     else
     {
-      ext->deactivate();
+        ext->deactivate();
     }
-  }
+}
 
-  bool MeshGraph::connect(const std::string & name)
-  {
+bool MeshGraph::connect(const std::string &name)
+{
     if (!initialised_)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     if (vertex_map_.find(name) == vertex_map_.end())
     {
-      ERROR("Vertex ["<<name<<"] does not exist, connection failed");
-      return false;
+        ERROR("Vertex [" << name << "] does not exist, connection failed");
+        return false;
     }
 
     return vertices_[vertex_map_.at(name)]->activate();
-  }
+}
 
-  bool MeshGraph::disconnect(const std::string & name)
-  {
+bool MeshGraph::disconnect(const std::string &name)
+{
     if (!initialised_)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     if (vertex_map_.find(name) == vertex_map_.end())
     {
-      WARNING("Vertex ["<<name<<"] does not exist");
-      return true;
+        WARNING("Vertex [" << name << "] does not exist");
+        return true;
     }
 
     return vertices_[vertex_map_.at(name)]->deactivate();
-  }
+}
 
-  bool MeshGraph::hasVertex(const std::string & name)
-  {
+bool MeshGraph::hasVertex(const std::string &name)
+{
     if (!initialised_)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     if (vertex_map_.find(name) == vertex_map_.end()) return false;
     return true;
-  }
+}
 
-  bool MeshGraph::getGoalDistanceEigen(Eigen::MatrixXd & dist)
-  {
+bool MeshGraph::getGoalDistanceEigen(Eigen::MatrixXd &dist)
+{
     if (!initialised_ || vertex_map_.size() == 0 || vertices_.size() == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
     dist.setZero(size_, size_);
     double tmpd, tmpbound;
     for (int j = 0; j < robot_size_; j++)
     {
-      checkActivation(vertices_[j]);
-      for (int l = j + 1; l < size_; l++)
-      {
-        checkActivation(vertices_[l]);
-        if (vertices_[l]->isActive() && vertices_[j]->isActive())
+        checkActivation(vertices_[j]);
+        for (int l = j + 1; l < size_; l++)
         {
-          if (l < robot_size_)	//	Both are robot links
-            dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
-          else	//	Robot link and external object
-          {
-            //	Object l is6 an obstacle to all links
-            if (vertices_[l]->getType() == OBSTACLE_TO_ALL)
+            checkActivation(vertices_[l]);
+            if (vertices_[l]->isActive() && vertices_[j]->isActive())
             {
-
-              //std::cout << "Link [" << vertices_[j]->getName() << "] is too close to [" << vertices_[l]->getName() << "] (" << tmpd << "), set desired distance to " << tmpbound << "\n";
-              dist(j, l) = tmpbound;
-
-            }
-            //	Object l is an obstacle to some particular links
-            else if (vertices_[l]->getType() == OBSTACLE)
-            {
-              //	Link j is in the interacting list
-              if (vertices_[l]->checkList(vertices_[j]->getName()))
-              {
-                if (checkClose(j, l, tmpd, tmpbound))
+                if (l < robot_size_)  //	Both are robot links
+                    dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
+                else  //	Robot link and external object
                 {
-                  //std::cout << "Link [" << vertices_[j]->getName() << "] is too close to [" << vertices_[l]->getName() << "] (" << tmpd << "), set desired distance to " << tmpbound << "\n";
-                  dist(j, l) = tmpbound;
+                    //	Object l is6 an obstacle to all links
+                    if (vertices_[l]->getType() == OBSTACLE_TO_ALL)
+                    {
+                        //std::cout << "Link [" << vertices_[j]->getName() << "] is too close to [" << vertices_[l]->getName() << "] (" << tmpd << "), set desired distance to " << tmpbound << "\n";
+                        dist(j, l) = tmpbound;
+                    }
+                    //	Object l is an obstacle to some particular links
+                    else if (vertices_[l]->getType() == OBSTACLE)
+                    {
+                        //	Link j is in the interacting list
+                        if (vertices_[l]->checkList(vertices_[j]->getName()))
+                        {
+                            if (checkClose(j, l, tmpd, tmpbound))
+                            {
+                                //std::cout << "Link [" << vertices_[j]->getName() << "] is too close to [" << vertices_[l]->getName() << "] (" << tmpd << "), set desired distance to " << tmpbound << "\n";
+                                dist(j, l) = tmpbound;
+                            }
+                        }
+                    }
+                    //	Object l is a goal, or ignore
                 }
-              }
+                //	HERE: j and l both are greater then robot_size_.
+                //	They both are external objects, which means the distance between them are not controllable,
+                //	and we do not care (leave as zero)
             }
-            //	Object l is a goal, or ignore
-          }
-          //	HERE: j and l both are greater then robot_size_.
-          //	They both are external objects, which means the distance between them are not controllable,
-          //	and we do not care (leave as zero)
         }
-      }
     }
     return true;
-  }
+}
 
-  bool MeshGraph::getAcutalDistanceEigen(Eigen::MatrixXd & dist)
-  {
+bool MeshGraph::getAcutalDistanceEigen(Eigen::MatrixXd &dist)
+{
     if (!initialised_ || vertex_map_.size() == 0 || vertices_.size() == 0)
     {
-      INDICATE_FAILURE
-      return false;
+        INDICATE_FAILURE
+        return false;
     }
 
     dist.setZero(size_, size_);
@@ -686,251 +680,244 @@ namespace exotica
 
     for (int j = 0; j < robot_size_; j++)
     {
-      checkActivation(vertices_[j]);
-      for (int l = 0; l < size_; l++)
-      {
-        checkActivation(vertices_[l]);
-        if (vertices_[l]->isActive() && vertices_[j]->isActive())
+        checkActivation(vertices_[j]);
+        for (int l = 0; l < size_; l++)
         {
-          if (l < robot_size_)	//	Both are robot links
-            dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
-          else	//	Robot link and external object
-          {
-            //	Object l is an obstacle to all links
-            if (vertices_[l]->getType() == OBSTACLE_TO_ALL)
+            checkActivation(vertices_[l]);
+            if (vertices_[l]->isActive() && vertices_[j]->isActive())
             {
-              dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
+                if (l < robot_size_)  //	Both are robot links
+                    dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
+                else  //	Robot link and external object
+                {
+                    //	Object l is an obstacle to all links
+                    if (vertices_[l]->getType() == OBSTACLE_TO_ALL)
+                    {
+                        dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
+                    }
+                    //	Object l is an obstacle to some particular links
+                    else if (vertices_[l]->getType() == OBSTACLE)
+                    {
+                        //	Link j is in the interacting list
+                        if (vertices_[l]->checkList(vertices_[j]->getName())) dist(j, l) =
+                                                                                  vertices_[j]->distance(vertices_[l]->position_);
+                    }
+                    else if (vertices_[l]->getType() == GOAL)
+                    {
+                        if (vertices_[l]->checkList(vertices_[j]->getName())) dist(j, l) =
+                                                                                  vertices_[j]->distance(vertices_[l]->position_);
+                    }
+                    //	Object l is a goal, or ignore
+                }
+                //	HERE: j and l both are greater then robot_size_.
+                //	They both are external objects, which means the distance between them are not controllable,
+                //	and we do not care (leave as zero)
             }
-            //	Object l is an obstacle to some particular links
-            else if (vertices_[l]->getType() == OBSTACLE)
-            {
-              //	Link j is in the interacting list
-              if (vertices_[l]->checkList(vertices_[j]->getName())) dist(j, l) =
-                  vertices_[j]->distance(vertices_[l]->position_);
-            }
-            else if (vertices_[l]->getType() == GOAL)
-            {
-              if (vertices_[l]->checkList(vertices_[j]->getName())) dist(j, l) =
-                  vertices_[j]->distance(vertices_[l]->position_);
-            }
-            //	Object l is a goal, or ignore
-          }
-          //	HERE: j and l both are greater then robot_size_.
-          //	They both are external objects, which means the distance between them are not controllable,
-          //	and we do not care (leave as zero)
         }
-
-      }
     }
     publishEdges();
     dist_ = dist;
     return true;
-  }
+}
 
-  void MeshGraph::publishEdges()
-  {
+void MeshGraph::publishEdges()
+{
     for (int i = 0; i < 5; i++)
     {
-      edges_[i].points.resize(0);
-      edges_[i].colors.resize(0);
+        edges_[i].points.resize(0);
+        edges_[i].colors.resize(0);
     }
     for (int j = 0; j < robot_size_; j++)
     {
-      checkActivation(vertices_[j]);
-      for (int l = 0; l < size_; l++)
-      {
-        checkActivation(vertices_[l]);
-        if (vertices_[l]->isActive() && vertices_[j]->isActive())
+        checkActivation(vertices_[j]);
+        for (int l = 0; l < size_; l++)
         {
-          //	Vision
-          if (true
-              || vertices_[j]->getType() != VERTEX_TYPE::DUMMY_LINK
-                  && vertices_[l]->getType() != VERTEX_TYPE::DUMMY_LINK
-//							&& vertice6s_[j]->getName().compare("goal_ori") != 0
-//							&& vertices_[l]->getName().compare("goal_ori") != 0
-                  && vertices_[j]->getName().compare("DummyTable_link6") != 0
-                  && vertices_[l]->getName().compare("DummyTable_link6") != 0)
-          {
-            geometry_msgs::Point tmpj, tmpl;
-            tf::pointEigenToMsg(vertices_[j]->position_, tmpj);
-            tf::pointEigenToMsg(vertices_[l]->position_, tmpl);
-            if (vertices_[l]->getType() == VERTEX_TYPE::LINK)
+            checkActivation(vertices_[l]);
+            if (vertices_[l]->isActive() && vertices_[j]->isActive())
             {
-              edges_[1].points.push_back(tmpj);
-              edges_[1].points.push_back(tmpl);
-            }
-            else if (vertices_[l]->getType() == VERTEX_TYPE::GOAL)
-            {
-              if (vertices_[l]->checkList(vertices_[j]->getName()))
-              {
-                edges_[2].points.push_back(tmpj);
-                edges_[2].points.push_back(tmpl);
-              }
-              else
-              {
-                edges_[0].points.push_back(tmpj);
-                edges_[0].points.push_back(tmpl);
-              }
-            }
-            else if (vertices_[l]->getType() == VERTEX_TYPE::OBSTACLE_TO_ALL)
-            {
-              double bound = vertices_[j]->getRadius()
-                  + vertices_[l]->getRadius() + eps_;
-              if (dist_(j, l) <= bound)
-              {
-                edges_[3].points.push_back(tmpj);
-                edges_[3].points.push_back(tmpl);
-              }
+                //	Vision
+                if (true || vertices_[j]->getType() != VERTEX_TYPE::DUMMY_LINK && vertices_[l]->getType() != VERTEX_TYPE::DUMMY_LINK
+                                //							&& vertice6s_[j]->getName().compare("goal_ori") != 0
+                                //							&& vertices_[l]->getName().compare("goal_ori") != 0
+                                && vertices_[j]->getName().compare("DummyTable_link6") != 0 && vertices_[l]->getName().compare("DummyTable_link6") != 0)
+                {
+                    geometry_msgs::Point tmpj, tmpl;
+                    tf::pointEigenToMsg(vertices_[j]->position_, tmpj);
+                    tf::pointEigenToMsg(vertices_[l]->position_, tmpl);
+                    if (vertices_[l]->getType() == VERTEX_TYPE::LINK)
+                    {
+                        edges_[1].points.push_back(tmpj);
+                        edges_[1].points.push_back(tmpl);
+                    }
+                    else if (vertices_[l]->getType() == VERTEX_TYPE::GOAL)
+                    {
+                        if (vertices_[l]->checkList(vertices_[j]->getName()))
+                        {
+                            edges_[2].points.push_back(tmpj);
+                            edges_[2].points.push_back(tmpl);
+                        }
+                        else
+                        {
+                            edges_[0].points.push_back(tmpj);
+                            edges_[0].points.push_back(tmpl);
+                        }
+                    }
+                    else if (vertices_[l]->getType() == VERTEX_TYPE::OBSTACLE_TO_ALL)
+                    {
+                        double bound = vertices_[j]->getRadius() + vertices_[l]->getRadius() + eps_;
+                        if (dist_(j, l) <= bound)
+                        {
+                            edges_[3].points.push_back(tmpj);
+                            edges_[3].points.push_back(tmpl);
+                        }
 
-              edges_[4].points.push_back(tmpj);
-              edges_[4].points.push_back(tmpl);
+                        edges_[4].points.push_back(tmpj);
+                        edges_[4].points.push_back(tmpl);
+                    }
+                }
             }
-          }
         }
-      }
     }
 
     for (int i = 0; i < 5; i++)
-      pubs_[i].publish(edges_[i]);
-  }
-  double MeshGraph::getInteractRange()
-  {
+        pubs_[i].publish(edges_[i]);
+}
+double MeshGraph::getInteractRange()
+{
     if (!initialised_) return 0;
     return interact_range_;
-  }
+}
 
-  double MeshGraph::getEps()
-  {
+double MeshGraph::getEps()
+{
     return eps_;
-  }
+}
 
-  double MeshGraph::getCurrentSize()
-  {
+double MeshGraph::getCurrentSize()
+{
     if (!initialised_) return -1;
     return vertex_map_.size();
-  }
+}
 
-  bool MeshGraph::checkClose(const int j, const int l, double &d, double &bound)
-  {
+bool MeshGraph::checkClose(const int j, const int l, double &d, double &bound)
+{
     if (j >= vertices_.size() || l >= vertices_.size())
     {
-      d = bound = 0;
-      return false;
+        d = bound = 0;
+        return false;
     }
     if (!vertices_[j]->isActive() || !vertices_[l]->isActive())
     {
-      d = bound = 0.0;
-      return false;
+        d = bound = 0.0;
+        return false;
     }
     d = vertices_[j]->distance(vertices_[l]->position_);
     bound = vertices_[j]->getRadius() + vertices_[l]->getRadius() + eps_;
     if (d < bound) return true;
     return false;
-  }
+}
 
-  void MeshGraph::printGraph()
-  {
+void MeshGraph::printGraph()
+{
     std::cout
         << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
     if (initialised_)
     {
-      std::cout << "Graph [" << name_ << "] has maximum size of " << size_
-          << ", currently has " << vertex_map_.size()
-          << " activated vertices: \n";
-      for (int i = 0; i < vertex_map_.size(); i++)
-      {
-        std::cout << "[" << vertices_[i]->getName() << "] is ";
-        switch (vertices_[i]->getType())
+        std::cout << "Graph [" << name_ << "] has maximum size of " << size_
+                  << ", currently has " << vertex_map_.size()
+                  << " activated vertices: \n";
+        for (int i = 0; i < vertex_map_.size(); i++)
         {
-        case LINK:
-          std::cout << "robot link [r=" << vertices_[i]->getRadius()
-              << "]\n Current position(" << vertices_[i]->position_.transpose()
-              << ")\n";
-          break;
-        case DUMMY_LINK:
-          std::cout << "dummy robot link [r=" << vertices_[i]->getRadius()
-              << "]\n Current position(" << vertices_[i]->position_.transpose()
-              << ")\n";
-          break;
-        case OBSTACLE_TO_ALL:
-          std::cout << "obstacle to all links [r=" << vertices_[i]->getRadius()
-              << "]\n Current position(" << vertices_[i]->position_.transpose()
-              << ")\n";
-          break;
-        case OBSTACLE:
-          std::cout << "obstacle [r=" << vertices_[i]->getRadius() << "] to ";
-          for (int j = 0; j < vertices_[i]->toLinks_.size(); j++)
-            std::cout << "[" << vertices_[i]->toLinks_[j] << "]";
-          std::cout << "\nCurrent position("
-              << vertices_[i]->position_.transpose() << ")\n";
-          break;
-        case GOAL:
-          std::cout << "goal to " << vertices_[i]->toLinks_[0]
-              << "\n Current position(" << vertices_[i]->position_.transpose()
-              << ")\n";
-          break;
-        default:
-          std::cout << "currently deactivated\n";
-          break;
+            std::cout << "[" << vertices_[i]->getName() << "] is ";
+            switch (vertices_[i]->getType())
+            {
+                case LINK:
+                    std::cout << "robot link [r=" << vertices_[i]->getRadius()
+                              << "]\n Current position(" << vertices_[i]->position_.transpose()
+                              << ")\n";
+                    break;
+                case DUMMY_LINK:
+                    std::cout << "dummy robot link [r=" << vertices_[i]->getRadius()
+                              << "]\n Current position(" << vertices_[i]->position_.transpose()
+                              << ")\n";
+                    break;
+                case OBSTACLE_TO_ALL:
+                    std::cout << "obstacle to all links [r=" << vertices_[i]->getRadius()
+                              << "]\n Current position(" << vertices_[i]->position_.transpose()
+                              << ")\n";
+                    break;
+                case OBSTACLE:
+                    std::cout << "obstacle [r=" << vertices_[i]->getRadius() << "] to ";
+                    for (int j = 0; j < vertices_[i]->toLinks_.size(); j++)
+                        std::cout << "[" << vertices_[i]->toLinks_[j] << "]";
+                    std::cout << "\nCurrent position("
+                              << vertices_[i]->position_.transpose() << ")\n";
+                    break;
+                case GOAL:
+                    std::cout << "goal to " << vertices_[i]->toLinks_[0]
+                              << "\n Current position(" << vertices_[i]->position_.transpose()
+                              << ")\n";
+                    break;
+                default:
+                    std::cout << "currently deactivated\n";
+                    break;
+            }
         }
-      }
     }
     else
     {
-      std::cout << "This graph has not been initialised\n";
+        std::cout << "This graph has not been initialised\n";
     }
     std::cout
         << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
-  }
+}
 
-  bool MeshGraph::computeVelocity()
-  {
+bool MeshGraph::computeVelocity()
+{
     dist_ = groundTruthDistance();
     if (first_time_)
     {
-      old_dist_ = dist_;
-      vel_.setZero();
-      first_time_ = false;
+        old_dist_ = dist_;
+        vel_.setZero();
+        first_time_ = false;
     }
     else
     {
-      vel_ = 20 * (dist_ - old_dist_);
-      old_dist_ = dist_;
+        vel_ = 20 * (dist_ - old_dist_);
+        old_dist_ = dist_;
     }
     //std::cout<<"velocity: \n"<<vel_<<std::endl;
     return true;
-  }
+}
 
-  Eigen::MatrixXd MeshGraph::groundTruthDistance()
-  {
+Eigen::MatrixXd MeshGraph::groundTruthDistance()
+{
     Eigen::MatrixXd dist;
     dist.resize(size_, size_);
     for (int j = 0; j < size_; j++)
     {
-      for (int l = 0; l < size_; l++)
-      {
-        dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
-      }
+        for (int l = 0; l < size_; l++)
+        {
+            dist(j, l) = vertices_[j]->distance(vertices_[l]->position_);
+        }
     }
     return dist;
-  }
+}
 
-  Eigen::MatrixXd MeshGraph::getVelocity()
-  {
+Eigen::MatrixXd MeshGraph::getVelocity()
+{
     return vel_;
-  }
+}
 
-  bool MeshGraph::hasActiveObstacle()
-  {
+bool MeshGraph::hasActiveObstacle()
+{
     for (int i = 0; i < vertices_.size(); i++)
     {
-      if (vertices_[i]->getType() == VERTEX_TYPE::OBSTACLE_TO_ALL
-          || vertices_[i]->getType() == VERTEX_TYPE::OBSTACLE)
-      {
-        if (vertices_[i]->isActive()) return true;
-      }
+        if (vertices_[i]->getType() == VERTEX_TYPE::OBSTACLE_TO_ALL || vertices_[i]->getType() == VERTEX_TYPE::OBSTACLE)
+        {
+            if (vertices_[i]->isActive()) return true;
+        }
     }
     return false;
-  }
-}	//	namespace exotica
-
+}
+}  //	namespace exotica

--- a/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
+++ b/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
@@ -30,121 +30,121 @@
  *
  */
 
-#include <dmesh_ros/dmesh_ros.h>
 #include <dmesh_ros/DMeshVertexInitializer.h>
+#include <dmesh_ros/dmesh_ros.h>
 REGISTER_TASKMAP_TYPE("DMeshROS", exotica::DMeshROS);
 
 namespace exotica
 {
-    DMeshROS::DMeshROS() : ir_(0.2)
+DMeshROS::DMeshROS() : ir_(0.2)
+{
+}
+
+DMeshROS::~DMeshROS()
+{
+}
+
+void DMeshROS::Instantiate(DMeshROSInitializer& init)
+{
+    init_ = init;
+}
+
+void DMeshROS::assignScene(Scene_ptr scene)
+{
+    scene_ = scene;
+    Initialize();
+}
+
+void DMeshROS::Initialize()
+{
+    q_size_ = scene_->getSolver().getNumJoints();
+    if (init_.Size > 0)
     {
+        size_ = init_.Size;
+    }
+    else
+    {
+        size_ = Frames.size();
+    }
+    kp_ = init_.PoseGain;
+    ko_ = init_.ObstacleGain;
+    kg_ = init_.GoalGain;
+    usePose_ = init_.UsePose;
+    wo_ = 10;
+    wg_ = 10;
+
+    radius_.resize(Frames.size());
+    links_.resize(Frames.size());
+    link_types_.resize(Frames.size());
+
+    std::vector<DMeshVertexInitializer> verts(Frames.size());
+
+    for (int i = 0; i < Frames.size(); i++)
+    {
+        verts[i] = DMeshVertexInitializer(init_.EndEffector[i]);
     }
 
-    DMeshROS::~DMeshROS()
+    gManager_.initialisation(verts, size_);
+
+    robot_size_ = Frames.size();
+
+    if (robot_size_ > size_) throw_named("The size of DMesh must be larger than number of vertices! " << robot_size_);
+
+    ext_size_ = size_ - robot_size_;
+
+    if (usePose_)
     {
+        task_size_ = (size_) * (size_ - 1) / 2 - robot_size_;
+    }
+    else
+    {
+        task_size_ = robot_size_ * ext_size_;
+    }
+    obs_close_.resize(ext_size_);
+
+    if (debug_) HIGHLIGHT_NAMED("DMeshROS", "Distance Mesh (ROS) has been initialised: Maximum Graph size=" << size_ << ", Robot link size=" << robot_size_ << ", Unconnected external object size=" << ext_size_);
+}
+
+void DMeshROS::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != task_size_) throw_named("Wrong size of phi!");
+    phi = computeLaplace();
+}
+
+void DMeshROS::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != task_size_) throw_named("Wrong size of phi!");
+    if (J.rows() != task_size_ || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+    phi = computeLaplace();
+    J = computeJacobian();
+}
+
+int DMeshROS::taskSpaceDim()
+{
+    //task_size_ = gManager_.getGraph()->getCurrentSize();
+    return task_size_;
+}
+
+Eigen::VectorXd DMeshROS::getGoalLaplace()
+{
+    Eigen::VectorXd goal = Eigen::VectorXd::Zero(task_size_);
+    updateGraphFromKS();
+
+    Eigen::MatrixXd dist;
+    if (!gManager_.getGraph()->getGoalDistanceEigen(dist))
+    {
+        throw_named("Failed to get distances!");
     }
 
-    void DMeshROS::Instantiate(DMeshROSInitializer& init)
+    int cnt = 0;
+    for (int j = 0; j < robot_size_; j++)
     {
-        init_ = init;
-    }
-
-    void DMeshROS::assignScene(Scene_ptr scene)
-    {
-        scene_ = scene;
-        Initialize();
-    }
-
-    void DMeshROS::Initialize()
-    {
-        q_size_ = scene_->getSolver().getNumJoints();
-        if(init_.Size>0)
+        int tmp = robot_size_;
+        if (usePose_) tmp = j + 2;
+        for (int l = tmp; l < size_; l++)
         {
-            size_ = init_.Size;
-        }
-        else
-        {
-            size_ = Frames.size();
-        }
-        kp_ = init_.PoseGain;
-        ko_ = init_.ObstacleGain;
-        kg_ = init_.GoalGain;
-        usePose_ = init_.UsePose;
-        wo_ = 10;
-        wg_ = 10;
-
-        radius_.resize(Frames.size());
-        links_.resize(Frames.size());
-        link_types_.resize(Frames.size());
-
-        std::vector<DMeshVertexInitializer> verts(Frames.size());
-
-        for(int i=0;i<Frames.size();i++)
-        {
-            verts[i] = DMeshVertexInitializer(init_.EndEffector[i]);
-        }
-
-        gManager_.initialisation(verts, size_);
-
-        robot_size_ = Frames.size();
-
-        if (robot_size_>size_) throw_named("The size of DMesh must be larger than number of vertices! " << robot_size_);
-
-        ext_size_ = size_ - robot_size_;
-
-        if (usePose_)
-        {
-            task_size_ = (size_) * (size_ - 1) / 2 - robot_size_;
-        }
-        else
-        {
-            task_size_ = robot_size_ * ext_size_;
-        }
-        obs_close_.resize(ext_size_);
-
-        if(debug_)  HIGHLIGHT_NAMED("DMeshROS", "Distance Mesh (ROS) has been initialised: Maximum Graph size="<<size_<<", Robot link size="<<robot_size_<<", Unconnected external object size="<<ext_size_);
-    }
-
-    void DMeshROS::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
-    {
-        if(phi.rows() != task_size_) throw_named("Wrong size of phi!");
-        phi = computeLaplace();
-    }
-
-    void DMeshROS::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
-    {
-        if(phi.rows() != task_size_) throw_named("Wrong size of phi!");
-        if(J.rows() != task_size_ || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
-        phi = computeLaplace();
-        J = computeJacobian();
-    }
-
-    int DMeshROS::taskSpaceDim()
-    {
-        //task_size_ = gManager_.getGraph()->getCurrentSize();
-        return task_size_;
-    }
-
-    Eigen::VectorXd DMeshROS::getGoalLaplace()
-    {
-        Eigen::VectorXd goal = Eigen::VectorXd::Zero(task_size_);
-        updateGraphFromKS();
-
-        Eigen::MatrixXd dist;
-        if (!gManager_.getGraph()->getGoalDistanceEigen(dist))
-        {
-            throw_named("Failed to get distances!");
-        }
-
-        int cnt = 0;
-        for (int j = 0; j < robot_size_; j++)
-        {
-            int tmp = robot_size_;
-            if (usePose_) tmp = j + 2;
-            for (int l = tmp; l < size_; l++)
+            switch (gManager_.getGraph()->getVertex(l)->getType())
             {
-                switch (gManager_.getGraph()->getVertex(l)->getType())
-                {
                 case VERTEX_TYPE::LINK:
                     goal(cnt) = kp_ * dist(j, l);
                     break;
@@ -158,56 +158,52 @@ namespace exotica
                     goal(cnt) = ko_;
                     break;
                 case VERTEX_TYPE::GOAL:
-                    goal(cnt) = gManager_.getGraph()->getVertex(l)->w_* gManager_.getGraph()->getVertex(l)->radius_;
+                    goal(cnt) = gManager_.getGraph()->getVertex(l)->w_ * gManager_.getGraph()->getVertex(l)->radius_;
                     break;
                 default:
                     //	All other types will zero for goal laplace
                     break;
-                }
-                cnt++;
             }
+            cnt++;
         }
-        return goal;
+    }
+    return goal;
+}
+
+Eigen::VectorXd DMeshROS::computeLaplace()
+{
+    updateGraphFromKS();
+    if (!gManager_.getGraph()->getAcutalDistanceEigen(dist_))
+    {
+        throw_named("Couldn't get actual distances!");
     }
 
-    Eigen::VectorXd DMeshROS::computeLaplace()
+    Eigen::VectorXd Phi = Eigen::VectorXd::Zero(task_size_);
+    int cnt = 0;
+    double b = 0, d = 0;
+    for (int j = 0; j < robot_size_; j++)
     {
-
-        updateGraphFromKS();
-        if (!gManager_.getGraph()->getAcutalDistanceEigen(dist_))
+        int tmp = robot_size_;
+        if (usePose_) tmp = j + 2;
+        for (int l = tmp; l < size_; l++)
         {
-            throw_named("Couldn't get actual distances!");
-        }
-
-        Eigen::VectorXd Phi = Eigen::VectorXd::Zero(task_size_);
-        int cnt = 0;
-        double b = 0, d = 0;
-        for (int j = 0; j < robot_size_; j++)
-        {
-            int tmp = robot_size_;
-            if (usePose_) tmp = j + 2;
-            for (int l = tmp; l < size_; l++)
+            b = d = 0;
+            switch (gManager_.getGraph()->getVertex(l)->getType())
             {
-                b = d = 0;
-                switch (gManager_.getGraph()->getVertex(l)->getType())
-                {
                 case VERTEX_TYPE::LINK:
                     Phi(cnt) = kp_ * dist_(j, l);
                     break;
                 case VERTEX_TYPE::OBSTACLE:
                     if (gManager_.getGraph()->getVertex(l)->checkList(links_[j]))
                     {
-                        if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius()
-                                - gManager_.getGraph()->getVertex(l)->getRadius() < 0.05)
+                        if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius() - gManager_.getGraph()->getVertex(l)->getRadius() < 0.05)
                             Phi(cnt) = ko_ * (1 - exp(-wo_ * dist_(j, l)));
                         else
                             Phi(cnt) = ko_;
-
                     }
                     break;
                 case VERTEX_TYPE::OBSTACLE_TO_ALL:
-                    if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius()
-                            - gManager_.getGraph()->getVertex(l)->getRadius() < 0.05)
+                    if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius() - gManager_.getGraph()->getVertex(l)->getRadius() < 0.05)
                         Phi(cnt) = ko_ * (1 - exp(-wo_ * dist_(j, l)));
                     else
                         Phi(cnt) = ko_;
@@ -217,161 +213,145 @@ namespace exotica
                     break;
                 default:
                     break;
-                }
-                cnt++;
             }
+            cnt++;
         }
-        HIGHLIGHT(cnt);
-        return Phi;
     }
+    HIGHLIGHT(cnt);
+    return Phi;
+}
 
-    Eigen::MatrixXd DMeshROS::computeJacobian()
+Eigen::MatrixXd DMeshROS::computeJacobian()
+{
+    Eigen::MatrixXd J = Eigen::MatrixXd::Zero(task_size_, q_size_);
+    double d_ = 0;
+    int cnt;
+    for (int i = 0; i < q_size_; i++)
     {
-        Eigen::MatrixXd J = Eigen::MatrixXd::Zero(task_size_, q_size_);
-        double d_ = 0;
-        int cnt;
-        for (int i = 0; i < q_size_; i++)
+        cnt = 0;
+        for (int j = 0; j < robot_size_; j++)
         {
-            cnt = 0;
-            for (int j = 0; j < robot_size_; j++)
+            int tmp = robot_size_;
+            if (usePose_) tmp = j + 2;
+            for (int l = tmp; l < size_; l++)
             {
-                int tmp = robot_size_;
-                if (usePose_) tmp = j + 2;
-                for (int l = tmp; l < size_; l++)
+                if (dist_(j, l) > 0)
                 {
-                    if (dist_(j, l) > 0)
+                    switch (gManager_.getGraph()->getVertex(l)->getType())
                     {
-                        switch (gManager_.getGraph()->getVertex(l)->getType())
-                        {
                         case VERTEX_TYPE::LINK:
-                            d_ = ((gManager_.getGraph()->getVertex(j)->position_
-                                   - gManager_.getGraph()->getVertex(l)->position_).dot(
-                                      Eigen::Vector3d(
-                                          Kinematics.J[j].data.block(0, i, 3, 1)
-                                          - Kinematics.J[l].data.block(0, i, 3, 1)))) / dist_(j, l);
+                            d_ = ((gManager_.getGraph()->getVertex(j)->position_ - gManager_.getGraph()->getVertex(l)->position_).dot(Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1) - Kinematics.J[l].data.block(0, i, 3, 1)))) / dist_(j, l);
                             J(cnt, i) = kp_ * d_;
                             break;
                         case VERTEX_TYPE::OBSTACLE:
                             if (gManager_.getGraph()->getVertex(l)->checkList(
-                                        links_[j]))
+                                    links_[j]))
                             {
-                                if (dist_(j, l)
-                                        - gManager_.getGraph()->getVertex(j)->getRadius()
-                                        - gManager_.getGraph()->getVertex(l)->getRadius() < 0.5)
+                                if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius() - gManager_.getGraph()->getVertex(l)->getRadius() < 0.5)
                                 {
-                                    d_ = ((gManager_.getGraph()->getVertex(j)->position_
-                                           - gManager_.getGraph()->getVertex(l)->position_).dot(
-                                              Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1))))
-                                            / dist_(j, l);
+                                    d_ = ((gManager_.getGraph()->getVertex(j)->position_ - gManager_.getGraph()->getVertex(l)->position_).dot(Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1)))) / dist_(j, l);
                                     J(cnt, i) = ko_ * wo_ * d_ * exp(-wo_ * dist_(j, l));
                                 }
                             }
                             break;
                         case VERTEX_TYPE::OBSTACLE_TO_ALL:
-                            if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius()
-                                    - gManager_.getGraph()->getVertex(l)->getRadius() < 0.5)
+                            if (dist_(j, l) - gManager_.getGraph()->getVertex(j)->getRadius() - gManager_.getGraph()->getVertex(l)->getRadius() < 0.5)
                             {
-                                d_ = ((gManager_.getGraph()->getVertex(j)->position_
-                                       - gManager_.getGraph()->getVertex(l)->position_).dot(
-                                          Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1))))
-                                        / dist_(j, l);
+                                d_ = ((gManager_.getGraph()->getVertex(j)->position_ - gManager_.getGraph()->getVertex(l)->position_).dot(Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1)))) / dist_(j, l);
                                 J(cnt, i) = ko_ * wo_ * d_ * exp(-wo_ * dist_(j, l));
                             }
 
                             break;
                         case VERTEX_TYPE::GOAL:
-                            d_ = ((gManager_.getGraph()->getVertex(j)->position_
-                                   - gManager_.getGraph()->getVertex(l)->position_).dot(
-                                      Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1)))) / dist_(j, l);
+                            d_ = ((gManager_.getGraph()->getVertex(j)->position_ - gManager_.getGraph()->getVertex(l)->position_).dot(Eigen::Vector3d(Kinematics.J[j].data.block(0, i, 3, 1)))) / dist_(j, l);
                             J(cnt, i) = gManager_.getGraph()->getVertex(l)->w_ * d_;
                             break;
                         default:
                             break;
-                        }
                     }
-                    cnt++;
                 }
+                cnt++;
             }
         }
     }
-
-    void DMeshROS::updateGraphFromKS()
-    {
-        int M = Kinematics.Phi.rows();
-        Eigen::VectorXd EffPhi(M*3);
-        for(int i=0;i<M;i++)
-        {
-            EffPhi(i*3) = Kinematics.Phi(i).p[0];
-            EffPhi(i*3+1) = Kinematics.Phi(i).p[1];
-            EffPhi(i*3+2) = Kinematics.Phi(i).p[2];
-        }
-        gManager_.getGraph()->updateLinksRef(EffPhi);
-    }
-
-    void DMeshROS::updateGraphFromExternal(const std::string & name,
-                                           const Eigen::Vector3d & pose)
-    {
-        if (!gManager_.getGraph()->updateLink(name, pose))
-        {
-            throw_named("Can't update the link!");
-        }
-    }
-
-    void DMeshROS::updateGraphFromTF()
-    {
-        Eigen::VectorXd tmp = Eigen::VectorXd::Zero(robot_size_ * 3);
-        for (int i = 1; i < robot_size_ - 1; i++)
-        {
-            try
-            {
-                listener_.lookupTransform("/base", "/" + links_[i], ros::Time(0), transform_);
-            } catch (tf::TransformException &ex)
-            {
-
-                ros::Duration(1.0).sleep();
-                throw_named(ex.what());
-            }
-            tmp(3 * i) = transform_.getOrigin().x();
-            tmp(3 * i + 1) = transform_.getOrigin().y();
-            tmp(3 * i + 2) = transform_.getOrigin().z();
-        }
-        tmp(3 * (robot_size_ - 1)) = 0.3;
-        tmp(3 * (robot_size_ - 1) + 1) = 5;
-        tmp(3 * (robot_size_ - 1) + 2) = 0.2;
-
-        if (!gManager_.getGraph()->updateLinksRef(tmp))
-        {
-            throw_named("Can't update link references!");
-        }
-    }
-
-    void DMeshROS::updateExternal(const exotica::MeshVertex & ext)
-    {
-        if (!gManager_.getGraph()->updateExternal(ext))
-        {
-            throw_named("Update "<<ext.name<<" failed");
-        }
-    }
-
-  void DMeshROS::updateExternal(const exotica::MeshVertexArray & ext)
-  {
-    for (int i = 0; i < ext.vertices.size(); i++)
-    {
-      updateExternal(ext.vertices[i]);
-    }
-  }
-
-  void DMeshROS::removeVertex(const std::string & name)
-  {
-    if (!gManager_.getGraph()->removeVertex(name))
-    {
-      ROS_ERROR_STREAM("Remove "<<name<<" failed");
-    }
-  }
-
-  bool DMeshROS::hasActiveObstacle()
-  {
-    return gManager_.getGraph()->hasActiveObstacle();
-  }
 }
 
+void DMeshROS::updateGraphFromKS()
+{
+    int M = Kinematics.Phi.rows();
+    Eigen::VectorXd EffPhi(M * 3);
+    for (int i = 0; i < M; i++)
+    {
+        EffPhi(i * 3) = Kinematics.Phi(i).p[0];
+        EffPhi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        EffPhi(i * 3 + 2) = Kinematics.Phi(i).p[2];
+    }
+    gManager_.getGraph()->updateLinksRef(EffPhi);
+}
+
+void DMeshROS::updateGraphFromExternal(const std::string& name,
+                                       const Eigen::Vector3d& pose)
+{
+    if (!gManager_.getGraph()->updateLink(name, pose))
+    {
+        throw_named("Can't update the link!");
+    }
+}
+
+void DMeshROS::updateGraphFromTF()
+{
+    Eigen::VectorXd tmp = Eigen::VectorXd::Zero(robot_size_ * 3);
+    for (int i = 1; i < robot_size_ - 1; i++)
+    {
+        try
+        {
+            listener_.lookupTransform("/base", "/" + links_[i], ros::Time(0), transform_);
+        }
+        catch (tf::TransformException& ex)
+        {
+            ros::Duration(1.0).sleep();
+            throw_named(ex.what());
+        }
+        tmp(3 * i) = transform_.getOrigin().x();
+        tmp(3 * i + 1) = transform_.getOrigin().y();
+        tmp(3 * i + 2) = transform_.getOrigin().z();
+    }
+    tmp(3 * (robot_size_ - 1)) = 0.3;
+    tmp(3 * (robot_size_ - 1) + 1) = 5;
+    tmp(3 * (robot_size_ - 1) + 2) = 0.2;
+
+    if (!gManager_.getGraph()->updateLinksRef(tmp))
+    {
+        throw_named("Can't update link references!");
+    }
+}
+
+void DMeshROS::updateExternal(const exotica::MeshVertex& ext)
+{
+    if (!gManager_.getGraph()->updateExternal(ext))
+    {
+        throw_named("Update " << ext.name << " failed");
+    }
+}
+
+void DMeshROS::updateExternal(const exotica::MeshVertexArray& ext)
+{
+    for (int i = 0; i < ext.vertices.size(); i++)
+    {
+        updateExternal(ext.vertices[i]);
+    }
+}
+
+void DMeshROS::removeVertex(const std::string& name)
+{
+    if (!gManager_.getGraph()->removeVertex(name))
+    {
+        ROS_ERROR_STREAM("Remove " << name << " failed");
+    }
+}
+
+bool DMeshROS::hasActiveObstacle()
+{
+    return gManager_.getGraph()->hasActiveObstacle();
+}
+}

--- a/exotations/task_maps/dmesh_ros/tests/test_maps.cpp
+++ b/exotations/task_maps/dmesh_ros/tests/test_maps.cpp
@@ -34,8 +34,8 @@
 
 using namespace exotica;
 
-std::string urdf_string="<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"revolute\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint2\" type=\"revolute\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint3\" type=\"revolute\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
-std::string srdf_string="<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
+std::string urdf_string = "<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"revolute\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint2\" type=\"revolute\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint3\" type=\"revolute\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
+std::string srdf_string = "<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
 bool printInfo = true;
 
 #define NUM_TRIALS 100
@@ -44,15 +44,16 @@ void testRandom(UnconstrainedEndPoseProblem_ptr problem)
 {
     Eigen::VectorXd x(3);
     INFO_PLAIN("Testing random configurations:")
-    for(int i=0;i<NUM_TRIALS;i++)
+    for (int i = 0; i < NUM_TRIALS; i++)
     {
         x.setRandom();
         problem->Update(x);
-        if(printInfo)
+        if (printInfo)
         {
-            INFO_PLAIN("x = "<<x.transpose());
-            INFO_PLAIN("y = "<<problem->Phi.transpose());
-            INFO_PLAIN("J = \n"<<problem->J);
+            INFO_PLAIN("x = " << x.transpose());
+            INFO_PLAIN("y = " << problem->Phi.transpose());
+            INFO_PLAIN("J = \n"
+                       << problem->J);
         }
     }
     INFO_PLAIN("Test passed");
@@ -64,20 +65,22 @@ void testValues(Eigen::MatrixXdRefConst Xref, Eigen::MatrixXdRefConst Yref, Eige
     int N = Xref.cols();
     int M = Yref.cols();
     int L = Xref.rows();
-    for(int i=0;i<L;i++)
+    for (int i = 0; i < L; i++)
     {
         Eigen::VectorXd x = Xref.row(i);
         Eigen::VectorXd y = Yref.row(i);
-        Eigen::MatrixXd J = Jref.middleRows(i*M,M);
+        Eigen::MatrixXd J = Jref.middleRows(i * M, M);
         problem->Update(x);
         double errY = (y - problem->Phi).norm();
         double errJ = (J - problem->J).norm();
-        if(errY > eps) throw_pretty("Task space error out of bounds: " << errY);
-        if(errJ > eps)
+        if (errY > eps) throw_pretty("Task space error out of bounds: " << errY);
+        if (errJ > eps)
         {
-            HIGHLIGHT("x: "<<x.transpose());
-            HIGHLIGHT("J*:\n"<<J);
-            HIGHLIGHT("J:\n"<<problem->J);
+            HIGHLIGHT("x: " << x.transpose());
+            HIGHLIGHT("J*:\n"
+                      << J);
+            HIGHLIGHT("J:\n"
+                      << problem->J);
             throw_pretty("Jacobian error out of bounds: " << errJ);
         }
     }
@@ -88,7 +91,7 @@ void testValues(Eigen::MatrixXdRefConst Xref, Eigen::MatrixXdRefConst Yref, Eige
 void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
 {
     INFO_PLAIN("Testing Jacobian:");
-    for(int j=0;j<NUM_TRIALS;j++)
+    for (int j = 0; j < NUM_TRIALS; j++)
     {
         Eigen::VectorXd x0(problem->N);
         x0.setRandom();
@@ -96,31 +99,32 @@ void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
         Eigen::VectorXd y0 = problem->Phi;
         Eigen::MatrixXd J0 = problem->J;
         Eigen::MatrixXd J = Eigen::MatrixXd::Zero(J0.rows(), J0.cols());
-        for(int i=0;i<problem->N;i++)
+        for (int i = 0; i < problem->N; i++)
         {
             Eigen::VectorXd x = x0;
-            x(i)+=eps;
+            x(i) += eps;
             problem->Update(x);
-            J.col(i) = (problem->Phi - y0)/eps;
+            J.col(i) = (problem->Phi - y0) / eps;
         }
-        double errJ = (J-J0).norm();
-        if(errJ > eps) throw_pretty("Jacobian error out of bounds: " << errJ);
+        double errJ = (J - J0).norm();
+        if (errJ > eps) throw_pretty("Jacobian error out of bounds: " << errJ);
     }
     INFO_PLAIN("Test passed");
 }
 
 UnconstrainedEndPoseProblem_ptr setupProbelm(Initializer& map)
 {
-    Initializer scene("Scene",{{"Name",std::string("MyScene")},{"JointGroup",std::string("arm")}});
+    Initializer scene("Scene", {{"Name", std::string("MyScene")}, {"JointGroup", std::string("arm")}});
     map.addProperty(Property("Scene", true, std::string("MyScene")));
-    Eigen::VectorXd W(3);W << 3,2,1;
-    Initializer problem("exotica/UnconstrainedEndPoseProblem",{
-                            {"Name",std::string("MyProblem")},
-                            {"PlanningScene",scene},
-                            {"Maps",std::vector<Initializer>({map})},
-                            {"W",W},
-                        });
-    Server::Instance()->getModel("robot_description",urdf_string,srdf_string);
+    Eigen::VectorXd W(3);
+    W << 3, 2, 1;
+    Initializer problem("exotica/UnconstrainedEndPoseProblem", {
+                                                                   {"Name", std::string("MyProblem")},
+                                                                   {"PlanningScene", scene},
+                                                                   {"Maps", std::vector<Initializer>({map})},
+                                                                   {"W", W},
+                                                               });
+    Server::Instance()->getModel("robot_description", urdf_string, srdf_string);
     return std::static_pointer_cast<UnconstrainedEndPoseProblem>(Setup::createProblem(problem));
 }
 
@@ -132,19 +136,16 @@ void testDMesh()
     nh.setParam("/MeshGraphManager/DummyTable", false);
     nh.setParam("/MeshGraphManager/ExternalTopic", "/MeshGraphManager/Updates");
     HIGHLIGHT("DMesh test");
-    Initializer map("exotica/DMeshROS",{
-                        {"Name",std::string("DMeshROS")},
-                        {"PoseGain",0.1},
-                        {"ObstacleGain",1.0},
-                        {"GoalGain",0.1},
-                        {"UsePose",true},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Name",std::string("A")}, {"LinkType",std::string("LINK")}, {"ConnectTo",std::string("B C D E")}, {"Link",std::string("base")}, {"Radius", 0.4} }),
-                             Initializer("Frame",{{"Name",std::string("B")}, {"LinkType",std::string("LINK")}, {"ConnectTo",std::string("A C D E")}, {"Link",std::string("endeff")}, {"Radius", 0.4} }),
-                             Initializer("Frame",{{"Name",std::string("C")}, {"LinkType",std::string("OBSTACLE")}, {"ConnectTo",std::string("B A D E")}, {"Link",std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.4 0.0 0.7 0.0 0.0 0.0 1.0")}}),
-                             Initializer("Frame",{{"Name",std::string("D")}, {"LinkType",std::string("OBSTACLE")}, {"ConnectTo",std::string("B C A E")}, {"Link",std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.0 0.4 0.7 0.0 0.0 0.0 1.0")}}),
-                             Initializer("Frame",{{"Name",std::string("E")}, {"LinkType",std::string("GOAL")}, {"ConnectTo",std::string("B C D A")}, {"Link",std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.0 -0.4 1.0 0.0 0.0 0.0 1.0")}})
-                                        }) } });
+    Initializer map("exotica/DMeshROS", {{"Name", std::string("DMeshROS")},
+                                         {"PoseGain", 0.1},
+                                         {"ObstacleGain", 1.0},
+                                         {"GoalGain", 0.1},
+                                         {"UsePose", true},
+                                         {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Name", std::string("A")}, {"LinkType", std::string("LINK")}, {"ConnectTo", std::string("B C D E")}, {"Link", std::string("base")}, {"Radius", 0.4}}),
+                                                                                   Initializer("Frame", {{"Name", std::string("B")}, {"LinkType", std::string("LINK")}, {"ConnectTo", std::string("A C D E")}, {"Link", std::string("endeff")}, {"Radius", 0.4}}),
+                                                                                   Initializer("Frame", {{"Name", std::string("C")}, {"LinkType", std::string("OBSTACLE")}, {"ConnectTo", std::string("B A D E")}, {"Link", std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.4 0.0 0.7 0.0 0.0 0.0 1.0")}}),
+                                                                                   Initializer("Frame", {{"Name", std::string("D")}, {"LinkType", std::string("OBSTACLE")}, {"ConnectTo", std::string("B C A E")}, {"Link", std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.0 0.4 0.7 0.0 0.0 0.0 1.0")}}),
+                                                                                   Initializer("Frame", {{"Name", std::string("E")}, {"LinkType", std::string("GOAL")}, {"ConnectTo", std::string("B C D A")}, {"Link", std::string("base")}, {"Radius", 0.2}, {"LinkOffset", std::string("0.0 -0.4 1.0 0.0 0.0 0.0 1.0")}})})}});
     UnconstrainedEndPoseProblem_ptr problem = setupProbelm(map);
     testRandom(problem);
 
@@ -153,9 +154,9 @@ void testDMesh()
     int L = 5;
     Eigen::MatrixXd X(L, N);
     Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
+    Eigen::MatrixXd J(L * M, N);
 
-/*    X << 0.680375, -0.211234, 0.566198, 0.59688, 0.823295, -0.604897, -0.329554, 0.536459, -0.444451, 0.10794, -0.0452059, 0.257742, -0.270431, 0.0268018, 0.904459;
+    /*    X << 0.680375, -0.211234, 0.566198, 0.59688, 0.823295, -0.604897, -0.329554, 0.536459, -0.444451, 0.10794, -0.0452059, 0.257742, -0.270431, 0.0268018, 0.904459;
     Y << 0.0645323, 0.0522249, 1.21417, 0.292945, 0.199075, 1.12724, 0.208378, -0.0712708, 1.19893, 0.0786457, 0.00852213, 1.23952, 0.356984, -0.0989639, 1.06844;
     J << -0.0522249, 0.594015, 0.327994
             , 0.0645323, 0.480726, 0.26544
@@ -177,7 +178,7 @@ void testDMesh()
     testJacobian(problem);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     ros::init(argc, argv, "EXOTica_test_maps");
     testDMesh();

--- a/exotations/task_maps/task_map/include/task_map/CoM.h
+++ b/exotations/task_maps/task_map/include/task_map/CoM.h
@@ -33,48 +33,47 @@
 #ifndef COM_H_
 #define COM_H_
 
+#include <exotica/KinematicTree.h>
 #include <exotica/TaskMap.h>
 #include <task_map/CoMInitializer.h>
-#include <exotica/KinematicTree.h>
 #include <visualization_msgs/MarkerArray.h>
 
 namespace exotica
 {
-  class CoM: public TaskMap, public Instantiable<CoMInitializer>
-  {
-    public:
-      CoM();
-      virtual ~CoM();
+class CoM : public TaskMap, public Instantiable<CoMInitializer>
+{
+public:
+    CoM();
+    virtual ~CoM();
 
-      virtual void Instantiate(CoMInitializer& init);
+    virtual void Instantiate(CoMInitializer& init);
 
-      virtual void assignScene(Scene_ptr scene);
+    virtual void assignScene(Scene_ptr scene);
 
-      void Initialize();
+    void Initialize();
 
-      void InitDebug();
+    void InitDebug();
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-    private:
+private:
+    Eigen::VectorXd mass_;
+    ros::Publisher com_pub_;
+    ros::Publisher COM_pub_;
+    ros::Publisher goal_pub_;
+    visualization_msgs::Marker com_marker_;
+    visualization_msgs::Marker COM_marker_;
+    visualization_msgs::Marker goal_marker_;
+    bool enable_z_;
+    int dim_;
 
-      Eigen::VectorXd mass_;
-      ros::Publisher com_pub_;
-      ros::Publisher COM_pub_;
-      ros::Publisher goal_pub_;
-      visualization_msgs::Marker com_marker_;
-      visualization_msgs::Marker COM_marker_;
-      visualization_msgs::Marker goal_marker_;
-      bool enable_z_;
-      int dim_;
-
-      CoMInitializer init_;
-      Scene_ptr scene_;
-  };
+    CoMInitializer init_;
+    Scene_ptr scene_;
+};
 }
 
 #endif /* COM_H_ */

--- a/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
+++ b/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
@@ -38,30 +38,29 @@
 
 namespace exotica
 {
-  class CollisionCheck: public TaskMap, public Instantiable<CollisionCheckInitializer>
-  {
-    public:
-      CollisionCheck();
-      virtual ~CollisionCheck()
-      {
-      }
+class CollisionCheck : public TaskMap, public Instantiable<CollisionCheckInitializer>
+{
+public:
+    CollisionCheck();
+    virtual ~CollisionCheck()
+    {
+    }
 
-      virtual void Instantiate(CollisionCheckInitializer& init);
+    virtual void Instantiate(CollisionCheckInitializer& init);
 
-      virtual void assignScene(Scene_ptr scene);
+    virtual void assignScene(Scene_ptr scene);
 
-      void Initialize();
+    void Initialize();
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-      Scene_ptr scene_;
-      CollisionScene_ptr cscene_;
-      CollisionCheckInitializer init_;
+    Scene_ptr scene_;
+    CollisionScene_ptr cscene_;
+    CollisionCheckInitializer init_;
+};
 
-  };
-
-  typedef std::shared_ptr<exotica::CollisionCheck> CollisionCheck_ptr;
+typedef std::shared_ptr<exotica::CollisionCheck> CollisionCheck_ptr;
 }
 #endif

--- a/exotations/task_maps/task_map/include/task_map/Distance.h
+++ b/exotations/task_maps/task_map/include/task_map/Distance.h
@@ -36,25 +36,25 @@
 #include <exotica/TaskMap.h>
 #include <task_map/DistanceInitializer.h>
 
-namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
 {
-  class Distance: public TaskMap, public Instantiable<DistanceInitializer>
-  {
-    public:
-      Distance();
-      virtual ~Distance()
-      {
-      }
+class Distance : public TaskMap, public Instantiable<DistanceInitializer>
+{
+public:
+    Distance();
+    virtual ~Distance()
+    {
+    }
 
-       virtual void Instantiate(DistanceInitializer& init);
+    virtual void Instantiate(DistanceInitializer& init);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual int taskSpaceDim();
-  };
-  typedef std::shared_ptr<Distance> Distance_Ptr;
+    virtual int taskSpaceDim();
+};
+typedef std::shared_ptr<Distance> Distance_Ptr;
 }
 
 #endif

--- a/exotations/task_maps/task_map/include/task_map/EffFrame.h
+++ b/exotations/task_maps/task_map/include/task_map/EffFrame.h
@@ -36,37 +36,37 @@
 #include <exotica/TaskMap.h>
 #include <task_map/EffFrameInitializer.h>
 
-namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
 {
-  class EffFrame: public TaskMap, public Instantiable<EffFrameInitializer>
-  {
-    public:
-      /**
+class EffFrame : public TaskMap, public Instantiable<EffFrameInitializer>
+{
+public:
+    /**
        * \brief Default constructor
        */
-      EffFrame();
-      virtual ~EffFrame()
-      {
-      }
+    EffFrame();
+    virtual ~EffFrame()
+    {
+    }
 
-      virtual void Instantiate(EffFrameInitializer& init);
+    virtual void Instantiate(EffFrameInitializer& init);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-      virtual int taskSpaceJacobianDim();
+    virtual int taskSpaceJacobianDim();
 
-      virtual std::vector<TaskVectorEntry> getLieGroupIndices();
+    virtual std::vector<TaskVectorEntry> getLieGroupIndices();
 
-      RotationType rotationType;
-      int bigStride;
-      int smallStride;
-  };
+    RotationType rotationType;
+    int bigStride;
+    int smallStride;
+};
 
-  typedef std::shared_ptr<EffFrame> EffFrame_ptr;  //!< Task Map smart pointer
+typedef std::shared_ptr<EffFrame> EffFrame_ptr;  //!< Task Map smart pointer
 }
 
 #endif

--- a/exotations/task_maps/task_map/include/task_map/EffOrientation.h
+++ b/exotations/task_maps/task_map/include/task_map/EffOrientation.h
@@ -36,36 +36,36 @@
 #include <exotica/TaskMap.h>
 #include <task_map/EffOrientationInitializer.h>
 
-namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
 {
-  class EffOrientation: public TaskMap, public Instantiable<EffOrientationInitializer>
-  {
-    public:
-      /**
+class EffOrientation : public TaskMap, public Instantiable<EffOrientationInitializer>
+{
+public:
+    /**
        * \brief Default constructor
        */
-      EffOrientation();
-      virtual ~EffOrientation()
-      {
-      }
+    EffOrientation();
+    virtual ~EffOrientation()
+    {
+    }
 
-      virtual void Instantiate(EffOrientationInitializer& init);
+    virtual void Instantiate(EffOrientationInitializer& init);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-      virtual int taskSpaceJacobianDim();
+    virtual int taskSpaceJacobianDim();
 
-      virtual std::vector<TaskVectorEntry> getLieGroupIndices();
+    virtual std::vector<TaskVectorEntry> getLieGroupIndices();
 
-      RotationType rotationType;
-      int stride;
-  };
-  
-  typedef std::shared_ptr<EffOrientation> EffOrientation_ptr;  //!< Task Map smart pointer
+    RotationType rotationType;
+    int stride;
+};
+
+typedef std::shared_ptr<EffOrientation> EffOrientation_ptr;  //!< Task Map smart pointer
 }
 
 #endif

--- a/exotations/task_maps/task_map/include/task_map/EffPosition.h
+++ b/exotations/task_maps/task_map/include/task_map/EffPosition.h
@@ -36,28 +36,27 @@
 #include <exotica/TaskMap.h>
 #include <task_map/EffPositionInitializer.h>
 
-namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
 {
-  class EffPosition: public TaskMap, public Instantiable<EffPositionInitializer>
-  {
-    public:
-      /**
+class EffPosition : public TaskMap, public Instantiable<EffPositionInitializer>
+{
+public:
+    /**
        * \brief Default constructor
        */
-      EffPosition();
-      virtual ~EffPosition()
-      {
-      }
+    EffPosition();
+    virtual ~EffPosition()
+    {
+    }
 
-      virtual void Instantiate(EffPositionInitializer& init) {}
+    virtual void Instantiate(EffPositionInitializer& init) {}
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
-
-      virtual int taskSpaceDim();
-  };
-  typedef std::shared_ptr<EffPosition> EffPosition_ptr;  //!< Task Map smart pointer
+    virtual int taskSpaceDim();
+};
+typedef std::shared_ptr<EffPosition> EffPosition_ptr;  //!< Task Map smart pointer
 }
 
 #endif

--- a/exotations/task_maps/task_map/include/task_map/IMesh.h
+++ b/exotations/task_maps/task_map/include/task_map/IMesh.h
@@ -33,57 +33,55 @@
 #ifndef IMESH_H_
 #define IMESH_H_
 
-#include <exotica/TaskMap.h>
 #include <exotica/KinematicTree.h>
+#include <exotica/TaskMap.h>
 #include <task_map/IMeshInitializer.h>
 #include <visualization_msgs/Marker.h>
 
 namespace exotica
 {
-  class IMesh: public TaskMap, public Instantiable<IMeshInitializer>
-  {
-    public:
+class IMesh : public TaskMap, public Instantiable<IMeshInitializer>
+{
+public:
+    IMesh();
 
-      IMesh();
+    virtual void Instantiate(IMeshInitializer& init);
 
-      virtual void Instantiate(IMeshInitializer& init);
+    virtual ~IMesh();
 
-      virtual ~IMesh();
+    virtual void assignScene(Scene_ptr scene);
 
-      virtual void assignScene(Scene_ptr scene);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual int taskSpaceDim();
 
-      virtual int taskSpaceDim();
+    void setWeight(int i, int j, double weight);
+    void setWeights(const Eigen::MatrixXd& weights);
+    Eigen::MatrixXd getWeights();
 
-      void setWeight(int i, int j, double weight);
-      void setWeights(const Eigen::MatrixXd & weights);
-      Eigen::MatrixXd getWeights();
+    static Eigen::VectorXd computeLaplace(Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights, Eigen::MatrixXd* dist = nullptr, Eigen::VectorXd* wsum = nullptr);
 
-      static Eigen::VectorXd computeLaplace(Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights, Eigen::MatrixXd* dist = nullptr, Eigen::VectorXd* wsum = nullptr);
+    void computeGoalLaplace(const Eigen::VectorXd& x, Eigen::VectorXd& goal);
 
-      void computeGoalLaplace(const Eigen::VectorXd &x, Eigen::VectorXd &goal);
+    static void computeGoalLaplace(const std::vector<KDL::Frame>& nodes, Eigen::VectorXd& goal, Eigen::MatrixXdRefConst Weights);
 
-      static void computeGoalLaplace(const std::vector<KDL::Frame>& nodes, Eigen::VectorXd &goal, Eigen::MatrixXdRefConst Weights);
+    virtual void debug(Eigen::VectorXdRefConst phi);
+    void initDebug(std::string ref);
+    void destroyDebug();
 
-      virtual void debug(Eigen::VectorXdRefConst phi);
-      void initDebug(std::string ref);
-      void destroyDebug();
+protected:
+    Eigen::MatrixXd weights_;
 
-    protected:
+    int eff_size_;
+    bool Debug;
 
-      Eigen::MatrixXd weights_;
-
-      int eff_size_;
-      bool Debug;
-
-      ros::Publisher imesh_mark_pub_;
-      visualization_msgs::Marker imesh_mark_;
-      Scene_ptr scene_;
-  };
-  typedef std::shared_ptr<IMesh> IMesh_Ptr;
+    ros::Publisher imesh_mark_pub_;
+    visualization_msgs::Marker imesh_mark_;
+    Scene_ptr scene_;
+};
+typedef std::shared_ptr<IMesh> IMesh_Ptr;
 }
 
 #endif /* IMESH_H_ */

--- a/exotations/task_maps/task_map/include/task_map/Identity.h
+++ b/exotations/task_maps/task_map/include/task_map/Identity.h
@@ -38,36 +38,35 @@
 
 namespace exotica
 {
-  class Identity: public TaskMap, public Instantiable<IdentityInitializer>
-  {
-    public:
-      Identity();
-      virtual ~Identity()
-      {
-      }
+class Identity : public TaskMap, public Instantiable<IdentityInitializer>
+{
+public:
+    Identity();
+    virtual ~Identity()
+    {
+    }
 
-      virtual void Instantiate(IdentityInitializer& init);
+    virtual void Instantiate(IdentityInitializer& init);
 
-      virtual void assignScene(Scene_ptr scene);
+    virtual void assignScene(Scene_ptr scene);
 
-      void Initialize();
+    void Initialize();
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::VectorXdRef phidot, Eigen::MatrixXdRef J, Eigen::MatrixXdRef Jdot);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::VectorXdRef phidot, Eigen::MatrixXdRef J, Eigen::MatrixXdRef Jdot);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-      std::vector<int> jointMap;
-      Eigen::VectorXd jointRef;
-      int N;
-      Scene_ptr scene_;
-      IdentityInitializer init_;
+    std::vector<int> jointMap;
+    Eigen::VectorXd jointRef;
+    int N;
+    Scene_ptr scene_;
+    IdentityInitializer init_;
+};
 
-  };
-
-  typedef std::shared_ptr<exotica::Identity> Identity_ptr;
+typedef std::shared_ptr<exotica::Identity> Identity_ptr;
 }
 #endif

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -38,42 +38,41 @@
 
 namespace exotica
 {
-  /**
+/**
    * \brief	Implementation of joint limits task map.
    * 			Note: we dont want to always stay at the centre of the joint range,
    * 			be lazy as long as the joint is not too close to the low/high limits
    */
-  class JointLimit: public TaskMap, public Instantiable<JointLimitInitializer>
-  {
-    public:
-      //	Default constructor
-      JointLimit();
-      //	Default destructor
-      ~JointLimit();
+class JointLimit : public TaskMap, public Instantiable<JointLimitInitializer>
+{
+public:
+    //	Default constructor
+    JointLimit();
+    //	Default destructor
+    ~JointLimit();
 
-      virtual void Instantiate(JointLimitInitializer& init);
+    virtual void Instantiate(JointLimitInitializer& init);
 
-      virtual void assignScene(Scene_ptr scene);
+    virtual void assignScene(Scene_ptr scene);
 
-      void Initialize();
+    void Initialize();
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual int taskSpaceDim();
+    virtual int taskSpaceDim();
 
-    private:
-      Eigen::VectorXd low_limits_;	//	Lower joint limits
-      Eigen::VectorXd high_limits_;	//	Higher joint limits
-      Eigen::VectorXd center_;		//	Center of the joint range
-      Eigen::VectorXd tau_;			//	Joint limits tolerance
-      bool initialised_;
-      Scene_ptr scene_;
-      JointLimitInitializer init_;
-      int N;
-
-  };
+private:
+    Eigen::VectorXd low_limits_;   //	Lower joint limits
+    Eigen::VectorXd high_limits_;  //	Higher joint limits
+    Eigen::VectorXd center_;       //	Center of the joint range
+    Eigen::VectorXd tau_;          //	Joint limits tolerance
+    bool initialised_;
+    Scene_ptr scene_;
+    JointLimitInitializer init_;
+    int N;
+};
 }
 
 #endif /* JOINTLIMIT_H_ */

--- a/exotations/task_maps/task_map/include/task_map/SphereCollision.h
+++ b/exotations/task_maps/task_map/include/task_map/SphereCollision.h
@@ -38,36 +38,34 @@
 #include <task_map/SphereInitializer.h>
 #include <visualization_msgs/Marker.h>
 
-namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
 {
-  class SphereCollision: public TaskMap, public Instantiable<SphereCollisionInitializer>
-  {
-    public:
-      SphereCollision();
-      virtual ~SphereCollision() {}
+class SphereCollision : public TaskMap, public Instantiable<SphereCollisionInitializer>
+{
+public:
+    SphereCollision();
+    virtual ~SphereCollision() {}
+    virtual void Instantiate(SphereCollisionInitializer& init);
 
-      virtual void Instantiate(SphereCollisionInitializer& init);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+    virtual int taskSpaceDim();
 
-      virtual int taskSpaceDim();
+protected:
+    double distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB);
+    Eigen::VectorXd Jacobian(const KDL::Frame& effA, const KDL::Frame& effB, const KDL::Jacobian& jacA, const KDL::Jacobian& jacB, double rA, double rB);
 
-    protected:
+    std::map<std::string, std::vector<int>> groups;
+    std::vector<double> radiuses;
 
-      double distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB);
-      Eigen::VectorXd Jacobian(const KDL::Frame& effA, const KDL::Frame& effB, const KDL::Jacobian& jacA, const KDL::Jacobian& jacB, double rA, double rB);
-
-      std::map<std::string,std::vector<int>> groups;
-      std::vector<double> radiuses;
-
-      visualization_msgs::MarkerArray debug_msg;
-      ros::Publisher debug_pub;
-      bool debug;
-      double eps;
-  };
-  typedef std::shared_ptr<SphereCollision> SphereCollision_ptr;  //!< Task Map smart pointer
+    visualization_msgs::MarkerArray debug_msg;
+    ros::Publisher debug_pub;
+    bool debug;
+    double eps;
+};
+typedef std::shared_ptr<SphereCollision> SphereCollision_ptr;  //!< Task Map smart pointer
 }
 
 #endif

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -36,36 +36,35 @@ REGISTER_TASKMAP_TYPE("CollisionCheck", exotica::CollisionCheck);
 
 namespace exotica
 {
-  CollisionCheck::CollisionCheck()
-  {
+CollisionCheck::CollisionCheck()
+{
+}
 
-  }
+void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != 1) throw_named("Wrong size of phi!");
+    cscene_->updateCollisionObjectTransforms();
+    phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance) ? -1.0 : 0.0;
+}
 
-  void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
-  {
-      if(phi.rows() != 1) throw_named("Wrong size of phi!");
-      cscene_->updateCollisionObjectTransforms();
-      phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance)?-1.0:0.0;
-  }
+void CollisionCheck::Instantiate(CollisionCheckInitializer& init)
+{
+    init_ = init;
+}
 
-  void CollisionCheck::Instantiate(CollisionCheckInitializer& init)
-  {
-      init_ = init;
-  }
+void CollisionCheck::assignScene(Scene_ptr scene)
+{
+    scene_ = scene;
+    Initialize();
+}
 
-  void CollisionCheck::assignScene(Scene_ptr scene)
-  {
-      scene_ = scene;
-      Initialize();
-  }
+void CollisionCheck::Initialize()
+{
+    cscene_ = scene_->getCollisionScene();
+}
 
-  void CollisionCheck::Initialize()
-  {
-      cscene_ = scene_->getCollisionScene();
-  }
-
-  int CollisionCheck::taskSpaceDim()
-  {
-      return 1;
-  }
+int CollisionCheck::taskSpaceDim()
+{
+    return 1;
+}
 }

--- a/exotations/task_maps/task_map/src/Distance.cpp
+++ b/exotations/task_maps/task_map/src/Distance.cpp
@@ -36,41 +36,40 @@ REGISTER_TASKMAP_TYPE("Distance", exotica::Distance);
 
 namespace exotica
 {
-  Distance::Distance()
-  {
+Distance::Distance()
+{
     //!< Empty constructor
-  }
+}
 
-    void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
     {
-        if(phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
-        for(int i=0;i<Kinematics.Phi.rows();i++)
+        phi(i) = Kinematics.Phi(i).p.Norm();
+    }
+}
+
+void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
+    if (J.rows() != Kinematics.J.rows() || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    {
+        phi(i) = Kinematics.Phi(i).p.Norm();
+        for (int j = 0; j < J.cols(); j++)
         {
-            phi(i) = Kinematics.Phi(i).p.Norm();
+            J(i, j) = (Kinematics.Phi(i).p[0] * Kinematics.J[i].data(0, j) + Kinematics.Phi(i).p[1] * Kinematics.J[i].data(1, j) + Kinematics.Phi(i).p[2] * Kinematics.J[i].data(2, j)) / phi(i);
         }
     }
+}
 
-    void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
-    {
-        if(phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
-        if(J.rows() != Kinematics.J.rows() || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
-        for(int i=0;i<Kinematics.Phi.rows();i++)
-        {
-            phi(i) = Kinematics.Phi(i).p.Norm();
-            for (int j = 0; j < J.cols(); j++)
-            {
-                J(i,j) = ( Kinematics.Phi(i).p[0]*Kinematics.J[i].data(0,j) + Kinematics.Phi(i).p[1]*Kinematics.J[i].data(1,j) + Kinematics.Phi(i).p[2]*Kinematics.J[i].data(2,j) ) / phi(i);
-            }
-        }
-    }
+void Distance::Instantiate(DistanceInitializer& init)
+{
+}
 
-    void Distance::Instantiate(DistanceInitializer& init)
-    {
-
-    }
-
-    int Distance::taskSpaceDim()
-    {
-        return Kinematics.Phi.rows();
-    }
+int Distance::taskSpaceDim()
+{
+    return Kinematics.Phi.rows();
+}
 }

--- a/exotations/task_maps/task_map/src/EffPosition.cpp
+++ b/exotations/task_maps/task_map/src/EffPosition.cpp
@@ -36,36 +36,36 @@ REGISTER_TASKMAP_TYPE("EffPosition", exotica::EffPosition);
 
 namespace exotica
 {
-    EffPosition::EffPosition()
-    {
-    }
+EffPosition::EffPosition()
+{
+}
 
-    void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != Kinematics.Phi.rows() * 3) throw_named("Wrong size of phi!");
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
     {
-        if(phi.rows() != Kinematics.Phi.rows()*3) throw_named("Wrong size of phi!");
-        for(int i=0;i<Kinematics.Phi.rows();i++)
-        {
-            phi(i*3) = Kinematics.Phi(i).p[0];
-            phi(i*3+1) = Kinematics.Phi(i).p[1];
-            phi(i*3+2) = Kinematics.Phi(i).p[2];
-        }
+        phi(i * 3) = Kinematics.Phi(i).p[0];
+        phi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        phi(i * 3 + 2) = Kinematics.Phi(i).p[2];
     }
+}
 
-    void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != Kinematics.Phi.rows() * 3) throw_named("Wrong size of phi!");
+    if (J.rows() != Kinematics.J.rows() * 3 || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
     {
-        if(phi.rows() != Kinematics.Phi.rows()*3) throw_named("Wrong size of phi!");
-        if(J.rows() != Kinematics.J.rows()*3 || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
-        for(int i=0;i<Kinematics.Phi.rows();i++)
-        {
-            phi(i*3) = Kinematics.Phi(i).p[0];
-            phi(i*3+1) = Kinematics.Phi(i).p[1];
-            phi(i*3+2) = Kinematics.Phi(i).p[2];
-            J.middleRows(i*3,3) = Kinematics.J[i].data.topRows(3);
-        }
+        phi(i * 3) = Kinematics.Phi(i).p[0];
+        phi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        phi(i * 3 + 2) = Kinematics.Phi(i).p[2];
+        J.middleRows(i * 3, 3) = Kinematics.J[i].data.topRows(3);
     }
+}
 
-    int EffPosition::taskSpaceDim()
-    {
-        return Kinematics.Phi.rows()*3;
-    }
+int EffPosition::taskSpaceDim()
+{
+    return Kinematics.Phi.rows() * 3;
+}
 }

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -37,316 +37,315 @@ REGISTER_TASKMAP_TYPE("IMesh", exotica::IMesh);
 
 namespace exotica
 {
-    IMesh::IMesh() : eff_size_(0)
+IMesh::IMesh() : eff_size_(0)
+{
+}
+
+IMesh::~IMesh()
+{
+}
+
+void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    int M = eff_size_;
+
+    if (phi.rows() != M * 3) throw_named("Wrong size of phi!");
+
+    Eigen::VectorXd EffPhi;
+    for (int i = 0; i < M; i++)
     {
+        EffPhi(i * 3) = Kinematics.Phi(i).p[0];
+        EffPhi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        EffPhi(i * 3 + 2) = Kinematics.Phi(i).p[2];
     }
+    phi = computeLaplace(EffPhi, weights_);
 
-    IMesh::~IMesh()
+    if (Debug) debug(phi);
+}
+
+void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    int M = eff_size_;
+    int N = Kinematics.J[0].data.cols();
+
+    if (phi.rows() != M * 3) throw_named("Wrong size of phi!");
+    if (J.rows() != M * 3 || J.cols() != N) throw_named("Wrong size of J! " << N);
+
+    Eigen::MatrixXd dist;
+    Eigen::VectorXd wsum;
+    Eigen::VectorXd EffPhi(M * 3);
+    for (int i = 0; i < M; i++)
     {
+        EffPhi(i * 3) = Kinematics.Phi(i).p[0];
+        EffPhi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        EffPhi(i * 3 + 2) = Kinematics.Phi(i).p[2];
     }
+    phi = computeLaplace(EffPhi, weights_, &dist, &wsum);
 
-    void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+    double A, _A, Sk, Sl, w, _w;
+    int i, j, k, l;
+    Eigen::Vector3d distance, _distance = Eigen::Vector3d::Zero(3, 1);
+    for (i = 0; i < N; i++)
     {
-        int M = eff_size_;
-
-        if(phi.rows() != M*3) throw_named("Wrong size of phi!");
-
-        Eigen::VectorXd EffPhi;
-        for(int i=0;i<M;i++)
+        for (j = 0; j < M; j++)
         {
-            EffPhi(i*3) = Kinematics.Phi(i).p[0];
-            EffPhi(i*3+1) = Kinematics.Phi(i).p[1];
-            EffPhi(i*3+2) = Kinematics.Phi(i).p[2];
-        }
-        phi = computeLaplace(EffPhi, weights_);
-
-        if(Debug) debug(phi);
-    }
-
-    void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
-    {
-        int M = eff_size_;
-        int N = Kinematics.J[0].data.cols();
-
-        if(phi.rows() != M*3) throw_named("Wrong size of phi!");
-        if(J.rows() != M*3 || J.cols() != N) throw_named("Wrong size of J! " << N);
-
-        Eigen::MatrixXd dist;
-        Eigen::VectorXd wsum;
-        Eigen::VectorXd EffPhi(M*3);
-        for(int i=0;i<M;i++)
-        {
-            EffPhi(i*3) = Kinematics.Phi(i).p[0];
-            EffPhi(i*3+1) = Kinematics.Phi(i).p[1];
-            EffPhi(i*3+2) = Kinematics.Phi(i).p[2];
-        }
-        phi = computeLaplace(EffPhi, weights_, &dist, &wsum);
-
-        double A, _A, Sk, Sl, w, _w;
-        int i, j, k, l;
-        Eigen::Vector3d distance, _distance = Eigen::Vector3d::Zero(3, 1);
-        for (i = 0; i < N; i++)
-        {
-            for (j = 0; j < M; j++)
-            {
-                if (j < M)
-                    J.block(3 * j, i, 3, 1) = Kinematics.J[j].data.block(0, i, 3, 1);
-                for (l = 0; l < M; l++)
-                {
-                    if (j != l)
-                    {
-                        if (dist(j, l) > 0 && wsum(j) > 0 && weights_(j, l) > 0)
-                        {
-                            A = dist(j, l) * wsum(j);
-                            w = weights_(j, l) / A;
-
-                            _A = 0;
-                            distance = EffPhi.segment(j*3, 3) - EffPhi.segment(l*3, 3);
-                            _distance = Kinematics.J[j].data.block(0, i, 3, 1) - Kinematics.J[l].data.block(0, i, 3, 1);
-
-                            Sl = distance.dot(_distance) / dist(j, l);
-                            for (k = 0; k < M; k++)
-                            {
-                                if (j != k && dist(j, k) > 0 && weights_(j, k) > 0)
-                                {
-                                    distance = EffPhi.segment(j*3, 3) - EffPhi.segment(k*3, 3);
-                                    _distance = Kinematics.J[j].data.block(0, i, 3, 1) - Kinematics.J[k].data.block(0, i, 3, 1);
-                                    Sk = distance.dot(_distance) / dist(j, k);
-                                    _A += weights_(j, k) * (Sl * dist(j, k) - Sk * dist(j, l))
-                                            / (dist(j, k) * dist(j, k));
-                                }
-                            }
-                            _w = -weights_(j, l) * _A / (A * A);
-                        }
-                        else
-                        {
-                            _w = 0;
-                            w = 0;
-                        }
-                        J.block(3 * j, i, 3, 1) -= EffPhi.segment(l*3, 3) * _w
-                                +  Kinematics.J[l].data.block(0, i, 3, 1) * w;
-                    }
-                }
-            }
-        }
-
-        if(Debug) debug(phi);
-    }
-
-    Eigen::MatrixXd IMesh::getWeights()
-    {
-        return weights_;
-    }
-
-    void IMesh::initDebug(std::string ref)
-    {
-        imesh_mark_.header.frame_id = ref;
-        imesh_mark_.ns = getObjectName();
-        imesh_mark_pub_ = Server::advertise<visualization_msgs::Marker>(ns_ +"/InteractionMesh", 1, true);
-        if(debug_) HIGHLIGHT("InteractionMesh connectivity is published on ROS topic "<<imesh_mark_pub_.getTopic()<<", in reference frame "<<ref);
-    }
-
-    void IMesh::Instantiate(IMeshInitializer& init)
-    {
-        Debug = init.Debug;
-        if(Debug)
-        {
-            initDebug(init.ReferenceFrame);
-        }
-        eff_size_ = Frames.size();
-        weights_.setOnes(eff_size_, eff_size_);
-        if(init.Weights.rows()==eff_size_*eff_size_)
-        {
-            weights_.array() = init.Weights.array();
-            HIGHLIGHT("Loading iMesh weights.\n"<<weights_);
-        }
-    }
-
-    void IMesh::assignScene(Scene_ptr scene)
-    {
-        scene_ = scene;
-    }
-
-    void IMesh::debug(Eigen::VectorXdRefConst phi)
-    {
-        static int textid = 0;
-        {
-            imesh_mark_.scale.x = 0.005;
-            imesh_mark_.color.a = imesh_mark_.color.r = 1;
-            imesh_mark_.type = visualization_msgs::Marker::LINE_LIST;
-            imesh_mark_.pose = geometry_msgs::Pose();
-            imesh_mark_.ns = getObjectName();
-            imesh_mark_.points.clear();
-            std::vector<geometry_msgs::Point> points(eff_size_);
-            for (int i = 0; i < eff_size_; i++)
-            {
-                points[i].x = Kinematics.Phi(i).p[0];
-                points[i].y = Kinematics.Phi(i).p[1];
-                points[i].z = Kinematics.Phi(i).p[2];
-            }
-
-            for(int i=0;i<eff_size_;i++)
-            {
-                for(int j=i+1;j<eff_size_;j++)
-                {
-                    if(weights_(i, j)>0.0)
-                    {
-                        imesh_mark_.points.push_back(points[i]);
-                        imesh_mark_.points.push_back(points[j]);
-                    }
-                }
-            }
-            imesh_mark_.header.stamp = ros::Time::now();
-            imesh_mark_pub_.publish(imesh_mark_);
-        }
-        {
-            imesh_mark_.ns = getObjectName()+"Raw";
-            imesh_mark_.points.clear();
-            std::vector<geometry_msgs::Point> points(eff_size_);
-            for (int i = 0; i < eff_size_; i++)
-            {
-                points[i].x = phi(i*3);
-                points[i].y = phi(i*3+1);
-                points[i].z = phi(i*3+2);
-            }
-
-            for(int i=0;i<eff_size_;i++)
-            {
-                for(int j=i+1;j<eff_size_;j++)
-                {
-                    if(weights_(i, j)>0.0)
-                    {
-                        imesh_mark_.points.push_back(points[i]);
-                        imesh_mark_.points.push_back(points[j]);
-                    }
-                }
-            }
-            imesh_mark_.header.stamp = ros::Time::now();
-            imesh_mark_pub_.publish(imesh_mark_);
-
-            imesh_mark_.points.clear();
-            imesh_mark_.scale.z = 0.05;
-            imesh_mark_.color.a = imesh_mark_.color.r = imesh_mark_.color.g = imesh_mark_.color.b = 1;
-            imesh_mark_.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-            imesh_mark_.text = std::to_string(textid);
-            imesh_mark_.pose.position = points[textid];
-            imesh_mark_.pose.position.z += 0.05;
-            imesh_mark_.ns = getObjectName()+"Id";
-            imesh_mark_.header.stamp = ros::Time::now();
-            imesh_mark_pub_.publish(imesh_mark_);
-
-            textid=(textid+1)%eff_size_;
-        }
-    }
-
-    void IMesh::destroyDebug()
-    {
-        imesh_mark_.points.clear();
-        imesh_mark_.action = visualization_msgs::Marker::DELETE;
-        imesh_mark_.header.stamp = ros::Time::now();
-        imesh_mark_pub_.publish(imesh_mark_);
-    }
-
-    int IMesh::taskSpaceDim()
-    {
-        return 3 * eff_size_;
-    }
-
-    Eigen::VectorXd IMesh::computeLaplace(Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights, Eigen::MatrixXd* dist_ptr, Eigen::VectorXd* wsum_ptr)
-    {
-        int N = EffPhi.rows()/3;
-        Eigen::VectorXd Phi = Eigen::VectorXd::Zero(N*3);
-        Eigen::MatrixXd dist = Eigen::MatrixXd::Zero(N, N);
-        Eigen::VectorXd wsum = Eigen::VectorXd::Zero(N);
-        /** Compute distance matrix (inverse proportional) */
-        for (int j = 0; j < N; j++)
-        {
-            for (int l = j + 1; l < N; l++)
-            {
-                if (!(j >= N && l >= N))
-                {
-                    dist(j, l) = dist(l, j) = (EffPhi.segment(j*3, 3) - EffPhi.segment(l*3, 3)).norm();
-                }
-            }
-        }
-        /** Computer weight normaliser */
-        for (int j = 0; j < N; j++)
-        {
-            for (int l = 0; l < N; l++)
-            {
-                if (dist(j, l) > 0 && j != l)
-                {
-                    wsum(j) += Weights(j,l) / dist(j, l);
-                }
-            }
-        }
-        /** Compute Laplace coordinates */
-        for (int j = 0; j < N; j++)
-        {
-            Phi.segment(j*3, 3) = EffPhi.segment(j*3, 3);
-            for (int l = 0; l < N; l++)
+            if (j < M)
+                J.block(3 * j, i, 3, 1) = Kinematics.J[j].data.block(0, i, 3, 1);
+            for (l = 0; l < M; l++)
             {
                 if (j != l)
                 {
-                    if (dist(j, l) > 0 && wsum(j) > 0)
+                    if (dist(j, l) > 0 && wsum(j) > 0 && weights_(j, l) > 0)
                     {
-                        Phi.segment(j*3, 3) -= EffPhi.segment(l*3, 3) * Weights(j,l) / (dist(j, l) * wsum(j));
+                        A = dist(j, l) * wsum(j);
+                        w = weights_(j, l) / A;
+
+                        _A = 0;
+                        distance = EffPhi.segment(j * 3, 3) - EffPhi.segment(l * 3, 3);
+                        _distance = Kinematics.J[j].data.block(0, i, 3, 1) - Kinematics.J[l].data.block(0, i, 3, 1);
+
+                        Sl = distance.dot(_distance) / dist(j, l);
+                        for (k = 0; k < M; k++)
+                        {
+                            if (j != k && dist(j, k) > 0 && weights_(j, k) > 0)
+                            {
+                                distance = EffPhi.segment(j * 3, 3) - EffPhi.segment(k * 3, 3);
+                                _distance = Kinematics.J[j].data.block(0, i, 3, 1) - Kinematics.J[k].data.block(0, i, 3, 1);
+                                Sk = distance.dot(_distance) / dist(j, k);
+                                _A += weights_(j, k) * (Sl * dist(j, k) - Sk * dist(j, l)) / (dist(j, k) * dist(j, k));
+                            }
+                        }
+                        _w = -weights_(j, l) * _A / (A * A);
                     }
+                    else
+                    {
+                        _w = 0;
+                        w = 0;
+                    }
+                    J.block(3 * j, i, 3, 1) -= EffPhi.segment(l * 3, 3) * _w + Kinematics.J[l].data.block(0, i, 3, 1) * w;
                 }
             }
         }
-        if(dist_ptr) *dist_ptr = dist;
-        if(wsum_ptr) *wsum_ptr = wsum;
-        return Phi;
     }
 
-    void IMesh::computeGoalLaplace(const std::vector<KDL::Frame>& nodes, Eigen::VectorXd &goal, Eigen::MatrixXdRefConst Weights)
-    {
-        int N = nodes.size();
-        Eigen::VectorXd EffPhi(3*N);
-        for(int i=0;i<N;i++)
-        {
-            EffPhi(i*3) = nodes[i].p[0];
-            EffPhi(i*3+1) = nodes[i].p[1];
-            EffPhi(i*3+2) = nodes[i].p[2];
-        }
-        goal = computeLaplace(EffPhi, Weights);
-    }
+    if (Debug) debug(phi);
+}
 
-    void IMesh::computeGoalLaplace(const Eigen::VectorXd &x, Eigen::VectorXd &goal)
-    {
-        scene_->Update(x);
-        Eigen::VectorXd EffPhi;
-        for(int i=0;i<eff_size_;i++)
-        {
-            EffPhi(i*3) = Kinematics.Phi(i).p[0];
-            EffPhi(i*3+1) = Kinematics.Phi(i).p[1];
-            EffPhi(i*3+2) = Kinematics.Phi(i).p[2];
-        }
-        goal = computeLaplace(EffPhi, weights_);
-    }
+Eigen::MatrixXd IMesh::getWeights()
+{
+    return weights_;
+}
 
-    void IMesh::setWeight(int i, int j, double weight)
-    {
-        uint M = weights_.cols();
-        if (i < 0 || i >= M || j < 0 || j >= M)
-        {
-            throw_named("Invalid weight element (" << i << "," << j << "). Weight matrix " << M << "x" << M );
-        }
-        if (weight < 0)
-        {
-            throw_named("Invalid weight: " << weight );
-        }
-        weights_(i, j) = weight;
-    }
+void IMesh::initDebug(std::string ref)
+{
+    imesh_mark_.header.frame_id = ref;
+    imesh_mark_.ns = getObjectName();
+    imesh_mark_pub_ = Server::advertise<visualization_msgs::Marker>(ns_ + "/InteractionMesh", 1, true);
+    if (debug_) HIGHLIGHT("InteractionMesh connectivity is published on ROS topic " << imesh_mark_pub_.getTopic() << ", in reference frame " << ref);
+}
 
-    void IMesh::setWeights(const Eigen::MatrixXd & weights)
+void IMesh::Instantiate(IMeshInitializer& init)
+{
+    Debug = init.Debug;
+    if (Debug)
     {
-        uint M = weights_.cols();
-        if (weights.rows() != M || weights.cols() != M)
-        {
-            throw_named("Invalid weight matrix (" << weights.rows() << "X" << weights.cols() << "). Has to be" << M << "x" << M );
-        }
-        weights_ = weights;
+        initDebug(init.ReferenceFrame);
     }
+    eff_size_ = Frames.size();
+    weights_.setOnes(eff_size_, eff_size_);
+    if (init.Weights.rows() == eff_size_ * eff_size_)
+    {
+        weights_.array() = init.Weights.array();
+        HIGHLIGHT("Loading iMesh weights.\n"
+                  << weights_);
+    }
+}
+
+void IMesh::assignScene(Scene_ptr scene)
+{
+    scene_ = scene;
+}
+
+void IMesh::debug(Eigen::VectorXdRefConst phi)
+{
+    static int textid = 0;
+    {
+        imesh_mark_.scale.x = 0.005;
+        imesh_mark_.color.a = imesh_mark_.color.r = 1;
+        imesh_mark_.type = visualization_msgs::Marker::LINE_LIST;
+        imesh_mark_.pose = geometry_msgs::Pose();
+        imesh_mark_.ns = getObjectName();
+        imesh_mark_.points.clear();
+        std::vector<geometry_msgs::Point> points(eff_size_);
+        for (int i = 0; i < eff_size_; i++)
+        {
+            points[i].x = Kinematics.Phi(i).p[0];
+            points[i].y = Kinematics.Phi(i).p[1];
+            points[i].z = Kinematics.Phi(i).p[2];
+        }
+
+        for (int i = 0; i < eff_size_; i++)
+        {
+            for (int j = i + 1; j < eff_size_; j++)
+            {
+                if (weights_(i, j) > 0.0)
+                {
+                    imesh_mark_.points.push_back(points[i]);
+                    imesh_mark_.points.push_back(points[j]);
+                }
+            }
+        }
+        imesh_mark_.header.stamp = ros::Time::now();
+        imesh_mark_pub_.publish(imesh_mark_);
+    }
+    {
+        imesh_mark_.ns = getObjectName() + "Raw";
+        imesh_mark_.points.clear();
+        std::vector<geometry_msgs::Point> points(eff_size_);
+        for (int i = 0; i < eff_size_; i++)
+        {
+            points[i].x = phi(i * 3);
+            points[i].y = phi(i * 3 + 1);
+            points[i].z = phi(i * 3 + 2);
+        }
+
+        for (int i = 0; i < eff_size_; i++)
+        {
+            for (int j = i + 1; j < eff_size_; j++)
+            {
+                if (weights_(i, j) > 0.0)
+                {
+                    imesh_mark_.points.push_back(points[i]);
+                    imesh_mark_.points.push_back(points[j]);
+                }
+            }
+        }
+        imesh_mark_.header.stamp = ros::Time::now();
+        imesh_mark_pub_.publish(imesh_mark_);
+
+        imesh_mark_.points.clear();
+        imesh_mark_.scale.z = 0.05;
+        imesh_mark_.color.a = imesh_mark_.color.r = imesh_mark_.color.g = imesh_mark_.color.b = 1;
+        imesh_mark_.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+        imesh_mark_.text = std::to_string(textid);
+        imesh_mark_.pose.position = points[textid];
+        imesh_mark_.pose.position.z += 0.05;
+        imesh_mark_.ns = getObjectName() + "Id";
+        imesh_mark_.header.stamp = ros::Time::now();
+        imesh_mark_pub_.publish(imesh_mark_);
+
+        textid = (textid + 1) % eff_size_;
+    }
+}
+
+void IMesh::destroyDebug()
+{
+    imesh_mark_.points.clear();
+    imesh_mark_.action = visualization_msgs::Marker::DELETE;
+    imesh_mark_.header.stamp = ros::Time::now();
+    imesh_mark_pub_.publish(imesh_mark_);
+}
+
+int IMesh::taskSpaceDim()
+{
+    return 3 * eff_size_;
+}
+
+Eigen::VectorXd IMesh::computeLaplace(Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights, Eigen::MatrixXd* dist_ptr, Eigen::VectorXd* wsum_ptr)
+{
+    int N = EffPhi.rows() / 3;
+    Eigen::VectorXd Phi = Eigen::VectorXd::Zero(N * 3);
+    Eigen::MatrixXd dist = Eigen::MatrixXd::Zero(N, N);
+    Eigen::VectorXd wsum = Eigen::VectorXd::Zero(N);
+    /** Compute distance matrix (inverse proportional) */
+    for (int j = 0; j < N; j++)
+    {
+        for (int l = j + 1; l < N; l++)
+        {
+            if (!(j >= N && l >= N))
+            {
+                dist(j, l) = dist(l, j) = (EffPhi.segment(j * 3, 3) - EffPhi.segment(l * 3, 3)).norm();
+            }
+        }
+    }
+    /** Computer weight normaliser */
+    for (int j = 0; j < N; j++)
+    {
+        for (int l = 0; l < N; l++)
+        {
+            if (dist(j, l) > 0 && j != l)
+            {
+                wsum(j) += Weights(j, l) / dist(j, l);
+            }
+        }
+    }
+    /** Compute Laplace coordinates */
+    for (int j = 0; j < N; j++)
+    {
+        Phi.segment(j * 3, 3) = EffPhi.segment(j * 3, 3);
+        for (int l = 0; l < N; l++)
+        {
+            if (j != l)
+            {
+                if (dist(j, l) > 0 && wsum(j) > 0)
+                {
+                    Phi.segment(j * 3, 3) -= EffPhi.segment(l * 3, 3) * Weights(j, l) / (dist(j, l) * wsum(j));
+                }
+            }
+        }
+    }
+    if (dist_ptr) *dist_ptr = dist;
+    if (wsum_ptr) *wsum_ptr = wsum;
+    return Phi;
+}
+
+void IMesh::computeGoalLaplace(const std::vector<KDL::Frame>& nodes, Eigen::VectorXd& goal, Eigen::MatrixXdRefConst Weights)
+{
+    int N = nodes.size();
+    Eigen::VectorXd EffPhi(3 * N);
+    for (int i = 0; i < N; i++)
+    {
+        EffPhi(i * 3) = nodes[i].p[0];
+        EffPhi(i * 3 + 1) = nodes[i].p[1];
+        EffPhi(i * 3 + 2) = nodes[i].p[2];
+    }
+    goal = computeLaplace(EffPhi, Weights);
+}
+
+void IMesh::computeGoalLaplace(const Eigen::VectorXd& x, Eigen::VectorXd& goal)
+{
+    scene_->Update(x);
+    Eigen::VectorXd EffPhi;
+    for (int i = 0; i < eff_size_; i++)
+    {
+        EffPhi(i * 3) = Kinematics.Phi(i).p[0];
+        EffPhi(i * 3 + 1) = Kinematics.Phi(i).p[1];
+        EffPhi(i * 3 + 2) = Kinematics.Phi(i).p[2];
+    }
+    goal = computeLaplace(EffPhi, weights_);
+}
+
+void IMesh::setWeight(int i, int j, double weight)
+{
+    uint M = weights_.cols();
+    if (i < 0 || i >= M || j < 0 || j >= M)
+    {
+        throw_named("Invalid weight element (" << i << "," << j << "). Weight matrix " << M << "x" << M);
+    }
+    if (weight < 0)
+    {
+        throw_named("Invalid weight: " << weight);
+    }
+    weights_(i, j) = weight;
+}
+
+void IMesh::setWeights(const Eigen::MatrixXd& weights)
+{
+    uint M = weights_.cols();
+    if (weights.rows() != M || weights.cols() != M)
+    {
+        throw_named("Invalid weight matrix (" << weights.rows() << "X" << weights.cols() << "). Has to be" << M << "x" << M);
+    }
+    weights_ = weights;
+}
 }

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -36,81 +36,79 @@ REGISTER_TASKMAP_TYPE("JointLimit", exotica::JointLimit);
 
 namespace exotica
 {
-    JointLimit::JointLimit()
-    {
-    }
-
-    JointLimit::~JointLimit()
-    {
-    }
-
-    void JointLimit::Instantiate(JointLimitInitializer& init)
-    {
-        init_ = init;
-    }
-
-    void JointLimit::assignScene(Scene_ptr scene)
-    {
-        scene_ = scene;
-        Initialize();
-    }
-
-    void JointLimit::Initialize()
-    {
-        double percent = init_.SafePercentage;
-
-        std::vector<std::string> jnts = scene_->getJointNames();
-        N = jnts.size();
-        Eigen::MatrixXd limits = scene_->getSolver().getJointLimits();
-        low_limits_ = limits.col(0);
-        high_limits_ = limits.col(1);
-        tau_.resize(N);
-        for (int i = 0; i < N; i++)
-        {
-            tau_(i) = percent * (high_limits_(i) - low_limits_(i))*0.5;
-        }
-    }
-
-    int JointLimit::taskSpaceDim()
-    {
-        return N;
-    }
-
-    void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
-    {
-        if(phi.rows() != N) throw_named("Wrong size of phi!");
-        phi.setZero();
-        for(int i=0;i<N;i++)
-        {
-            if (x(i) < low_limits_(i) + tau_(i))
-            {
-                phi(i) = x(i) - low_limits_(i) - tau_(i);
-            }
-            if (x(i) > high_limits_(i) - tau_(i))
-            {
-                phi(i) = x(i) - high_limits_(i) + tau_(i);
-            }
-        }
-    }
-
-    void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
-    {
-        if(phi.rows() != N) throw_named("Wrong size of phi!");
-        if(J.rows() != N || J.cols() != N) throw_named("Wrong size of J! " << N);
-        phi.setZero();
-        J = Eigen::MatrixXd::Identity(N,N);
-        for(int i=0;i<N;i++)
-        {
-            if (x(i) < low_limits_(i) + tau_(i))
-            {
-                phi(i) = x(i) - low_limits_(i) - tau_(i);
-            }
-            if (x(i) > high_limits_(i) - tau_(i))
-            {
-                phi(i) = x(i) - high_limits_(i) + tau_(i);
-            }
-        }
-    }
-
+JointLimit::JointLimit()
+{
 }
 
+JointLimit::~JointLimit()
+{
+}
+
+void JointLimit::Instantiate(JointLimitInitializer& init)
+{
+    init_ = init;
+}
+
+void JointLimit::assignScene(Scene_ptr scene)
+{
+    scene_ = scene;
+    Initialize();
+}
+
+void JointLimit::Initialize()
+{
+    double percent = init_.SafePercentage;
+
+    std::vector<std::string> jnts = scene_->getJointNames();
+    N = jnts.size();
+    Eigen::MatrixXd limits = scene_->getSolver().getJointLimits();
+    low_limits_ = limits.col(0);
+    high_limits_ = limits.col(1);
+    tau_.resize(N);
+    for (int i = 0; i < N; i++)
+    {
+        tau_(i) = percent * (high_limits_(i) - low_limits_(i)) * 0.5;
+    }
+}
+
+int JointLimit::taskSpaceDim()
+{
+    return N;
+}
+
+void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != N) throw_named("Wrong size of phi!");
+    phi.setZero();
+    for (int i = 0; i < N; i++)
+    {
+        if (x(i) < low_limits_(i) + tau_(i))
+        {
+            phi(i) = x(i) - low_limits_(i) - tau_(i);
+        }
+        if (x(i) > high_limits_(i) - tau_(i))
+        {
+            phi(i) = x(i) - high_limits_(i) + tau_(i);
+        }
+    }
+}
+
+void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != N) throw_named("Wrong size of phi!");
+    if (J.rows() != N || J.cols() != N) throw_named("Wrong size of J! " << N);
+    phi.setZero();
+    J = Eigen::MatrixXd::Identity(N, N);
+    for (int i = 0; i < N; i++)
+    {
+        if (x(i) < low_limits_(i) + tau_(i))
+        {
+            phi(i) = x(i) - low_limits_(i) - tau_(i);
+        }
+        if (x(i) > high_limits_(i) - tau_(i))
+        {
+            phi(i) = x(i) - high_limits_(i) + tau_(i);
+        }
+    }
+}
+}

--- a/exotations/task_maps/task_map/src/SphereCollision.cpp
+++ b/exotations/task_maps/task_map/src/SphereCollision.cpp
@@ -36,142 +36,142 @@ REGISTER_TASKMAP_TYPE("SphereCollision", exotica::SphereCollision);
 
 namespace exotica
 {
-    SphereCollision::SphereCollision()
-    {
-    }
+SphereCollision::SphereCollision()
+{
+}
 
-    void SphereCollision::Instantiate(SphereCollisionInitializer& init)
+void SphereCollision::Instantiate(SphereCollisionInitializer& init)
+{
+    eps = 1.0 / init.Precision;
+    for (int i = 0; i < init.EndEffector.size(); i++)
     {
-        eps = 1.0/init.Precision;
-        for(int i=0;i<init.EndEffector.size();i++)
+        SphereInitializer sphere(init.EndEffector[i]);
+        groups[sphere.Group].push_back(i);
+        radiuses.push_back(sphere.Radius);
+        visualization_msgs::Marker mrk;
+        mrk.action = visualization_msgs::Marker::ADD;
+        mrk.header.frame_id = init.ReferenceFrame;
+        mrk.id = i;
+        mrk.type = visualization_msgs::Marker::SPHERE;
+        mrk.scale.x = mrk.scale.y = mrk.scale.z = sphere.Radius * 2;
+        debug_msg.markers.push_back(mrk);
+    }
+    for (auto& it : groups)
+    {
+        std_msgs::ColorRGBA col = randomColor();
+        col.a = init.Alpha;
+        for (int i : it.second)
         {
-            SphereInitializer sphere(init.EndEffector[i]);
-            groups[sphere.Group].push_back(i);
-            radiuses.push_back(sphere.Radius);
-            visualization_msgs::Marker mrk;
-            mrk.action = visualization_msgs::Marker::ADD;
-            mrk.header.frame_id = init.ReferenceFrame;
-            mrk.id = i;
-            mrk.type = visualization_msgs::Marker::SPHERE;
-            mrk.scale.x = mrk.scale.y = mrk.scale.z = sphere.Radius*2;
-            debug_msg.markers.push_back(mrk);
+            debug_msg.markers[i].color = col;
+            debug_msg.markers[i].ns = it.first;
         }
-        for(auto& it : groups)
+    }
+    debug = init.Debug;
+    if (debug)
+    {
+        debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ + "/CollisionSpheres", 1, true);
+    }
+}
+
+double SphereCollision::distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB)
+{
+    return 1.0 / (1.0 + exp(5.0 * eps * ((effA.p - effB.p).Norm() - rA - rB)));
+}
+
+Eigen::VectorXd SphereCollision::Jacobian(const KDL::Frame& effA, const KDL::Frame& effB, const KDL::Jacobian& jacA, const KDL::Jacobian& jacB, double rA, double rB)
+{
+    int n = jacA.columns();
+    Eigen::VectorXd ret = Eigen::VectorXd::Zero(n);
+    Eigen::VectorXd eA(3);
+    Eigen::VectorXd eB(3);
+    for (int i = 0; i < n; i++)
+    {
+        eA << effA.p[0], effA.p[1], effA.p[2];
+        eB << effB.p[0], effB.p[1], effB.p[2];
+        ret(i) = -(double)((jacA.data.col(i).head(3) - jacB.data.col(i).head(3)).adjoint() * (eA - eB)) / (effA.p - effB.p).Norm();
+    }
+    return ret;
+}
+
+void SphereCollision::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != taskSpaceDim()) throw_named("Wrong size of phi!");
+    phi.setZero();
+
+    auto Aend = groups.end()--;
+    auto Bend = groups.end();
+    int phiI = 0;
+    for (auto A = groups.begin(); A != Aend; A++)
+    {
+        for (auto B = std::next(A); B != Bend; B++)
         {
-            std_msgs::ColorRGBA col = randomColor();
-            col.a = init.Alpha;
-            for(int i : it.second)
+            for (int ii = 0; ii < A->second.size(); ii++)
             {
-                debug_msg.markers[i].color = col;
-                debug_msg.markers[i].ns = it.first;
-            }
-        }
-        debug = init.Debug;
-        if(debug)
-        {
-            debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ +"/CollisionSpheres", 1, true);
-        }
-    }
-
-    double SphereCollision::distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB)
-    {
-        return 1.0/(1.0 + exp(5.0 * eps * ((effA.p-effB.p).Norm()-rA-rB)));
-    }
-
-    Eigen::VectorXd SphereCollision::Jacobian(const KDL::Frame& effA, const KDL::Frame& effB, const KDL::Jacobian& jacA, const KDL::Jacobian& jacB, double rA, double rB)
-    {
-        int n = jacA.columns();
-        Eigen::VectorXd ret = Eigen::VectorXd::Zero(n);
-        Eigen::VectorXd eA(3);
-        Eigen::VectorXd eB(3);
-        for(int i=0;i<n;i++)
-        {
-            eA << effA.p[0], effA.p[1], effA.p[2];
-            eB << effB.p[0], effB.p[1], effB.p[2];
-            ret(i) = -(double)((jacA.data.col(i).head(3)-jacB.data.col(i).head(3)).adjoint()*(eA-eB)) / (effA.p-effB.p).Norm();
-        }
-        return ret;
-    }
-
-    void SphereCollision::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
-    {
-        if(phi.rows() != taskSpaceDim()) throw_named("Wrong size of phi!");
-        phi.setZero();
-
-        auto Aend = groups.end()--;
-        auto Bend = groups.end();
-        int phiI = 0;
-        for(auto A=groups.begin(); A!=Aend; A++)
-        {
-            for(auto B=std::next(A); B!=Bend; B++)
-            {
-                for(int ii=0;ii<A->second.size();ii++)
+                for (int jj = 0; jj < B->second.size(); jj++)
                 {
-                    for(int jj=0;jj<B->second.size();jj++)
-                    {
-                        int i = A->second[ii];
-                        int j = B->second[jj];
-                        phi(phiI) += distance(Kinematics.Phi(i), Kinematics.Phi(j), radiuses[i], radiuses[j]);
-                    }
+                    int i = A->second[ii];
+                    int j = B->second[jj];
+                    phi(phiI) += distance(Kinematics.Phi(i), Kinematics.Phi(j), radiuses[i], radiuses[j]);
                 }
-                phiI++;
             }
-        }
-
-        if(debug)
-        {
-            for(int i=0;i<debug_msg.markers.size();i++)
-            {
-                debug_msg.markers[i].pose.position.x = Kinematics.Phi(i).p[0];
-                debug_msg.markers[i].pose.position.y = Kinematics.Phi(i).p[1];
-                debug_msg.markers[i].pose.position.z = Kinematics.Phi(i).p[2];
-            }
-            debug_pub.publish(debug_msg);
+            phiI++;
         }
     }
 
-    void SphereCollision::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+    if (debug)
     {
-        if(phi.rows() != taskSpaceDim()) throw_named("Wrong size of phi!");
-        if(J.rows() != taskSpaceDim() || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
-        phi.setZero();
-        J.setZero();
-
-        auto Aend = groups.end()--;
-        auto Bend = groups.end();
-        int phiI = 0;
-        for(auto A=groups.begin(); A!=Aend; A++)
+        for (int i = 0; i < debug_msg.markers.size(); i++)
         {
-            for(auto B=std::next(A); B!=Bend; B++)
+            debug_msg.markers[i].pose.position.x = Kinematics.Phi(i).p[0];
+            debug_msg.markers[i].pose.position.y = Kinematics.Phi(i).p[1];
+            debug_msg.markers[i].pose.position.z = Kinematics.Phi(i).p[2];
+        }
+        debug_pub.publish(debug_msg);
+    }
+}
+
+void SphereCollision::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != taskSpaceDim()) throw_named("Wrong size of phi!");
+    if (J.rows() != taskSpaceDim() || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+    phi.setZero();
+    J.setZero();
+
+    auto Aend = groups.end()--;
+    auto Bend = groups.end();
+    int phiI = 0;
+    for (auto A = groups.begin(); A != Aend; A++)
+    {
+        for (auto B = std::next(A); B != Bend; B++)
+        {
+            for (int ii = 0; ii < A->second.size(); ii++)
             {
-                for(int ii=0;ii<A->second.size();ii++)
+                for (int jj = 0; jj < B->second.size(); jj++)
                 {
-                    for(int jj=0;jj<B->second.size();jj++)
-                    {
-                        int i = A->second[ii];
-                        int j = B->second[jj];
-                        phi(phiI) += distance(Kinematics.Phi(i), Kinematics.Phi(j), radiuses[i], radiuses[j]);
-                        J.row(phiI) += Jacobian(Kinematics.Phi(i), Kinematics.Phi(j), Kinematics.J(i), Kinematics.J(j), radiuses[i], radiuses[j]);
-                    }
+                    int i = A->second[ii];
+                    int j = B->second[jj];
+                    phi(phiI) += distance(Kinematics.Phi(i), Kinematics.Phi(j), radiuses[i], radiuses[j]);
+                    J.row(phiI) += Jacobian(Kinematics.Phi(i), Kinematics.Phi(j), Kinematics.J(i), Kinematics.J(j), radiuses[i], radiuses[j]);
                 }
-                phiI++;
             }
-        }
-
-        if(debug)
-        {
-            for(int i=0;i<debug_msg.markers.size();i++)
-            {
-                debug_msg.markers[i].pose.position.x = Kinematics.Phi(i).p[0];
-                debug_msg.markers[i].pose.position.y = Kinematics.Phi(i).p[1];
-                debug_msg.markers[i].pose.position.z = Kinematics.Phi(i).p[2];
-            }
-            debug_pub.publish(debug_msg);
+            phiI++;
         }
     }
 
-    int SphereCollision::taskSpaceDim()
+    if (debug)
     {
-        return groups.size()*(groups.size()-1)/2;
+        for (int i = 0; i < debug_msg.markers.size(); i++)
+        {
+            debug_msg.markers[i].pose.position.x = Kinematics.Phi(i).p[0];
+            debug_msg.markers[i].pose.position.y = Kinematics.Phi(i).p[1];
+            debug_msg.markers[i].pose.position.z = Kinematics.Phi(i).p[2];
+        }
+        debug_pub.publish(debug_msg);
     }
+}
+
+int SphereCollision::taskSpaceDim()
+{
+    return groups.size() * (groups.size() - 1) / 2;
+}
 }

--- a/exotations/task_maps/task_map/src/task_map_py.cpp
+++ b/exotations/task_maps/task_map/src/task_map_py.cpp
@@ -1,16 +1,16 @@
 #include <exotica/Exotica.h>
 #undef NDEBUG
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/eigen.h>
 
 #include <task_map/CoM.h>
+#include <task_map/Distance.h>
 #include <task_map/EffFrame.h>
 #include <task_map/EffOrientation.h>
 #include <task_map/EffPosition.h>
-#include <task_map/Identity.h>
 #include <task_map/IMesh.h>
-#include <task_map/Distance.h>
+#include <task_map/Identity.h>
 #include <task_map/JointLimit.h>
 #include <task_map/SphereCollision.h>
 
@@ -23,29 +23,29 @@ PYBIND11_MODULE(task_map_py, module)
 
     py::module::import("pyexotica");
 
-    py::class_<EffFrame, std::shared_ptr<EffFrame>, TaskMap> effFrame (module, "EffFrame");
+    py::class_<EffFrame, std::shared_ptr<EffFrame>, TaskMap> effFrame(module, "EffFrame");
     effFrame.def_readonly("rotationType", &EffFrame::rotationType);
 
-    py::class_<EffPosition, std::shared_ptr<EffPosition>, TaskMap> effPosition (module, "EffPosition");
+    py::class_<EffPosition, std::shared_ptr<EffPosition>, TaskMap> effPosition(module, "EffPosition");
 
-    py::class_<EffOrientation, std::shared_ptr<EffOrientation>, TaskMap> effOrientation (module, "EffOrientation");
+    py::class_<EffOrientation, std::shared_ptr<EffOrientation>, TaskMap> effOrientation(module, "EffOrientation");
     effOrientation.def_readonly("rotationType", &EffOrientation::rotationType);
 
-    py::class_<CoM, std::shared_ptr<CoM>, TaskMap> com (module, "CoM");
+    py::class_<CoM, std::shared_ptr<CoM>, TaskMap> com(module, "CoM");
 
-    py::class_<Distance, std::shared_ptr<Distance>, TaskMap> distance (module, "Distance");
+    py::class_<Distance, std::shared_ptr<Distance>, TaskMap> distance(module, "Distance");
 
-    py::class_<Identity, std::shared_ptr<Identity>, TaskMap> identity (module, "Identity");
+    py::class_<Identity, std::shared_ptr<Identity>, TaskMap> identity(module, "Identity");
     identity.def_readonly("N", &Identity::N);
     identity.def_readonly("jointMap", &Identity::jointMap);
     identity.def_readwrite("jointRef", &Identity::jointRef);
 
-    py::class_<IMesh, std::shared_ptr<IMesh>, TaskMap> iMesh (module, "IMesh");
+    py::class_<IMesh, std::shared_ptr<IMesh>, TaskMap> iMesh(module, "IMesh");
     iMesh.def_property("W", &IMesh::getWeights, &IMesh::setWeights);
     iMesh.def("setWeight", &IMesh::setWeight);
-    iMesh.def_static("computeLaplace", [](Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights){ return IMesh::computeLaplace(EffPhi, Weights);});
+    iMesh.def_static("computeLaplace", [](Eigen::VectorXdRefConst EffPhi, Eigen::MatrixXdRefConst Weights) { return IMesh::computeLaplace(EffPhi, Weights); });
 
-    py::class_<JointLimit, std::shared_ptr<JointLimit>, TaskMap> jointLimit (module, "JointLimit");
+    py::class_<JointLimit, std::shared_ptr<JointLimit>, TaskMap> jointLimit(module, "JointLimit");
 
-    py::class_<SphereCollision, std::shared_ptr<SphereCollision>, TaskMap> sphereCollision (module, "SphereCollision");
+    py::class_<SphereCollision, std::shared_ptr<SphereCollision>, TaskMap> sphereCollision(module, "SphereCollision");
 }

--- a/exotations/task_maps/task_map/tests/test_maps.cpp
+++ b/exotations/task_maps/task_map/tests/test_maps.cpp
@@ -34,8 +34,8 @@
 
 using namespace exotica;
 
-std::string urdf_string="<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"revolute\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint2\" type=\"revolute\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint3\" type=\"revolute\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
-std::string srdf_string="<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
+std::string urdf_string = "<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><inertial><mass value=\"0.2\"/><origin xyz=\"0 0 0.1\"/><inertia ixx=\"0.00381666666667\" ixy=\"0\" ixz=\"0\" iyy=\"0.0036\" iyz=\"0\" izz=\"0.00381666666667\"/></inertial><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"revolute\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint2\" type=\"revolute\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint3\" type=\"revolute\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /><limit effort=\"200\"  velocity=\"1.0\" lower=\"-0.4\" upper=\"0.4\"/><safety_controller k_position=\"30\" k_velocity=\"30\" soft_lower_limit=\"-0.4\" soft_upper_limit=\"0.4\"/></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
+std::string srdf_string = "<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
 bool printInfo = false;
 
 #define NUM_TRIALS 100
@@ -44,15 +44,16 @@ void testRandom(UnconstrainedEndPoseProblem_ptr problem)
 {
     Eigen::VectorXd x(3);
     INFO_PLAIN("Testing random configurations:")
-    for(int i=0;i<NUM_TRIALS;i++)
+    for (int i = 0; i < NUM_TRIALS; i++)
     {
         x.setRandom();
         problem->Update(x);
-        if(printInfo)
+        if (printInfo)
         {
-            INFO_PLAIN("x = "<<x.transpose());
-            INFO_PLAIN("y = "<<problem->Phi.data.transpose());
-            INFO_PLAIN("J = \n"<<problem->J);
+            INFO_PLAIN("x = " << x.transpose());
+            INFO_PLAIN("y = " << problem->Phi.data.transpose());
+            INFO_PLAIN("J = \n"
+                       << problem->J);
         }
     }
     INFO_PLAIN("Test passed");
@@ -64,26 +65,28 @@ void testValues(Eigen::MatrixXdRefConst Xref, Eigen::MatrixXdRefConst Yref, Eige
     int N = Xref.cols();
     int M = Yref.cols();
     int L = Xref.rows();
-    for(int i=0;i<L;i++)
+    for (int i = 0; i < L; i++)
     {
         Eigen::VectorXd x = Xref.row(i);
         TaskSpaceVector y = problem->y;
         y.data = Yref.row(i);
-        Eigen::MatrixXd J = Jref.middleRows(i*M,M);
+        Eigen::MatrixXd J = Jref.middleRows(i * M, M);
         problem->Update(x);
         double errY = (y - problem->Phi).norm();
         double errJ = (J - problem->J).norm();
-        if(errY > eps)
+        if (errY > eps)
         {
-            HIGHLIGHT("y:  "<<problem->Phi.data.transpose());
-            HIGHLIGHT("y*: "<<y.data.transpose());
+            HIGHLIGHT("y:  " << problem->Phi.data.transpose());
+            HIGHLIGHT("y*: " << y.data.transpose());
             throw_pretty("Task space error out of bounds: " << errY);
         }
-        if(errJ > eps)
+        if (errJ > eps)
         {
-            HIGHLIGHT("x: "<<x.transpose());
-            HIGHLIGHT("J*:\n"<<J);
-            HIGHLIGHT("J:\n"<<problem->J);
+            HIGHLIGHT("x: " << x.transpose());
+            HIGHLIGHT("J*:\n"
+                      << J);
+            HIGHLIGHT("J:\n"
+                      << problem->J);
             throw_pretty("Jacobian error out of bounds: " << errJ);
         }
     }
@@ -94,7 +97,7 @@ void testValues(Eigen::MatrixXdRefConst Xref, Eigen::MatrixXdRefConst Yref, Eige
 void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
 {
     INFO_PLAIN("Testing Jacobian:");
-    for(int j=0;j<NUM_TRIALS;j++)
+    for (int j = 0; j < NUM_TRIALS; j++)
     {
         Eigen::VectorXd x0(problem->N);
         x0.setRandom();
@@ -102,19 +105,21 @@ void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
         TaskSpaceVector y0 = problem->Phi;
         Eigen::MatrixXd J0 = problem->J;
         Eigen::MatrixXd J = Eigen::MatrixXd::Zero(J0.rows(), J0.cols());
-        for(int i=0;i<problem->N;i++)
+        for (int i = 0; i < problem->N; i++)
         {
             Eigen::VectorXd x = x0;
-            x(i)+=eps;
+            x(i) += eps;
             problem->Update(x);
-            J.col(i) = (problem->Phi - y0)/eps;
+            J.col(i) = (problem->Phi - y0) / eps;
         }
-        double errJ = (J-J0).norm();
-        if(errJ > eps)
+        double errJ = (J - J0).norm();
+        if (errJ > eps)
         {
-            HIGHLIGHT("x: "<<x0.transpose());
-            HIGHLIGHT("J*:\n"<<J);
-            HIGHLIGHT("J:\n"<<J0);
+            HIGHLIGHT("x: " << x0.transpose());
+            HIGHLIGHT("J*:\n"
+                      << J);
+            HIGHLIGHT("J:\n"
+                      << J0);
             throw_pretty("Jacobian error out of bounds: " << errJ);
         }
     }
@@ -123,26 +128,24 @@ void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
 
 UnconstrainedEndPoseProblem_ptr setupProblem(Initializer& map)
 {
-    Initializer scene("Scene",{{"Name",std::string("MyScene")},{"JointGroup",std::string("arm")}});
-    Eigen::VectorXd W(3);W << 3,2,1;
-    Initializer problem("exotica/UnconstrainedEndPoseProblem",{
-                            {"Name",std::string("MyProblem")},
-                            {"PlanningScene",scene},
-                            {"Maps",std::vector<Initializer>({map})},
-                            {"W",W},
-                        });
-    Server::Instance()->getModel("robot_description",urdf_string,srdf_string);
+    Initializer scene("Scene", {{"Name", std::string("MyScene")}, {"JointGroup", std::string("arm")}});
+    Eigen::VectorXd W(3);
+    W << 3, 2, 1;
+    Initializer problem("exotica/UnconstrainedEndPoseProblem", {
+                                                                   {"Name", std::string("MyProblem")},
+                                                                   {"PlanningScene", scene},
+                                                                   {"Maps", std::vector<Initializer>({map})},
+                                                                   {"W", W},
+                                                               });
+    Server::Instance()->getModel("robot_description", urdf_string, srdf_string);
     return std::static_pointer_cast<UnconstrainedEndPoseProblem>(Setup::createProblem(problem));
 }
 
 void testEffPosition()
 {
     HIGHLIGHT("End-effector position test");
-    Initializer map("exotica/EffPosition",{
-                        {"Name",std::string("Position")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("endeff")}})
-                                        }) } });
+    Initializer map("exotica/EffPosition", {{"Name", std::string("Position")},
+                                            {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
     UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
     testRandom(problem);
 
@@ -151,26 +154,12 @@ void testEffPosition()
     int L = 5;
     Eigen::MatrixXd X(L, N);
     Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
+    Eigen::MatrixXd J(L * M, N);
 
     X << 0.680375, -0.211234, 0.566198, 0.59688, 0.823295, -0.604897, -0.329554, 0.536459, -0.444451, 0.10794, -0.0452059, 0.257742, -0.270431, 0.0268018, 0.904459;
     Y << 0.0645323, 0.0522249, 1.21417, 0.292945, 0.199075, 1.12724, 0.208378, -0.0712708, 1.19893, 0.0786457, 0.00852213, 1.23952, 0.356984, -0.0989639, 1.06844;
-    J << -0.0522249, 0.594015, 0.327994
-            , 0.0645323, 0.480726, 0.26544
-            , 0, -0.0830172, -0.156401
-            , -0.199075, 0.560144, 0.363351
-            , 0.292945, 0.380655, 0.246921
-            , 0, -0.354186, -0.0974994
-            , 0.0712708, 0.708627, 0.423983
-            , 0.208378, -0.24237, -0.145014
-            , 0, -0.220229, -0.0413455
-            ,-0.00852213, 0.784922, 0.437315
-            , 0.0786457, 0.085055, 0.0473879
-            , 0, -0.0791061, -0.0949228
-            , 0.0989639, 0.595968, 0.258809
-            , 0.356984, -0.165215, -0.0717477
-            , 0, -0.370448, -0.361068;
-    testValues(X ,Y ,J ,problem);
+    J << -0.0522249, 0.594015, 0.327994, 0.0645323, 0.480726, 0.26544, 0, -0.0830172, -0.156401, -0.199075, 0.560144, 0.363351, 0.292945, 0.380655, 0.246921, 0, -0.354186, -0.0974994, 0.0712708, 0.708627, 0.423983, 0.208378, -0.24237, -0.145014, 0, -0.220229, -0.0413455, -0.00852213, 0.784922, 0.437315, 0.0786457, 0.085055, 0.0473879, 0, -0.0791061, -0.0949228, 0.0989639, 0.595968, 0.258809, 0.356984, -0.165215, -0.0717477, 0, -0.370448, -0.361068;
+    testValues(X, Y, J, problem);
 
     testJacobian(problem);
 }
@@ -180,15 +169,12 @@ void testEffOrientation()
     HIGHLIGHT("End-effector orientation test");
     std::vector<std::string> types = {"Quaternion", "ZYX", "ZYZ", "AngleAxis", "Matrix", "RPY"};
 
-    for(std::string type : types)
+    for (std::string type : types)
     {
-        INFO_PLAIN("Rotation type "<<type);
-        Initializer map("exotica/EffOrientation",{
-                            {"Name",std::string("Orientation")},
-                            {"Type",type},
-                            {"EndEffector",std::vector<Initializer>({
-                                 Initializer("Frame",{{"Link",std::string("endeff")}})
-                                            }) } });
+        INFO_PLAIN("Rotation type " << type);
+        Initializer map("exotica/EffOrientation", {{"Name", std::string("Orientation")},
+                                                   {"Type", type},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
 
@@ -201,15 +187,12 @@ void testEffFrame()
     HIGHLIGHT("End-effector frame test");
     std::vector<std::string> types = {"Quaternion", "ZYX", "ZYZ", "AngleAxis", "Matrix", "RPY"};
 
-    for(std::string type : types)
+    for (std::string type : types)
     {
-        INFO_PLAIN("Rotation type "<<type);
-        Initializer map("exotica/EffFrame",{
-                            {"Name",std::string("Frame")},
-                            {"Type",type},
-                            {"EndEffector",std::vector<Initializer>({
-                                 Initializer("Frame",{{"Link",std::string("endeff")}})
-                                            }) } });
+        INFO_PLAIN("Rotation type " << type);
+        Initializer map("exotica/EffFrame", {{"Name", std::string("Frame")},
+                                             {"Type", type},
+                                             {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
 
@@ -220,11 +203,8 @@ void testEffFrame()
 void testDistance()
 {
     HIGHLIGHT("Distance test");
-    Initializer map("exotica/Distance",{
-                        {"Name",std::string("Distance")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("endeff")}})
-                                        }) } });
+    Initializer map("exotica/Distance", {{"Name", std::string("Distance")},
+                                         {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
     UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
     testRandom(problem);
 
@@ -233,16 +213,16 @@ void testDistance()
     int L = 5;
     Eigen::MatrixXd X(L, N);
     Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
+    Eigen::MatrixXd J(L * M, N);
 
     X << 0.83239, 0.271423, 0.434594, -0.716795, 0.213938, -0.967399, -0.514226, -0.725537, 0.608354, -0.686642, -0.198111, -0.740419, -0.782382, 0.997849, -0.563486;
     Y << 1.19368, 1.14431, 1.19326, 1.14377, 1.1541;
     J << 0, -0.145441, -0.16562,
-            0, 0.0918504, 0.234405,
-            0, 0.107422, -0.0555943,
-            0, 0.169924, 0.235715,
-            0, -0.188516, -0.000946239;
-    testValues(X ,Y ,J ,problem);
+        0, 0.0918504, 0.234405,
+        0, 0.107422, -0.0555943,
+        0, 0.169924, 0.235715,
+        0, -0.188516, -0.000946239;
+    testValues(X, Y, J, problem);
 
     testJacobian(problem);
 }
@@ -250,9 +230,8 @@ void testDistance()
 void testJointLimit()
 {
     HIGHLIGHT("Joint limit test");
-    Initializer map("exotica/JointLimit",{
-                        {"Name",std::string("JointLimit")},
-                        {"SafePercentage", 0.0} });
+    Initializer map("exotica/JointLimit", {{"Name", std::string("JointLimit")},
+                                           {"SafePercentage", 0.0}});
     UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
     testRandom(problem);
 
@@ -261,11 +240,74 @@ void testJointLimit()
     int L = 5;
     Eigen::MatrixXd X(L, N);
     Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
+    Eigen::MatrixXd J(L * M, N);
 
     X << 0.0258648, 0.678224, 0.22528, -0.407937, 0.275105, 0.0485744, -0.012834, 0.94555, -0.414966, 0.542715, 0.05349, 0.539828, -0.199543, 0.783059, -0.433371;
     Y << 0, 0.278224, 0, -0.00793676, 0, 0, 0, 0.54555, -0.0149664, 0.142715, 0, 0.139828, 0, 0.383059, -0.0333705;
-    J <<    1, 0, 0,
+    J << 1, 0, 0,
+        0, 1, 0,
+        0, 0, 1,
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1,
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1,
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1,
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1;
+    testValues(X, Y, J, problem);
+}
+
+void testSphereCollision()
+{
+    HIGHLIGHT("Sphere collision test");
+    Initializer map("exotica/SphereCollision", {{"Name", std::string("SphereCollision")},
+                                                {"Precision", 1e-2},
+                                                {"ReferenceFrame", std::string("base")},
+                                                {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("base")}, {"Radius", 0.3}, {"Group", std::string("base")}}),
+                                                                                          Initializer("Frame", {{"Link", std::string("endeff")}, {"Radius", 0.3}, {"Group", std::string("eff")}})})}});
+    UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+    testRandom(problem);
+
+    int N = problem->N;
+    int M = problem->PhiN;
+    int L = 5;
+    Eigen::MatrixXd X(L, N);
+    Eigen::MatrixXd Y(L, M);
+    Eigen::MatrixXd J(L * M, N);
+
+    X << -0.590167, 1.2309, 1.67611, -1.72098, 1.79731, 0.103981, -1.65578, -1.23114, 0.652908, 1.56093, -0.604428, -1.74331, -1.91991, -0.169193, -1.74762;
+    Y << 1, 5.71023e-44, 1.83279e-110, 6.87352e-16, 7.26371e-45;
+    J << 0, 0.431392, 0.449344,
+        0, 0.431735, 0.26014,
+        0, -0.234475, -0.0135658,
+        0, -0.349195, -0.447214,
+        0, -0.270171, -0.430172;
+    testValues(X, Y, J, problem);
+}
+
+void testIdentity()
+{
+    HIGHLIGHT("Identity test");
+    Initializer map("exotica/Identity", {{"Name", std::string("Identity")}});
+    UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+    testRandom(problem);
+
+    {
+        int N = problem->N;
+        int M = problem->PhiN;
+        int L = 5;
+        Eigen::MatrixXd X(L, N);
+        Eigen::MatrixXd Y(L, M);
+        Eigen::MatrixXd J(L * M, N);
+
+        X << -0.52344, 0.941268, 0.804416, 0.70184, -0.466669, 0.0795207, -0.249586, 0.520497, 0.0250707, 0.335448, 0.0632129, -0.921439, -0.124725, 0.86367, 0.86162;
+        Y << -0.52344, 0.941268, 0.804416, 0.70184, -0.466669, 0.0795207, -0.249586, 0.520497, 0.0250707, 0.335448, 0.0632129, -0.921439, -0.124725, 0.86367, 0.86162;
+        J << 1, 0, 0,
             0, 1, 0,
             0, 0, 1,
             1, 0, 0,
@@ -280,83 +322,13 @@ void testJointLimit()
             1, 0, 0,
             0, 1, 0,
             0, 0, 1;
-    testValues(X ,Y ,J ,problem);
-}
-
-void testSphereCollision()
-{
-    HIGHLIGHT("Sphere collision test");
-    Initializer map("exotica/SphereCollision",{
-                        {"Name",std::string("SphereCollision")},
-                        {"Precision",1e-2},
-                        {"ReferenceFrame",std::string("base")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("base")}, {"Radius", 0.3}, {"Group", std::string("base")}}),
-                             Initializer("Frame",{{"Link",std::string("endeff")}, {"Radius", 0.3}, {"Group", std::string("eff")}})
-                                        }) } });
-    UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
-    testRandom(problem);
-
-    int N = problem->N;
-    int M = problem->PhiN;
-    int L = 5;
-    Eigen::MatrixXd X(L, N);
-    Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
-
-    X << -0.590167, 1.2309, 1.67611, -1.72098, 1.79731, 0.103981, -1.65578, -1.23114, 0.652908, 1.56093, -0.604428, -1.74331, -1.91991, -0.169193, -1.74762;
-    Y << 1, 5.71023e-44, 1.83279e-110, 6.87352e-16, 7.26371e-45;
-    J <<    0, 0.431392, 0.449344,
-            0, 0.431735, 0.26014,
-            0, -0.234475, -0.0135658,
-            0, -0.349195, -0.447214,
-            0, -0.270171, -0.430172;
-    testValues(X ,Y ,J ,problem);
-}
-
-void testIdentity()
-{
-    HIGHLIGHT("Identity test");
-    Initializer map("exotica/Identity",{
-                        {"Name",std::string("Identity")}
-                    });
-    UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
-    testRandom(problem);
-
-    {
-        int N = problem->N;
-        int M = problem->PhiN;
-        int L = 5;
-        Eigen::MatrixXd X(L, N);
-        Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
-
-        X << -0.52344, 0.941268, 0.804416, 0.70184, -0.466669, 0.0795207, -0.249586, 0.520497, 0.0250707, 0.335448, 0.0632129, -0.921439, -0.124725, 0.86367, 0.86162;
-        Y << -0.52344, 0.941268, 0.804416, 0.70184, -0.466669, 0.0795207, -0.249586, 0.520497, 0.0250707, 0.335448, 0.0632129, -0.921439, -0.124725, 0.86367, 0.86162;
-        J <<    1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1;
-        testValues(X ,Y ,J ,problem);
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 
     HIGHLIGHT("Identity test with reference");
-    map = Initializer("exotica/Identity",{
-                        {"Name",std::string("Identity")},
-                        {"JointRef",std::string("0.5 0.5 0.5")}
-                    });
+    map = Initializer("exotica/Identity", {{"Name", std::string("Identity")},
+                                           {"JointRef", std::string("0.5 0.5 0.5")}});
     problem = setupProblem(map);
     testRandom(problem);
 
@@ -366,34 +338,32 @@ void testIdentity()
         int L = 5;
         Eigen::MatrixXd X(L, N);
         Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
+        Eigen::MatrixXd J(L * M, N);
 
         X << 0.441905, -0.431413, 0.477069, 0.279958, -0.291903, 0.375723, -0.668052, -0.119791, 0.76015, 0.658402, -0.339326, -0.542064, 0.786745, -0.29928, 0.37334;
         Y << -0.0580953, -0.931413, -0.0229314, -0.220042, -0.791903, -0.124277, -1.16805, -0.619791, 0.26015, 0.158402, -0.839326, -1.04206, 0.286745, -0.79928, -0.12666;
-        J <<    1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1,
-                1, 0, 0,
-                0, 1, 0,
-                0, 0, 1;
-        testValues(X ,Y ,J ,problem);
+        J << 1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1;
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 
     HIGHLIGHT("Identity test with subset of joints");
-    map = Initializer("exotica/Identity",{
-                        {"Name",std::string("Identity")},
-                        {"JointMap",std::string("0")}
-                    });
+    map = Initializer("exotica/Identity", {{"Name", std::string("Identity")},
+                                           {"JointMap", std::string("0")}});
     problem = setupProblem(map);
     testRandom(problem);
 
@@ -403,16 +373,16 @@ void testIdentity()
         int L = 5;
         Eigen::MatrixXd X(L, N);
         Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
+        Eigen::MatrixXd J(L * M, N);
 
         X << 0.912937, 0.17728, 0.314608, 0.717353, -0.12088, 0.84794, -0.203127, 0.629534, 0.368437, 0.821944, -0.0350187, -0.56835, 0.900505, 0.840257, -0.70468;
         Y << 0.912937, 0.717353, -0.203127, 0.821944, 0.900505;
-        J <<    1, 0, 0,
-                1, 0, 0,
-                1, 0, 0,
-                1, 0, 0,
-                1, 0, 0;
-        testValues(X ,Y ,J ,problem);
+        J << 1, 0, 0,
+            1, 0, 0,
+            1, 0, 0,
+            1, 0, 0,
+            1, 0, 0;
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 }
@@ -420,9 +390,8 @@ void testIdentity()
 void testCoM()
 {
     HIGHLIGHT("CoM test");
-    Initializer map("exotica/CoM",{
-                        {"Name",std::string("CoM")},
-                        {"EnableZ", true} });
+    Initializer map("exotica/CoM", {{"Name", std::string("CoM")},
+                                    {"EnableZ", true}});
     UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
     testRandom(problem);
 
@@ -432,37 +401,34 @@ void testCoM()
         int L = 5;
         Eigen::MatrixXd X(L, N);
         Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
+        Eigen::MatrixXd J(L * M, N);
 
         X << -0.281809, 0.10497, 0.15886, -0.0948483, 0.374775, -0.80072, 0.061616, 0.514588, -0.39141, 0.984457, 0.153942, 0.755228, 0.495619, 0.25782, -0.929158;
         Y << 0.081112, -0.0234831, 0.924368, 0.0080578, -0.000766568, 0.895465, 0.157569, 0.00972105, 0.897157, 0.117213, 0.176455, 0.846633, -0.0587457, -0.0317596, 0.877501;
-        J <<    0.0234831, 0.455657, 0.200919,
-                0.081112, -0.131919, -0.0581688,
-                0, -0.0844429, -0.0565023,
-                0.000766568, 0.443462, 0.19642,
-                0.0080578, -0.0421882, -0.0186862,
-                0, -0.00809418, 0.0895227,
-                -0.00972105, 0.446309, 0.214617,
-                0.157569, 0.0275346, 0.0132406,
-                0, -0.157868, -0.0266211,
-                -0.176455, 0.219463, 0.0736575,
-                0.117213, 0.330384, 0.110885,
-                0, -0.211838, -0.170949,
-                0.0317596, 0.376061, 0.149235,
-                -0.0587457, 0.203309, 0.0806805,
-                0, 0.0667812, 0.134774;
-        testValues(X ,Y ,J ,problem);
+        J << 0.0234831, 0.455657, 0.200919,
+            0.081112, -0.131919, -0.0581688,
+            0, -0.0844429, -0.0565023,
+            0.000766568, 0.443462, 0.19642,
+            0.0080578, -0.0421882, -0.0186862,
+            0, -0.00809418, 0.0895227,
+            -0.00972105, 0.446309, 0.214617,
+            0.157569, 0.0275346, 0.0132406,
+            0, -0.157868, -0.0266211,
+            -0.176455, 0.219463, 0.0736575,
+            0.117213, 0.330384, 0.110885,
+            0, -0.211838, -0.170949,
+            0.0317596, 0.376061, 0.149235,
+            -0.0587457, 0.203309, 0.0806805,
+            0, 0.0667812, 0.134774;
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 
     HIGHLIGHT("CoM test with a subset of links");
-    map = Initializer("exotica/CoM",{
-                        {"Name",std::string("CoM")},
-                        {"EnableZ", true},
-                        {"EndEffector",std::vector<Initializer>({
-                               Initializer("Frame",{{"Link",std::string("link2")}}),
-                               Initializer("Frame",{{"Link",std::string("endeff")}})
-                                          }) }});
+    map = Initializer("exotica/CoM", {{"Name", std::string("CoM")},
+                                      {"EnableZ", true},
+                                      {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("link2")}}),
+                                                                                Initializer("Frame", {{"Link", std::string("endeff")}})})}});
     problem = setupProblem(map);
     testRandom(problem);
 
@@ -472,33 +438,32 @@ void testCoM()
         int L = 5;
         Eigen::MatrixXd X(L, N);
         Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
+        Eigen::MatrixXd J(L * M, N);
 
         X << 0.299414, -0.503912, 0.258959, -0.541726, 0.40124, -0.366266, -0.342446, -0.537144, -0.851678, 0.266144, -0.552687, 0.302264, 0.0213719, 0.942931, -0.439916;
         Y << -0.167532, -0.0517162, 0.913823, 0.083533, -0.0502684, 0.931962, -0.3632, 0.129477, 0.693081, -0.17971, -0.048991, 0.907923, 0.314586, 0.00672432, 0.823106;
-        J <<    0.0517162, 0.443188, 0.254921,
-                -0.167532, 0.13681, 0.0786927,
-                0, 0.175333, 0.0666905,
-                0.0502684, 0.412954, 0.235481,
-                0.083533, -0.248507, -0.141708,
-                0, -0.0974919, -0.00961589,
-                -0.129477, 0.228967, 0.0468775,
-                -0.3632, -0.0816248, -0.0167114,
-                0, 0.385588, 0.270459,
-                0.048991, 0.441801, 0.257042,
-                -0.17971, 0.12044, 0.0700725,
-                0, 0.186268, 0.0681488,
-                -0.00672432, 0.373021, 0.240882,
-                0.314586, 0.00797337, 0.00514888,
-                0, -0.314658, -0.132569;
-        testValues(X ,Y ,J ,problem);
+        J << 0.0517162, 0.443188, 0.254921,
+            -0.167532, 0.13681, 0.0786927,
+            0, 0.175333, 0.0666905,
+            0.0502684, 0.412954, 0.235481,
+            0.083533, -0.248507, -0.141708,
+            0, -0.0974919, -0.00961589,
+            -0.129477, 0.228967, 0.0468775,
+            -0.3632, -0.0816248, -0.0167114,
+            0, 0.385588, 0.270459,
+            0.048991, 0.441801, 0.257042,
+            -0.17971, 0.12044, 0.0700725,
+            0, 0.186268, 0.0681488,
+            -0.00672432, 0.373021, 0.240882,
+            0.314586, 0.00797337, 0.00514888,
+            0, -0.314658, -0.132569;
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 
     HIGHLIGHT("CoM test with projection on XY plane");
-    map = Initializer("exotica/CoM",{
-                        {"Name",std::string("CoM")},
-                        {"EnableZ", false} });
+    map = Initializer("exotica/CoM", {{"Name", std::string("CoM")},
+                                      {"EnableZ", false}});
     problem = setupProblem(map);
     testRandom(problem);
 
@@ -508,21 +473,21 @@ void testCoM()
         int L = 5;
         Eigen::MatrixXd X(L, N);
         Eigen::MatrixXd Y(L, M);
-        Eigen::MatrixXd J(L*M, N);
+        Eigen::MatrixXd J(L * M, N);
 
         X << 0.350952, -0.0340994, -0.0361284, -0.390089, 0.424175, -0.634888, 0.243646, -0.918271, -0.172033, 0.391968, 0.347873, 0.27528, -0.305768, -0.630755, 0.218212;
         Y << -0.0228141, -0.0083524, 0.0595937, -0.0245025, -0.392081, -0.0974653, 0.200868, 0.0830305, -0.232814, 0.0734919;
-        J <<    0.0083524, 0.453225, 0.202958,
-                -0.0228141, 0.165929, 0.0743046,
-                0.0245025, 0.420734, 0.195957,
-                0.0595937, -0.172988, -0.0805696,
-                0.0974653, 0.254325, 0.0971889,
-                -0.392081, 0.0632213, 0.0241597,
-                -0.0830305, 0.394279, 0.162599,
-                0.200868, 0.162978, 0.0672114,
-                -0.0734919, 0.394649, 0.189283,
-                -0.232814, -0.124578, -0.0597504;
-        testValues(X ,Y ,J ,problem);
+        J << 0.0083524, 0.453225, 0.202958,
+            -0.0228141, 0.165929, 0.0743046,
+            0.0245025, 0.420734, 0.195957,
+            0.0595937, -0.172988, -0.0805696,
+            0.0974653, 0.254325, 0.0971889,
+            -0.392081, 0.0632213, 0.0241597,
+            -0.0830305, 0.394279, 0.162599,
+            0.200868, 0.162978, 0.0672114,
+            -0.0734919, 0.394649, 0.189283,
+            -0.232814, -0.124578, -0.0597504;
+        testValues(X, Y, J, problem);
     }
     testJacobian(problem);
 }
@@ -530,15 +495,11 @@ void testCoM()
 void testIMesh()
 {
     HIGHLIGHT("Interaction mesh test");
-    Initializer map("exotica/IMesh",{
-                        {"Name",std::string("IMesh")},
-                        {"ReferenceFrame",std::string("base")},
-                        {"EndEffector",std::vector<Initializer>({
-                               Initializer("Frame",{{"Link",std::string("base")}}),
-                               Initializer("Frame",{{"Link",std::string("link2")}}),
-                               Initializer("Frame",{{"Link",std::string("endeff")}})
-                                          }) }
-                         });
+    Initializer map("exotica/IMesh", {{"Name", std::string("IMesh")},
+                                      {"ReferenceFrame", std::string("base")},
+                                      {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("base")}}),
+                                                                                Initializer("Frame", {{"Link", std::string("link2")}}),
+                                                                                Initializer("Frame", {{"Link", std::string("endeff")}})})}});
     UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
     testRandom(problem);
 
@@ -547,67 +508,67 @@ void testIMesh()
     int L = 5;
     Eigen::MatrixXd X(L, N);
     Eigen::MatrixXd Y(L, M);
-    Eigen::MatrixXd J(L*M, N);
+    Eigen::MatrixXd J(L * M, N);
     J.setZero();
     Y.setZero();
     X.setZero();
 
     X << 0.278917, 0.51947, -0.813039, -0.730195, 0.0404201, -0.843536, -0.860187, -0.59069, -0.0771591, 0.639355, 0.146637, 0.511162, -0.896122, -0.684386, 0.999987;
     Y << -0.0115151, -0.00329772, -0.652131, -0.01588, -0.00454774, 0.000489, 0.0418479, 0.0119845, 0.906934,
-            0.0647007, -0.0579245, -0.635726, 0.0879002, -0.0786944, 0.0262201, -0.230697, 0.206536, 0.836692,
-            0.0846586, -0.098373, -0.626482, 0.111269, -0.129294, 0.0559699, -0.308935, 0.358981, 0.824647,
-            -0.0715067, -0.0531681, -0.641823, -0.0962226, -0.0715454, 0.0264905, 0.261816, 0.194671, 0.879061,
-            0.014318, -0.0178999, -0.646355, 0.0198797, -0.024853, 0.00185134, -0.0509673, 0.0637179, 0.869616;
-    J <<    0.00329772, -0.194435, -0.112919,
-            -0.0115151, -0.0556828, -0.0323379,
-            0, 0.00993552, -0.0177924,
-            0.00454774, -0.267977, -0.155057,
-            -0.01588, -0.0767438, -0.0444055,
-            0, 0.0165184, 0.00951859,
-            -0.0119845, 0.706188, 0.414101,
-            0.0418479, 0.202239, 0.118591,
-            0, -0.0420476, 0.139591,
-            0.0579245, -0.143241, -0.0744983,
-            0.0647007, 0.128239, 0.066696,
-            0, -0.0728714, -0.0644042,
-            0.0786944, -0.18799, -0.100693,
-            0.0879002, 0.168302, 0.0901469,
-            0, -0.11798, -0.0656211,
-            -0.206536, 0.493387, 0.232834,
-            -0.230697, -0.441714, -0.208449,
-            0, 0.298475, 0.326197,
-            0.098373, -0.124335, -0.0691047,
-            0.0846586, 0.144477, 0.0802994,
-            0, -0.110572, -0.0639689,
-            0.129294, -0.151303, -0.0843603,
-            0.111269, 0.175813, 0.0980263,
-            0, -0.17058, -0.0955839,
-            -0.358981, 0.420088, 0.230469,
-            -0.308935, -0.488141, -0.267804,
-            0, 0.457396, 0.270273,
-            0.0531681, -0.159255, -0.085326,
-            -0.0715067, -0.118412, -0.0634434,
-            0, 0.0748349, 0.0556152,
-            0.0715454, -0.207141, -0.112843,
-            -0.0962226, -0.154018, -0.0839033,
-            0, 0.119906, 0.0666997,
-            -0.194671, 0.56362, 0.285766,
-            0.261816, 0.419075, 0.212479,
-            0, -0.315274, -0.273879,
-            0.0178999, -0.122936, -0.0735487,
-            0.014318, 0.153692, 0.0919485,
-            0, -0.0190144, 0.0184454,
-            0.024853, -0.170294, -0.100978,
-            0.0198797, 0.212897, 0.12624,
-            0, -0.0318257, -0.0186769,
-            -0.0637179, 0.436598, 0.267206,
-            -0.0509673, -0.545823, -0.334054,
-            0, 0.0786625, -0.152426;
-    testValues(X ,Y ,J ,problem);
+        0.0647007, -0.0579245, -0.635726, 0.0879002, -0.0786944, 0.0262201, -0.230697, 0.206536, 0.836692,
+        0.0846586, -0.098373, -0.626482, 0.111269, -0.129294, 0.0559699, -0.308935, 0.358981, 0.824647,
+        -0.0715067, -0.0531681, -0.641823, -0.0962226, -0.0715454, 0.0264905, 0.261816, 0.194671, 0.879061,
+        0.014318, -0.0178999, -0.646355, 0.0198797, -0.024853, 0.00185134, -0.0509673, 0.0637179, 0.869616;
+    J << 0.00329772, -0.194435, -0.112919,
+        -0.0115151, -0.0556828, -0.0323379,
+        0, 0.00993552, -0.0177924,
+        0.00454774, -0.267977, -0.155057,
+        -0.01588, -0.0767438, -0.0444055,
+        0, 0.0165184, 0.00951859,
+        -0.0119845, 0.706188, 0.414101,
+        0.0418479, 0.202239, 0.118591,
+        0, -0.0420476, 0.139591,
+        0.0579245, -0.143241, -0.0744983,
+        0.0647007, 0.128239, 0.066696,
+        0, -0.0728714, -0.0644042,
+        0.0786944, -0.18799, -0.100693,
+        0.0879002, 0.168302, 0.0901469,
+        0, -0.11798, -0.0656211,
+        -0.206536, 0.493387, 0.232834,
+        -0.230697, -0.441714, -0.208449,
+        0, 0.298475, 0.326197,
+        0.098373, -0.124335, -0.0691047,
+        0.0846586, 0.144477, 0.0802994,
+        0, -0.110572, -0.0639689,
+        0.129294, -0.151303, -0.0843603,
+        0.111269, 0.175813, 0.0980263,
+        0, -0.17058, -0.0955839,
+        -0.358981, 0.420088, 0.230469,
+        -0.308935, -0.488141, -0.267804,
+        0, 0.457396, 0.270273,
+        0.0531681, -0.159255, -0.085326,
+        -0.0715067, -0.118412, -0.0634434,
+        0, 0.0748349, 0.0556152,
+        0.0715454, -0.207141, -0.112843,
+        -0.0962226, -0.154018, -0.0839033,
+        0, 0.119906, 0.0666997,
+        -0.194671, 0.56362, 0.285766,
+        0.261816, 0.419075, 0.212479,
+        0, -0.315274, -0.273879,
+        0.0178999, -0.122936, -0.0735487,
+        0.014318, 0.153692, 0.0919485,
+        0, -0.0190144, 0.0184454,
+        0.024853, -0.170294, -0.100978,
+        0.0198797, 0.212897, 0.12624,
+        0, -0.0318257, -0.0186769,
+        -0.0637179, 0.436598, 0.267206,
+        -0.0509673, -0.545823, -0.334054,
+        0, 0.0786625, -0.152426;
+    testValues(X, Y, J, problem);
     testJacobian(problem);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     ros::init(argc, argv, "EXOTica_test_maps");
     testEffPosition();

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -1,32 +1,31 @@
 #ifndef COLLISIONSCENE_H
 #define COLLISIONSCENE_H
 
-#include <exotica/Tools.h>
-#include <exotica/Object.h>
 #include <exotica/Factory.h>
-#include <string>
-#include <sstream>
-#include <Eigen/Dense>
 #include <exotica/KinematicElement.h>
+#include <exotica/Object.h>
+#include <exotica/Tools.h>
+#include <Eigen/Dense>
+#include <sstream>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
 #define REGISTER_COLLISION_SCENE_TYPE(TYPE, DERIV) EXOTICA_REGISTER(exotica::CollisionScene, TYPE, DERIV)
 namespace exotica
 {
-
 class AllowedCollisionMatrix
 {
 public:
     AllowedCollisionMatrix() {}
-    AllowedCollisionMatrix(const AllowedCollisionMatrix& acm) {entries_ = acm.entries_;}
-    inline void clear() {entries_.clear();}
-    inline bool hasEntry(const std::string& name) const {return entries_.find(name)==entries_.end();}
-    inline void setEntry(const std::string& name1, const std::string& name2) {entries_[name1].insert(name2);}
+    AllowedCollisionMatrix(const AllowedCollisionMatrix& acm) { entries_ = acm.entries_; }
+    inline void clear() { entries_.clear(); }
+    inline bool hasEntry(const std::string& name) const { return entries_.find(name) == entries_.end(); }
+    inline void setEntry(const std::string& name1, const std::string& name2) { entries_[name1].insert(name2); }
     inline void getAllEntryNames(std::vector<std::string>& names) const
     {
         names.clear();
-        for(auto& it : entries_)
+        for (auto& it : entries_)
         {
             names.push_back(it.first);
         }
@@ -34,9 +33,10 @@ public:
     inline bool getAllowedCollision(const std::string& name1, const std::string& name2) const
     {
         auto it = entries_.find(name1);
-        if(it==entries_.end()) return true;
-        return it->second.find(name2)==it->second.end();
+        if (it == entries_.end()) return true;
+        return it->second.find(name2) == it->second.end();
     }
+
 private:
     std::unordered_map<std::string, std::unordered_set<std::string>> entries_;
 };
@@ -55,13 +55,13 @@ struct CollisionProxy
     inline std::string print() const
     {
         std::stringstream ss;
-        if(e1 && e2)
+        if (e1 && e2)
         {
-            ss<<"Proxy: '"<<e1->Segment.getName()<<"' - '"<<e2->Segment.getName()<<"', c1: "<<contact1.transpose()<<" c1: "<<contact2.transpose()<<" d: "<<distance;
+            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c1: " << contact2.transpose() << " d: " << distance;
         }
         else
         {
-            ss<<"Proxy (empty)";
+            ss << "Proxy (empty)";
         }
         return ss.str();
     }
@@ -71,14 +71,11 @@ struct CollisionProxy
 class CollisionScene : public Uncopyable
 {
 public:
-
     CollisionScene() {}
-
     /**
        * \brief Destructor
        */
     virtual ~CollisionScene() {}
-
     /**
        * \brief Checks if the whole robot is valid (collision only).
        * @param self Indicate if self collision check is required.
@@ -92,23 +89,20 @@ public:
     /// @param o2 Name of object 2.
     /// @return True is the two objects are not colliding.
     ///
-    virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0) {throw_pretty("Not implemented!");}
-
+    virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0) { throw_pretty("Not implemented!"); }
     ///
     /// \brief Computes collision distances.
     /// \param self Indicate if self collision check is required.
     /// \return Collision proximity objects for all colliding pairs of shapes.
     ///
-    virtual std::vector<CollisionProxy> getCollisionDistance(bool self) {throw_pretty("Not implemented!");}
-
+    virtual std::vector<CollisionProxy> getCollisionDistance(bool self) { throw_pretty("Not implemented!"); }
     ///
     /// \brief Computes collision distances between two objects.
     /// \param o1 Name of object 1.
     /// \param o2 Name of object 2.
     /// \return Vector of proximity objects.
     ///
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2) {throw_pretty("Not implemented!");}
-
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2) { throw_pretty("Not implemented!"); }
     /**
        * @brief      Gets the collision world links.
        * @return     The collision world links.
@@ -121,7 +115,7 @@ public:
        */
     virtual std::vector<std::string> getCollisionRobotLinks() = 0;
 
-    virtual Eigen::Vector3d getTranslation(const std::string & name) = 0;
+    virtual Eigen::Vector3d getTranslation(const std::string& name) = 0;
 
     inline void setACM(const AllowedCollisionMatrix& acm)
     {
@@ -140,7 +134,6 @@ public:
     virtual void updateCollisionObjectTransforms() = 0;
 
 protected:
-
     /// The allowed collisiom matrix
     AllowedCollisionMatrix acm_;
 };
@@ -149,4 +142,4 @@ typedef exotica::Factory<exotica::CollisionScene> CollisionScene_fac;
 typedef std::shared_ptr<CollisionScene> CollisionScene_ptr;
 }
 
-#endif // COLLISIONSCENE_H
+#endif  // COLLISIONSCENE_H

--- a/exotica/include/exotica/Exotica.h
+++ b/exotica/include/exotica/Exotica.h
@@ -34,14 +34,14 @@
 #define EXOTICA_H
 
 //!< Core Library
-#include <exotica/Version.h>
-#include <exotica/Tools.h>
-#include <exotica/Setup.h>
-#include <exotica/PlanningProblem.h>
-#include <exotica/MotionSolver.h>
 #include <exotica/Loaders/XMLLoader.h>
+#include <exotica/MotionSolver.h>
+#include <exotica/PlanningProblem.h>
 #include <exotica/Problems/SamplingProblem.h>
 #include <exotica/Problems/UnconstrainedEndPoseProblem.h>
 #include <exotica/Problems/UnconstrainedTimeIndexedProblem.h>
+#include <exotica/Setup.h>
+#include <exotica/Tools.h>
+#include <exotica/Version.h>
 
-#endif // EXOTICA_H
+#endif  // EXOTICA_H

--- a/exotica/include/exotica/KinematicElement.h
+++ b/exotica/include/exotica/KinematicElement.h
@@ -2,27 +2,24 @@
 #define KINEMATICELEMENT_H
 
 #include <exotica/Tools.h>
-#include <kdl/segment.hpp>
-#include <kdl/frames.hpp>
 #include <geometric_shapes/shapes.h>
+#include <kdl/frames.hpp>
+#include <kdl/segment.hpp>
 #include <stack>
 
 class KinematicElement
 {
 public:
-    KinematicElement(int id, std::shared_ptr<KinematicElement> parent, KDL::Segment segment) :
-        Parent(parent), Segment(segment), Id(id), IsControlled(false),
-        ControlId(-1), Shape(nullptr), isRobotLink(false), ClosestRobotLink(nullptr),
-        IsTrajectoryGenerated(false)
+    KinematicElement(int id, std::shared_ptr<KinematicElement> parent, KDL::Segment segment) : Parent(parent), Segment(segment), Id(id), IsControlled(false), ControlId(-1), Shape(nullptr), isRobotLink(false), ClosestRobotLink(nullptr), IsTrajectoryGenerated(false)
     {
     }
     inline void updateClosestRobotLink()
     {
         std::shared_ptr<KinematicElement> element = Parent;
         ClosestRobotLink = nullptr;
-        while(element && element->Id>0)
+        while (element && element->Id > 0)
         {
-            if(element->isRobotLink)
+            if (element->isRobotLink)
             {
                 ClosestRobotLink = element;
                 break;
@@ -34,7 +31,7 @@ public:
 
     inline KDL::Frame getPose(const double& x)
     {
-        if(IsTrajectoryGenerated)
+        if (IsTrajectoryGenerated)
         {
             return GeneratedOffset;
         }
@@ -57,19 +54,20 @@ public:
     std::vector<double> JointLimits;
     shapes::ShapeConstPtr Shape;
     bool isRobotLink;
+
 private:
     inline void setChildrenClosestRobotLink()
     {
         std::stack<std::shared_ptr<KinematicElement>> elements;
-        for(auto child : Children) elements.push(child);
-        while(!elements.empty())
+        for (auto child : Children) elements.push(child);
+        while (!elements.empty())
         {
             auto parent = elements.top();
             elements.pop();
             parent->ClosestRobotLink = ClosestRobotLink;
-            for(auto child : parent->Children) elements.push(child);
+            for (auto child : parent->Children) elements.push(child);
         }
     }
 };
 
-#endif // KINEMATICELEMENT_H
+#endif  // KINEMATICELEMENT_H

--- a/exotica/include/exotica/Loaders/XMLLoader.h
+++ b/exotica/include/exotica/Loaders/XMLLoader.h
@@ -1,35 +1,34 @@
 #ifndef XMLLOADER_H
 #define XMLLOADER_H
 
-#include <exotica/Property.h>
 #include <exotica/MotionSolver.h>
 #include <exotica/PlanningProblem.h>
+#include <exotica/Property.h>
 #include <exotica/Setup.h>
 
 namespace exotica
 {
-
 class XMLLoader
 {
 public:
     static std::shared_ptr<XMLLoader> Instance()
     {
-      if (!instance_) instance_.reset(new XMLLoader);
-      return instance_;
+        if (!instance_) instance_.reset(new XMLLoader);
+        return instance_;
     }
 
     ~XMLLoader() noexcept
     {
     }
 
-    Initializer loadXML(std::string file_name, bool parsePathAsXML=false);
-    void loadXML(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML=false);
-    static void load(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML=false)
+    Initializer loadXML(std::string file_name, bool parsePathAsXML = false);
+    void loadXML(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML = false);
+    static void load(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML = false)
     {
-        Instance()->loadXML(file_name,solver,problem,solver_name,problem_name, parsePathAsXML);
+        Instance()->loadXML(file_name, solver, problem, solver_name, problem_name, parsePathAsXML);
     }
 
-    static Initializer load(std::string file_name, bool parsePathAsXML=false)
+    static Initializer load(std::string file_name, bool parsePathAsXML = false)
     {
         return Instance()->loadXML(file_name, parsePathAsXML);
     }
@@ -48,7 +47,6 @@ private:
     XMLLoader();
     static std::shared_ptr<XMLLoader> instance_;
 };
-
 }
 
-#endif // XMLLOADER_H
+#endif  // XMLLOADER_H

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -34,33 +34,32 @@
 #define EXOTICA_MOTION_SOLVER_H
 
 #include "exotica/Object.h"
-#include "exotica/TaskMap.h"
 #include "exotica/PlanningProblem.h"
-#include "exotica/Server.h"
 #include "exotica/Property.h"
+#include "exotica/Server.h"
+#include "exotica/TaskMap.h"
 
 #define REGISTER_MOTIONSOLVER_TYPE(TYPE, DERIV) EXOTICA_REGISTER(exotica::MotionSolver, TYPE, DERIV)
 
 namespace exotica
 {
-    class MotionSolver: public Object, Uncopyable, public virtual InstantiableBase
-    {
-    public:
-        MotionSolver();
-        virtual ~MotionSolver() {}
-        virtual void InstantiateBase(const Initializer& init);
-        virtual void specifyProblem(PlanningProblem_ptr pointer);
-        virtual void Solve(Eigen::MatrixXd & solution) = 0;
-        PlanningProblem_ptr getProblem() {return problem_;}
-        virtual std::string print(std::string prepend);
+class MotionSolver : public Object, Uncopyable, public virtual InstantiableBase
+{
+public:
+    MotionSolver();
+    virtual ~MotionSolver() {}
+    virtual void InstantiateBase(const Initializer& init);
+    virtual void specifyProblem(PlanningProblem_ptr pointer);
+    virtual void Solve(Eigen::MatrixXd& solution) = 0;
+    PlanningProblem_ptr getProblem() { return problem_; }
+    virtual std::string print(std::string prepend);
 
-    protected:
+protected:
+    PlanningProblem_ptr problem_;
+};
 
-        PlanningProblem_ptr problem_;
-    };
-
-    typedef exotica::Factory<exotica::MotionSolver> MotionSolver_fac;
-    typedef std::shared_ptr<exotica::MotionSolver> MotionSolver_ptr;
+typedef exotica::Factory<exotica::MotionSolver> MotionSolver_fac;
+typedef std::shared_ptr<exotica::MotionSolver> MotionSolver_ptr;
 }
 
 #endif

--- a/exotica/include/exotica/Object.h
+++ b/exotica/include/exotica/Object.h
@@ -33,66 +33,67 @@
 #ifndef EXOTICA_OBJECT_H
 #define EXOTICA_OBJECT_H
 
-#include <string>   //!< C++ type strings
-#include <exotica/Tools.h>
 #include <exotica/Server.h>
+#include <exotica/Tools.h>
+#include <string>  //!< C++ type strings
 
-#include "exotica/Property.h"
 #include "exotica/ObjectInitializer.h"
+#include "exotica/Property.h"
 
 namespace exotica
 {
-  template<typename BO> class Factory;
+template <typename BO>
+class Factory;
 
-  class Object
-  {
-      template<typename BO> friend class Factory;
-    public:
+class Object
+{
+    template <typename BO>
+    friend class Factory;
 
-      /**
+public:
+    /**
        * \brief Constructor: default
        */
-      Object()
-          : ns_(""),debug_(false)
-      {
+    Object()
+        : ns_(""), debug_(false)
+    {
         //!< Empty constructor
-      }
+    }
 
-      virtual ~Object()
-      {
+    virtual ~Object()
+    {
+    }
 
-      }
-
-      /**
+    /**
        * \brief Type Information wrapper: must be virtual so that it is polymorphic...
        * @return String containing the type of the object
        */
-      inline virtual std::string type()
-      {
+    inline virtual std::string type()
+    {
         return getTypeName(typeid(*this));
-      }
+    }
 
-      std::string getObjectName()
-      {
+    std::string getObjectName()
+    {
         return object_name_;
-      }
+    }
 
-      void InstatiateObject(const Initializer& init)
-      {
-         ObjectInitializer oinit(init);
-         object_name_=oinit.Name;
-         debug_=oinit.Debug;
-      }
+    void InstatiateObject(const Initializer& init)
+    {
+        ObjectInitializer oinit(init);
+        object_name_ = oinit.Name;
+        debug_ = oinit.Debug;
+    }
 
-      virtual std::string print(std::string prepend)
-      {
+    virtual std::string print(std::string prepend)
+    {
         return prepend + "  " + object_name_ + " (" + type() + ")";
-      }
+    }
 
-      //	Namespace, i.e. problem/scene/...etc
-      std::string ns_;
-      std::string object_name_;
-      bool debug_;
-  };
+    //	Namespace, i.e. problem/scene/...etc
+    std::string ns_;
+    std::string object_name_;
+    bool debug_;
+};
 }
 #endif

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -34,47 +34,46 @@
 #define EXOTICA_MOTION_PLANNING_PROBLEM_H
 
 #include <exotica/Object.h>
-#include <exotica/TaskMap.h>
-#include <exotica/Server.h>
-#include <exotica/Scene.h>
-#include <exotica/Tools.h>
 #include <exotica/Problem.h>
+#include <exotica/Scene.h>
+#include <exotica/Server.h>
+#include <exotica/TaskMap.h>
 #include <exotica/TaskSpaceVector.h>
+#include <exotica/Tools.h>
 
-#include <vector>
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
 
 #define REGISTER_PROBLEM_TYPE(TYPE, DERIV) EXOTICA_REGISTER_CORE(exotica::PlanningProblem, TYPE, DERIV)
 
 namespace exotica
 {
-    class PlanningProblem: public Object, Uncopyable, public virtual InstantiableBase
-    {
-    public:
-        PlanningProblem();
-        virtual ~PlanningProblem() {}
-        virtual void InstantiateBase(const Initializer& init);
-        TaskMap_map& getTaskMaps();
-        TaskMap_vec& getTasks();
-        Scene_ptr getScene();
-        virtual std::string print(std::string prepend);
-        void setStartState(Eigen::VectorXdRefConst x);
-        Eigen::VectorXd getStartState();
-        Eigen::VectorXd applyStartState();
-        int N;
-        virtual void preupdate();
+class PlanningProblem : public Object, Uncopyable, public virtual InstantiableBase
+{
+public:
+    PlanningProblem();
+    virtual ~PlanningProblem() {}
+    virtual void InstantiateBase(const Initializer& init);
+    TaskMap_map& getTaskMaps();
+    TaskMap_vec& getTasks();
+    Scene_ptr getScene();
+    virtual std::string print(std::string prepend);
+    void setStartState(Eigen::VectorXdRefConst x);
+    Eigen::VectorXd getStartState();
+    Eigen::VectorXd applyStartState();
+    int N;
+    virtual void preupdate();
 
-    protected:
-        Scene_ptr scene_;
-        TaskMap_map TaskMaps;
-        TaskMap_vec Tasks;
-        KinematicRequestFlags Flags;
-        Eigen::VectorXd startState;
+protected:
+    Scene_ptr scene_;
+    TaskMap_map TaskMaps;
+    TaskMap_vec Tasks;
+    KinematicRequestFlags Flags;
+    Eigen::VectorXd startState;
+};
 
-    };
-
-    typedef Factory<PlanningProblem> PlanningProblem_fac;
-    typedef std::shared_ptr<PlanningProblem> PlanningProblem_ptr;
+typedef Factory<PlanningProblem> PlanningProblem_fac;
+typedef std::shared_ptr<PlanningProblem> PlanningProblem_ptr;
 }
 #endif

--- a/exotica/include/exotica/Problems/SamplingProblem.h
+++ b/exotica/include/exotica/Problems/SamplingProblem.h
@@ -39,54 +39,52 @@
 
 namespace exotica
 {
-  class SamplingProblem: public PlanningProblem, public Instantiable<SamplingProblemInitializer>
-  {
-    public:
-      SamplingProblem();
-      virtual ~SamplingProblem();
+class SamplingProblem : public PlanningProblem, public Instantiable<SamplingProblemInitializer>
+{
+public:
+    SamplingProblem();
+    virtual ~SamplingProblem();
 
-      virtual void Instantiate(SamplingProblemInitializer& init);
+    virtual void Instantiate(SamplingProblemInitializer& init);
 
-      void Update(Eigen::VectorXdRefConst x);
-      bool isValid(Eigen::VectorXdRefConst x);
+    void Update(Eigen::VectorXdRefConst x);
+    bool isValid(Eigen::VectorXdRefConst x);
 
-      int getSpaceDim();
+    int getSpaceDim();
 
-      void setGoal(const std::string & task_name, Eigen::VectorXdRefConst goal);
-      void setThreshold(const std::string & task_name, Eigen::VectorXdRefConst threshold);
-      void setRho(const std::string & task_name, const double rho);
-      Eigen::VectorXd getGoal(const std::string & task_name);
-      Eigen::VectorXd getThreshold(const std::string & task_name);
-      double getRho(const std::string & task_name);
+    void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    void setThreshold(const std::string& task_name, Eigen::VectorXdRefConst threshold);
+    void setRho(const std::string& task_name, const double rho);
+    Eigen::VectorXd getGoal(const std::string& task_name);
+    Eigen::VectorXd getThreshold(const std::string& task_name);
+    double getRho(const std::string& task_name);
 
-      std::vector<double>& getBounds();
-      bool isCompoundStateSpace();
-      std::string local_planner_config_;
-      bool full_body_plan_;
+    std::vector<double>& getBounds();
+    bool isCompoundStateSpace();
+    std::string local_planner_config_;
+    bool full_body_plan_;
 
-      SamplingProblemInitializer Parameters;
+    SamplingProblemInitializer Parameters;
 
-      void setGoalState(Eigen::VectorXdRefConst qT);
+    void setGoalState(Eigen::VectorXdRefConst qT);
 
-      Eigen::VectorXd goal_;
-      Eigen::VectorXd Rho;
-      TaskSpaceVector y;
-      TaskSpaceVector Phi;
-      Eigen::VectorXd threshold_;
+    Eigen::VectorXd goal_;
+    Eigen::VectorXd Rho;
+    TaskSpaceVector y;
+    TaskSpaceVector Phi;
+    Eigen::VectorXd threshold_;
 
-      int PhiN;
-      int JN;
-      int NumTasks;
-      Eigen::MatrixXd S;
+    int PhiN;
+    int JN;
+    int NumTasks;
+    Eigen::MatrixXd S;
 
-    private:
-      std::vector<double> bounds_;
-      bool compound_;
+private:
+    std::vector<double> bounds_;
+    bool compound_;
+};
 
-  };
-
-  typedef std::shared_ptr<exotica::SamplingProblem> SamplingProblem_ptr;
-
+typedef std::shared_ptr<exotica::SamplingProblem> SamplingProblem_ptr;
 }
 
 #endif

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -38,38 +38,37 @@
 
 namespace exotica
 {
-    /**
+/**
     * Unconstrained end-pose problem implementation
     */
-    class UnconstrainedEndPoseProblem: public PlanningProblem, public Instantiable<UnconstrainedEndPoseProblemInitializer>
-    {
-    public:
-        UnconstrainedEndPoseProblem();
-        virtual ~UnconstrainedEndPoseProblem();
+class UnconstrainedEndPoseProblem : public PlanningProblem, public Instantiable<UnconstrainedEndPoseProblemInitializer>
+{
+public:
+    UnconstrainedEndPoseProblem();
+    virtual ~UnconstrainedEndPoseProblem();
 
-        virtual void Instantiate(UnconstrainedEndPoseProblemInitializer& init);
-        void Update(Eigen::VectorXdRefConst x);
+    virtual void Instantiate(UnconstrainedEndPoseProblemInitializer& init);
+    void Update(Eigen::VectorXdRefConst x);
 
-        void setGoal(const std::string & task_name, Eigen::VectorXdRefConst goal);
-        void setRho(const std::string & task_name, const double rho);
-        Eigen::VectorXd getGoal(const std::string & task_name);
-        double getRho(const std::string & task_name);
-        Eigen::VectorXd getNominalPose();
-        void setNominalPose(Eigen::VectorXdRefConst qNominal_in);
+    void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    void setRho(const std::string& task_name, const double rho);
+    Eigen::VectorXd getGoal(const std::string& task_name);
+    double getRho(const std::string& task_name);
+    Eigen::VectorXd getNominalPose();
+    void setNominalPose(Eigen::VectorXdRefConst qNominal_in);
 
-        Eigen::VectorXd Rho;
-        TaskSpaceVector y;
-        Eigen::MatrixXd W;
-        TaskSpaceVector Phi;
-        Eigen::MatrixXd J;
-        Eigen::VectorXd qNominal;
+    Eigen::VectorXd Rho;
+    TaskSpaceVector y;
+    Eigen::MatrixXd W;
+    TaskSpaceVector Phi;
+    Eigen::MatrixXd J;
+    Eigen::VectorXd qNominal;
 
-        int PhiN;
-        int JN;
-        int NumTasks;
-
-    };
-    typedef std::shared_ptr<exotica::UnconstrainedEndPoseProblem> UnconstrainedEndPoseProblem_ptr;
+    int PhiN;
+    int JN;
+    int NumTasks;
+};
+typedef std::shared_ptr<exotica::UnconstrainedEndPoseProblem> UnconstrainedEndPoseProblem_ptr;
 }
 
 #endif

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -42,50 +42,48 @@
 
 namespace exotica
 {
-
-  /**
+/**
    * \brief Unconstrained time-indexed problem.
    */
-  class UnconstrainedTimeIndexedProblem: public PlanningProblem, public Instantiable<UnconstrainedTimeIndexedProblemInitializer>
-  {
-    public:
-      UnconstrainedTimeIndexedProblem();
-      virtual ~UnconstrainedTimeIndexedProblem();
-      virtual void Instantiate(UnconstrainedTimeIndexedProblemInitializer& init);
-      double getDuration();
-      void Update(Eigen::VectorXdRefConst x, int t);
-      void setGoal(const std::string & task_name, Eigen::VectorXdRefConst goal, int t = 0);
-      void setRho(const std::string & task_name, const double rho, int t = 0);
-      Eigen::VectorXd getGoal(const std::string & task_name, int t = 0);
-      double getRho(const std::string & task_name, int t = 0);
-      std::vector<Eigen::VectorXd> getInitialTrajectory();
-      void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
+class UnconstrainedTimeIndexedProblem : public PlanningProblem, public Instantiable<UnconstrainedTimeIndexedProblemInitializer>
+{
+public:
+    UnconstrainedTimeIndexedProblem();
+    virtual ~UnconstrainedTimeIndexedProblem();
+    virtual void Instantiate(UnconstrainedTimeIndexedProblemInitializer& init);
+    double getDuration();
+    void Update(Eigen::VectorXdRefConst x, int t);
+    void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t = 0);
+    void setRho(const std::string& task_name, const double rho, int t = 0);
+    Eigen::VectorXd getGoal(const std::string& task_name, int t = 0);
+    double getRho(const std::string& task_name, int t = 0);
+    std::vector<Eigen::VectorXd> getInitialTrajectory();
+    void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
 
+    int T;          //!< Number of time steps
+    double tau;     //!< Time step duration
+    double Q_rate;  //!< System transition error covariance multipler (per unit time) (constant throughout the trajectory)
+    double H_rate;  //!< Control error covariance multipler (per unit time) (constant throughout the trajectory)
+    double W_rate;  //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)
+    Eigen::MatrixXd W;
+    Eigen::MatrixXd H;
+    Eigen::MatrixXd Q;
 
-      int T; //!< Number of time steps
-      double tau; //!< Time step duration
-      double Q_rate; //!< System transition error covariance multipler (per unit time) (constant throughout the trajectory)
-      double H_rate; //!< Control error covariance multipler (per unit time) (constant throughout the trajectory)
-      double W_rate; //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)
-      Eigen::MatrixXd W;
-      Eigen::MatrixXd H;
-      Eigen::MatrixXd Q;
+    std::vector<Eigen::VectorXd> Rho;
+    std::vector<TaskSpaceVector> y;
+    std::vector<TaskSpaceVector> Phi;
+    std::vector<Eigen::VectorXd> ydiff;
+    std::vector<Eigen::MatrixXd> J;
 
-      std::vector<Eigen::VectorXd> Rho;
-      std::vector<TaskSpaceVector> y;
-      std::vector<TaskSpaceVector> Phi;
-      std::vector<Eigen::VectorXd> ydiff;
-      std::vector<Eigen::MatrixXd> J;
+    int PhiN;
+    int JN;
+    int NumTasks;
 
-      int PhiN;
-      int JN;
-      int NumTasks;
+private:
+    std::vector<Eigen::VectorXd> InitialTrajectory;
+};
 
-    private:
-      std::vector<Eigen::VectorXd> InitialTrajectory;
-  };
-
-  typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;
+typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;
 }
 
 #endif

--- a/exotica/include/exotica/Property.h
+++ b/exotica/include/exotica/Property.h
@@ -2,24 +2,27 @@
 #define PROPERTY_H
 
 #include <exotica/Tools.h>
-#include <exotica/Tools/Printable.h>
-#include <exotica/Tools/Exception.h>
 #include <exotica/Tools/Conversions.h>
-#include <memory>
-#include <map>
-#include <vector>
-#include <typeinfo>
+#include <exotica/Tools/Exception.h>
+#include <exotica/Tools/Printable.h>
 #include <boost/any.hpp>
 #include <initializer_list>
+#include <map>
+#include <memory>
+#include <typeinfo>
+#include <vector>
 
 namespace exotica
 {
-
 class Property
 {
 public:
     boost::any get() const;
-    template<typename C> void set(const C val) {value = val;}
+    template <typename C>
+    void set(const C val)
+    {
+        value = val;
+    }
     Property(std::string prop_name);
     Property(std::string prop_name, bool isRequired);
     Property(std::string prop_name, bool isRequired, boost::any val);
@@ -42,7 +45,7 @@ class Initializer
 public:
     Initializer();
     Initializer(std::string name_);
-    Initializer(std::string name_, std::map<std::string,boost::any> properties_);
+    Initializer(std::string name_, std::map<std::string, boost::any> properties_);
     std::string getName() const;
     void setName(std::string name_);
     void addProperty(const Property& prop);
@@ -72,11 +75,10 @@ public:
     virtual std::vector<Initializer> getAllTemplates() const = 0;
 };
 
-template<class C>
+template <class C>
 class Instantiable : public virtual InstantiableBase
 {
 public:
-
     virtual void InstantiateInternal(const Initializer& init)
     {
         InstantiateBase(init);
@@ -97,7 +99,6 @@ public:
 
     virtual void Instantiate(C& init) = 0;
 };
-
 }
 
-#endif // PROPERTY_H
+#endif  // PROPERTY_H

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -33,149 +33,149 @@
 #ifndef EXOTICA_EXOTICA_INCLUDE_EXOTICA_SCENE_H_
 #define EXOTICA_EXOTICA_INCLUDE_EXOTICA_SCENE_H_
 
-#include "exotica/Object.h"
-#include "exotica/Server.h"
-#include "exotica/KinematicTree.h"
+#include <exotica/CollisionScene.h>
 #include <exotica/Property.h>
 #include <exotica/SceneInitializer.h>
-#include <exotica/CollisionScene.h>
-#include <moveit_msgs/PlanningScene.h>
-#include <moveit/planning_scene/planning_scene.h>
 #include <exotica/Trajectory.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit_msgs/PlanningScene.h>
+#include "exotica/KinematicTree.h"
+#include "exotica/Object.h"
+#include "exotica/Server.h"
 
 namespace exotica
 {
-  struct AttachedObject
-  {
-      AttachedObject() : Parent("") {}
-      AttachedObject(std::string parent) : Parent(parent) {}
-      AttachedObject(std::string parent, KDL::Frame pose) : Parent(parent), Pose(pose) {}
-      std::string Parent;
-      KDL::Frame Pose;
-  };
+struct AttachedObject
+{
+    AttachedObject() : Parent("") {}
+    AttachedObject(std::string parent) : Parent(parent) {}
+    AttachedObject(std::string parent, KDL::Frame pose) : Parent(parent), Pose(pose) {}
+    std::string Parent;
+    KDL::Frame Pose;
+};
 
 /// The class of EXOTica Scene
-  class Scene: public Object, Uncopyable, public Instantiable<SceneInitializer>
-  {
-    public:
-      Scene(const std::string & name);
-      Scene();
-      virtual ~Scene();
-      virtual void Instantiate(SceneInitializer& init);
-      std::shared_ptr<KinematicResponse> RequestKinematics(KinematicsRequest& Request);
-      std::string getName();
-      virtual void Update(Eigen::VectorXdRefConst x, double t = 0);
-      void setCollisionScene(const moveit_msgs::PlanningSceneConstPtr & scene);
-      CollisionScene_ptr & getCollisionScene();
-      std::string getRootFrameName();
-      std::string getRootJointName();
-      std::string getModelRootLinkName();
-      planning_scene::PlanningScenePtr getPlanningScene();
-      exotica::KinematicTree & getSolver();
-      robot_model::RobotModelPtr getRobotModel();
-      void getJointNames(std::vector<std::string> & joints);
-      std::vector<std::string> getJointNames();
-      std::vector<std::string> getModelJointNames();
-      Eigen::VectorXd getModelState();
-      Eigen::VectorXd getControlledState();
-      std::map<std::string, double> getModelStateMap();
-      void setModelState(Eigen::VectorXdRefConst x, double t = 0);
-      void setModelState(std::map<std::string, double> x, double t = 0);
-      std::string getGroupName();
+class Scene : public Object, Uncopyable, public Instantiable<SceneInitializer>
+{
+public:
+    Scene(const std::string& name);
+    Scene();
+    virtual ~Scene();
+    virtual void Instantiate(SceneInitializer& init);
+    std::shared_ptr<KinematicResponse> RequestKinematics(KinematicsRequest& Request);
+    std::string getName();
+    virtual void Update(Eigen::VectorXdRefConst x, double t = 0);
+    void setCollisionScene(const moveit_msgs::PlanningSceneConstPtr& scene);
+    CollisionScene_ptr& getCollisionScene();
+    std::string getRootFrameName();
+    std::string getRootJointName();
+    std::string getModelRootLinkName();
+    planning_scene::PlanningScenePtr getPlanningScene();
+    exotica::KinematicTree& getSolver();
+    robot_model::RobotModelPtr getRobotModel();
+    void getJointNames(std::vector<std::string>& joints);
+    std::vector<std::string> getJointNames();
+    std::vector<std::string> getModelJointNames();
+    Eigen::VectorXd getModelState();
+    Eigen::VectorXd getControlledState();
+    std::map<std::string, double> getModelStateMap();
+    void setModelState(Eigen::VectorXdRefConst x, double t = 0);
+    void setModelState(std::map<std::string, double> x, double t = 0);
+    std::string getGroupName();
 
-      void addTrajectoryFromFile(const std::string& link, const std::string& traj);
-      void addTrajectory(const std::string& link, const std::string& traj);
-      void addTrajectory(const std::string& link, std::shared_ptr<Trajectory> traj);
-      std::shared_ptr<Trajectory> getTrajectory(const std::string& link);
-      void removeTrajectory(const std::string& link);
+    void addTrajectoryFromFile(const std::string& link, const std::string& traj);
+    void addTrajectory(const std::string& link, const std::string& traj);
+    void addTrajectory(const std::string& link, std::shared_ptr<Trajectory> traj);
+    std::shared_ptr<Trajectory> getTrajectory(const std::string& link);
+    void removeTrajectory(const std::string& link);
 
-      /// \brief Updates exotica scene object frames from the MoveIt scene.
-      void updateSceneFrames();
-      ///
-      /// \brief Attaches existing object to a new parent. E.g. attaching a grasping target to the end-effector. The relative transformation will be computed from current object and new parent transformations in the world frame.
-      /// \param name Name of the object to attach.
-      /// \param parent Name of the new parent frame.
-      ///
-      void attachObject(const std::string& name, const std::string& parent);
-      ///
-      /// \brief Attaches existing object to a new parent specifying an offset in the new parent local frame.
-      /// \param name Name of the object to attach.
-      /// \param parent Name of the new parent frame.
-      /// \param pose Relative pose of the attached object in the new parent's local frame.
-      ///
-      void attachObjectLocal(const std::string& name, const std::string& parent, const KDL::Frame& pose);
-      ///
-      /// \brief Detaches an object and leaves it a at its current world location. This effectively attaches the object to the world frame.
-      /// \param name Name of the object to detach.
-      ///
-      void detachObject(const std::string& name);
-      bool hasAttachedObject(const std::string& name);
+    /// \brief Updates exotica scene object frames from the MoveIt scene.
+    void updateSceneFrames();
+    ///
+    /// \brief Attaches existing object to a new parent. E.g. attaching a grasping target to the end-effector. The relative transformation will be computed from current object and new parent transformations in the world frame.
+    /// \param name Name of the object to attach.
+    /// \param parent Name of the new parent frame.
+    ///
+    void attachObject(const std::string& name, const std::string& parent);
+    ///
+    /// \brief Attaches existing object to a new parent specifying an offset in the new parent local frame.
+    /// \param name Name of the object to attach.
+    /// \param parent Name of the new parent frame.
+    /// \param pose Relative pose of the attached object in the new parent's local frame.
+    ///
+    void attachObjectLocal(const std::string& name, const std::string& parent, const KDL::Frame& pose);
+    ///
+    /// \brief Detaches an object and leaves it a at its current world location. This effectively attaches the object to the world frame.
+    /// \param name Name of the object to detach.
+    ///
+    void detachObject(const std::string& name);
+    bool hasAttachedObject(const std::string& name);
 
-      void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
+    void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
 
-
-      /**
+    /**
        * @brief      Update the internal MoveIt planning scene from a
        * moveit_msgs::PlanningSceneWorld
        *
        * @param[in]  world  moveit_msgs::PlanningSceneWorld
        */
-      void updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
+    void updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
 
-      BASE_TYPE getBaseType()
-      {
+    BASE_TYPE getBaseType()
+    {
         return BaseType;
-      }
+    }
 
-      void updateTrajectoryGenerators(double t = 0);
+    void updateTrajectoryGenerators(double t = 0);
 
-      void publishScene();
-      void publishProxies(const std::vector<CollisionProxy>& proxies);
-      visualization_msgs::Marker proxyToMarker(const std::vector<CollisionProxy>& proxies, const std::string& frame);
-      void loadScene(const std::string& scene, bool updateCollisionScene = true);
-      void loadSceneFile(const std::string& file_name, bool updateCollisionScene = true);
-      std::string getScene();
-      void cleanScene();
-    private:
-      /// The name of the scene
-      std::string name_;
+    void publishScene();
+    void publishProxies(const std::vector<CollisionProxy>& proxies);
+    visualization_msgs::Marker proxyToMarker(const std::vector<CollisionProxy>& proxies, const std::string& frame);
+    void loadScene(const std::string& scene, bool updateCollisionScene = true);
+    void loadSceneFile(const std::string& file_name, bool updateCollisionScene = true);
+    std::string getScene();
+    void cleanScene();
 
-      /// The kinematica tree
-      exotica::KinematicTree kinematica_;
+private:
+    /// The name of the scene
+    std::string name_;
 
-      /// Robot model
-      robot_model::RobotModelPtr model_;
+    /// The kinematica tree
+    exotica::KinematicTree kinematica_;
 
-      ///   Joint group
-      robot_model::JointModelGroup* group;
+    /// Robot model
+    robot_model::RobotModelPtr model_;
 
-      /// Robot base type
-      BASE_TYPE BaseType;
+    ///   Joint group
+    robot_model::JointModelGroup* group;
 
-      /// The collision scene
-      CollisionScene_ptr collision_scene_;
+    /// Robot base type
+    BASE_TYPE BaseType;
 
-      /// Internal moveit planning scene
-      planning_scene::PlanningScenePtr ps_;
+    /// The collision scene
+    CollisionScene_ptr collision_scene_;
 
-      /// Visual debug
-      ros::Publisher ps_pub_;
-      ros::Publisher proxy_pub_;
+    /// Internal moveit planning scene
+    planning_scene::PlanningScenePtr ps_;
 
-      /// \brief List of attached objects
-      /// These objects will be reattached if the scene gets reloaded.
-      std::map<std::string, AttachedObject> attached_objects_;
+    /// Visual debug
+    ros::Publisher ps_pub_;
+    ros::Publisher proxy_pub_;
 
-      /// \brief List of frames/links added on top of robot links and scene objects defined in the MoveIt scene.
-      std::map<std::string, std::shared_ptr<KinematicElement>> custom_links_;
+    /// \brief List of attached objects
+    /// These objects will be reattached if the scene gets reloaded.
+    std::map<std::string, AttachedObject> attached_objects_;
 
-      std::map<std::string, std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>> trajectory_generators_;
+    /// \brief List of frames/links added on top of robot links and scene objects defined in the MoveIt scene.
+    std::map<std::string, std::shared_ptr<KinematicElement>> custom_links_;
 
-      bool force_collision_;
-  };
-  typedef std::shared_ptr<Scene> Scene_ptr;
+    std::map<std::string, std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>> trajectory_generators_;
+
+    bool force_collision_;
+};
+typedef std::shared_ptr<Scene> Scene_ptr;
 //  typedef std::map<std::string, Scene_ptr> Scene_map;
 
-} //  namespace exotica
+}  //  namespace exotica
 
 #endif /* EXOTICA_EXOTICA_INCLUDE_EXOTICA_SCENE_H_ */

--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -34,171 +34,174 @@
 #define EXOTICA_INCLUDE_EXOTICA_SERVER_H_
 
 #include <ros/ros.h>
-#include "Tools.h"
-#include <typeinfo>
 #include <Eigen/Dense>
-#include <map>
 #include <boost/any.hpp>
+#include <map>
+#include <typeinfo>
+#include "Tools.h"
 
 #include <eigen_conversions/eigen_msg.h>
-#include <std_msgs/Bool.h>
-#include <std_msgs/Float64MultiArray.h>
-#include <std_msgs/Float64.h>
-#include <std_msgs/Int64.h>
-#include <std_msgs/String.h>
 #include <exotica/Tools.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
+#include <std_msgs/Bool.h>
+#include <std_msgs/Float64.h>
+#include <std_msgs/Float64MultiArray.h>
+#include <std_msgs/Int64.h>
+#include <std_msgs/String.h>
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 namespace exotica
 {
-    class RosNode
-    {
-    public:
-        RosNode() = delete;
-        RosNode(std::shared_ptr<ros::NodeHandle> nh, int numThreads = 2);
-        ~RosNode();
-        inline ros::NodeHandle& getNodeHandle() { return *nh_; }
-        inline tf::TransformBroadcaster& getTF() { return tf_; }
-    protected:
-        std::shared_ptr<ros::NodeHandle> nh_;
-        ros::AsyncSpinner sp_;
-        tf::TransformBroadcaster tf_;
-    };
+class RosNode
+{
+public:
+    RosNode() = delete;
+    RosNode(std::shared_ptr<ros::NodeHandle> nh, int numThreads = 2);
+    ~RosNode();
+    inline ros::NodeHandle &getNodeHandle() { return *nh_; }
+    inline tf::TransformBroadcaster &getTF() { return tf_; }
+protected:
+    std::shared_ptr<ros::NodeHandle> nh_;
+    ros::AsyncSpinner sp_;
+    tf::TransformBroadcaster tf_;
+};
 
-  //	Implementation of EXOTica Server class
-  class Server : public Uncopyable
-  {
-
-    public:
-      /*
+//	Implementation of EXOTica Server class
+class Server : public Uncopyable
+{
+public:
+    /*
        * \brief	Get the server
        */
-      static std::shared_ptr<Server> Instance()
-      {
+    static std::shared_ptr<Server> Instance()
+    {
         if (!singleton_server_) singleton_server_.reset(new Server);
         return singleton_server_;
-      }
-      virtual ~Server();
+    }
+    virtual ~Server();
 
-      /*
+    /*
        * \brief	Check if a robot model exist
        * @param	path	Robot model name
        * @return	True if exist, false otherwise
        */
-      bool hasModel(const std::string & path);
+    bool hasModel(const std::string &path);
 
-      /*
+    /*
        * \brief	Get robot model
        * @param	path	Robot model name
        * @param	model	Robot model
        */
-      void getModel(std::string path, robot_model::RobotModelPtr& model, std::string urdf="", std::string srdf="");
+    void getModel(std::string path, robot_model::RobotModelPtr &model, std::string urdf = "", std::string srdf = "");
 
-      /*
+    /*
        * \brief	Get robot model
        * @param	path	Robot model name
        * @return	robot model
        */
-      robot_model::RobotModelConstPtr getModel(std::string path, std::string urdf="", std::string srdf="");
+    robot_model::RobotModelConstPtr getModel(std::string path, std::string urdf = "", std::string srdf = "");
 
-      /*
+    /*
        * \brief	Get the name of ther server
        * @return	Server name
        */
-      std::string getName();
+    std::string getName();
 
-      inline static void InitRos(std::shared_ptr<ros::NodeHandle> nh, int numThreads = 2)
-      {
-          Instance()->node_.reset(new RosNode(nh, numThreads));
-      }
+    inline static void InitRos(std::shared_ptr<ros::NodeHandle> nh, int numThreads = 2)
+    {
+        Instance()->node_.reset(new RosNode(nh, numThreads));
+    }
 
-      inline static bool isRos() { return Instance()->node_!=nullptr; }
+    inline static bool isRos() { return Instance()->node_ != nullptr; }
+    inline ros::NodeHandle &getNodeHandle()
+    {
+        if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
+        return node_->getNodeHandle();
+    }
 
-      inline ros::NodeHandle& getNodeHandle()
-      {
-          if(!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-          return node_->getNodeHandle();
-      }
+    template <typename T>
+    static bool getParam(const std::string &name, T &param)
+    {
+        return Instance()->getNodeHandle().getParam(name, param);
+    }
 
-      template<typename T> static bool getParam(const std::string& name, T& param)
-      {
-          return Instance()->getNodeHandle().getParam(name, param);
-      }
+    inline bool static hasParam(const std::string &name)
+    {
+        if (isRos())
+        {
+            return Instance()->getNodeHandle().hasParam(name);
+        }
+        else
+        {
+            return false;
+        }
+    }
 
-      inline bool static hasParam(const std::string& name)
-      {
-          if(isRos())
-          {
-              return Instance()->getNodeHandle().hasParam(name);
-          }
-          else
-          {
-              return false;
-          }
-      }
+    template <typename T>
+    static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, bool latch = false)
+    {
+        return Instance()->getNodeHandle().advertise<T>(topic, queue_size, latch);
+    }
 
-      template<typename T> static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, bool latch=false)
-      {
-          return Instance()->getNodeHandle().advertise<T>(topic, queue_size, latch);
-      }
+    template <typename T>
+    static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, const ros::SubscriberStatusCallback &connect_cb, const ros::SubscriberStatusCallback &disconnect_cb = ros::SubscriberStatusCallback(), const ros::VoidConstPtr &tracked_object = ros::VoidConstPtr(), bool latch = false)
+    {
+        return Instance()->getNodeHandle().advertise<T>(topic, queue_size, connect_cb, disconnect_cb, tracked_object, latch);
+    }
 
-      template<typename T> static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, const ros::SubscriberStatusCallback &connect_cb, const ros::SubscriberStatusCallback &disconnect_cb=ros::SubscriberStatusCallback(), const ros::VoidConstPtr &tracked_object=ros::VoidConstPtr(), bool latch=false)
-      {
-          return Instance()->getNodeHandle().advertise<T>(topic, queue_size, connect_cb, disconnect_cb, tracked_object, latch);
-      }
+    template <typename T>
+    static ros::Publisher advertise(ros::AdvertiseOptions &ops)
+    {
+        return Instance()->getNodeHandle().advertise<T>(ops);
+    }
 
-      template<typename T> static ros::Publisher advertise(ros::AdvertiseOptions &ops)
-      {
-          return Instance()->getNodeHandle().advertise<T>(ops);
-      }
+    static void sendTransform(const tf::StampedTransform &transform)
+    {
+        if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
+        Instance()->node_->getTF().sendTransform(transform);
+    }
 
-      static void sendTransform(const tf::StampedTransform &transform)
-      {
-          if(!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-          Instance()->node_->getTF().sendTransform(transform);
-      }
+    static void sendTransform(const std::vector<tf::StampedTransform> &transforms)
+    {
+        if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
+        Instance()->node_->getTF().sendTransform(transforms);
+    }
 
-      static void sendTransform(const std::vector< tf::StampedTransform > &transforms)
-      {
-          if(!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-          Instance()->node_->getTF().sendTransform(transforms);
-      }
+    static void sendTransform(const geometry_msgs::TransformStamped &transform)
+    {
+        if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
+        Instance()->node_->getTF().sendTransform(transform);
+    }
 
-      static void sendTransform(const geometry_msgs::TransformStamped &transform)
-      {
-          if(!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-          Instance()->node_->getTF().sendTransform(transform);
-      }
+    static void sendTransform(const std::vector<geometry_msgs::TransformStamped> &transforms)
+    {
+        if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
+        Instance()->node_->getTF().sendTransform(transforms);
+    }
 
-      static void sendTransform(const std::vector< geometry_msgs::TransformStamped > &transforms)
-      {
-          if(!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-          Instance()->node_->getTF().sendTransform(transforms);
-      }
+    static void destroy();
 
-      static void destroy();
-    private:
-      /*
+private:
+    /*
        * \brief	Constructor
        */
-      Server();
-      static std::shared_ptr<Server> singleton_server_;
-      ///	\brief	Make sure the singleton does not get copied
-      Server(Server const&) = delete;
-      void operator=(Server const&) = delete;
-      robot_model::RobotModelPtr loadModel(std::string name, std::string urdf="", std::string srdf="");
+    Server();
+    static std::shared_ptr<Server> singleton_server_;
+    ///	\brief	Make sure the singleton does not get copied
+    Server(Server const &) = delete;
+    void operator=(Server const &) = delete;
+    robot_model::RobotModelPtr loadModel(std::string name, std::string urdf = "", std::string srdf = "");
 
-      /// \brief	The name of this server
-      std::string name_;
+    /// \brief	The name of this server
+    std::string name_;
 
-      std::shared_ptr<RosNode> node_;
+    std::shared_ptr<RosNode> node_;
 
-      /// \brief Robot model cache
-      std::map<std::string, robot_model::RobotModelPtr> robot_models_;
-  };
+    /// \brief Robot model cache
+    std::map<std::string, robot_model::RobotModelPtr> robot_models_;
+};
 
-  typedef std::shared_ptr<Server> Server_ptr;
+typedef std::shared_ptr<Server> Server_ptr;
 }
 
 #endif /* EXOTICA_INCLUDE_EXOTICA_SERVER_H_ */

--- a/exotica/include/exotica/Setup.h
+++ b/exotica/include/exotica/Setup.h
@@ -33,88 +33,86 @@
 #ifndef EXOTICA_INITIALISER_H
 #define EXOTICA_INITIALISER_H
 
-#include "exotica/Tools.h"
-#include "exotica/Object.h"
+#include <exotica/Property.h>
 #include "exotica/Factory.h"
 #include "exotica/MotionSolver.h"
+#include "exotica/Object.h"
 #include "exotica/PlanningProblem.h"
 #include "exotica/Server.h"
-#include <exotica/Property.h>
+#include "exotica/Tools.h"
 
 #include <pluginlib/class_loader.h>
 
 namespace exotica
 {
-  class Setup: public Object, Uncopyable
-  {
-    public:
+class Setup : public Object, Uncopyable
+{
+public:
+    ~Setup() noexcept
+    {
+    }
 
-      ~Setup() noexcept
-      {
-      }
-
-      static std::shared_ptr<Setup> Instance()
-      {
+    static std::shared_ptr<Setup> Instance()
+    {
         if (!singleton_initialiser_) singleton_initialiser_.reset(new Setup);
         return singleton_initialiser_;
-      }
+    }
 
-      static void Destroy()
-      {
-          Server::destroy();
-          if (singleton_initialiser_) singleton_initialiser_.reset();
-      }
+    static void Destroy()
+    {
+        Server::destroy();
+        if (singleton_initialiser_) singleton_initialiser_.reset();
+    }
 
-      static void printSupportedClasses();
-      static std::shared_ptr<exotica::MotionSolver> createSolver(const std::string & type, bool prepend = true) {return to_std_ptr(Instance()->solvers_.createInstance((prepend?"exotica/":"")+type));}
-      static std::shared_ptr<exotica::TaskMap> createMap(const std::string & type, bool prepend = true) {return to_std_ptr(Instance()->maps_.createInstance((prepend?"exotica/":"")+type));}
-      static std::shared_ptr<exotica::PlanningProblem> createProblem(const std::string & type, bool prepend = true) {return Instance()->problems_.createInstance((prepend?"exotica/":"")+type);}
-      static std::shared_ptr<exotica::CollisionScene> createCollisionScene(const std::string & type, bool prepend = true) {return to_std_ptr(Instance()->scenes_.createInstance((prepend?"exotica/":"")+type));}
-      static std::vector<std::string> getSolvers();
-      static std::vector<std::string> getProblems();
-      static std::vector<std::string> getMaps();
-      static std::vector<std::string> getCollisionScenes();
-      static std::vector<Initializer> getInitializers();
+    static void printSupportedClasses();
+    static std::shared_ptr<exotica::MotionSolver> createSolver(const std::string& type, bool prepend = true) { return to_std_ptr(Instance()->solvers_.createInstance((prepend ? "exotica/" : "") + type)); }
+    static std::shared_ptr<exotica::TaskMap> createMap(const std::string& type, bool prepend = true) { return to_std_ptr(Instance()->maps_.createInstance((prepend ? "exotica/" : "") + type)); }
+    static std::shared_ptr<exotica::PlanningProblem> createProblem(const std::string& type, bool prepend = true) { return Instance()->problems_.createInstance((prepend ? "exotica/" : "") + type); }
+    static std::shared_ptr<exotica::CollisionScene> createCollisionScene(const std::string& type, bool prepend = true) { return to_std_ptr(Instance()->scenes_.createInstance((prepend ? "exotica/" : "") + type)); }
+    static std::vector<std::string> getSolvers();
+    static std::vector<std::string> getProblems();
+    static std::vector<std::string> getMaps();
+    static std::vector<std::string> getCollisionScenes();
+    static std::vector<Initializer> getInitializers();
 
-      static std::shared_ptr<exotica::MotionSolver> createSolver(const Initializer& init)
-      {
-          std::shared_ptr<exotica::MotionSolver> ret = to_std_ptr(Instance()->solvers_.createInstance(init.getName()));
-          ret->InstantiateInternal(init);
-          return ret;
-      }
-      static std::shared_ptr<exotica::TaskMap> createMap(const Initializer& init)
-      {
-          std::shared_ptr<exotica::TaskMap> ret = to_std_ptr(Instance()->maps_.createInstance(init.getName()));
-          ret->InstantiateInternal(init);
-          return ret;
-      }
-      static std::shared_ptr<exotica::PlanningProblem> createProblem(const Initializer& init)
-      {
-          std::shared_ptr<exotica::PlanningProblem> ret = Instance()->problems_.createInstance(init.getName());
-          ret->InstantiateInternal(init);
-          return ret;
-      }
+    static std::shared_ptr<exotica::MotionSolver> createSolver(const Initializer& init)
+    {
+        std::shared_ptr<exotica::MotionSolver> ret = to_std_ptr(Instance()->solvers_.createInstance(init.getName()));
+        ret->InstantiateInternal(init);
+        return ret;
+    }
+    static std::shared_ptr<exotica::TaskMap> createMap(const Initializer& init)
+    {
+        std::shared_ptr<exotica::TaskMap> ret = to_std_ptr(Instance()->maps_.createInstance(init.getName()));
+        ret->InstantiateInternal(init);
+        return ret;
+    }
+    static std::shared_ptr<exotica::PlanningProblem> createProblem(const Initializer& init)
+    {
+        std::shared_ptr<exotica::PlanningProblem> ret = Instance()->problems_.createInstance(init.getName());
+        ret->InstantiateInternal(init);
+        return ret;
+    }
 
-    private:
-
-      /**
+private:
+    /**
        * \brief Default Constructor
        *
        *        Currently, is an empty constructor definition.
        */
-      Setup();
-      static std::shared_ptr<Setup> singleton_initialiser_;
-      ///	\brief	Make sure the singleton does not get copied
-      Setup(Setup const&) = delete;
-      void operator=(Setup const&) = delete;
+    Setup();
+    static std::shared_ptr<Setup> singleton_initialiser_;
+    ///	\brief	Make sure the singleton does not get copied
+    Setup(Setup const&) = delete;
+    void operator=(Setup const&) = delete;
 
-      pluginlib::ClassLoader<exotica::MotionSolver> solvers_;
-      pluginlib::ClassLoader<exotica::TaskMap> maps_;
-      pluginlib::ClassLoader<exotica::CollisionScene> scenes_;
-      PlanningProblem_fac problems_;
-  };
+    pluginlib::ClassLoader<exotica::MotionSolver> solvers_;
+    pluginlib::ClassLoader<exotica::TaskMap> maps_;
+    pluginlib::ClassLoader<exotica::CollisionScene> scenes_;
+    PlanningProblem_fac problems_;
+};
 
-  typedef std::shared_ptr<Setup> Setup_ptr;
+typedef std::shared_ptr<Setup> Setup_ptr;
 }
 
 #endif

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -33,14 +33,14 @@
 #ifndef EXOTICA_TASK_MAP_H
 #define EXOTICA_TASK_MAP_H
 
-#include <exotica/Object.h>       //!< The EXOTica base class
-#include <exotica/Factory.h>      //!< The Factory template
-#include <exotica/Server.h>
-#include <exotica/Scene.h>
+#include <exotica/Factory.h>  //!< The Factory template
+#include <exotica/Object.h>   //!< The EXOTica base class
 #include <exotica/Property.h>
+#include <exotica/Scene.h>
+#include <exotica/Server.h>
 #include <exotica/TaskSpaceVector.h>
 
-#include <Eigen/Dense>            //!< Generally dense manipulations should be enough
+#include <Eigen/Dense>  //!< Generally dense manipulations should be enough
 #include <string>
 
 /**
@@ -50,57 +50,50 @@
 
 namespace exotica
 {
-  class PlanningProblem;
+class PlanningProblem;
 
-  class TaskMap: public Object, Uncopyable, public virtual InstantiableBase
-  {
-    public:
-      /**
+class TaskMap : public Object, Uncopyable, public virtual InstantiableBase
+{
+public:
+    /**
        * \brief Default Constructor
        */
-      TaskMap();
-      virtual ~TaskMap() { }
+    TaskMap();
+    virtual ~TaskMap() {}
+    virtual void InstantiateBase(const Initializer& init);
 
-      virtual void InstantiateBase(const Initializer& init);
+    virtual void assignScene(Scene_ptr scene) {}
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) = 0;
 
-      virtual void assignScene(Scene_ptr scene) {}
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J) { throw_named("Not implemented"); }
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::VectorXdRef phidot, Eigen::MatrixXdRef J, Eigen::MatrixXdRef Jdot) { throw_named("Not implemented"); }
+    virtual int taskSpaceDim() = 0;
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) = 0;
+    virtual int taskSpaceJacobianDim() { return taskSpaceDim(); }
+    virtual void preupdate() {}
+    virtual std::vector<TaskVectorEntry> getLieGroupIndices() { return std::vector<TaskVectorEntry>(); }
+    void taskSpaceDim(int& task_dim);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J) { throw_named("Not implemented"); }
+    virtual std::string print(std::string prepend);
 
-      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::VectorXdRef phidot, Eigen::MatrixXdRef J, Eigen::MatrixXdRef Jdot) { throw_named("Not implemented"); }
+    std::vector<KinematicFrameRequest> GetFrames();
 
-      virtual int taskSpaceDim() = 0;
+    virtual void debug() {}
+    KinematicSolution Kinematics;
+    int Id;
+    int Start;
+    int Length;
+    int StartJ;
+    int LengthJ;
 
-      virtual int taskSpaceJacobianDim() { return taskSpaceDim();}
+protected:
+    std::vector<KinematicFrameRequest> Frames;
+};
 
-      virtual void preupdate() {}
-
-      virtual std::vector<TaskVectorEntry> getLieGroupIndices() {return std::vector<TaskVectorEntry>();}
-
-      void taskSpaceDim(int & task_dim);
-
-      virtual std::string print(std::string prepend);
-
-      std::vector<KinematicFrameRequest> GetFrames();
-
-      virtual void debug() { }
-      KinematicSolution Kinematics;
-      int Id;
-      int Start;
-      int Length;
-      int StartJ;
-      int LengthJ;
-    protected:
-
-      std::vector<KinematicFrameRequest> Frames;
-  };
-
-  //!< Typedefines for some common functionality
-  typedef Factory<TaskMap> TaskMap_fac;  //!< Task Map Factory
-  typedef std::shared_ptr<TaskMap> TaskMap_ptr;  //!< Task Map smart pointer
-  typedef std::map<std::string, TaskMap_ptr> TaskMap_map; //!< The mapping by name of TaskMaps
-  typedef std::vector<TaskMap_ptr> TaskMap_vec;
+//!< Typedefines for some common functionality
+typedef Factory<TaskMap> TaskMap_fac;                    //!< Task Map Factory
+typedef std::shared_ptr<TaskMap> TaskMap_ptr;            //!< Task Map smart pointer
+typedef std::map<std::string, TaskMap_ptr> TaskMap_map;  //!< The mapping by name of TaskMaps
+typedef std::vector<TaskMap_ptr> TaskMap_vec;
 }
 #endif

--- a/exotica/include/exotica/TaskSpaceVector.h
+++ b/exotica/include/exotica/TaskSpaceVector.h
@@ -33,14 +33,13 @@
 #ifndef TASKSPACEVECTOR_H
 #define TASKSPACEVECTOR_H
 
+#include <exotica/Tools.h>
 #include <Eigen/Dense>
 #include <kdl/frames.hpp>
 #include <vector>
-#include <exotica/Tools.h>
 
 namespace exotica
 {
-
 struct TaskVectorEntry
 {
     RotationType type;
@@ -53,7 +52,6 @@ struct TaskVectorEntry
 class TaskSpaceVector
 {
 public:
-
     TaskSpaceVector();
     TaskSpaceVector& operator=(std::initializer_list<double> other);
     Eigen::VectorXd operator-(const TaskSpaceVector& other);
@@ -61,9 +59,7 @@ public:
 
     Eigen::VectorXd data;
     std::vector<TaskVectorEntry> map;
-
 };
-
 }
 
-#endif // TASKSPACEVECTOR_H
+#endif  // TASKSPACEVECTOR_H

--- a/exotica/include/exotica/Tools.h
+++ b/exotica/include/exotica/Tools.h
@@ -33,92 +33,94 @@
 #ifndef EXOTICA_TOOLS_H
 #define EXOTICA_TOOLS_H
 
-#include <string>
 #include <Eigen/Dense>
 #include <kdl/tree.hpp>
+#include <string>
 
-#include <exotica/Tools/Exception.h>
-#include <exotica/Tools/Uncopyable.h>
-#include <exotica/Tools/Printable.h>
 #include <exotica/Tools/Conversions.h>
+#include <exotica/Tools/Exception.h>
+#include <exotica/Tools/Printable.h>
 #include <exotica/Tools/Timer.h>
+#include <exotica/Tools/Uncopyable.h>
 #include <exotica/Version.h>
 #include <std_msgs/ColorRGBA.h>
 
 /**
  * \brief A double-wrapper MACRO functionality for generating unique object names: The actual functionality is provided by EX_UNIQ (for 'exotica unique')
  */
-#define EX_CONC(x, y) x ## y
+#define EX_CONC(x, y) x##y
 #define EX_UNIQ(x, y) EX_CONC(x, y)
 
 namespace exotica
 {
-
-   /**
+/**
    * @brief randomColor Generates random opaque color.
    * @return Random color
    */
-  std_msgs::ColorRGBA randomColor();
-  inline std_msgs::ColorRGBA getColor(double r, double g, double b, double a = 1.0)
-  {
-      std_msgs::ColorRGBA ret;
-      ret.r = r;
-      ret.g = g;
-      ret.b = b;
-      ret.a = 1;
-      return ret;
-  }
+std_msgs::ColorRGBA randomColor();
+inline std_msgs::ColorRGBA getColor(double r, double g, double b, double a = 1.0)
+{
+    std_msgs::ColorRGBA ret;
+    ret.r = r;
+    ret.g = g;
+    ret.b = b;
+    ret.a = 1;
+    return ret;
+}
 
-  /**
+/**
    * @brief loadOBJ Loads mesh data from an OBJ file
    * @param file_name File name
    * @param tri Returned vertex indices of triangles
    * @param vert Vertex positions
    */
-  void loadOBJ(const std::string & data, Eigen::VectorXi& tri,
-      Eigen::VectorXd& vert);
+void loadOBJ(const std::string& data, Eigen::VectorXi& tri,
+             Eigen::VectorXd& vert);
 
-  void saveMatrix(std::string file_name,
-      const Eigen::Ref<const Eigen::MatrixXd> mat);
+void saveMatrix(std::string file_name,
+                const Eigen::Ref<const Eigen::MatrixXd> mat);
 
-  void getText(std::string& txt, KDL::Frame& ret);
+void getText(std::string& txt, KDL::Frame& ret);
 
-  template<typename T> std::vector<std::string> getKeys(std::map<std::string, T> map)
-  {
-      std::vector<std::string> ret;
-      for(auto& it : map) ret.push_back(it.first);
-      return ret;
-  }
+template <typename T>
+std::vector<std::string> getKeys(std::map<std::string, T> map)
+{
+    std::vector<std::string> ret;
+    for (auto& it : map) ret.push_back(it.first);
+    return ret;
+}
 
-  std::string getTypeName(const std::type_info& type);
+std::string getTypeName(const std::type_info& type);
 
-  std::string parsePath(const std::string& path);
+std::string parsePath(const std::string& path);
 
-  std::string loadFile(const std::string& path);
+std::string loadFile(const std::string& path);
 
-  bool pathExists(const std::string& path);
+bool pathExists(const std::string& path);
 }
 
 namespace
 {
-    template<class SharedPointer> struct Holder
-    {
-        SharedPointer p;
+template <class SharedPointer>
+struct Holder
+{
+    SharedPointer p;
 
-        Holder(const SharedPointer &p) : p(p) {}
-        Holder(const Holder &other) : p(other.p) {}
-        Holder(Holder &&other) : p(std::move(other.p)) {}
-
-        void operator () (...) { p.reset(); }
-    };
+    Holder(const SharedPointer& p) : p(p) {}
+    Holder(const Holder& other) : p(other.p) {}
+    Holder(Holder&& other) : p(std::move(other.p)) {}
+    void operator()(...) { p.reset(); }
+};
 }
 
-template<class T> std::shared_ptr<T> to_std_ptr(const boost::shared_ptr<T> &p)
+template <class T>
+std::shared_ptr<T> to_std_ptr(const boost::shared_ptr<T>& p)
 {
     return std::shared_ptr<T>(p.get(), Holder<boost::shared_ptr<T>>(p));
 }
 
-template<class T> std::shared_ptr<T> to_std_ptr(const std::shared_ptr<T> &p)
+template <class T>
+std::shared_ptr<T> to_std_ptr(const std::shared_ptr<T>& p)
 {
     return p;
 }

--- a/exotica/include/exotica/Tools/Conversions.h
+++ b/exotica/include/exotica/Tools/Conversions.h
@@ -1,277 +1,274 @@
 #ifndef CONVERSIONS_H
 #define CONVERSIONS_H
 
-#include <Eigen/Dense>
-#include <kdl/tree.hpp>
-#include <kdl/jacobian.hpp>
-#include <vector>
-#include <exotica/Tools/Exception.h>
+#include <exotica/BoolList.h>
+#include <exotica/Matrix.h>
 #include <exotica/MeshVertex.h>
 #include <exotica/StringList.h>
-#include <exotica/BoolList.h>
+#include <exotica/Tools/Exception.h>
 #include <exotica/Vector.h>
-#include <exotica/Matrix.h>
+#include <Eigen/Dense>
+#include <kdl/jacobian.hpp>
+#include <kdl/tree.hpp>
+#include <vector>
 
 namespace Eigen
 {
+/// \brief Convenience wrapper for storing references to sub-matrices/vectors
+template <typename Derived>
+class Ref_ptr : public std::shared_ptr<Ref<Derived>>
+{
+public:
+    inline Ref_ptr()
+        : std::shared_ptr<Ref<Derived>>()
+    {
+    }
 
-  /// \brief Convenience wrapper for storing references to sub-matrices/vectors
-  template<typename Derived>
-  class Ref_ptr: public std::shared_ptr<Ref<Derived> >
-  {
-    public:
-      inline Ref_ptr()
-          : std::shared_ptr<Ref<Derived> >()
-      {
-
-      }
-
-      inline Ref_ptr(const Eigen::Block<Derived>& other)
-      {
+    inline Ref_ptr(const Eigen::Block<Derived>& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
+    }
 
-      inline Ref_ptr(Eigen::Block<Derived>& other)
-      {
+    inline Ref_ptr(Eigen::Block<Derived>& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
+    }
 
-      inline Ref_ptr(const Eigen::VectorBlock<Derived>& other)
-      {
+    inline Ref_ptr(const Eigen::VectorBlock<Derived>& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
+    }
 
-      inline Ref_ptr(Eigen::VectorBlock<Derived>& other)
-      {
+    inline Ref_ptr(Eigen::VectorBlock<Derived>& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
+    }
 
-      inline Ref_ptr(Derived& other)
-      {
+    inline Ref_ptr(Derived& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
+    }
 
-      inline Ref_ptr(const Derived& other)
-      {
+    inline Ref_ptr(const Derived& other)
+    {
         this->reset(new Ref<Derived>(other));
-      }
-  };
+    }
+};
 
-  /// \brief Reference to sub-vector.
-  typedef Ref_ptr<VectorXd> VectorXdRef_ptr;
-  /// \brief Reference to sub-Matrix.
-  typedef Ref_ptr<MatrixXd> MatrixXdRef_ptr;
+/// \brief Reference to sub-vector.
+typedef Ref_ptr<VectorXd> VectorXdRef_ptr;
+/// \brief Reference to sub-Matrix.
+typedef Ref_ptr<MatrixXd> MatrixXdRef_ptr;
 
-  typedef Ref<VectorXd> VectorXdRef;
-  typedef const Ref<const VectorXd>& VectorXdRefConst;
-  typedef Ref<MatrixXd> MatrixXdRef;
-  typedef const Ref<const MatrixXd>& MatrixXdRefConst;
+typedef Ref<VectorXd> VectorXdRef;
+typedef const Ref<const VectorXd>& VectorXdRefConst;
+typedef Ref<MatrixXd> MatrixXdRef;
+typedef const Ref<const MatrixXd>& MatrixXdRefConst;
 
-  Eigen::VectorXd VectorTransform(double px=0.0, double py=0.0, double pz=0.0, double qx=0.0, double qy=0.0, double qz=0.0, double qw=1.0);
-  Eigen::VectorXd IdentityTransform();
-
+Eigen::VectorXd VectorTransform(double px = 0.0, double py = 0.0, double pz = 0.0, double qx = 0.0, double qy = 0.0, double qz = 0.0, double qw = 1.0);
+Eigen::VectorXd IdentityTransform();
 }
 
 namespace exotica
 {
-    enum RotationType
-    {
-        QUATERNION,
-        RPY,
-        ZYX,
-        ZYZ,
-        ANGLE_AXIS,
-        MATRIX
-    };
+enum RotationType
+{
+    QUATERNION,
+    RPY,
+    ZYX,
+    ZYZ,
+    ANGLE_AXIS,
+    MATRIX
+};
 
-    KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type);
+KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type);
 
-    Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type);
+Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type);
 
-    inline int getRotationTypeLength(RotationType type)
-    {
-        static int types[] = {4, 3, 3, 3, 3, 9};
-        return types[(int)type];
-    }
-
-    KDL::Frame getFrame(Eigen::VectorXdRefConst val);
-
-    KDL::Frame getFrameFromMatrix(Eigen::MatrixXdRefConst val);
-
-    Eigen::MatrixXd getFrame(const KDL::Frame& val);
-
-    Eigen::VectorXd getFrameAsVector(const KDL::Frame& val, RotationType type = RotationType::RPY);
-
-    typedef Eigen::Array<KDL::Frame,Eigen::Dynamic,1> ArrayFrame;
-    typedef Eigen::Array<KDL::Twist,Eigen::Dynamic,1> ArrayTwist;
-    typedef Eigen::Array<KDL::Jacobian,Eigen::Dynamic,1> ArrayJacobian;
-    typedef Eigen::Ref<Eigen::Array<KDL::Frame,Eigen::Dynamic,1>> ArrayFrameRef;
-    typedef Eigen::Ref<Eigen::Array<KDL::Twist,Eigen::Dynamic,1>> ArrayTwistRef;
-    typedef Eigen::Ref<Eigen::Array<KDL::Jacobian,Eigen::Dynamic,1>> ArrayJacobianRef;
-    typedef const Eigen::Ref<Eigen::Array<KDL::Frame,Eigen::Dynamic,1>>& ArrayFrameRefConst;
-    typedef const Eigen::Ref<Eigen::Array<KDL::Twist,Eigen::Dynamic,1>>& ArrayTwistRefConst;
-    typedef const Eigen::Ref<Eigen::Array<KDL::Jacobian,Eigen::Dynamic,1>>& ArrayJacobianRefConst;
-
-    inline bool IsContainerType(std::string type)
-    {
-        return type=="exotica::Initializer";
-    }
-
-    inline bool IsVectorType(std::string type)
-    {
-        return type.substr(0,11)=="std::vector";
-    }
-
-    inline bool IsVectorContainerType(std::string type)
-    {
-        return type=="std::vector<exotica::Initializer>";
-    }
-
-    template <class Key, class Val>
-    std::vector<Val> MapToVec( const  std::map<Key,Val> & map)
-    {
-        std::vector<Val> ret;
-        for( auto& val : map)
-        {
-            ret.push_back( val.second );
-        }
-        return ret;
-    }
-
-    template <class Key, class Val>
-    void appendMap(std::map<Key,Val>& orig, const std::map<Key,Val>& extra)
-    {
-        orig.insert(extra.begin(),extra.end());
-    }
-
-    template <class Val>
-    void appendVector(std::vector<Val>& orig, const std::vector<Val>& extra)
-    {
-        orig.insert(orig.end(), extra.begin(),extra.end());
-    }
-
-    bool contains(std::string key, const std::vector<std::string>& vec);
-
-    inline std::string trim(const std::string &s)
-    {
-       auto  wsfront=std::find_if_not(s.begin(),s.end(),[](int c){return std::isspace(c);});
-       return std::string(wsfront,std::find_if_not(s.rbegin(),std::string::const_reverse_iterator(wsfront),[](int c){return std::isspace(c);}).base());
-    }
-
-    inline Eigen::VectorXd parseVector(const std::string value)
-    {
-        Eigen::VectorXd ret;
-        double temp_entry;
-        int i = 0;
-
-        std::istringstream text_parser(value);
-
-        text_parser >> temp_entry;
-        while (!(text_parser.fail() || text_parser.bad()))
-        {
-            ret.conservativeResize(++i);
-            ret(i - 1) = temp_entry;
-            text_parser >> temp_entry;
-        }
-        if (i == 0) throw_pretty("Empty vector!");
-        return ret;
-    }
-
-    inline bool parseBool(const std::string value)
-    {
-        bool ret;
-        std::istringstream text_parser(value);
-        text_parser >> ret;
-        return ret;
-    }
-
-    inline double parseDouble(const std::string value)
-    {
-        double ret;
-        std::istringstream text_parser(value);
-
-        text_parser >> ret;
-        if ((text_parser.fail() || text_parser.bad()))
-        {
-            throw_pretty("Can't parse value!");
-        }
-        return ret;
-    }
-
-    inline int parseInt(const std::string value)
-    {
-        int ret;
-        std::istringstream text_parser(value);
-
-        text_parser >> ret;
-        if ((text_parser.fail() || text_parser.bad()))
-        {
-            throw_pretty("Can't parse value!");
-        }
-        return ret;
-    }
-
-    inline std::vector<std::string> parseList(const std::string& value, char token = ',')
-    {
-        std::stringstream ss(value);
-        std::string item;
-        std::vector<std::string> ret;
-        while (std::getline(ss, item, token))
-        {
-            ret.push_back(trim(item));
-        }
-        if (ret.size() == 0) throw_pretty("Empty vector!");
-        return ret;
-    }
-
-    inline std::vector<int> parseIntList(const std::string value)
-    {
-        std::istringstream text_parser(value);
-        std::stringstream ss(value);
-        std::string item;
-        std::vector<int> ret;
-        while (std::getline(ss, item, ','))
-        {
-            int tmp;
-            text_parser >> tmp;
-            if ((text_parser.fail() || text_parser.bad()))
-            {
-                throw_pretty("Can't parse value!");
-            }
-            ret.push_back(tmp);
-        }
-        if (ret.size() == 0) throw_pretty("Empty vector!");
-        return ret;
-    }
-
-    inline std::vector<bool> parseBoolList(const std::string value)
-    {
-        std::istringstream text_parser(value);
-        std::stringstream ss(value);
-        std::string item;
-        std::vector<bool> ret;
-        while (std::getline(ss, item, ','))
-        {
-            bool tmp;
-            text_parser >> tmp;
-            if ((text_parser.fail() || text_parser.bad()))
-            {
-                throw_pretty("Can't parse value!");
-            }
-            ret.push_back(tmp);
-        }
-        if (ret.size() == 0) throw_pretty("Empty vector!");
-        return ret;
-    }
-
-    void vectorExoticaToEigen(const exotica::Vector & exotica,
-        Eigen::VectorXd & eigen);
-    void vectorEigenToExotica(Eigen::VectorXd eigen,
-        exotica::Vector & exotica);
-    void matrixExoticaToEigen(const exotica::Matrix & exotica,
-        Eigen::MatrixXd & eigen);
-    void matrixEigenToExotica(const Eigen::MatrixXd & eigen,
-        exotica::Matrix & exotica);
+inline int getRotationTypeLength(RotationType type)
+{
+    static int types[] = {4, 3, 3, 3, 3, 9};
+    return types[(int)type];
 }
 
-#endif // CONVERSIONS_H
+KDL::Frame getFrame(Eigen::VectorXdRefConst val);
+
+KDL::Frame getFrameFromMatrix(Eigen::MatrixXdRefConst val);
+
+Eigen::MatrixXd getFrame(const KDL::Frame& val);
+
+Eigen::VectorXd getFrameAsVector(const KDL::Frame& val, RotationType type = RotationType::RPY);
+
+typedef Eigen::Array<KDL::Frame, Eigen::Dynamic, 1> ArrayFrame;
+typedef Eigen::Array<KDL::Twist, Eigen::Dynamic, 1> ArrayTwist;
+typedef Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1> ArrayJacobian;
+typedef Eigen::Ref<Eigen::Array<KDL::Frame, Eigen::Dynamic, 1>> ArrayFrameRef;
+typedef Eigen::Ref<Eigen::Array<KDL::Twist, Eigen::Dynamic, 1>> ArrayTwistRef;
+typedef Eigen::Ref<Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1>> ArrayJacobianRef;
+typedef const Eigen::Ref<Eigen::Array<KDL::Frame, Eigen::Dynamic, 1>>& ArrayFrameRefConst;
+typedef const Eigen::Ref<Eigen::Array<KDL::Twist, Eigen::Dynamic, 1>>& ArrayTwistRefConst;
+typedef const Eigen::Ref<Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1>>& ArrayJacobianRefConst;
+
+inline bool IsContainerType(std::string type)
+{
+    return type == "exotica::Initializer";
+}
+
+inline bool IsVectorType(std::string type)
+{
+    return type.substr(0, 11) == "std::vector";
+}
+
+inline bool IsVectorContainerType(std::string type)
+{
+    return type == "std::vector<exotica::Initializer>";
+}
+
+template <class Key, class Val>
+std::vector<Val> MapToVec(const std::map<Key, Val>& map)
+{
+    std::vector<Val> ret;
+    for (auto& val : map)
+    {
+        ret.push_back(val.second);
+    }
+    return ret;
+}
+
+template <class Key, class Val>
+void appendMap(std::map<Key, Val>& orig, const std::map<Key, Val>& extra)
+{
+    orig.insert(extra.begin(), extra.end());
+}
+
+template <class Val>
+void appendVector(std::vector<Val>& orig, const std::vector<Val>& extra)
+{
+    orig.insert(orig.end(), extra.begin(), extra.end());
+}
+
+bool contains(std::string key, const std::vector<std::string>& vec);
+
+inline std::string trim(const std::string& s)
+{
+    auto wsfront = std::find_if_not(s.begin(), s.end(), [](int c) { return std::isspace(c); });
+    return std::string(wsfront, std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(wsfront), [](int c) { return std::isspace(c); }).base());
+}
+
+inline Eigen::VectorXd parseVector(const std::string value)
+{
+    Eigen::VectorXd ret;
+    double temp_entry;
+    int i = 0;
+
+    std::istringstream text_parser(value);
+
+    text_parser >> temp_entry;
+    while (!(text_parser.fail() || text_parser.bad()))
+    {
+        ret.conservativeResize(++i);
+        ret(i - 1) = temp_entry;
+        text_parser >> temp_entry;
+    }
+    if (i == 0) throw_pretty("Empty vector!");
+    return ret;
+}
+
+inline bool parseBool(const std::string value)
+{
+    bool ret;
+    std::istringstream text_parser(value);
+    text_parser >> ret;
+    return ret;
+}
+
+inline double parseDouble(const std::string value)
+{
+    double ret;
+    std::istringstream text_parser(value);
+
+    text_parser >> ret;
+    if ((text_parser.fail() || text_parser.bad()))
+    {
+        throw_pretty("Can't parse value!");
+    }
+    return ret;
+}
+
+inline int parseInt(const std::string value)
+{
+    int ret;
+    std::istringstream text_parser(value);
+
+    text_parser >> ret;
+    if ((text_parser.fail() || text_parser.bad()))
+    {
+        throw_pretty("Can't parse value!");
+    }
+    return ret;
+}
+
+inline std::vector<std::string> parseList(const std::string& value, char token = ',')
+{
+    std::stringstream ss(value);
+    std::string item;
+    std::vector<std::string> ret;
+    while (std::getline(ss, item, token))
+    {
+        ret.push_back(trim(item));
+    }
+    if (ret.size() == 0) throw_pretty("Empty vector!");
+    return ret;
+}
+
+inline std::vector<int> parseIntList(const std::string value)
+{
+    std::istringstream text_parser(value);
+    std::stringstream ss(value);
+    std::string item;
+    std::vector<int> ret;
+    while (std::getline(ss, item, ','))
+    {
+        int tmp;
+        text_parser >> tmp;
+        if ((text_parser.fail() || text_parser.bad()))
+        {
+            throw_pretty("Can't parse value!");
+        }
+        ret.push_back(tmp);
+    }
+    if (ret.size() == 0) throw_pretty("Empty vector!");
+    return ret;
+}
+
+inline std::vector<bool> parseBoolList(const std::string value)
+{
+    std::istringstream text_parser(value);
+    std::stringstream ss(value);
+    std::string item;
+    std::vector<bool> ret;
+    while (std::getline(ss, item, ','))
+    {
+        bool tmp;
+        text_parser >> tmp;
+        if ((text_parser.fail() || text_parser.bad()))
+        {
+            throw_pretty("Can't parse value!");
+        }
+        ret.push_back(tmp);
+    }
+    if (ret.size() == 0) throw_pretty("Empty vector!");
+    return ret;
+}
+
+void vectorExoticaToEigen(const exotica::Vector& exotica,
+                          Eigen::VectorXd& eigen);
+void vectorEigenToExotica(Eigen::VectorXd eigen,
+                          exotica::Vector& exotica);
+void matrixExoticaToEigen(const exotica::Matrix& exotica,
+                          Eigen::MatrixXd& eigen);
+void matrixEigenToExotica(const Eigen::MatrixXd& eigen,
+                          exotica::Matrix& exotica);
+}
+
+#endif  // CONVERSIONS_H

--- a/exotica/include/exotica/Tools/Exception.h
+++ b/exotica/include/exotica/Tools/Exception.h
@@ -4,13 +4,27 @@
 #include <exception>
 #include <sstream>
 
-#define throw_pretty(m) {std::stringstream ss; ss<<m; throw exotica::Exception(ss.str(),__FILE__,__PRETTY_FUNCTION__,__LINE__);}
-#define throw_named(m) {std::stringstream ss; ss<<m; throw exotica::Exception(ss.str(),__FILE__,__PRETTY_FUNCTION__,__LINE__,this->object_name_);}
-#define throw_solve(m) {std::stringstream ss; ss<<m; throw exotica::SolveException(ss.str(),__FILE__,__PRETTY_FUNCTION__,__LINE__,this->object_name_);}
+#define throw_pretty(m)                                                              \
+    {                                                                                \
+        std::stringstream ss;                                                        \
+        ss << m;                                                                     \
+        throw exotica::Exception(ss.str(), __FILE__, __PRETTY_FUNCTION__, __LINE__); \
+    }
+#define throw_named(m)                                                                                   \
+    {                                                                                                    \
+        std::stringstream ss;                                                                            \
+        ss << m;                                                                                         \
+        throw exotica::Exception(ss.str(), __FILE__, __PRETTY_FUNCTION__, __LINE__, this->object_name_); \
+    }
+#define throw_solve(m)                                                                                        \
+    {                                                                                                         \
+        std::stringstream ss;                                                                                 \
+        ss << m;                                                                                              \
+        throw exotica::SolveException(ss.str(), __FILE__, __PRETTY_FUNCTION__, __LINE__, this->object_name_); \
+    }
 
 namespace exotica
 {
-
 class Exception : public std::exception
 {
 public:
@@ -25,14 +39,15 @@ public:
 
     Exception();
     explicit Exception(const std::string &msg, const char *file, const char *func, int line);
-    explicit Exception(const std::string &msg, const char *file, const char *func, int line, const std::string& object);
-    virtual const char* what() const noexcept override;
+    explicit Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object);
+    virtual const char *what() const noexcept override;
 
     std::string msg_;
     std::string file_;
     std::string func_;
     std::string line_;
     std::string object_;
+
 private:
     static ReportingType reporting_;
 };
@@ -46,9 +61,6 @@ class SolveException : public Exception
 {
     using Exception::Exception;
 };
-
 }
 
-
-
-#endif // EXCEPTION_H
+#endif  // EXCEPTION_H

--- a/exotica/include/exotica/Tools/Printable.h
+++ b/exotica/include/exotica/Tools/Printable.h
@@ -2,9 +2,9 @@
 #define PRINTABLE_H
 
 #include <iostream>
-#include <vector>
-#include <map>
 #include <kdl/frames.hpp>
+#include <map>
+#include <vector>
 
 /**
  * \brief A set of debugging tools: basically these provide easy ways of checking code execution through std::cout prints
@@ -14,23 +14,25 @@
 #endif
 
 #ifdef EXOTICA_DEBUG_MODE
-#define CHECK_EXECUTION         std::cout << "\033[1;32m[EXOTica]:\033[0m Ok in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n"; //!< With endline
-#define INDICATE_FAILURE        std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\033[0m\n";//!< With endline
-#define WARNING(x)				std::cout << "\033[1;32m[EXOTica]:\033[0m \033[33mWarning in " << __PRETTY_FUNCTION__ << ": " << x << "\033[0m\n";//!< With endline
-#define ERROR(x)				std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n" << x << "\033[0m\n";//!< With endline
-#define INFO(x)					std::clog << "\033[1;32m[EXOTica]:\033[0m Info in " << __PRETTY_FUNCTION__ << ": " << x << "\n";//!< With endline
+#define CHECK_EXECUTION std::cout << "\033[1;32m[EXOTica]:\033[0m Ok in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n";                        //!< With endline
+#define INDICATE_FAILURE std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\033[0m\n";  //!< With endline
+#define WARNING(x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[33mWarning in " << __PRETTY_FUNCTION__ << ": " << x << "\033[0m\n";                                                           //!< With endline
+#define ERROR(x) std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n" \
+                           << x << "\033[0m\n";                                                                   //!< With endline
+#define INFO(x) std::clog << "\033[1;32m[EXOTica]:\033[0m Info in " << __PRETTY_FUNCTION__ << ": " << x << "\n";  //!< With endline
 #else
-#define CHECK_EXECUTION         // No operation
-#define INDICATE_FAILURE        std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\033[0m\n";//!< With endline
-#define WARNING(x)        std::cout << "\033[1;32m[EXOTica]:\033[0m \033[33mWarning in " << __PRETTY_FUNCTION__ << ": " << x << "\033[0m\n";//!< With endline
-#define ERROR(x)                std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n" << x << "\033[0m\n";//!< With endline
+#define CHECK_EXECUTION                                                                                                                                                                         // No operation
+#define INDICATE_FAILURE std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\033[0m\n";  //!< With endline
+#define WARNING(x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[33mWarning in " << __PRETTY_FUNCTION__ << ": " << x << "\033[0m\n";                                                           //!< With endline
+#define ERROR(x) std::cerr << "\033[1;32m[EXOTica]:\033[0m \033[1;31mFailed in " << __FILE__ << " at line " << __LINE__ << " within function " << __PRETTY_FUNCTION__ << ".\n" \
+                           << x << "\033[0m\n";  //!< With endline
 #define INFO(x)
 #endif
-#define HIGHLIGHT(x)			std::cout << "\033[1;32m[EXOTica]:\033[0m \033[36m" << x << "\033[0m\n";
-#define HIGHLIGHT_NAMED(name, x)std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name <<"]\033[0m \033[36m" << x << "\033[0m\n";
-#define WARNING_NAMED(name, x)	std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name <<"]\033[0m \033[33m" << x << "\033[0m\n";
-#define INFO_NAMED(name, x)		std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name <<"]\033[0m " << x << "\n";
-#define INFO_PLAIN(x)		std::cout << x << "\n";
+#define HIGHLIGHT(x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[36m" << x << "\033[0m\n";
+#define HIGHLIGHT_NAMED(name, x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name << "]\033[0m \033[36m" << x << "\033[0m\n";
+#define WARNING_NAMED(name, x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name << "]\033[0m \033[33m" << x << "\033[0m\n";
+#define INFO_NAMED(name, x) std::cout << "\033[1;32m[EXOTica]:\033[0m \033[35m[" << name << "]\033[0m " << x << "\n";
+#define INFO_PLAIN(x) std::cout << x << "\n";
 
 class Printable
 {
@@ -38,20 +40,22 @@ public:
     virtual void print(std::ostream& os) const = 0;
 };
 
-std::ostream& operator<< (std::ostream& os, const Printable& s);
+std::ostream& operator<<(std::ostream& os, const Printable& s);
 
-template<typename T>std::ostream& operator<< (std::ostream& os, const std::vector<T>& s)
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::vector<T>& s)
 {
-    for(auto& p : s) os << p << "\n";
+    for (auto& p : s) os << p << "\n";
     return os;
 }
 
-template<typename I, typename T>std::ostream& operator<< (std::ostream& os, const std::map<I,T>& s)
+template <typename I, typename T>
+std::ostream& operator<<(std::ostream& os, const std::map<I, T>& s)
 {
-    for(auto& p : s) os << p.first << ": "<<p.second<<"\n";
+    for (auto& p : s) os << p.first << ": " << p.second << "\n";
     return os;
 }
 
 std::string toString(const KDL::Frame& s);
 
-#endif // PRINTABLE_H
+#endif  // PRINTABLE_H

--- a/exotica/include/exotica/Tools/Timer.h
+++ b/exotica/include/exotica/Tools/Timer.h
@@ -5,7 +5,6 @@
 
 namespace exotica
 {
-
 inline void sleep(double t)
 {
     std::this_thread::sleep_for(std::chrono::duration<double>(t));
@@ -16,7 +15,6 @@ class Timer
 public:
     Timer() : startTime_(std::chrono::high_resolution_clock::now())
     {
-
     }
 
     inline void reset()
@@ -32,7 +30,6 @@ public:
 private:
     std::chrono::time_point<std::chrono::high_resolution_clock> startTime_;
 };
-
 }
 
-#endif // TIMER_H
+#endif  // TIMER_H

--- a/exotica/include/exotica/Tools/Uncopyable.h
+++ b/exotica/include/exotica/Tools/Uncopyable.h
@@ -3,17 +3,15 @@
 
 namespace exotica
 {
-
 class Uncopyable
 {
-    public:
-        Uncopyable(){}
-        ~Uncopyable(){}
-    private:
-        Uncopyable(const Uncopyable&);
-        Uncopyable& operator=(const Uncopyable&);
+public:
+    Uncopyable() {}
+    ~Uncopyable() {}
+private:
+    Uncopyable(const Uncopyable&);
+    Uncopyable& operator=(const Uncopyable&);
 };
-
 }
 
-#endif // UNCOPYABLE_H
+#endif  // UNCOPYABLE_H

--- a/exotica/include/exotica/Trajectory.h
+++ b/exotica/include/exotica/Trajectory.h
@@ -5,14 +5,14 @@
 
 #include <Eigen/Dense>
 
-#include <kdl/trajectory.hpp>
-#include <kdl/trajectory_composite.hpp>
-#include <kdl/trajectory_stationary.hpp>
-#include <kdl/trajectory_segment.hpp>
-#include <kdl/rotational_interpolation.hpp>
-#include <kdl/rotational_interpolation_sa.hpp>
 #include <kdl/path.hpp>
 #include <kdl/path_line.hpp>
+#include <kdl/rotational_interpolation.hpp>
+#include <kdl/rotational_interpolation_sa.hpp>
+#include <kdl/trajectory.hpp>
+#include <kdl/trajectory_composite.hpp>
+#include <kdl/trajectory_segment.hpp>
+#include <kdl/trajectory_stationary.hpp>
 #include <kdl/velocityprofile.hpp>
 #include <kdl/velocityprofile_spline.hpp>
 
@@ -26,7 +26,7 @@ public:
     Trajectory();
     Trajectory(const std::string& data);
     Trajectory(Eigen::MatrixXdRefConst data, double radius = 1.0);
-    ~Trajectory(){}
+    ~Trajectory() {}
     KDL::Frame getPosition(double t);
     KDL::Twist getVelocity(double t);
     KDL::Twist getAcceleration(double t);
@@ -34,6 +34,7 @@ public:
     Eigen::MatrixXd getData();
     double getRadius();
     std::string toString();
+
 protected:
     void constructFromData(Eigen::MatrixXdRefConst data, double radius);
     double radius_;

--- a/exotica/include/exotica/Version.h
+++ b/exotica/include/exotica/Version.h
@@ -7,4 +7,4 @@ extern const char Version[];
 extern const char Branch[];
 }
 
-#endif // VERSION_H
+#endif  // VERSION_H

--- a/exotica/include/tinyxml2/tinyxml2.h
+++ b/exotica/include/tinyxml2/tinyxml2.h
@@ -26,19 +26,19 @@
 #define TINYXML2_INCLUDED
 
 #if defined(ANDROID_NDK) || defined(__BORLANDC__)
-#   include <ctype.h>
-#   include <limits.h>
-#   include <stdio.h>
-#   include <stdlib.h>
-#   include <string.h>
-#   include <stdarg.h>
+#include <ctype.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #else
-#   include <cctype>
-#   include <climits>
-#   include <cstdio>
-#   include <cstdlib>
-#   include <cstring>
-#   include <cstdarg>
+#include <cctype>
+#include <climits>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #endif
 
 /*
@@ -52,44 +52,54 @@
  AStyle.exe --style=1tbs --indent-switches --break-closing-brackets --indent-preprocessor tinyxml2.cpp tinyxml2.h
  */
 
-#if defined( _DEBUG ) || defined( DEBUG ) || defined (__DEBUG__)
-#   ifndef DEBUG
-#       define DEBUG
-#   endif
+#if defined(_DEBUG) || defined(DEBUG) || defined(__DEBUG__)
+#ifndef DEBUG
+#define DEBUG
+#endif
 #endif
 
 #ifdef _MSC_VER
-#   pragma warning(push)
-#   pragma warning(disable: 4251)
+#pragma warning(push)
+#pragma warning(disable : 4251)
 #endif
 
 #ifdef _WIN32
-#   ifdef TINYXML2_EXPORT
-#       define TINYXML2_LIB __declspec(dllexport)
-#   elif defined(TINYXML2_IMPORT)
-#       define TINYXML2_LIB __declspec(dllimport)
-#   else
-#       define TINYXML2_LIB
-#   endif
+#ifdef TINYXML2_EXPORT
+#define TINYXML2_LIB __declspec(dllexport)
+#elif defined(TINYXML2_IMPORT)
+#define TINYXML2_LIB __declspec(dllimport)
 #else
-#   define TINYXML2_LIB
+#define TINYXML2_LIB
+#endif
+#else
+#define TINYXML2_LIB
 #endif
 
 #if defined(DEBUG)
-#   if defined(_MSC_VER)
-#       define TIXMLASSERT( x )           if ( !(x)) { __debugbreak(); } //if ( !(x)) WinDebugBreak()
-#   elif defined (ANDROID_NDK)
-#       include <android/log.h>
-#       define TIXMLASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }
-#   else
-#       include <assert.h>
-#       define TIXMLASSERT                assert
-#   endif
-#   else
-#       define TIXMLASSERT( x )           {}
+#if defined(_MSC_VER)
+#define TIXMLASSERT(x)  \
+    if (!(x))           \
+    {                   \
+        __debugbreak(); \
+    }  //if ( !(x)) WinDebugBreak()
+#elif defined(ANDROID_NDK)
+#include <android/log.h>
+#define TIXMLASSERT(x)                                                                          \
+    if (!(x))                                                                                   \
+    {                                                                                           \
+        __android_log_assert("assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__); \
+    }
+#else
+#include <assert.h>
+#define TIXMLASSERT assert
+#endif
+#else
+#define TIXMLASSERT(x) \
+    {                  \
+    }
 #endif
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
 // Microsoft visual studio, version 2005 and higher.
 /*int _snprintf_s(
  char *buffer,
@@ -98,20 +108,20 @@
  const char *format [,
  argument] ...
  );*/
-inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
+inline int TIXML_SNPRINTF(char* buffer, size_t size, const char* format, ...)
 {
-  va_list va;
-  va_start( va, format );
-  int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
-  va_end( va );
-  return result;
+    va_list va;
+    va_start(va, format);
+    int result = vsnprintf_s(buffer, size, _TRUNCATE, format, va);
+    va_end(va);
+    return result;
 }
-#define TIXML_SSCANF   sscanf_s
+#define TIXML_SSCANF sscanf_s
 #else
 // GCC version 3 and higher
 //#warning( "Using sn* functions." )
 #define TIXML_SNPRINTF snprintf
-#define TIXML_SSCANF   sscanf
+#define TIXML_SSCANF sscanf
 #endif
 
 static const int TIXML2_MAJOR_VERSION = 1;
@@ -120,26 +130,26 @@ static const int TIXML2_PATCH_VERSION = 14;
 
 namespace tinyxml2
 {
-  class XMLDocument;
-  class XMLElement;
-  class XMLAttribute;
-  class XMLComment;
-  class XMLText;
-  class XMLDeclaration;
-  class XMLUnknown;
-  class XMLPrinter;
+class XMLDocument;
+class XMLElement;
+class XMLAttribute;
+class XMLComment;
+class XMLText;
+class XMLDeclaration;
+class XMLUnknown;
+class XMLPrinter;
 
-  /*
+/*
    A class that wraps strings. Normally stores the start and end
    pointers into the XML file itself, and will apply normalization
    and entity translation if actually read. Can also store (and memory
    manage) a traditional char[]
    */
-  class StrPair
-  {
-    public:
-      enum
-      {
+class StrPair
+{
+public:
+    enum
+    {
         NEEDS_ENTITY_PROCESSING = 0x01,
         NEEDS_NEWLINE_NORMALIZATION = 0x02,
         COLLAPSE_WHITESPACE = 0x04,
@@ -150,239 +160,239 @@ namespace tinyxml2
         ATTRIBUTE_VALUE = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
         ATTRIBUTE_VALUE_LEAVE_ENTITIES = NEEDS_NEWLINE_NORMALIZATION,
         COMMENT = NEEDS_NEWLINE_NORMALIZATION
-      };
+    };
 
-      StrPair()
-          : _flags(0), _start(0), _end(0)
-      {
-      }
-      ~StrPair();
+    StrPair()
+        : _flags(0), _start(0), _end(0)
+    {
+    }
+    ~StrPair();
 
-      void Set(char* start, char* end, int flags)
-      {
+    void Set(char* start, char* end, int flags)
+    {
         Reset();
         _start = start;
         _end = end;
         _flags = flags | NEEDS_FLUSH;
-      }
+    }
 
-      const char* GetStr();
+    const char* GetStr();
 
-      bool Empty() const
-      {
+    bool Empty() const
+    {
         return _start == _end;
-      }
+    }
 
-      void SetInternedStr(const char* str)
-      {
+    void SetInternedStr(const char* str)
+    {
         Reset();
         _start = const_cast<char*>(str);
-      }
+    }
 
-      void SetStr(const char* str, int flags = 0);
+    void SetStr(const char* str, int flags = 0);
 
-      char* ParseText(char* in, const char* endTag, int strFlags);
-      char* ParseName(char* in);
+    char* ParseText(char* in, const char* endTag, int strFlags);
+    char* ParseName(char* in);
 
-    private:
-      void Reset();
-      void CollapseWhitespace();
+private:
+    void Reset();
+    void CollapseWhitespace();
 
-      enum
-      {
-        NEEDS_FLUSH = 0x100, NEEDS_DELETE = 0x200
-      };
+    enum
+    {
+        NEEDS_FLUSH = 0x100,
+        NEEDS_DELETE = 0x200
+    };
 
-      // After parsing, if *_end != 0, it can be set to zero.
-      int _flags;
-      char* _start;
-      char* _end;
-  };
+    // After parsing, if *_end != 0, it can be set to zero.
+    int _flags;
+    char* _start;
+    char* _end;
+};
 
-  /*
+/*
    A dynamic array of Plain Old Data. Doesn't support constructors, etc.
    Has a small initial memory pool, so that low or no usage will not
    cause a call to new/delete
    */
-  template<class T, int INIT>
-  class DynArray
-  {
-    public:
-      DynArray<T, INIT>()
-      {
+template <class T, int INIT>
+class DynArray
+{
+public:
+    DynArray<T, INIT>()
+    {
         _mem = _pool;
         _allocated = INIT;
         _size = 0;
-      }
+    }
 
-      ~DynArray()
-      {
+    ~DynArray()
+    {
         if (_mem != _pool)
         {
-          delete[] _mem;
+            delete[] _mem;
         }
-      }
+    }
 
-      void Clear()
-      {
+    void Clear()
+    {
         _size = 0;
-      }
+    }
 
-      void Push(T t)
-      {
+    void Push(T t)
+    {
         EnsureCapacity(_size + 1);
         _mem[_size++] = t;
-      }
+    }
 
-      T* PushArr(int count)
-      {
+    T* PushArr(int count)
+    {
         EnsureCapacity(_size + count);
         T* ret = &_mem[_size];
         _size += count;
         return ret;
-      }
+    }
 
-      T Pop()
-      {
+    T Pop()
+    {
         return _mem[--_size];
-      }
+    }
 
-      void PopArr(int count)
-      {
+    void PopArr(int count)
+    {
         TIXMLASSERT(_size >= count);
         _size -= count;
-      }
+    }
 
-      bool Empty() const
-      {
+    bool Empty() const
+    {
         return _size == 0;
-      }
+    }
 
-      T& operator[](int i)
-      {
-        TIXMLASSERT(i>= 0 && i < _size);
+    T& operator[](int i)
+    {
+        TIXMLASSERT(i >= 0 && i < _size);
         return _mem[i];
-      }
+    }
 
-      const T& operator[](int i) const
-      {
-        TIXMLASSERT(i>= 0 && i < _size);
+    const T& operator[](int i) const
+    {
+        TIXMLASSERT(i >= 0 && i < _size);
         return _mem[i];
-      }
+    }
 
-      const T& PeekTop() const
-      {
+    const T& PeekTop() const
+    {
         TIXMLASSERT(_size > 0);
         return _mem[_size - 1];
-      }
+    }
 
-      int Size() const
-      {
+    int Size() const
+    {
         return _size;
-      }
+    }
 
-      int Capacity() const
-      {
+    int Capacity() const
+    {
         return _allocated;
-      }
+    }
 
-      const T* Mem() const
-      {
+    const T* Mem() const
+    {
         return _mem;
-      }
+    }
 
-      T* Mem()
-      {
+    T* Mem()
+    {
         return _mem;
-      }
+    }
 
-    private:
-      void EnsureCapacity(int cap)
-      {
+private:
+    void EnsureCapacity(int cap)
+    {
         if (cap > _allocated)
         {
-          int newAllocated = cap * 2;
-          T* newMem = new T[newAllocated];
-          memcpy(newMem, _mem, sizeof(T) * _size);// warning: not using constructors, only works for PODs
-          if (_mem != _pool)
-          {
-            delete[] _mem;
-          }
-          _mem = newMem;
-          _allocated = newAllocated;
+            int newAllocated = cap * 2;
+            T* newMem = new T[newAllocated];
+            memcpy(newMem, _mem, sizeof(T) * _size);  // warning: not using constructors, only works for PODs
+            if (_mem != _pool)
+            {
+                delete[] _mem;
+            }
+            _mem = newMem;
+            _allocated = newAllocated;
         }
-      }
+    }
 
-      T* _mem;
-      T _pool[INIT];
-      int _allocated;		// objects allocated
-      int _size;			// number objects in use
-  };
+    T* _mem;
+    T _pool[INIT];
+    int _allocated;  // objects allocated
+    int _size;       // number objects in use
+};
 
-  /*
+/*
    Parent virtual class of a pool for fast allocation
    and deallocation of objects.
    */
-  class MemPool
-  {
-    public:
-      MemPool()
-      {
-      }
-      virtual ~MemPool()
-      {
-      }
+class MemPool
+{
+public:
+    MemPool()
+    {
+    }
+    virtual ~MemPool()
+    {
+    }
 
-      virtual int ItemSize() const = 0;
-      virtual void* Alloc() = 0;
-      virtual void Free(void*) = 0;
-      virtual void SetTracked() = 0;
-  };
+    virtual int ItemSize() const = 0;
+    virtual void* Alloc() = 0;
+    virtual void Free(void*) = 0;
+    virtual void SetTracked() = 0;
+};
 
-  /*
+/*
    Template child class to create pools of the correct type.
    */
-  template<int SIZE>
-  class MemPoolT: public MemPool
-  {
-    public:
-      MemPoolT()
-          : _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(
-              0)
-      {
-      }
-      ~MemPoolT()
-      {
+template <int SIZE>
+class MemPoolT : public MemPool
+{
+public:
+    MemPoolT()
+        : _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)
+    {
+    }
+    ~MemPoolT()
+    {
         // Delete the blocks.
         for (int i = 0; i < _blockPtrs.Size(); ++i)
         {
-          delete _blockPtrs[i];
+            delete _blockPtrs[i];
         }
-      }
+    }
 
-      virtual int ItemSize() const
-      {
+    virtual int ItemSize() const
+    {
         return SIZE;
-      }
-      int CurrentAllocs() const
-      {
+    }
+    int CurrentAllocs() const
+    {
         return _currentAllocs;
-      }
+    }
 
-      virtual void* Alloc()
-      {
+    virtual void* Alloc()
+    {
         if (!_root)
         {
-          // Need a new block.
-          Block* block = new Block();
-          _blockPtrs.Push(block);
+            // Need a new block.
+            Block* block = new Block();
+            _blockPtrs.Push(block);
 
-          for (int i = 0; i < COUNT - 1; ++i)
-          {
-            block->chunk[i].next = &block->chunk[i + 1];
-          }
-          block->chunk[COUNT - 1].next = 0;
-          _root = block->chunk;
+            for (int i = 0; i < COUNT - 1; ++i)
+            {
+                block->chunk[i].next = &block->chunk[i + 1];
+            }
+            block->chunk[COUNT - 1].next = 0;
+            _root = block->chunk;
         }
         void* result = _root;
         _root = _root->next;
@@ -390,78 +400,77 @@ namespace tinyxml2
         ++_currentAllocs;
         if (_currentAllocs > _maxAllocs)
         {
-          _maxAllocs = _currentAllocs;
+            _maxAllocs = _currentAllocs;
         }
         _nAllocs++;
         _nUntracked++;
         return result;
-      }
-      virtual void Free(void* mem)
-      {
+    }
+    virtual void Free(void* mem)
+    {
         if (!mem)
         {
-          return;
+            return;
         }
         --_currentAllocs;
-        Chunk* chunk = (Chunk*) mem;
+        Chunk* chunk = (Chunk*)mem;
 #ifdef DEBUG
-        memset( chunk, 0xfe, sizeof(Chunk) );
+        memset(chunk, 0xfe, sizeof(Chunk));
 #endif
         chunk->next = _root;
         _root = chunk;
-      }
-      void Trace(const char* name)
-      {
+    }
+    void Trace(const char* name)
+    {
         printf(
             "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
             name, _maxAllocs, _maxAllocs * SIZE / 1024, _currentAllocs, SIZE,
             _nAllocs, _blockPtrs.Size());
-      }
+    }
 
-      void SetTracked()
-      {
+    void SetTracked()
+    {
         _nUntracked--;
-      }
+    }
 
-      int Untracked() const
-      {
+    int Untracked() const
+    {
         return _nUntracked;
-      }
+    }
 
-      // This number is perf sensitive. 4k seems like a good tradeoff on my machine.
-      // The test file is large, 170k.
-      // Release:		VS2010 gcc(no opt)
-      //		1k:		4000
-      //		2k:		4000
-      //		4k:		3900	21000
-      //		16k:	5200
-      //		32k:	4300
-      //		64k:	4000	21000
-      enum
-      {
+    // This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+    // The test file is large, 170k.
+    // Release:		VS2010 gcc(no opt)
+    //		1k:		4000
+    //		2k:		4000
+    //		4k:		3900	21000
+    //		16k:	5200
+    //		32k:	4300
+    //		64k:	4000	21000
+    enum
+    {
         COUNT = (4 * 1024) / SIZE
-      }; // Some compilers do not accept to use COUNT in private part if COUNT is private
+    };  // Some compilers do not accept to use COUNT in private part if COUNT is private
 
-    private:
-      union Chunk
-      {
-          Chunk* next;
-          char mem[SIZE];
-      };
-      struct Block
-      {
-          Chunk chunk[COUNT];
-      };
-      DynArray<Block*, 10> _blockPtrs;
-      Chunk* _root;
+private:
+    union Chunk {
+        Chunk* next;
+        char mem[SIZE];
+    };
+    struct Block
+    {
+        Chunk chunk[COUNT];
+    };
+    DynArray<Block*, 10> _blockPtrs;
+    Chunk* _root;
 
-      int _currentAllocs;
-      int _nAllocs;
-      int _maxAllocs;
-      int _nUntracked;
-  };
+    int _currentAllocs;
+    int _nAllocs;
+    int _maxAllocs;
+    int _nUntracked;
+};
 
-  /**
+/**
    Implements the interface to the "Visitor pattern" (see the Accept() method.)
    If you call the Accept() method, it requires being passed a XMLVisitor
    class to handle callbacks. For nodes that contain other nodes (Document, Element)
@@ -480,149 +489,147 @@ namespace tinyxml2
 
    @sa XMLNode::Accept()
    */
-  class TINYXML2_LIB XMLVisitor
-  {
-    public:
-      virtual ~XMLVisitor()
-      {
-      }
+class TINYXML2_LIB XMLVisitor
+{
+public:
+    virtual ~XMLVisitor()
+    {
+    }
 
-      /// Visit a document.
-      virtual bool VisitEnter(const XMLDocument& /*doc*/)
-      {
+    /// Visit a document.
+    virtual bool VisitEnter(const XMLDocument& /*doc*/)
+    {
         return true;
-      }
-      /// Visit a document.
-      virtual bool VisitExit(const XMLDocument& /*doc*/)
-      {
+    }
+    /// Visit a document.
+    virtual bool VisitExit(const XMLDocument& /*doc*/)
+    {
         return true;
-      }
+    }
 
-      /// Visit an element.
-      virtual bool VisitEnter(const XMLElement& /*element*/,
-          const XMLAttribute* /*firstAttribute*/)
-      {
+    /// Visit an element.
+    virtual bool VisitEnter(const XMLElement& /*element*/,
+                            const XMLAttribute* /*firstAttribute*/)
+    {
         return true;
-      }
-      /// Visit an element.
-      virtual bool VisitExit(const XMLElement& /*element*/)
-      {
+    }
+    /// Visit an element.
+    virtual bool VisitExit(const XMLElement& /*element*/)
+    {
         return true;
-      }
+    }
 
-      /// Visit a declaration.
-      virtual bool Visit(const XMLDeclaration& /*declaration*/)
-      {
+    /// Visit a declaration.
+    virtual bool Visit(const XMLDeclaration& /*declaration*/)
+    {
         return true;
-      }
-      /// Visit a text node.
-      virtual bool Visit(const XMLText& /*text*/)
-      {
+    }
+    /// Visit a text node.
+    virtual bool Visit(const XMLText& /*text*/)
+    {
         return true;
-      }
-      /// Visit a comment node.
-      virtual bool Visit(const XMLComment& /*comment*/)
-      {
+    }
+    /// Visit a comment node.
+    virtual bool Visit(const XMLComment& /*comment*/)
+    {
         return true;
-      }
-      /// Visit an unknown node.
-      virtual bool Visit(const XMLUnknown& /*unknown*/)
-      {
+    }
+    /// Visit an unknown node.
+    virtual bool Visit(const XMLUnknown& /*unknown*/)
+    {
         return true;
-      }
-  };
+    }
+};
 
-  /*
+/*
    Utility functionality.
    */
-  class XMLUtil
-  {
-    public:
-      // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
-      // correct, but simple, and usually works.
-      static const char* SkipWhiteSpace(const char* p)
-      {
-        while (!IsUTF8Continuation(*p)
-            && isspace(*reinterpret_cast<const unsigned char*>(p)))
+class XMLUtil
+{
+public:
+    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+    // correct, but simple, and usually works.
+    static const char* SkipWhiteSpace(const char* p)
+    {
+        while (!IsUTF8Continuation(*p) && isspace(*reinterpret_cast<const unsigned char*>(p)))
         {
-          ++p;
+            ++p;
         }
         return p;
-      }
-      static char* SkipWhiteSpace(char* p)
-      {
-        while (!IsUTF8Continuation(*p)
-            && isspace(*reinterpret_cast<unsigned char*>(p)))
+    }
+    static char* SkipWhiteSpace(char* p)
+    {
+        while (!IsUTF8Continuation(*p) && isspace(*reinterpret_cast<unsigned char*>(p)))
         {
-          ++p;
+            ++p;
         }
         return p;
-      }
-      static bool IsWhiteSpace(char p)
-      {
+    }
+    static bool IsWhiteSpace(char p)
+    {
         return !IsUTF8Continuation(p) && isspace(static_cast<unsigned char>(p));
-      }
+    }
 
-      inline static bool IsNameStartChar(unsigned char ch)
-      {
+    inline static bool IsNameStartChar(unsigned char ch)
+    {
         return ((ch < 128) ? isalpha(ch) : 1) || ch == ':' || ch == '_';
-      }
+    }
 
-      inline static bool IsNameChar(unsigned char ch)
-      {
+    inline static bool IsNameChar(unsigned char ch)
+    {
         return IsNameStartChar(ch) || isdigit(ch) || ch == '.' || ch == '-';
-      }
+    }
 
-      inline static bool StringEqual(const char* p, const char* q, int nChar =
-          INT_MAX)
-      {
+    inline static bool StringEqual(const char* p, const char* q, int nChar =
+                                                                     INT_MAX)
+    {
         int n = 0;
         if (p == q)
         {
-          return true;
+            return true;
         }
         while (*p && *q && *p == *q && n < nChar)
         {
-          ++p;
-          ++q;
-          ++n;
+            ++p;
+            ++q;
+            ++n;
         }
         if ((n == nChar) || (*p == 0 && *q == 0))
         {
-          return true;
+            return true;
         }
         return false;
-      }
+    }
 
-      inline static int IsUTF8Continuation(const char p)
-      {
+    inline static int IsUTF8Continuation(const char p)
+    {
         return p & 0x80;
-      }
+    }
 
-      static const char* ReadBOM(const char* p, bool* hasBOM);
-      // p is the starting location,
-      // the UTF-8 value of the entity will be placed in value, and length filled in.
-      static const char* GetCharacterRef(const char* p, char* value,
-          int* length);
-      static void ConvertUTF32ToUTF8(unsigned long input, char* output,
-          int* length);
+    static const char* ReadBOM(const char* p, bool* hasBOM);
+    // p is the starting location,
+    // the UTF-8 value of the entity will be placed in value, and length filled in.
+    static const char* GetCharacterRef(const char* p, char* value,
+                                       int* length);
+    static void ConvertUTF32ToUTF8(unsigned long input, char* output,
+                                   int* length);
 
-      // converts primitive types to strings
-      static void ToStr(int v, char* buffer, int bufferSize);
-      static void ToStr(unsigned v, char* buffer, int bufferSize);
-      static void ToStr(bool v, char* buffer, int bufferSize);
-      static void ToStr(float v, char* buffer, int bufferSize);
-      static void ToStr(double v, char* buffer, int bufferSize);
+    // converts primitive types to strings
+    static void ToStr(int v, char* buffer, int bufferSize);
+    static void ToStr(unsigned v, char* buffer, int bufferSize);
+    static void ToStr(bool v, char* buffer, int bufferSize);
+    static void ToStr(float v, char* buffer, int bufferSize);
+    static void ToStr(double v, char* buffer, int bufferSize);
 
-      // converts strings to primitive types
-      static bool ToInt(const char* str, int* value);
-      static bool ToUnsigned(const char* str, unsigned* value);
-      static bool ToBool(const char* str, bool* value);
-      static bool ToFloat(const char* str, float* value);
-      static bool ToDouble(const char* str, double* value);
-  };
+    // converts strings to primitive types
+    static bool ToInt(const char* str, int* value);
+    static bool ToUnsigned(const char* str, unsigned* value);
+    static bool ToBool(const char* str, bool* value);
+    static bool ToFloat(const char* str, float* value);
+    static bool ToDouble(const char* str, double* value);
+};
 
-  /** XMLNode is a base class for every object that is in the
+/** XMLNode is a base class for every object that is in the
    XML Document Object Model (DOM), except XMLAttributes.
    Nodes have siblings, a parent, and children which can
    be navigated. A node is always in a XMLDocument.
@@ -647,80 +654,80 @@ namespace tinyxml2
 
    @endverbatim
    */
-  class TINYXML2_LIB XMLNode
-  {
-      friend class XMLDocument;
-      friend class XMLElement;
-    public:
+class TINYXML2_LIB XMLNode
+{
+    friend class XMLDocument;
+    friend class XMLElement;
 
-      /// Get the XMLDocument that owns this XMLNode.
-      const XMLDocument* GetDocument() const
-      {
+public:
+    /// Get the XMLDocument that owns this XMLNode.
+    const XMLDocument* GetDocument() const
+    {
         return _document;
-      }
-      /// Get the XMLDocument that owns this XMLNode.
-      XMLDocument* GetDocument()
-      {
+    }
+    /// Get the XMLDocument that owns this XMLNode.
+    XMLDocument* GetDocument()
+    {
         return _document;
-      }
+    }
 
-      /// Safely cast to an Element, or null.
-      virtual XMLElement* ToElement()
-      {
+    /// Safely cast to an Element, or null.
+    virtual XMLElement* ToElement()
+    {
         return 0;
-      }
-      /// Safely cast to Text, or null.
-      virtual XMLText* ToText()
-      {
+    }
+    /// Safely cast to Text, or null.
+    virtual XMLText* ToText()
+    {
         return 0;
-      }
-      /// Safely cast to a Comment, or null.
-      virtual XMLComment* ToComment()
-      {
+    }
+    /// Safely cast to a Comment, or null.
+    virtual XMLComment* ToComment()
+    {
         return 0;
-      }
-      /// Safely cast to a Document, or null.
-      virtual XMLDocument* ToDocument()
-      {
+    }
+    /// Safely cast to a Document, or null.
+    virtual XMLDocument* ToDocument()
+    {
         return 0;
-      }
-      /// Safely cast to a Declaration, or null.
-      virtual XMLDeclaration* ToDeclaration()
-      {
+    }
+    /// Safely cast to a Declaration, or null.
+    virtual XMLDeclaration* ToDeclaration()
+    {
         return 0;
-      }
-      /// Safely cast to an Unknown, or null.
-      virtual XMLUnknown* ToUnknown()
-      {
+    }
+    /// Safely cast to an Unknown, or null.
+    virtual XMLUnknown* ToUnknown()
+    {
         return 0;
-      }
+    }
 
-      virtual const XMLElement* ToElement() const
-      {
+    virtual const XMLElement* ToElement() const
+    {
         return 0;
-      }
-      virtual const XMLText* ToText() const
-      {
+    }
+    virtual const XMLText* ToText() const
+    {
         return 0;
-      }
-      virtual const XMLComment* ToComment() const
-      {
+    }
+    virtual const XMLComment* ToComment() const
+    {
         return 0;
-      }
-      virtual const XMLDocument* ToDocument() const
-      {
+    }
+    virtual const XMLDocument* ToDocument() const
+    {
         return 0;
-      }
-      virtual const XMLDeclaration* ToDeclaration() const
-      {
+    }
+    virtual const XMLDeclaration* ToDeclaration() const
+    {
         return 0;
-      }
-      virtual const XMLUnknown* ToUnknown() const
-      {
+    }
+    virtual const XMLUnknown* ToUnknown() const
+    {
         return 0;
-      }
+    }
 
-      /** The meaning of 'value' changes for the specific type.
+    /** The meaning of 'value' changes for the specific type.
        @verbatim
        Document:	empty
        Element:	name of the element
@@ -729,136 +736,136 @@ namespace tinyxml2
        Text:		the text string
        @endverbatim
        */
-      const char* Value() const;
+    const char* Value() const;
 
-      /** Set the Value of an XML node.
+    /** Set the Value of an XML node.
        @sa Value()
        */
-      void SetValue(const char* val, bool staticMem = false);
+    void SetValue(const char* val, bool staticMem = false);
 
-      /// Get the parent of this node on the DOM.
-      const XMLNode* Parent() const
-      {
+    /// Get the parent of this node on the DOM.
+    const XMLNode* Parent() const
+    {
         return _parent;
-      }
+    }
 
-      XMLNode* Parent()
-      {
+    XMLNode* Parent()
+    {
         return _parent;
-      }
+    }
 
-      /// Returns true if this node has no children.
-      bool NoChildren() const
-      {
+    /// Returns true if this node has no children.
+    bool NoChildren() const
+    {
         return !_firstChild;
-      }
+    }
 
-      /// Get the first child node, or null if none exists.
-      const XMLNode* FirstChild() const
-      {
+    /// Get the first child node, or null if none exists.
+    const XMLNode* FirstChild() const
+    {
         return _firstChild;
-      }
+    }
 
-      XMLNode* FirstChild()
-      {
+    XMLNode* FirstChild()
+    {
         return _firstChild;
-      }
+    }
 
-      /** Get the first child element, or optionally the first child
+    /** Get the first child element, or optionally the first child
        element with the specified name.
        */
-      const XMLElement* FirstChildElement(const char* value = 0) const;
+    const XMLElement* FirstChildElement(const char* value = 0) const;
 
-      XMLElement* FirstChildElement(const char* value = 0)
-      {
+    XMLElement* FirstChildElement(const char* value = 0)
+    {
         return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement(
             value));
-      }
+    }
 
-      /// Get the last child node, or null if none exists.
-      const XMLNode* LastChild() const
-      {
+    /// Get the last child node, or null if none exists.
+    const XMLNode* LastChild() const
+    {
         return _lastChild;
-      }
+    }
 
-      XMLNode* LastChild()
-      {
+    XMLNode* LastChild()
+    {
         return const_cast<XMLNode*>(const_cast<const XMLNode*>(this)->LastChild());
-      }
+    }
 
-      /** Get the last child element or optionally the last child
+    /** Get the last child element or optionally the last child
        element with the specified name.
        */
-      const XMLElement* LastChildElement(const char* value = 0) const;
+    const XMLElement* LastChildElement(const char* value = 0) const;
 
-      XMLElement* LastChildElement(const char* value = 0)
-      {
+    XMLElement* LastChildElement(const char* value = 0)
+    {
         return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(
             value));
-      }
+    }
 
-      /// Get the previous (left) sibling node of this node.
-      const XMLNode* PreviousSibling() const
-      {
+    /// Get the previous (left) sibling node of this node.
+    const XMLNode* PreviousSibling() const
+    {
         return _prev;
-      }
+    }
 
-      XMLNode* PreviousSibling()
-      {
+    XMLNode* PreviousSibling()
+    {
         return _prev;
-      }
+    }
 
-      /// Get the previous (left) sibling element of this node, with an optionally supplied name.
-      const XMLElement* PreviousSiblingElement(const char* value = 0) const;
+    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+    const XMLElement* PreviousSiblingElement(const char* value = 0) const;
 
-      XMLElement* PreviousSiblingElement(const char* value = 0)
-      {
+    XMLElement* PreviousSiblingElement(const char* value = 0)
+    {
         return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement(
             value));
-      }
+    }
 
-      /// Get the next (right) sibling node of this node.
-      const XMLNode* NextSibling() const
-      {
+    /// Get the next (right) sibling node of this node.
+    const XMLNode* NextSibling() const
+    {
         return _next;
-      }
+    }
 
-      XMLNode* NextSibling()
-      {
+    XMLNode* NextSibling()
+    {
         return _next;
-      }
+    }
 
-      /// Get the next (right) sibling element of this node, with an optionally supplied name.
-      const XMLElement* NextSiblingElement(const char* value = 0) const;
+    /// Get the next (right) sibling element of this node, with an optionally supplied name.
+    const XMLElement* NextSiblingElement(const char* value = 0) const;
 
-      XMLElement* NextSiblingElement(const char* value = 0)
-      {
+    XMLElement* NextSiblingElement(const char* value = 0)
+    {
         return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement(
             value));
-      }
+    }
 
-      /**
+    /**
        Add a child node as the last (right) child.
        If the child node is already part of the document,
        it is moved from its old location to the new location.
        Returns the addThis argument or 0 if the node does not
        belong to the same document.
        */
-      XMLNode* InsertEndChild(XMLNode* addThis);
+    XMLNode* InsertEndChild(XMLNode* addThis);
 
-      XMLNode* LinkEndChild(XMLNode* addThis)
-      {
+    XMLNode* LinkEndChild(XMLNode* addThis)
+    {
         return InsertEndChild(addThis);
-      }
-      /**
+    }
+    /**
        Add a child node as the first (left) child.
        If the child node is already part of the document,
        it is moved from its old location to the new location.
        Returns the addThis argument or 0 if the node does not
        belong to the same document.
        */
-      XMLNode* InsertFirstChild(XMLNode* addThis);
-      /**
+    XMLNode* InsertFirstChild(XMLNode* addThis);
+    /**
        Add a node after the specified child node.
        If the child node is already part of the document,
        it is moved from its old location to the new location.
@@ -866,19 +873,19 @@ namespace tinyxml2
        is not a child of this node, or if the node does not
        belong to the same document.
        */
-      XMLNode* InsertAfterChild(XMLNode* afterThis, XMLNode* addThis);
+    XMLNode* InsertAfterChild(XMLNode* afterThis, XMLNode* addThis);
 
-      /**
+    /**
        Delete all the children of this node.
        */
-      void DeleteChildren();
+    void DeleteChildren();
 
-      /**
+    /**
        Delete a child of this node.
        */
-      void DeleteChild(XMLNode* node);
+    void DeleteChild(XMLNode* node);
 
-      /**
+    /**
        Make a copy of this node, but not its children.
        You may pass in a Document pointer that will be
        the owner of the new Node. If the 'document' is
@@ -887,17 +894,17 @@ namespace tinyxml2
 
        Note: if called on a XMLDocument, this will return null.
        */
-      virtual XMLNode* ShallowClone(XMLDocument* document) const = 0;
+    virtual XMLNode* ShallowClone(XMLDocument* document) const = 0;
 
-      /**
+    /**
        Test if 2 nodes are the same, but don't test children.
        The 2 nodes do not need to be in the same Document.
 
        Note: if called on a XMLDocument, this will return false.
        */
-      virtual bool ShallowEqual(const XMLNode* compare) const = 0;
+    virtual bool ShallowEqual(const XMLNode* compare) const = 0;
 
-      /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
        XML tree will be conditionally visited and the host will be called back
        via the XMLVisitor interface.
 
@@ -919,33 +926,33 @@ namespace tinyxml2
        const char* xmlcstr = printer.CStr();
        @endverbatim
        */
-      virtual bool Accept(XMLVisitor* visitor) const = 0;
+    virtual bool Accept(XMLVisitor* visitor) const = 0;
 
-      // internal
-      virtual char* ParseDeep(char*, StrPair*);
+    // internal
+    virtual char* ParseDeep(char*, StrPair*);
 
-    protected:
-      XMLNode(XMLDocument*);
-      virtual ~XMLNode();
-      XMLNode(const XMLNode&);	// not supported
-      XMLNode& operator=(const XMLNode&);	// not supported
+protected:
+    XMLNode(XMLDocument*);
+    virtual ~XMLNode();
+    XMLNode(const XMLNode&);             // not supported
+    XMLNode& operator=(const XMLNode&);  // not supported
 
-      XMLDocument* _document;
-      XMLNode* _parent;
-      mutable StrPair _value;
+    XMLDocument* _document;
+    XMLNode* _parent;
+    mutable StrPair _value;
 
-      XMLNode* _firstChild;
-      XMLNode* _lastChild;
+    XMLNode* _firstChild;
+    XMLNode* _lastChild;
 
-      XMLNode* _prev;
-      XMLNode* _next;
+    XMLNode* _prev;
+    XMLNode* _next;
 
-    private:
-      MemPool* _memPool;
-      void Unlink(XMLNode* child);
-  };
+private:
+    MemPool* _memPool;
+    void Unlink(XMLNode* child);
+};
 
-  /** XML text.
+/** XML text.
 
    Note that a text node can have child element nodes, for example:
    @verbatim
@@ -957,82 +964,84 @@ namespace tinyxml2
    you generally want to leave it alone, but you can change the output mode with
    SetCData() and query it with CData().
    */
-  class TINYXML2_LIB XMLText: public XMLNode
-  {
-      friend class XMLBase;
-      friend class XMLDocument;
-    public:
-      virtual bool Accept(XMLVisitor* visitor) const;
+class TINYXML2_LIB XMLText : public XMLNode
+{
+    friend class XMLBase;
+    friend class XMLDocument;
 
-      virtual XMLText* ToText()
-      {
-        return this;
-      }
-      virtual const XMLText* ToText() const
-      {
-        return this;
-      }
+public:
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      /// Declare whether this should be CDATA or standard text.
-      void SetCData(bool isCData)
-      {
+    virtual XMLText* ToText()
+    {
+        return this;
+    }
+    virtual const XMLText* ToText() const
+    {
+        return this;
+    }
+
+    /// Declare whether this should be CDATA or standard text.
+    void SetCData(bool isCData)
+    {
         _isCData = isCData;
-      }
-      /// Returns true if this is a CDATA text element.
-      bool CData() const
-      {
+    }
+    /// Returns true if this is a CDATA text element.
+    bool CData() const
+    {
         return _isCData;
-      }
+    }
 
-      char* ParseDeep(char*, StrPair* endTag);
-      virtual XMLNode* ShallowClone(XMLDocument* document) const;
-      virtual bool ShallowEqual(const XMLNode* compare) const;
+    char* ParseDeep(char*, StrPair* endTag);
+    virtual XMLNode* ShallowClone(XMLDocument* document) const;
+    virtual bool ShallowEqual(const XMLNode* compare) const;
 
-    protected:
-      XMLText(XMLDocument* doc)
-          : XMLNode(doc), _isCData(false)
-      {
-      }
-      virtual ~XMLText()
-      {
-      }
-      XMLText(const XMLText&);	// not supported
-      XMLText& operator=(const XMLText&);	// not supported
+protected:
+    XMLText(XMLDocument* doc)
+        : XMLNode(doc), _isCData(false)
+    {
+    }
+    virtual ~XMLText()
+    {
+    }
+    XMLText(const XMLText&);             // not supported
+    XMLText& operator=(const XMLText&);  // not supported
 
-    private:
-      bool _isCData;
-  };
+private:
+    bool _isCData;
+};
 
-  /** An XML Comment. */
-  class TINYXML2_LIB XMLComment: public XMLNode
-  {
-      friend class XMLDocument;
-    public:
-      virtual XMLComment* ToComment()
-      {
+/** An XML Comment. */
+class TINYXML2_LIB XMLComment : public XMLNode
+{
+    friend class XMLDocument;
+
+public:
+    virtual XMLComment* ToComment()
+    {
         return this;
-      }
-      virtual const XMLComment* ToComment() const
-      {
+    }
+    virtual const XMLComment* ToComment() const
+    {
         return this;
-      }
+    }
 
-      virtual bool Accept(XMLVisitor* visitor) const;
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      char* ParseDeep(char*, StrPair* endTag);
-      virtual XMLNode* ShallowClone(XMLDocument* document) const;
-      virtual bool ShallowEqual(const XMLNode* compare) const;
+    char* ParseDeep(char*, StrPair* endTag);
+    virtual XMLNode* ShallowClone(XMLDocument* document) const;
+    virtual bool ShallowEqual(const XMLNode* compare) const;
 
-    protected:
-      XMLComment(XMLDocument* doc);
-      virtual ~XMLComment();
-      XMLComment(const XMLComment&);	// not supported
-      XMLComment& operator=(const XMLComment&);	// not supported
+protected:
+    XMLComment(XMLDocument* doc);
+    virtual ~XMLComment();
+    XMLComment(const XMLComment&);             // not supported
+    XMLComment& operator=(const XMLComment&);  // not supported
 
-    private:
-  };
+private:
+};
 
-  /** In correct XML the declaration is the first entry in the file.
+/** In correct XML the declaration is the first entry in the file.
    @verbatim
    <?xml version="1.0" standalone="yes"?>
    @endverbatim
@@ -1043,67 +1052,69 @@ namespace tinyxml2
    The text of the declaration isn't interpreted. It is parsed
    and written as a string.
    */
-  class TINYXML2_LIB XMLDeclaration: public XMLNode
-  {
-      friend class XMLDocument;
-    public:
-      virtual XMLDeclaration* ToDeclaration()
-      {
+class TINYXML2_LIB XMLDeclaration : public XMLNode
+{
+    friend class XMLDocument;
+
+public:
+    virtual XMLDeclaration* ToDeclaration()
+    {
         return this;
-      }
-      virtual const XMLDeclaration* ToDeclaration() const
-      {
+    }
+    virtual const XMLDeclaration* ToDeclaration() const
+    {
         return this;
-      }
+    }
 
-      virtual bool Accept(XMLVisitor* visitor) const;
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      char* ParseDeep(char*, StrPair* endTag);
-      virtual XMLNode* ShallowClone(XMLDocument* document) const;
-      virtual bool ShallowEqual(const XMLNode* compare) const;
+    char* ParseDeep(char*, StrPair* endTag);
+    virtual XMLNode* ShallowClone(XMLDocument* document) const;
+    virtual bool ShallowEqual(const XMLNode* compare) const;
 
-    protected:
-      XMLDeclaration(XMLDocument* doc);
-      virtual ~XMLDeclaration();
-      XMLDeclaration(const XMLDeclaration&);	// not supported
-      XMLDeclaration& operator=(const XMLDeclaration&);	// not supported
-  };
+protected:
+    XMLDeclaration(XMLDocument* doc);
+    virtual ~XMLDeclaration();
+    XMLDeclaration(const XMLDeclaration&);             // not supported
+    XMLDeclaration& operator=(const XMLDeclaration&);  // not supported
+};
 
-  /** Any tag that TinyXML-2 doesn't recognize is saved as an
+/** Any tag that TinyXML-2 doesn't recognize is saved as an
    unknown. It is a tag of text, but should not be modified.
    It will be written back to the XML, unchanged, when the file
    is saved.
 
    DTD tags get thrown into XMLUnknowns.
    */
-  class TINYXML2_LIB XMLUnknown: public XMLNode
-  {
-      friend class XMLDocument;
-    public:
-      virtual XMLUnknown* ToUnknown()
-      {
+class TINYXML2_LIB XMLUnknown : public XMLNode
+{
+    friend class XMLDocument;
+
+public:
+    virtual XMLUnknown* ToUnknown()
+    {
         return this;
-      }
-      virtual const XMLUnknown* ToUnknown() const
-      {
+    }
+    virtual const XMLUnknown* ToUnknown() const
+    {
         return this;
-      }
+    }
 
-      virtual bool Accept(XMLVisitor* visitor) const;
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      char* ParseDeep(char*, StrPair* endTag);
-      virtual XMLNode* ShallowClone(XMLDocument* document) const;
-      virtual bool ShallowEqual(const XMLNode* compare) const;
+    char* ParseDeep(char*, StrPair* endTag);
+    virtual XMLNode* ShallowClone(XMLDocument* document) const;
+    virtual bool ShallowEqual(const XMLNode* compare) const;
 
-    protected:
-      XMLUnknown(XMLDocument* doc);
-      virtual ~XMLUnknown();
-      XMLUnknown(const XMLUnknown&);	// not supported
-      XMLUnknown& operator=(const XMLUnknown&);	// not supported
-  };
+protected:
+    XMLUnknown(XMLDocument* doc);
+    virtual ~XMLUnknown();
+    XMLUnknown(const XMLUnknown&);             // not supported
+    XMLUnknown& operator=(const XMLUnknown&);  // not supported
+};
 
-  enum XMLError
-  {
+enum XMLError
+{
     XML_NO_ERROR = 0,
     XML_SUCCESS = 0,
 
@@ -1128,153 +1139,155 @@ namespace tinyxml2
 
     XML_CAN_NOT_CONVERT_TEXT,
     XML_NO_TEXT_NODE
-  };
+};
 
-  /** An attribute is a name-value pair. Elements have an arbitrary
+/** An attribute is a name-value pair. Elements have an arbitrary
    number of attributes, each with a unique name.
 
    @note The attributes are not XMLNodes. You may only query the
    Next() attribute in a list.
    */
-  class TINYXML2_LIB XMLAttribute
-  {
-      friend class XMLElement;
-    public:
-      /// The name of the attribute.
-      const char* Name() const;
+class TINYXML2_LIB XMLAttribute
+{
+    friend class XMLElement;
 
-      /// The value of the attribute.
-      const char* Value() const;
+public:
+    /// The name of the attribute.
+    const char* Name() const;
 
-      /// The next attribute in the list.
-      const XMLAttribute* Next() const
-      {
+    /// The value of the attribute.
+    const char* Value() const;
+
+    /// The next attribute in the list.
+    const XMLAttribute* Next() const
+    {
         return _next;
-      }
+    }
 
-      /** IntValue interprets the attribute as an integer, and returns the value.
+    /** IntValue interprets the attribute as an integer, and returns the value.
        If the value isn't an integer, 0 will be returned. There is no error checking;
        use QueryIntValue() if you need error checking.
        */
-      int IntValue() const
-      {
+    int IntValue() const
+    {
         int i = 0;
         QueryIntValue(&i);
         return i;
-      }
-      /// Query as an unsigned integer. See IntValue()
-      unsigned UnsignedValue() const
-      {
+    }
+    /// Query as an unsigned integer. See IntValue()
+    unsigned UnsignedValue() const
+    {
         unsigned i = 0;
         QueryUnsignedValue(&i);
         return i;
-      }
-      /// Query as a boolean. See IntValue()
-      bool BoolValue() const
-      {
+    }
+    /// Query as a boolean. See IntValue()
+    bool BoolValue() const
+    {
         bool b = false;
         QueryBoolValue(&b);
         return b;
-      }
-      /// Query as a double. See IntValue()
-      double DoubleValue() const
-      {
+    }
+    /// Query as a double. See IntValue()
+    double DoubleValue() const
+    {
         double d = 0;
         QueryDoubleValue(&d);
         return d;
-      }
-      /// Query as a float. See IntValue()
-      float FloatValue() const
-      {
+    }
+    /// Query as a float. See IntValue()
+    float FloatValue() const
+    {
         float f = 0;
         QueryFloatValue(&f);
         return f;
-      }
+    }
 
-      /** QueryIntValue interprets the attribute as an integer, and returns the value
+    /** QueryIntValue interprets the attribute as an integer, and returns the value
        in the provided parameter. The function will return XML_NO_ERROR on success,
        and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
        */
-      XMLError QueryIntValue(int* value) const;
-      /// See QueryIntValue
-      XMLError QueryUnsignedValue(unsigned int* value) const;
-      /// See QueryIntValue
-      XMLError QueryBoolValue(bool* value) const;
-      /// See QueryIntValue
-      XMLError QueryDoubleValue(double* value) const;
-      /// See QueryIntValue
-      XMLError QueryFloatValue(float* value) const;
+    XMLError QueryIntValue(int* value) const;
+    /// See QueryIntValue
+    XMLError QueryUnsignedValue(unsigned int* value) const;
+    /// See QueryIntValue
+    XMLError QueryBoolValue(bool* value) const;
+    /// See QueryIntValue
+    XMLError QueryDoubleValue(double* value) const;
+    /// See QueryIntValue
+    XMLError QueryFloatValue(float* value) const;
 
-      /// Set the attribute to a string value.
-      void SetAttribute(const char* value);
-      /// Set the attribute to value.
-      void SetAttribute(int value);
-      /// Set the attribute to value.
-      void SetAttribute(unsigned value);
-      /// Set the attribute to value.
-      void SetAttribute(bool value);
-      /// Set the attribute to value.
-      void SetAttribute(double value);
-      /// Set the attribute to value.
-      void SetAttribute(float value);
+    /// Set the attribute to a string value.
+    void SetAttribute(const char* value);
+    /// Set the attribute to value.
+    void SetAttribute(int value);
+    /// Set the attribute to value.
+    void SetAttribute(unsigned value);
+    /// Set the attribute to value.
+    void SetAttribute(bool value);
+    /// Set the attribute to value.
+    void SetAttribute(double value);
+    /// Set the attribute to value.
+    void SetAttribute(float value);
 
-    private:
-      enum
-      {
+private:
+    enum
+    {
         BUF_SIZE = 200
-      };
+    };
 
-      XMLAttribute()
-          : _next(0), _memPool(0)
-      {
-      }
-      virtual ~XMLAttribute()
-      {
-      }
+    XMLAttribute()
+        : _next(0), _memPool(0)
+    {
+    }
+    virtual ~XMLAttribute()
+    {
+    }
 
-      XMLAttribute(const XMLAttribute&);	// not supported
-      void operator=(const XMLAttribute&);	// not supported
-      void SetName(const char* name);
+    XMLAttribute(const XMLAttribute&);    // not supported
+    void operator=(const XMLAttribute&);  // not supported
+    void SetName(const char* name);
 
-      char* ParseDeep(char* p, bool processEntities);
+    char* ParseDeep(char* p, bool processEntities);
 
-      mutable StrPair _name;
-      mutable StrPair _value;
-      XMLAttribute* _next;
-      MemPool* _memPool;
-  };
+    mutable StrPair _name;
+    mutable StrPair _value;
+    XMLAttribute* _next;
+    MemPool* _memPool;
+};
 
-  /** The element is a container class. It has a value, the element name,
+/** The element is a container class. It has a value, the element name,
    and can contain other elements, text, comments, and unknowns.
    Elements also contain an arbitrary number of attributes.
    */
-  class TINYXML2_LIB XMLElement: public XMLNode
-  {
-      friend class XMLBase;
-      friend class XMLDocument;
-    public:
-      /// Get the name of an element (which is the Value() of the node.)
-      const char* Name() const
-      {
+class TINYXML2_LIB XMLElement : public XMLNode
+{
+    friend class XMLBase;
+    friend class XMLDocument;
+
+public:
+    /// Get the name of an element (which is the Value() of the node.)
+    const char* Name() const
+    {
         return Value();
-      }
-      /// Set the name of the element.
-      void SetName(const char* str, bool staticMem = false)
-      {
+    }
+    /// Set the name of the element.
+    void SetName(const char* str, bool staticMem = false)
+    {
         SetValue(str, staticMem);
-      }
+    }
 
-      virtual XMLElement* ToElement()
-      {
+    virtual XMLElement* ToElement()
+    {
         return this;
-      }
-      virtual const XMLElement* ToElement() const
-      {
+    }
+    virtual const XMLElement* ToElement() const
+    {
         return this;
-      }
-      virtual bool Accept(XMLVisitor* visitor) const;
+    }
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      /** Given an attribute name, Attribute() returns the value
+    /** Given an attribute name, Attribute() returns the value
        for the attribute of that name, or null if none
        exists. For example:
 
@@ -1297,49 +1310,49 @@ namespace tinyxml2
        }
        @endverbatim
        */
-      const char* Attribute(const char* name, const char* value = 0) const;
+    const char* Attribute(const char* name, const char* value = 0) const;
 
-      /** Given an attribute name, IntAttribute() returns the value
+    /** Given an attribute name, IntAttribute() returns the value
        of the attribute interpreted as an integer. 0 will be
        returned if there is an error. For a method with error
        checking, see QueryIntAttribute()
        */
-      int IntAttribute(const char* name) const
-      {
+    int IntAttribute(const char* name) const
+    {
         int i = 0;
         QueryIntAttribute(name, &i);
         return i;
-      }
-      /// See IntAttribute()
-      unsigned UnsignedAttribute(const char* name) const
-      {
+    }
+    /// See IntAttribute()
+    unsigned UnsignedAttribute(const char* name) const
+    {
         unsigned i = 0;
         QueryUnsignedAttribute(name, &i);
         return i;
-      }
-      /// See IntAttribute()
-      bool BoolAttribute(const char* name) const
-      {
+    }
+    /// See IntAttribute()
+    bool BoolAttribute(const char* name) const
+    {
         bool b = false;
         QueryBoolAttribute(name, &b);
         return b;
-      }
-      /// See IntAttribute()
-      double DoubleAttribute(const char* name) const
-      {
+    }
+    /// See IntAttribute()
+    double DoubleAttribute(const char* name) const
+    {
         double d = 0;
         QueryDoubleAttribute(name, &d);
         return d;
-      }
-      /// See IntAttribute()
-      float FloatAttribute(const char* name) const
-      {
+    }
+    /// See IntAttribute()
+    float FloatAttribute(const char* name) const
+    {
         float f = 0;
         QueryFloatAttribute(name, &f);
         return f;
-      }
+    }
 
-      /** Given an attribute name, QueryIntAttribute() returns
+    /** Given an attribute name, QueryIntAttribute() returns
        XML_NO_ERROR, XML_WRONG_ATTRIBUTE_TYPE if the conversion
        can't be performed, or XML_NO_ATTRIBUTE if the attribute
        doesn't exist. If successful, the result of the conversion
@@ -1352,58 +1365,58 @@ namespace tinyxml2
        QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
        @endverbatim
        */
-      XMLError QueryIntAttribute(const char* name, int* value) const
-      {
+    XMLError QueryIntAttribute(const char* name, int* value) const
+    {
         const XMLAttribute* a = FindAttribute(name);
         if (!a)
         {
-          return XML_NO_ATTRIBUTE;
+            return XML_NO_ATTRIBUTE;
         }
         return a->QueryIntValue(value);
-      }
-      /// See QueryIntAttribute()
-      XMLError QueryUnsignedAttribute(const char* name,
-          unsigned int* value) const
-      {
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryUnsignedAttribute(const char* name,
+                                    unsigned int* value) const
+    {
         const XMLAttribute* a = FindAttribute(name);
         if (!a)
         {
-          return XML_NO_ATTRIBUTE;
+            return XML_NO_ATTRIBUTE;
         }
         return a->QueryUnsignedValue(value);
-      }
-      /// See QueryIntAttribute()
-      XMLError QueryBoolAttribute(const char* name, bool* value) const
-      {
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryBoolAttribute(const char* name, bool* value) const
+    {
         const XMLAttribute* a = FindAttribute(name);
         if (!a)
         {
-          return XML_NO_ATTRIBUTE;
+            return XML_NO_ATTRIBUTE;
         }
         return a->QueryBoolValue(value);
-      }
-      /// See QueryIntAttribute()
-      XMLError QueryDoubleAttribute(const char* name, double* value) const
-      {
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryDoubleAttribute(const char* name, double* value) const
+    {
         const XMLAttribute* a = FindAttribute(name);
         if (!a)
         {
-          return XML_NO_ATTRIBUTE;
+            return XML_NO_ATTRIBUTE;
         }
         return a->QueryDoubleValue(value);
-      }
-      /// See QueryIntAttribute()
-      XMLError QueryFloatAttribute(const char* name, float* value) const
-      {
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryFloatAttribute(const char* name, float* value) const
+    {
         const XMLAttribute* a = FindAttribute(name);
         if (!a)
         {
-          return XML_NO_ATTRIBUTE;
+            return XML_NO_ATTRIBUTE;
         }
         return a->QueryFloatValue(value);
-      }
+    }
 
-      /** Given an attribute name, QueryAttribute() returns
+    /** Given an attribute name, QueryAttribute() returns
        XML_NO_ERROR, XML_WRONG_ATTRIBUTE_TYPE if the conversion
        can't be performed, or XML_NO_ATTRIBUTE if the attribute
        doesn't exist. It is overloaded for the primitive types,
@@ -1420,82 +1433,82 @@ namespace tinyxml2
        QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
        @endverbatim
        */
-      int QueryAttribute(const char* name, int* value) const
-      {
+    int QueryAttribute(const char* name, int* value) const
+    {
         return QueryIntAttribute(name, value);
-      }
+    }
 
-      int QueryAttribute(const char* name, unsigned int* value) const
-      {
+    int QueryAttribute(const char* name, unsigned int* value) const
+    {
         return QueryUnsignedAttribute(name, value);
-      }
+    }
 
-      int QueryAttribute(const char* name, bool* value) const
-      {
+    int QueryAttribute(const char* name, bool* value) const
+    {
         return QueryBoolAttribute(name, value);
-      }
+    }
 
-      int QueryAttribute(const char* name, double* value) const
-      {
+    int QueryAttribute(const char* name, double* value) const
+    {
         return QueryDoubleAttribute(name, value);
-      }
+    }
 
-      int QueryAttribute(const char* name, float* value) const
-      {
+    int QueryAttribute(const char* name, float* value) const
+    {
         return QueryFloatAttribute(name, value);
-      }
+    }
 
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, const char* value)
-      {
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, const char* value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, int value)
-      {
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, int value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, unsigned value)
-      {
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, unsigned value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, bool value)
-      {
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, bool value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, double value)
-      {
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, double value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
-      /// Sets the named attribute to value.
-      void SetAttribute(const char* name, float value)
-      {
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, float value)
+    {
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
-      }
+    }
 
-      /**
+    /**
        Delete an attribute.
        */
-      void DeleteAttribute(const char* name);
+    void DeleteAttribute(const char* name);
 
-      /// Return the first attribute in the list.
-      const XMLAttribute* FirstAttribute() const
-      {
+    /// Return the first attribute in the list.
+    const XMLAttribute* FirstAttribute() const
+    {
         return _rootAttribute;
-      }
-      /// Query a specific attribute in the list.
-      const XMLAttribute* FindAttribute(const char* name) const;
+    }
+    /// Query a specific attribute in the list.
+    const XMLAttribute* FindAttribute(const char* name) const;
 
-      /** Convenience function for easy access to the text inside an element. Although easy
+    /** Convenience function for easy access to the text inside an element. Although easy
        and concise, GetText() is limited compared to getting the XMLText child
        and accessing it directly.
 
@@ -1523,9 +1536,9 @@ namespace tinyxml2
        @endverbatim
        GetText() will return "This is ".
        */
-      const char* GetText() const;
+    const char* GetText() const;
 
-      /** Convenience function for easy access to the text inside an element. Although easy
+    /** Convenience function for easy access to the text inside an element. Although easy
        and concise, SetText() is limited compared to creating an XMLText child
        and mutating it directly.
 
@@ -1559,19 +1572,19 @@ namespace tinyxml2
        <foo>Hullaballoo!</foo>
        @endverbatim
        */
-      void SetText(const char* inText);
-      /// Convenince method for setting text inside and element. See SetText() for important limitations.
-      void SetText(int value);
-      /// Convenince method for setting text inside and element. See SetText() for important limitations.
-      void SetText(unsigned value);
-      /// Convenince method for setting text inside and element. See SetText() for important limitations.
-      void SetText(bool value);
-      /// Convenince method for setting text inside and element. See SetText() for important limitations.
-      void SetText(double value);
-      /// Convenince method for setting text inside and element. See SetText() for important limitations.
-      void SetText(float value);
+    void SetText(const char* inText);
+    /// Convenince method for setting text inside and element. See SetText() for important limitations.
+    void SetText(int value);
+    /// Convenince method for setting text inside and element. See SetText() for important limitations.
+    void SetText(unsigned value);
+    /// Convenince method for setting text inside and element. See SetText() for important limitations.
+    void SetText(bool value);
+    /// Convenince method for setting text inside and element. See SetText() for important limitations.
+    void SetText(double value);
+    /// Convenince method for setting text inside and element. See SetText() for important limitations.
+    void SetText(float value);
 
-      /**
+    /**
        Convenience method to query the value of a child text node. This is probably best
        shown by example. Given you have a document is this form:
        @verbatim
@@ -1597,82 +1610,84 @@ namespace tinyxml2
        to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
 
        */
-      XMLError QueryIntText(int* ival) const;
-      /// See QueryIntText()
-      XMLError QueryUnsignedText(unsigned* uval) const;
-      /// See QueryIntText()
-      XMLError QueryBoolText(bool* bval) const;
-      /// See QueryIntText()
-      XMLError QueryDoubleText(double* dval) const;
-      /// See QueryIntText()
-      XMLError QueryFloatText(float* fval) const;
+    XMLError QueryIntText(int* ival) const;
+    /// See QueryIntText()
+    XMLError QueryUnsignedText(unsigned* uval) const;
+    /// See QueryIntText()
+    XMLError QueryBoolText(bool* bval) const;
+    /// See QueryIntText()
+    XMLError QueryDoubleText(double* dval) const;
+    /// See QueryIntText()
+    XMLError QueryFloatText(float* fval) const;
 
-      // internal:
-      enum
-      {
-        OPEN,		// <foo>
-        CLOSED,		// <foo/>
-        CLOSING		// </foo>
-      };
-      int ClosingType() const
-      {
+    // internal:
+    enum
+    {
+        OPEN,    // <foo>
+        CLOSED,  // <foo/>
+        CLOSING  // </foo>
+    };
+    int ClosingType() const
+    {
         return _closingType;
-      }
-      char* ParseDeep(char* p, StrPair* endTag);
-      virtual XMLNode* ShallowClone(XMLDocument* document) const;
-      virtual bool ShallowEqual(const XMLNode* compare) const;
+    }
+    char* ParseDeep(char* p, StrPair* endTag);
+    virtual XMLNode* ShallowClone(XMLDocument* document) const;
+    virtual bool ShallowEqual(const XMLNode* compare) const;
 
-    private:
-      XMLElement(XMLDocument* doc);
-      virtual ~XMLElement();
-      XMLElement(const XMLElement&);	// not supported
-      void operator=(const XMLElement&);	// not supported
+private:
+    XMLElement(XMLDocument* doc);
+    virtual ~XMLElement();
+    XMLElement(const XMLElement&);      // not supported
+    void operator=(const XMLElement&);  // not supported
 
-      XMLAttribute* FindAttribute(const char* name);
-      XMLAttribute* FindOrCreateAttribute(const char* name);
-      //void LinkAttribute( XMLAttribute* attrib );
-      char* ParseAttributes(char* p);
+    XMLAttribute* FindAttribute(const char* name);
+    XMLAttribute* FindOrCreateAttribute(const char* name);
+    //void LinkAttribute( XMLAttribute* attrib );
+    char* ParseAttributes(char* p);
 
-      enum
-      {
+    enum
+    {
         BUF_SIZE = 200
-      };
-      int _closingType;
-      // The attribute list is ordered; there is no 'lastAttribute'
-      // because the list needs to be scanned for dupes before adding
-      // a new attribute.
-      XMLAttribute* _rootAttribute;
-  };
+    };
+    int _closingType;
+    // The attribute list is ordered; there is no 'lastAttribute'
+    // because the list needs to be scanned for dupes before adding
+    // a new attribute.
+    XMLAttribute* _rootAttribute;
+};
 
-  enum Whitespace
-  {
-    PRESERVE_WHITESPACE, COLLAPSE_WHITESPACE
-  };
+enum Whitespace
+{
+    PRESERVE_WHITESPACE,
+    COLLAPSE_WHITESPACE
+};
 
-  /** A Document binds together all the functionality.
+/** A Document binds together all the functionality.
    It can be saved, loaded, and printed to the screen.
    All Nodes are connected and allocated to a Document.
    If the Document is deleted, all its Nodes are also deleted.
    */
-  class TINYXML2_LIB XMLDocument: public XMLNode
-  {
-      friend class XMLElement;
-    public:
-      /// constructor
-      XMLDocument(bool processEntities = true,
-          Whitespace = PRESERVE_WHITESPACE);
-      ~XMLDocument();
+class TINYXML2_LIB XMLDocument : public XMLNode
+{
+    friend class XMLElement;
 
-      virtual XMLDocument* ToDocument()
-      {
-        return this;
-      }
-      virtual const XMLDocument* ToDocument() const
-      {
-        return this;
-      }
+public:
+    /// constructor
+    XMLDocument(bool processEntities = true,
+                Whitespace = PRESERVE_WHITESPACE);
+    ~XMLDocument();
 
-      /**
+    virtual XMLDocument* ToDocument()
+    {
+        return this;
+    }
+    virtual const XMLDocument* ToDocument() const
+    {
+        return this;
+    }
+
+    /**
        Parse an XML file from a character string.
        Returns XML_NO_ERROR (0) on success, or
        an errorID.
@@ -1682,76 +1697,76 @@ namespace tinyxml2
        specified, TinyXML-2 will assume 'xml' points to a
        null terminated string.
        */
-      XMLError Parse(const char* xml, size_t nBytes = (size_t) (-1));
+    XMLError Parse(const char* xml, size_t nBytes = (size_t)(-1));
 
-      /**
+    /**
        Load an XML file from disk.
        Returns XML_NO_ERROR (0) on success, or
        an errorID.
        */
-      XMLError LoadFile(const char* filename);
+    XMLError LoadFile(const char* filename);
 
-      /**
+    /**
        Load an XML file from disk. You are responsible
        for providing and closing the FILE*.
 
        Returns XML_NO_ERROR (0) on success, or
        an errorID.
        */
-      XMLError LoadFile(FILE*);
+    XMLError LoadFile(FILE*);
 
-      /**
+    /**
        Save the XML file to disk.
        Returns XML_NO_ERROR (0) on success, or
        an errorID.
        */
-      XMLError SaveFile(const char* filename, bool compact = false);
+    XMLError SaveFile(const char* filename, bool compact = false);
 
-      /**
+    /**
        Save the XML file to disk. You are responsible
        for providing and closing the FILE*.
 
        Returns XML_NO_ERROR (0) on success, or
        an errorID.
        */
-      XMLError SaveFile(FILE* fp, bool compact = false);
+    XMLError SaveFile(FILE* fp, bool compact = false);
 
-      bool ProcessEntities() const
-      {
+    bool ProcessEntities() const
+    {
         return _processEntities;
-      }
-      Whitespace WhitespaceMode() const
-      {
+    }
+    Whitespace WhitespaceMode() const
+    {
         return _whitespace;
-      }
+    }
 
-      /**
+    /**
        Returns true if this document has a leading Byte Order Mark of UTF8.
        */
-      bool HasBOM() const
-      {
+    bool HasBOM() const
+    {
         return _writeBOM;
-      }
-      /** Sets whether to write the BOM when writing the file.
+    }
+    /** Sets whether to write the BOM when writing the file.
        */
-      void SetBOM(bool useBOM)
-      {
+    void SetBOM(bool useBOM)
+    {
         _writeBOM = useBOM;
-      }
+    }
 
-      /** Return the root element of DOM. Equivalent to FirstChildElement().
+    /** Return the root element of DOM. Equivalent to FirstChildElement().
        To get the first node, use FirstChild().
        */
-      XMLElement* RootElement()
-      {
+    XMLElement* RootElement()
+    {
         return FirstChildElement();
-      }
-      const XMLElement* RootElement() const
-      {
+    }
+    const XMLElement* RootElement() const
+    {
         return FirstChildElement();
-      }
+    }
 
-      /** Print the Document. If the Printer is not provided, it will
+    /** Print the Document. If the Printer is not provided, it will
        print to stdout. If you provide Printer, this can print to a file:
        @verbatim
        XMLPrinter printer( fp );
@@ -1765,28 +1780,28 @@ namespace tinyxml2
        // printer.CStr() has a const char* to the XML
        @endverbatim
        */
-      void Print(XMLPrinter* streamer = 0) const;
-      virtual bool Accept(XMLVisitor* visitor) const;
+    void Print(XMLPrinter* streamer = 0) const;
+    virtual bool Accept(XMLVisitor* visitor) const;
 
-      /**
+    /**
        Create a new Element associated with
        this Document. The memory for the Element
        is managed by the Document.
        */
-      XMLElement* NewElement(const char* name);
-      /**
+    XMLElement* NewElement(const char* name);
+    /**
        Create a new Comment associated with
        this Document. The memory for the Comment
        is managed by the Document.
        */
-      XMLComment* NewComment(const char* comment);
-      /**
+    XMLComment* NewComment(const char* comment);
+    /**
        Create a new Text associated with
        this Document. The memory for the Text
        is managed by the Document.
        */
-      XMLText* NewText(const char* text);
-      /**
+    XMLText* NewText(const char* text);
+    /**
        Create a new Declaration associated with
        this Document. The memory for the object
        is managed by the Document.
@@ -1797,82 +1812,82 @@ namespace tinyxml2
        <?xml version="1.0" encoding="UTF-8"?>
        @endverbatim
        */
-      XMLDeclaration* NewDeclaration(const char* text = 0);
-      /**
+    XMLDeclaration* NewDeclaration(const char* text = 0);
+    /**
        Create a new Unknown associated with
        this Document. The memory for the object
        is managed by the Document.
        */
-      XMLUnknown* NewUnknown(const char* text);
+    XMLUnknown* NewUnknown(const char* text);
 
-      /**
+    /**
        Delete a node associated with this document.
        It will be unlinked from the DOM.
        */
-      void DeleteNode(XMLNode* node)
-      {
+    void DeleteNode(XMLNode* node)
+    {
         node->_parent->DeleteChild(node);
-      }
+    }
 
-      void SetError(XMLError error, const char* str1, const char* str2);
+    void SetError(XMLError error, const char* str1, const char* str2);
 
-      /// Return true if there was an error parsing the document.
-      bool Error() const
-      {
+    /// Return true if there was an error parsing the document.
+    bool Error() const
+    {
         return _errorID != XML_NO_ERROR;
-      }
-      /// Return the errorID.
-      XMLError ErrorID() const
-      {
+    }
+    /// Return the errorID.
+    XMLError ErrorID() const
+    {
         return _errorID;
-      }
-      /// Return a possibly helpful diagnostic location or string.
-      const char* GetErrorStr1() const
-      {
+    }
+    /// Return a possibly helpful diagnostic location or string.
+    const char* GetErrorStr1() const
+    {
         return _errorStr1;
-      }
-      /// Return a possibly helpful secondary diagnostic location or string.
-      const char* GetErrorStr2() const
-      {
+    }
+    /// Return a possibly helpful secondary diagnostic location or string.
+    const char* GetErrorStr2() const
+    {
         return _errorStr2;
-      }
-      /// If there is an error, print it to stdout.
-      void PrintError() const;
+    }
+    /// If there is an error, print it to stdout.
+    void PrintError() const;
 
-      /// Clear the document, resetting it to the initial state.
-      void Clear();
+    /// Clear the document, resetting it to the initial state.
+    void Clear();
 
-      // internal
-      char* Identify(char* p, XMLNode** node);
+    // internal
+    char* Identify(char* p, XMLNode** node);
 
-      virtual XMLNode* ShallowClone(XMLDocument* /*document*/) const
-      {
+    virtual XMLNode* ShallowClone(XMLDocument* /*document*/) const
+    {
         return 0;
-      }
-      virtual bool ShallowEqual(const XMLNode* /*compare*/) const
-      {
+    }
+    virtual bool ShallowEqual(const XMLNode* /*compare*/) const
+    {
         return false;
-      }
+    }
 
-    private:
-      XMLDocument(const XMLDocument&);	// not supported
-      void operator=(const XMLDocument&);	// not supported
+private:
+    XMLDocument(const XMLDocument&);     // not supported
+    void operator=(const XMLDocument&);  // not supported
 
-      bool _writeBOM;
-      bool _processEntities;
-      XMLError _errorID;
-      Whitespace _whitespace;
-      const char* _errorStr1;
-      const char* _errorStr2;
-      char* _charBuffer;
+    bool _writeBOM;
+    bool _processEntities;
+    XMLError _errorID;
+    Whitespace _whitespace;
+    const char* _errorStr1;
+    const char* _errorStr2;
+    char* _charBuffer;
 
-      MemPoolT<sizeof(XMLElement)> _elementPool;
-      MemPoolT<sizeof(XMLAttribute)> _attributePool;
-      MemPoolT<sizeof(XMLText)> _textPool;
-      MemPoolT<sizeof(XMLComment)> _commentPool;
-  };
+    MemPoolT<sizeof(XMLElement)> _elementPool;
+    MemPoolT<sizeof(XMLAttribute)> _attributePool;
+    MemPoolT<sizeof(XMLText)> _textPool;
+    MemPoolT<sizeof(XMLComment)> _commentPool;
+};
 
-  /**
+/**
    A XMLHandle is a class that wraps a node pointer with null checks; this is
    an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
    DOM structure. It is a separate utility class.
@@ -1927,187 +1942,187 @@ namespace tinyxml2
 
    See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
    */
-  class TINYXML2_LIB XMLHandle
-  {
-    public:
-      /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
-      XMLHandle(XMLNode* node)
-      {
+class TINYXML2_LIB XMLHandle
+{
+public:
+    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+    XMLHandle(XMLNode* node)
+    {
         _node = node;
-      }
-      /// Create a handle from a node.
-      XMLHandle(XMLNode& node)
-      {
+    }
+    /// Create a handle from a node.
+    XMLHandle(XMLNode& node)
+    {
         _node = &node;
-      }
-      /// Copy constructor
-      XMLHandle(const XMLHandle& ref)
-      {
+    }
+    /// Copy constructor
+    XMLHandle(const XMLHandle& ref)
+    {
         _node = ref._node;
-      }
-      /// Assignment
-      XMLHandle& operator=(const XMLHandle& ref)
-      {
+    }
+    /// Assignment
+    XMLHandle& operator=(const XMLHandle& ref)
+    {
         _node = ref._node;
         return *this;
-      }
+    }
 
-      /// Get the first child of this handle.
-      XMLHandle FirstChild()
-      {
+    /// Get the first child of this handle.
+    XMLHandle FirstChild()
+    {
         return XMLHandle(_node ? _node->FirstChild() : 0);
-      }
-      /// Get the first child element of this handle.
-      XMLHandle FirstChildElement(const char* value = 0)
-      {
+    }
+    /// Get the first child element of this handle.
+    XMLHandle FirstChildElement(const char* value = 0)
+    {
         return XMLHandle(_node ? _node->FirstChildElement(value) : 0);
-      }
-      /// Get the last child of this handle.
-      XMLHandle LastChild()
-      {
+    }
+    /// Get the last child of this handle.
+    XMLHandle LastChild()
+    {
         return XMLHandle(_node ? _node->LastChild() : 0);
-      }
-      /// Get the last child element of this handle.
-      XMLHandle LastChildElement(const char* _value = 0)
-      {
+    }
+    /// Get the last child element of this handle.
+    XMLHandle LastChildElement(const char* _value = 0)
+    {
         return XMLHandle(_node ? _node->LastChildElement(_value) : 0);
-      }
-      /// Get the previous sibling of this handle.
-      XMLHandle PreviousSibling()
-      {
+    }
+    /// Get the previous sibling of this handle.
+    XMLHandle PreviousSibling()
+    {
         return XMLHandle(_node ? _node->PreviousSibling() : 0);
-      }
-      /// Get the previous sibling element of this handle.
-      XMLHandle PreviousSiblingElement(const char* _value = 0)
-      {
+    }
+    /// Get the previous sibling element of this handle.
+    XMLHandle PreviousSiblingElement(const char* _value = 0)
+    {
         return XMLHandle(_node ? _node->PreviousSiblingElement(_value) : 0);
-      }
-      /// Get the next sibling of this handle.
-      XMLHandle NextSibling()
-      {
+    }
+    /// Get the next sibling of this handle.
+    XMLHandle NextSibling()
+    {
         return XMLHandle(_node ? _node->NextSibling() : 0);
-      }
-      /// Get the next sibling element of this handle.
-      XMLHandle NextSiblingElement(const char* _value = 0)
-      {
+    }
+    /// Get the next sibling element of this handle.
+    XMLHandle NextSiblingElement(const char* _value = 0)
+    {
         return XMLHandle(_node ? _node->NextSiblingElement(_value) : 0);
-      }
+    }
 
-      /// Safe cast to XMLNode. This can return null.
-      XMLNode* ToNode()
-      {
+    /// Safe cast to XMLNode. This can return null.
+    XMLNode* ToNode()
+    {
         return _node;
-      }
-      /// Safe cast to XMLElement. This can return null.
-      XMLElement* ToElement()
-      {
+    }
+    /// Safe cast to XMLElement. This can return null.
+    XMLElement* ToElement()
+    {
         return ((_node && _node->ToElement()) ? _node->ToElement() : 0);
-      }
-      /// Safe cast to XMLText. This can return null.
-      XMLText* ToText()
-      {
+    }
+    /// Safe cast to XMLText. This can return null.
+    XMLText* ToText()
+    {
         return ((_node && _node->ToText()) ? _node->ToText() : 0);
-      }
-      /// Safe cast to XMLUnknown. This can return null.
-      XMLUnknown* ToUnknown()
-      {
+    }
+    /// Safe cast to XMLUnknown. This can return null.
+    XMLUnknown* ToUnknown()
+    {
         return ((_node && _node->ToUnknown()) ? _node->ToUnknown() : 0);
-      }
-      /// Safe cast to XMLDeclaration. This can return null.
-      XMLDeclaration* ToDeclaration()
-      {
+    }
+    /// Safe cast to XMLDeclaration. This can return null.
+    XMLDeclaration* ToDeclaration()
+    {
         return ((_node && _node->ToDeclaration()) ? _node->ToDeclaration() : 0);
-      }
+    }
 
-    private:
-      XMLNode* _node;
-  };
+private:
+    XMLNode* _node;
+};
 
-  /**
+/**
    A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
    same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
    */
-  class TINYXML2_LIB XMLConstHandle
-  {
-    public:
-      XMLConstHandle(const XMLNode* node)
-      {
+class TINYXML2_LIB XMLConstHandle
+{
+public:
+    XMLConstHandle(const XMLNode* node)
+    {
         _node = node;
-      }
-      XMLConstHandle(const XMLNode& node)
-      {
+    }
+    XMLConstHandle(const XMLNode& node)
+    {
         _node = &node;
-      }
-      XMLConstHandle(const XMLConstHandle& ref)
-      {
+    }
+    XMLConstHandle(const XMLConstHandle& ref)
+    {
         _node = ref._node;
-      }
+    }
 
-      XMLConstHandle& operator=(const XMLConstHandle& ref)
-      {
+    XMLConstHandle& operator=(const XMLConstHandle& ref)
+    {
         _node = ref._node;
         return *this;
-      }
+    }
 
-      const XMLConstHandle FirstChild() const
-      {
+    const XMLConstHandle FirstChild() const
+    {
         return XMLConstHandle(_node ? _node->FirstChild() : 0);
-      }
-      const XMLConstHandle FirstChildElement(const char* value = 0) const
-      {
+    }
+    const XMLConstHandle FirstChildElement(const char* value = 0) const
+    {
         return XMLConstHandle(_node ? _node->FirstChildElement(value) : 0);
-      }
-      const XMLConstHandle LastChild() const
-      {
+    }
+    const XMLConstHandle LastChild() const
+    {
         return XMLConstHandle(_node ? _node->LastChild() : 0);
-      }
-      const XMLConstHandle LastChildElement(const char* _value = 0) const
-      {
+    }
+    const XMLConstHandle LastChildElement(const char* _value = 0) const
+    {
         return XMLConstHandle(_node ? _node->LastChildElement(_value) : 0);
-      }
-      const XMLConstHandle PreviousSibling() const
-      {
+    }
+    const XMLConstHandle PreviousSibling() const
+    {
         return XMLConstHandle(_node ? _node->PreviousSibling() : 0);
-      }
-      const XMLConstHandle PreviousSiblingElement(const char* _value = 0) const
-      {
+    }
+    const XMLConstHandle PreviousSiblingElement(const char* _value = 0) const
+    {
         return XMLConstHandle(_node ? _node->PreviousSiblingElement(_value) : 0);
-      }
-      const XMLConstHandle NextSibling() const
-      {
+    }
+    const XMLConstHandle NextSibling() const
+    {
         return XMLConstHandle(_node ? _node->NextSibling() : 0);
-      }
-      const XMLConstHandle NextSiblingElement(const char* _value = 0) const
-      {
+    }
+    const XMLConstHandle NextSiblingElement(const char* _value = 0) const
+    {
         return XMLConstHandle(_node ? _node->NextSiblingElement(_value) : 0);
-      }
+    }
 
-      const XMLNode* ToNode() const
-      {
+    const XMLNode* ToNode() const
+    {
         return _node;
-      }
-      const XMLElement* ToElement() const
-      {
+    }
+    const XMLElement* ToElement() const
+    {
         return ((_node && _node->ToElement()) ? _node->ToElement() : 0);
-      }
-      const XMLText* ToText() const
-      {
+    }
+    const XMLText* ToText() const
+    {
         return ((_node && _node->ToText()) ? _node->ToText() : 0);
-      }
-      const XMLUnknown* ToUnknown() const
-      {
+    }
+    const XMLUnknown* ToUnknown() const
+    {
         return ((_node && _node->ToUnknown()) ? _node->ToUnknown() : 0);
-      }
-      const XMLDeclaration* ToDeclaration() const
-      {
+    }
+    const XMLDeclaration* ToDeclaration() const
+    {
         return ((_node && _node->ToDeclaration()) ? _node->ToDeclaration() : 0);
-      }
+    }
 
-    private:
-      const XMLNode* _node;
-  };
+private:
+    const XMLNode* _node;
+};
 
-  /**
+/**
    Printing functionality. The XMLPrinter gives you more
    options than the XMLDocument::Print() method.
 
@@ -2149,130 +2164,131 @@ namespace tinyxml2
    printer.CloseElement();
    @endverbatim
    */
-  class TINYXML2_LIB XMLPrinter: public XMLVisitor
-  {
-    public:
-      /** Construct the printer. If the FILE* is specified,
+class TINYXML2_LIB XMLPrinter : public XMLVisitor
+{
+public:
+    /** Construct the printer. If the FILE* is specified,
        this will print to the FILE. Else it will print
        to memory, and the result is available in CStr().
        If 'compact' is set to true, then output is created
        with only required whitespace and newlines.
        */
-      XMLPrinter(FILE* file = 0, bool compact = false, int depth = 0);
-      virtual ~XMLPrinter()
-      {
-      }
+    XMLPrinter(FILE* file = 0, bool compact = false, int depth = 0);
+    virtual ~XMLPrinter()
+    {
+    }
 
-      /** If streaming, write the BOM and declaration. */
-      void PushHeader(bool writeBOM, bool writeDeclaration);
-      /** If streaming, start writing an element.
+    /** If streaming, write the BOM and declaration. */
+    void PushHeader(bool writeBOM, bool writeDeclaration);
+    /** If streaming, start writing an element.
        The element must be closed with CloseElement()
        */
-      void OpenElement(const char* name);
-      /// If streaming, add an attribute to an open element.
-      void PushAttribute(const char* name, const char* value);
-      void PushAttribute(const char* name, int value);
-      void PushAttribute(const char* name, unsigned value);
-      void PushAttribute(const char* name, bool value);
-      void PushAttribute(const char* name, double value);
-      /// If streaming, close the Element.
-      virtual void CloseElement();
+    void OpenElement(const char* name);
+    /// If streaming, add an attribute to an open element.
+    void PushAttribute(const char* name, const char* value);
+    void PushAttribute(const char* name, int value);
+    void PushAttribute(const char* name, unsigned value);
+    void PushAttribute(const char* name, bool value);
+    void PushAttribute(const char* name, double value);
+    /// If streaming, close the Element.
+    virtual void CloseElement();
 
-      /// Add a text node.
-      void PushText(const char* text, bool cdata = false);
-      /// Add a text node from an integer.
-      void PushText(int value);
-      /// Add a text node from an unsigned.
-      void PushText(unsigned value);
-      /// Add a text node from a bool.
-      void PushText(bool value);
-      /// Add a text node from a float.
-      void PushText(float value);
-      /// Add a text node from a double.
-      void PushText(double value);
+    /// Add a text node.
+    void PushText(const char* text, bool cdata = false);
+    /// Add a text node from an integer.
+    void PushText(int value);
+    /// Add a text node from an unsigned.
+    void PushText(unsigned value);
+    /// Add a text node from a bool.
+    void PushText(bool value);
+    /// Add a text node from a float.
+    void PushText(float value);
+    /// Add a text node from a double.
+    void PushText(double value);
 
-      /// Add a comment
-      void PushComment(const char* comment);
+    /// Add a comment
+    void PushComment(const char* comment);
 
-      void PushDeclaration(const char* value);
-      void PushUnknown(const char* value);
+    void PushDeclaration(const char* value);
+    void PushUnknown(const char* value);
 
-      virtual bool VisitEnter(const XMLDocument& /*doc*/);
-      virtual bool VisitExit(const XMLDocument& /*doc*/)
-      {
+    virtual bool VisitEnter(const XMLDocument& /*doc*/);
+    virtual bool VisitExit(const XMLDocument& /*doc*/)
+    {
         return true;
-      }
+    }
 
-      virtual bool VisitEnter(const XMLElement& element,
-          const XMLAttribute* attribute);
-      virtual bool VisitExit(const XMLElement& element);
+    virtual bool VisitEnter(const XMLElement& element,
+                            const XMLAttribute* attribute);
+    virtual bool VisitExit(const XMLElement& element);
 
-      virtual bool Visit(const XMLText& text);
-      virtual bool Visit(const XMLComment& comment);
-      virtual bool Visit(const XMLDeclaration& declaration);
-      virtual bool Visit(const XMLUnknown& unknown);
+    virtual bool Visit(const XMLText& text);
+    virtual bool Visit(const XMLComment& comment);
+    virtual bool Visit(const XMLDeclaration& declaration);
+    virtual bool Visit(const XMLUnknown& unknown);
 
-      /**
+    /**
        If in print to memory mode, return a pointer to
        the XML file in memory.
        */
-      const char* CStr() const
-      {
+    const char* CStr() const
+    {
         return _buffer.Mem();
-      }
-      /**
+    }
+    /**
        If in print to memory mode, return the size
        of the XML file in memory. (Note the size returned
        includes the terminating null.)
        */
-      int CStrSize() const
-      {
+    int CStrSize() const
+    {
         return _buffer.Size();
-      }
-      /**
+    }
+    /**
        If in print to memory mode, reset the buffer to the
        beginning.
        */
-      void ClearBuffer()
-      {
+    void ClearBuffer()
+    {
         _buffer.Clear();
         _buffer.Push(0);
-      }
+    }
 
-    protected:
-      void SealElement();
-      bool _elementJustOpened;
-      DynArray<const char*, 10> _stack;
+protected:
+    void SealElement();
+    bool _elementJustOpened;
+    DynArray<const char*, 10> _stack;
 
-    private:
-      void PrintSpace(int depth);
-      void PrintString(const char*, bool restrictedEntitySet);// prints out, after detecting entities.
-      void Print(const char* format, ...);
+private:
+    void PrintSpace(int depth);
+    void PrintString(const char*, bool restrictedEntitySet);  // prints out, after detecting entities.
+    void Print(const char* format, ...);
 
-      bool _firstElement;
-      FILE* _fp;
-      int _depth;
-      int _textDepth;
-      bool _processEntities;
-      bool _compactMode;
+    bool _firstElement;
+    FILE* _fp;
+    int _depth;
+    int _textDepth;
+    bool _processEntities;
+    bool _compactMode;
 
-      enum
-      {
-        ENTITY_RANGE = 64, BUF_SIZE = 200
-      };
-      bool _entityFlag[ENTITY_RANGE];
-      bool _restrictedEntityFlag[ENTITY_RANGE];
+    enum
+    {
+        ENTITY_RANGE = 64,
+        BUF_SIZE = 200
+    };
+    bool _entityFlag[ENTITY_RANGE];
+    bool _restrictedEntityFlag[ENTITY_RANGE];
 
-      DynArray<char, 20> _buffer;
+    DynArray<char, 20> _buffer;
 #ifdef _MSC_VER
-      DynArray< char, 20 > _accumulator;
+    DynArray<char, 20> _accumulator;
 #endif
-  };
+};
 
-}	// tinyxml2
+}  // tinyxml2
 
 #if defined(_MSC_VER)
-#   pragma warning(pop)
+#pragma warning(pop)
 #endif
 
-#endif // TINYXML2_INCLUDED
+#endif  // TINYXML2_INCLUDED

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -34,10 +34,10 @@
 #include <moveit/robot_model/robot_model.h>
 #include <algorithm>
 
-#include <kdl/frames_io.hpp>
 #include <eigen_conversions/eigen_kdl.h>
-#include <visualization_msgs/MarkerArray.h>
 #include <geometric_shapes/shape_operations.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <kdl/frames_io.hpp>
 
 #ifdef KIN_DEBUG_MODE
 #include <iostream>
@@ -45,10 +45,8 @@
 
 namespace exotica
 {
-
 KinematicResponse::KinematicResponse() : Flags(KIN_FK)
 {
-
 }
 
 KinematicResponse::KinematicResponse(KinematicRequestFlags flags, int size, int n)
@@ -56,11 +54,11 @@ KinematicResponse::KinematicResponse(KinematicRequestFlags flags, int size, int 
     Flags = flags;
     Frame.resize(size);
     Phi.resize(size);
-    if(Flags & KIN_FK_VEL) PhiDot.resize(size);
+    if (Flags & KIN_FK_VEL) PhiDot.resize(size);
     KDL::Jacobian Jzero(n);
     Jzero.data.setZero();
-    if(Flags & KIN_J) J = ArrayJacobian::Constant(size, Jzero);
-    if(Flags & KIN_J_DOT) JDot = ArrayJacobian::Constant(size, Jzero);
+    if (Flags & KIN_J) J = ArrayJacobian::Constant(size, Jzero);
+    if (Flags & KIN_J_DOT) JDot = ArrayJacobian::Constant(size, Jzero);
 }
 
 KinematicsRequest::KinematicsRequest() : Flags(KIN_FK)
@@ -69,48 +67,43 @@ KinematicsRequest::KinematicsRequest() : Flags(KIN_FK)
 
 KinematicFrameRequest::KinematicFrameRequest()
 {
-
 }
 
-KinematicFrameRequest::KinematicFrameRequest(std::string frameALinkName, KDL::Frame frameAOffset, std::string frameBLinkName, KDL::Frame frameBOffset) :
-    FrameALinkName(frameALinkName), FrameAOffset(frameAOffset), FrameBLinkName(frameBLinkName), FrameBOffset(frameBOffset)
+KinematicFrameRequest::KinematicFrameRequest(std::string frameALinkName, KDL::Frame frameAOffset, std::string frameBLinkName, KDL::Frame frameBOffset) : FrameALinkName(frameALinkName), FrameAOffset(frameAOffset), FrameBLinkName(frameBLinkName), FrameBOffset(frameBOffset)
 {
-
 }
 
-KinematicSolution::KinematicSolution() : Start(-1), Length(-1), Phi(nullptr,0), PhiDot(nullptr,0), J(nullptr,0), JDot(nullptr,0)
+KinematicSolution::KinematicSolution() : Start(-1), Length(-1), Phi(nullptr, 0), PhiDot(nullptr, 0), J(nullptr, 0), JDot(nullptr, 0)
 {
-
 }
 
-KinematicSolution::KinematicSolution(int start, int length) : Start(start), Length(length), Phi(nullptr,0), PhiDot(nullptr,0), J(nullptr,0), JDot(nullptr,0)
+KinematicSolution::KinematicSolution(int start, int length) : Start(start), Length(length), Phi(nullptr, 0), PhiDot(nullptr, 0), J(nullptr, 0), JDot(nullptr, 0)
 {
 }
 
 void KinematicSolution::Create(std::shared_ptr<KinematicResponse> solution)
 {
-    if(Start < 0 || Length < 0) throw_pretty("Kinematic solution was not initialized!");
-    new (&Phi) Eigen::Map<ArrayFrame>(solution->Phi.data()+Start, Length);
-    if(solution->Flags & KIN_FK_VEL) new (&PhiDot) Eigen::Map<ArrayTwist>(solution->PhiDot.data()+Start, Length);
-    if(solution->Flags & KIN_J) new (&J) Eigen::Map<ArrayJacobian>(solution->J.data()+Start, Length);
-    if(solution->Flags & KIN_J_DOT) new (&JDot) Eigen::Map<ArrayJacobian>(solution->JDot.data()+Start, Length);
+    if (Start < 0 || Length < 0) throw_pretty("Kinematic solution was not initialized!");
+    new (&Phi) Eigen::Map<ArrayFrame>(solution->Phi.data() + Start, Length);
+    if (solution->Flags & KIN_FK_VEL) new (&PhiDot) Eigen::Map<ArrayTwist>(solution->PhiDot.data() + Start, Length);
+    if (solution->Flags & KIN_J) new (&J) Eigen::Map<ArrayJacobian>(solution->J.data() + Start, Length);
+    if (solution->Flags & KIN_J_DOT) new (&JDot) Eigen::Map<ArrayJacobian>(solution->JDot.data() + Start, Length);
 }
 
 int KinematicTree::getNumJoints()
 {
-  return NumControlledJoints;
+    return NumControlledJoints;
 }
 
 KinematicTree::KinematicTree() : StateSize(-1), Debug(false)
 {
-
 }
 
 void KinematicTree::Instantiate(std::string JointGroup, robot_model::RobotModelPtr model, const std::string& name)
 {
-    if (!model) throw_pretty("No robot model provided!");    
+    if (!model) throw_pretty("No robot model provided!");
     robot_model::JointModelGroup* group = model->getJointModelGroup(JointGroup);
-    if(!group) throw_pretty("Joint group '"<<JointGroup<<"' not defined in the robot model!");
+    if (!group) throw_pretty("Joint group '" << JointGroup << "' not defined in the robot model!");
     ControlledJointsNames = group->getVariableNames();
     ModelJointsNames = model->getVariableNames();
     name_ = name;
@@ -126,14 +119,14 @@ void KinematicTree::Instantiate(std::string JointGroup, robot_model::RobotModelP
         throw_pretty("Can't load URDF model!");
     }
 
-    if(Server::isRos())
+    if (Server::isRos())
     {
-        shapes_pub_ = Server::advertise<visualization_msgs::MarkerArray>(name_+(name_==""?"":"/")+"CollisionShapes", 100, true);
+        shapes_pub_ = Server::advertise<visualization_msgs::MarkerArray>(name_ + (name_ == "" ? "" : "/") + "CollisionShapes", 100, true);
         debugSceneChanged = true;
     }
 }
 
-void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
+void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
 {
     Tree.clear();
     TreeMap.clear();
@@ -142,27 +135,28 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
     // Handle the root joint
     const robot_model::JointModel* RootJoint = Model->getRootJoint();
     std::string WorldFrameName;
-    for(const srdf::Model::VirtualJoint& s : Model->getSRDF()->getVirtualJoints())
+    for (const srdf::Model::VirtualJoint& s : Model->getSRDF()->getVirtualJoints())
     {
-        if(s.name_ == RootJoint->getName())
+        if (s.name_ == RootJoint->getName())
         {
             WorldFrameName = s.parent_frame_;
         }
     }
-    if(WorldFrameName == "") throw_pretty("Can't initialize root joint!");
+    if (WorldFrameName == "") throw_pretty("Can't initialize root joint!");
 
     // Extract Root Inertial
     double RootMass = 0.0;
     KDL::Vector RootCoG = KDL::Vector::Zero();
     auto& UrdfRootInertial = Model->getURDF()->getRoot()->inertial;
-    if (UrdfRootInertial) {
-      RootMass = UrdfRootInertial->mass;
-      RootCoG = KDL::Vector(UrdfRootInertial->origin.position.x,
-                            UrdfRootInertial->origin.position.y,
-                            UrdfRootInertial->origin.position.z);
-      if (Debug)
-        HIGHLIGHT_NAMED("Root Inertial", "Mass: " << RootMass
-                                                  << " kg - CoG: " << RootCoG);
+    if (UrdfRootInertial)
+    {
+        RootMass = UrdfRootInertial->mass;
+        RootCoG = KDL::Vector(UrdfRootInertial->origin.position.x,
+                              UrdfRootInertial->origin.position.y,
+                              UrdfRootInertial->origin.position.z);
+        if (Debug)
+            HIGHLIGHT_NAMED("Root Inertial", "Mass: " << RootMass
+                                                      << " kg - CoG: " << RootCoG);
     }
     // TODO: Note, this does not set the rotational inertia component, i.e. the
     // inertial matrix would be wrong
@@ -170,11 +164,11 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
 
     // Add general world_frame joint
     Tree.push_back(std::shared_ptr<KinematicElement>(new KinematicElement(Tree.size(), nullptr, KDL::Segment(WorldFrameName, KDL::Joint(RootJoint->getName(), KDL::Joint::None)))));
-    if(RootJoint->getType()==robot_model::JointModel::FIXED)
+    if (RootJoint->getType() == robot_model::JointModel::FIXED)
     {
         ModelBaseType = BASE_TYPE::FIXED;
     }
-    else if(RootJoint->getType() == robot_model::JointModel::FLOATING)
+    else if (RootJoint->getType() == robot_model::JointModel::FLOATING)
     {
         ModelBaseType = BASE_TYPE::FLOATING;
         Tree.resize(7);
@@ -186,92 +180,100 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
             RootJoint->getName() + "/rot_z",
             RootJoint->getName() + "/rot_y",
             RootJoint->getName() + "/rot_x"};
-        for (int i = 0; i < 6; i++) {
-          Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
-              i, Tree[i], KDL::Segment(floatingBaseVariableNames[i],
-                                       KDL::Joint(floatingBaseVariableNames[i],
-                                                  types[i]))));
-          if (i > 0) Tree[i]->Children.push_back(Tree[i + 1]);
+        for (int i = 0; i < 6; i++)
+        {
+            Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
+                i, Tree[i], KDL::Segment(floatingBaseVariableNames[i],
+                                         KDL::Joint(floatingBaseVariableNames[i],
+                                                    types[i]))));
+            if (i > 0) Tree[i]->Children.push_back(Tree[i + 1]);
         }
 
         // The floating base rotation is defined as xyzw quaternion in the robot
         // model, but we are following a RPY-fixed axis (YPR rotating axis)
         // virtual joint convention in exotica - thus delete the rot_w from the
         // list of joint names
-        auto RotW = std::find(ControlledJointsNames.begin(), ControlledJointsNames.end(),RootJoint->getVariableNames()[6]);
-        if(RotW!=ControlledJointsNames.end()) ControlledJointsNames.erase(RotW);
-        RotW = std::find(ModelJointsNames.begin(), ModelJointsNames.end(),RootJoint->getVariableNames()[6]);
-        if(RotW!=ModelJointsNames.end()) ModelJointsNames.erase(RotW);
+        auto RotW = std::find(ControlledJointsNames.begin(), ControlledJointsNames.end(), RootJoint->getVariableNames()[6]);
+        if (RotW != ControlledJointsNames.end()) ControlledJointsNames.erase(RotW);
+        RotW = std::find(ModelJointsNames.begin(), ModelJointsNames.end(), RootJoint->getVariableNames()[6]);
+        if (RotW != ModelJointsNames.end()) ModelJointsNames.erase(RotW);
     }
-    else if(RootJoint->getType() ==  robot_model::JointModel::PLANAR)
+    else if (RootJoint->getType() == robot_model::JointModel::PLANAR)
     {
         ModelBaseType = BASE_TYPE::PLANAR;
         Tree.resize(4);
         KDL::Joint::JointType types[] = {KDL::Joint::TransX, KDL::Joint::TransY,
                                          KDL::Joint::RotZ};
-        for (int i = 0; i < 3; i++) {
-          Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
-              i, Tree[i],
-              KDL::Segment(
-                  RootJoint->getVariableNames()[i],
-                  KDL::Joint(RootJoint->getVariableNames()[i], types[i]))));
-          if (i > 0) Tree[i]->Children.push_back(Tree[i + 1]);
+        for (int i = 0; i < 3; i++)
+        {
+            Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
+                i, Tree[i],
+                KDL::Segment(
+                    RootJoint->getVariableNames()[i],
+                    KDL::Joint(RootJoint->getVariableNames()[i], types[i]))));
+            if (i > 0) Tree[i]->Children.push_back(Tree[i + 1]);
         }
     }
     else
     {
-        throw_pretty("Unsupported root joint type: "<< RootJoint->getTypeName());
+        throw_pretty("Unsupported root joint type: " << RootJoint->getTypeName());
     }
 
-    AddElement(RobotKinematics.getRootSegment(), *(Tree.end()-1));
+    AddElement(RobotKinematics.getRootSegment(), *(Tree.end() - 1));
 
     // Set root inertial
-    if (RootJoint->getType() == robot_model::JointModel::FIXED) {
-      Tree[2]->Segment.setInertia(RootInertial);
-    } else if (RootJoint->getType() == robot_model::JointModel::FLOATING) {
-      Tree[7]->Segment.setInertia(RootInertial);
-    } else if (RootJoint->getType() == robot_model::JointModel::PLANAR) {
-      Tree[4]->Segment.setInertia(RootInertial);
+    if (RootJoint->getType() == robot_model::JointModel::FIXED)
+    {
+        Tree[2]->Segment.setInertia(RootInertial);
+    }
+    else if (RootJoint->getType() == robot_model::JointModel::FLOATING)
+    {
+        Tree[7]->Segment.setInertia(RootInertial);
+    }
+    else if (RootJoint->getType() == robot_model::JointModel::PLANAR)
+    {
+        Tree[4]->Segment.setInertia(RootInertial);
     }
 
     ModelTree = Tree;
 
     UpdateModel();
 
-    if (Debug) {
-      for (int i = 0; i < Tree.size() - 1; i++)
-        HIGHLIGHT_NAMED(
-            "Tree", "Joint: " << Tree[i]->Segment.getJoint().getName() << " - Link: " << Tree[i]->Segment.getName()
-                        << ", mass: " << Tree[i]->Segment.getInertia().getMass()
-                        << ", CoM: " << Tree[i]->Segment.getInertia().getCOG());
+    if (Debug)
+    {
+        for (int i = 0; i < Tree.size() - 1; i++)
+            HIGHLIGHT_NAMED(
+                "Tree", "Joint: " << Tree[i]->Segment.getJoint().getName() << " - Link: " << Tree[i]->Segment.getName()
+                                  << ", mass: " << Tree[i]->Segment.getInertia().getMass()
+                                  << ", CoM: " << Tree[i]->Segment.getInertia().getCOG());
     }
 
     NumJoints = ModelJointsNames.size();
     NumControlledJoints = ControlledJointsNames.size();
     if (NumControlledJoints < 1) throw_pretty("No update joints specified!");
     ControlledJoints.resize(NumControlledJoints);
-    for(std::shared_ptr<KinematicElement> Joint : Tree)
+    for (std::shared_ptr<KinematicElement> Joint : Tree)
     {
         Joint->isRobotLink = true;
         Joint->ControlId = IsControlled(Joint);
         Joint->IsControlled = Joint->ControlId >= 0;
-        if(Joint->IsControlled) ControlledJoints[Joint->ControlId] = Joint;
+        if (Joint->IsControlled) ControlledJoints[Joint->ControlId] = Joint;
         ModelJointsMap[Joint->Segment.getJoint().getName()] = Joint;
         if (Joint->IsControlled)
         {
-          ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
+            ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
 
-          // The ModelBaseType defined above refers to the base type of the
-          // overall robot model - not of the set of controlled joints. E.g. a
-          // floating-base robot can have a scene defined where the
-          // floating-base virtual joint is _not_ part of the planning
-          // group/scene. Thus we need to establish the BaseType of the joint
-          // group, the ControlledBaseType - if a controlled joint corresponds
-          // to a floating base joint, the ControlledBaseType is the same as the
-          // ModelBaseType.
-          if (Joint->Segment.getJoint().getName() ==
-              RootJoint->getName() + "/trans_x")
-            ControlledBaseType = ModelBaseType;
+            // The ModelBaseType defined above refers to the base type of the
+            // overall robot model - not of the set of controlled joints. E.g. a
+            // floating-base robot can have a scene defined where the
+            // floating-base virtual joint is _not_ part of the planning
+            // group/scene. Thus we need to establish the BaseType of the joint
+            // group, the ControlledBaseType - if a controlled joint corresponds
+            // to a floating base joint, the ControlledBaseType is the same as the
+            // ModelBaseType.
+            if (Joint->Segment.getJoint().getName() ==
+                RootJoint->getName() + "/trans_x")
+                ControlledBaseType = ModelBaseType;
         }
     }
     Tree[0]->isRobotLink = false;
@@ -283,11 +285,11 @@ void KinematicTree::UpdateModel()
 {
     Root = Tree[0];
     TreeState = Eigen::VectorXd::Zero(Tree.size());
-    for(std::shared_ptr<KinematicElement> Joint : Tree)
+    for (std::shared_ptr<KinematicElement> Joint : Tree)
     {
         TreeMap[Joint->Segment.getName()] = Joint;
     }
-    debugTree.resize(Tree.size()-1);
+    debugTree.resize(Tree.size() - 1);
     debugSceneChanged = true;
 }
 
@@ -301,32 +303,32 @@ void KinematicTree::resetModel()
 
 void KinematicTree::changeParent(const std::string& name, const std::string& parent_name, const KDL::Frame& pose, bool relative)
 {
-    if(TreeMap.find(name)==TreeMap.end()) throw_pretty("Attempting to attach unknown frame '"<<name<<"'!");
+    if (TreeMap.find(name) == TreeMap.end()) throw_pretty("Attempting to attach unknown frame '" << name << "'!");
     std::shared_ptr<KinematicElement> child = TreeMap.find(name)->second;
-    if(child->Id<ModelTree.size()) throw_pretty("Can't re-attach robot link '"<<name<<"'!");
-    if(child->Shape) throw_pretty("Can't re-attach collision shape without reattaching the object! ('"<<name<<"')");
+    if (child->Id < ModelTree.size()) throw_pretty("Can't re-attach robot link '" << name << "'!");
+    if (child->Shape) throw_pretty("Can't re-attach collision shape without reattaching the object! ('" << name << "')");
     std::shared_ptr<KinematicElement> parent;
-    if(parent_name=="")
+    if (parent_name == "")
     {
-        if(TreeMap.find(Tree[0]->Segment.getName())==TreeMap.end()) throw_pretty("Attempting to attach to unknown frame '"<<Tree[0]->Segment.getName()<<"'!");
+        if (TreeMap.find(Tree[0]->Segment.getName()) == TreeMap.end()) throw_pretty("Attempting to attach to unknown frame '" << Tree[0]->Segment.getName() << "'!");
         parent = TreeMap.find(Tree[0]->Segment.getName())->second;
     }
     else
     {
-        if(TreeMap.find(parent_name)==TreeMap.end()) throw_pretty("Attempting to attach to unknown frame '"<<parent_name<<"'!");
+        if (TreeMap.find(parent_name) == TreeMap.end()) throw_pretty("Attempting to attach to unknown frame '" << parent_name << "'!");
         parent = TreeMap.find(parent_name)->second;
     }
-    if(parent->Shape) throw_pretty("Can't attach object to a collision shape object! ('"<<parent_name<<"')");
-    if(relative)
+    if (parent->Shape) throw_pretty("Can't attach object to a collision shape object! ('" << parent_name << "')");
+    if (relative)
     {
         child->Segment = KDL::Segment(child->Segment.getName(), child->Segment.getJoint(), pose, child->Segment.getInertia());
     }
     else
     {
-        child->Segment = KDL::Segment(child->Segment.getName(), child->Segment.getJoint(), parent->Frame.Inverse()*child->Frame*pose, child->Segment.getInertia());
+        child->Segment = KDL::Segment(child->Segment.getName(), child->Segment.getJoint(), parent->Frame.Inverse() * child->Frame * pose, child->Segment.getInertia());
     }
     auto it = std::find(child->Parent->Children.begin(), child->Parent->Children.end(), child);
-    if(it != child->Parent->Children.end())
+    if (it != child->Parent->Children.end())
         child->Parent->Children.erase(it);
     child->Parent = parent;
     parent->Children.push_back(child);
@@ -337,28 +339,28 @@ void KinematicTree::changeParent(const std::string& name, const std::string& par
 std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia)
 {
     std::shared_ptr<KinematicElement> parent_element;
-    if(parent=="")
+    if (parent == "")
     {
         parent_element = Tree[0];
     }
     else
     {
         bool found = false;
-        for(const auto& element : Tree)
+        for (const auto& element : Tree)
         {
-            if(element->Segment.getName()==parent)
+            if (element->Segment.getName() == parent)
             {
                 parent_element = element;
                 found = true;
                 break;
             }
         }
-        if(!found) throw_pretty("Can't find parent link named '"<<parent<<"'!");
+        if (!found) throw_pretty("Can't find parent link named '" << parent << "'!");
     }
     KDL::Frame transformKDL;
     tf::transformEigenToKDL(transform, transformKDL);
     std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent_element, KDL::Segment(name, KDL::Joint(KDL::Joint::None), transformKDL, inertia)));
-    if(shape)
+    if (shape)
     {
         NewElement->Shape = shape;
         CollisionTreeMap[NewElement->Segment.getName()] = NewElement;
@@ -375,8 +377,8 @@ void KinematicTree::AddElement(KDL::SegmentMap::const_iterator segment, std::sha
 {
     std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent, segment->second.segment));
     Tree.push_back(NewElement);
-    if(parent) parent->Children.push_back(NewElement);
-    for(KDL::SegmentMap::const_iterator child : segment->second.children)
+    if (parent) parent->Children.push_back(NewElement);
+    for (KDL::SegmentMap::const_iterator child : segment->second.children)
     {
         AddElement(child, NewElement);
     }
@@ -384,9 +386,9 @@ void KinematicTree::AddElement(KDL::SegmentMap::const_iterator segment, std::sha
 
 int KinematicTree::IsControlled(std::shared_ptr<KinematicElement> Joint)
 {
-    for(int i = 0;i<ControlledJointsNames.size();i++)
+    for (int i = 0; i < ControlledJointsNames.size(); i++)
     {
-        if(ControlledJointsNames[i]==Joint->Segment.getJoint().getName()) return i;
+        if (ControlledJointsNames[i] == Joint->Segment.getJoint().getName()) return i;
     }
     return -1;
 }
@@ -394,109 +396,108 @@ int KinematicTree::IsControlled(std::shared_ptr<KinematicElement> Joint)
 std::shared_ptr<KinematicResponse> KinematicTree::RequestFrames(const KinematicsRequest& request)
 {
     Flags = request.Flags;
-    if(Flags&KIN_J_DOT) Flags = Flags | KIN_J;
+    if (Flags & KIN_J_DOT) Flags = Flags | KIN_J;
     Solution.reset(new KinematicResponse(Flags, request.Frames.size(), NumControlledJoints));
 
-    StateSize=NumControlledJoints;
-    if(((Flags&KIN_FK_VEL) || (Flags&KIN_J_DOT))) StateSize = NumControlledJoints*2;
+    StateSize = NumControlledJoints;
+    if (((Flags & KIN_FK_VEL) || (Flags & KIN_J_DOT))) StateSize = NumControlledJoints * 2;
 
-    for(int i=0;i<request.Frames.size();i++)
+    for (int i = 0; i < request.Frames.size(); i++)
     {
-        if(request.Frames[i].FrameALinkName=="")
+        if (request.Frames[i].FrameALinkName == "")
             Solution->Frame[i].FrameA = Root;
         else
-            try 
+            try
             {
-                Solution->Frame[i].FrameA = TreeMap.at(request.Frames[i].FrameALinkName);    
+                Solution->Frame[i].FrameA = TreeMap.at(request.Frames[i].FrameALinkName);
             }
             catch (const std::out_of_range& e)
             {
-                throw_pretty("No FrameA link exists named '"<<request.Frames[i].FrameALinkName<<"'");
+                throw_pretty("No FrameA link exists named '" << request.Frames[i].FrameALinkName << "'");
             }
-        if(request.Frames[i].FrameBLinkName=="")
+        if (request.Frames[i].FrameBLinkName == "")
             Solution->Frame[i].FrameB = Root;
         else
-            try 
+            try
             {
                 Solution->Frame[i].FrameB = TreeMap.at(request.Frames[i].FrameBLinkName);
             }
-            catch(const std::out_of_range& e)
+            catch (const std::out_of_range& e)
             {
-                throw_pretty("No FrameB link exists named '"<<request.Frames[i].FrameBLinkName<<"'");
+                throw_pretty("No FrameB link exists named '" << request.Frames[i].FrameBLinkName << "'");
             }
 
         Solution->Frame[i].FrameAOffset = request.Frames[i].FrameAOffset;
         Solution->Frame[i].FrameBOffset = request.Frames[i].FrameBOffset;
     }
 
-    if(Debug)
+    if (Debug)
     {
-        for(KinematicFrame& frame : Solution->Frame)
+        for (KinematicFrame& frame : Solution->Frame)
         {
-            HIGHLIGHT(frame.FrameB->Segment.getName() << " " << (frame.FrameBOffset==KDL::Frame::Identity()?"":toString(frame.FrameBOffset)) << " -> "<< frame.FrameA->Segment.getName() << " " << (frame.FrameAOffset==KDL::Frame::Identity()?"":toString(frame.FrameAOffset)));
+            HIGHLIGHT(frame.FrameB->Segment.getName() << " " << (frame.FrameBOffset == KDL::Frame::Identity() ? "" : toString(frame.FrameBOffset)) << " -> " << frame.FrameA->Segment.getName() << " " << (frame.FrameAOffset == KDL::Frame::Identity() ? "" : toString(frame.FrameAOffset)));
         }
     }
 
-    debugFrames.resize(Solution->Frame.size()*2);
+    debugFrames.resize(Solution->Frame.size() * 2);
 
     return Solution;
 }
 
 void KinematicTree::Update(Eigen::VectorXdRefConst x)
 {
-    if(x.rows()!=StateSize) throw_pretty("Wrong state vector size! Got " << x.rows() << " expected " << StateSize);
+    if (x.rows() != StateSize) throw_pretty("Wrong state vector size! Got " << x.rows() << " expected " << StateSize);
     UpdateTree(x);
     UpdateFK();
-    if(Flags & KIN_J) UpdateJ();
-    if(Debug) publishFrames();
+    if (Flags & KIN_J) UpdateJ();
+    if (Debug) publishFrames();
 }
 
 void KinematicTree::UpdateTree(Eigen::VectorXdRefConst x)
 {
-    for(int i=0; i<ControlledJoints.size();i++)
+    for (int i = 0; i < ControlledJoints.size(); i++)
     {
         TreeState(ControlledJoints[i]->Id) = x(i);
     }
-    for(std::shared_ptr<KinematicElement> element : Tree)
+    for (std::shared_ptr<KinematicElement> element : Tree)
     {
         KDL::Frame ParentFrame;
-        if(element->Id>0) ParentFrame = element->Parent->Frame;
+        if (element->Id > 0) ParentFrame = element->Parent->Frame;
         element->Frame = ParentFrame * element->getPose(TreeState(element->Id));
     }
 }
 
 void KinematicTree::publishFrames()
 {
-    if(Server::isRos())
+    if (Server::isRos())
     {
         int i = 0;
-        for(std::shared_ptr<KinematicElement> element : Tree)
+        for (std::shared_ptr<KinematicElement> element : Tree)
         {
-
             tf::Transform T;
             tf::transformKDLToTF(element->Frame, T);
-            if(i>0) debugTree[i-1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootFrameName()), tf::resolve("exotica", element->Segment.getName()));
+            if (i > 0) debugTree[i - 1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica", getRootFrameName()), tf::resolve("exotica", element->Segment.getName()));
             i++;
         }
         Server::sendTransform(debugTree);
         i = 0;
-        for(KinematicFrame&  frame : Solution->Frame)
+        for (KinematicFrame& frame : Solution->Frame)
         {
             tf::Transform T;
             tf::transformKDLToTF(frame.TempB, T);
-            debugFrames[i*2] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootFrameName()), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()));
+            debugFrames[i * 2] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica", getRootFrameName()), tf::resolve("exotica", "Frame" + std::to_string(i) + "B" + frame.FrameB->Segment.getName()));
             tf::transformKDLToTF(frame.TempAB, T);
-            debugFrames[i*2+1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()), tf::resolve("exotica","Frame"+std::to_string(i)+"A"+frame.FrameA->Segment.getName()));
+            debugFrames[i * 2 + 1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica", "Frame" + std::to_string(i) + "B" + frame.FrameB->Segment.getName()), tf::resolve("exotica", "Frame" + std::to_string(i) + "A" + frame.FrameA->Segment.getName()));
             i++;
         }
         Server::sendTransform(debugFrames);
-        if(debugSceneChanged)
+        if (debugSceneChanged)
         {
             debugSceneChanged = false;
             visualization_msgs::MarkerArray msg;
-            for(int i=0; i<Tree.size();i++)
+            for (int i = 0; i < Tree.size(); i++)
             {
-                if(Tree[i]->Shape && Tree[i]->Parent->Id>=ModelTree.size())
+                if (Tree[i]->Shape && Tree[i]->Parent->Id >= ModelTree.size())
                 {
                     visualization_msgs::Marker mrk;
                     shapes::constructMarkerFromShape(Tree[i]->Shape.get(), mrk);
@@ -504,9 +505,9 @@ void KinematicTree::publishFrames()
                     mrk.frame_locked = true;
                     mrk.id = i;
                     mrk.ns = "CollisionObjects";
-                    mrk.color.r=mrk.color.g=mrk.color.b=0.5;
-                    mrk.color.a=1.0;
-                    mrk.header.frame_id = "exotica/"+Tree[i]->Segment.getName();
+                    mrk.color.r = mrk.color.g = mrk.color.b = 0.5;
+                    mrk.color.a = 1.0;
+                    mrk.header.frame_id = "exotica/" + Tree[i]->Segment.getName();
                     msg.markers.push_back(mrk);
                 }
             }
@@ -519,7 +520,7 @@ KDL::Frame KinematicTree::FK(KinematicFrame& frame)
 {
     frame.TempA = frame.FrameA->Frame * frame.FrameAOffset;
     frame.TempB = frame.FrameB->Frame * frame.FrameBOffset;
-    frame.TempAB = frame.TempB.Inverse()*frame.TempA;
+    frame.TempAB = frame.TempB.Inverse() * frame.TempA;
     return frame.TempAB;
 }
 
@@ -535,19 +536,19 @@ KDL::Frame KinematicTree::FK(std::shared_ptr<KinematicElement> elementA, const K
 
 KDL::Frame KinematicTree::FK(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB)
 {
-    std::string nameA = elementA==""?Root->Segment.getName():elementA;
-    std::string nameB = elementB==""?Root->Segment.getName():elementB;
+    std::string nameA = elementA == "" ? Root->Segment.getName() : elementA;
+    std::string nameB = elementB == "" ? Root->Segment.getName() : elementB;
     auto A = TreeMap.find(nameA);
-    if(A==TreeMap.end()) throw_pretty("Can't find link '"<<nameA<<"'!");
+    if (A == TreeMap.end()) throw_pretty("Can't find link '" << nameA << "'!");
     auto B = TreeMap.find(nameB);
-    if(B==TreeMap.end()) throw_pretty("Can't find link '"<<nameB<<"'!");
+    if (B == TreeMap.end()) throw_pretty("Can't find link '" << nameB << "'!");
     return FK(A->second, offsetA, B->second, offsetB);
 }
 
 void KinematicTree::UpdateFK()
 {
     int i = 0;
-    for(KinematicFrame&  frame : Solution->Frame)
+    for (KinematicFrame& frame : Solution->Frame)
     {
         Solution->Phi(i) = FK(frame);
         i++;
@@ -568,12 +569,12 @@ Eigen::MatrixXd KinematicTree::Jacobian(std::shared_ptr<KinematicElement> elemen
 
 Eigen::MatrixXd KinematicTree::Jacobian(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB)
 {
-    std::string nameA = elementA==""?Root->Segment.getName():elementA;
-    std::string nameB = elementB==""?Root->Segment.getName():elementB;
+    std::string nameA = elementA == "" ? Root->Segment.getName() : elementA;
+    std::string nameB = elementB == "" ? Root->Segment.getName() : elementB;
     auto A = TreeMap.find(nameA);
-    if(A==TreeMap.end()) throw_pretty("Can't find link '"<<nameA<<"'!");
+    if (A == TreeMap.end()) throw_pretty("Can't find link '" << nameA << "'!");
     auto B = TreeMap.find(nameB);
-    if(B==TreeMap.end()) throw_pretty("Can't find link '"<<nameB<<"'!");
+    if (B == TreeMap.end()) throw_pretty("Can't find link '" << nameB << "'!");
     return Jacobian(A->second, offsetA, B->second, offsetB);
 }
 
@@ -581,25 +582,24 @@ void KinematicTree::ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J)
 {
     J.data.setZero();
     std::shared_ptr<KinematicElement> it = frame.FrameA;
-    while(it!=nullptr)
+    while (it != nullptr)
     {
-        if(it->IsControlled)
+        if (it->IsControlled)
         {
             KDL::Frame SegmentReference;
-            if(it->Parent!=nullptr) SegmentReference = it->Parent->Frame;
-            J.setColumn(it->ControlId, frame.TempB.M.Inverse()*(SegmentReference.M*it->Segment.twist(TreeState(it->Id), 1.0)).RefPoint(frame.TempA.p-it->Frame.p));
-
+            if (it->Parent != nullptr) SegmentReference = it->Parent->Frame;
+            J.setColumn(it->ControlId, frame.TempB.M.Inverse() * (SegmentReference.M * it->Segment.twist(TreeState(it->Id), 1.0)).RefPoint(frame.TempA.p - it->Frame.p));
         }
         it = it->Parent;
     }
     it = frame.FrameB;
-    while(it!=nullptr)
+    while (it != nullptr)
     {
-        if(it->IsControlled)
+        if (it->IsControlled)
         {
             KDL::Frame SegmentReference;
-            if(it->Parent!=nullptr) SegmentReference = it->Parent->Frame;
-            J.setColumn(it->ControlId, J.getColumn(it->ControlId) - (frame.TempB.M.Inverse()*(SegmentReference.M*it->Segment.twist(TreeState(it->Id), 1.0)).RefPoint(frame.TempA.p-it->Frame.p)));
+            if (it->Parent != nullptr) SegmentReference = it->Parent->Frame;
+            J.setColumn(it->ControlId, J.getColumn(it->ControlId) - (frame.TempB.M.Inverse() * (SegmentReference.M * it->Segment.twist(TreeState(it->Id), 1.0)).RefPoint(frame.TempA.p - it->Frame.p)));
         }
         it = it->Parent;
     }
@@ -608,7 +608,7 @@ void KinematicTree::ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J)
 void KinematicTree::UpdateJ()
 {
     int i = 0;
-    for(const KinematicFrame&  frame : Solution->Frame)
+    for (const KinematicFrame& frame : Solution->Frame)
     {
         ComputeJ(frame, Solution->J(i));
         i++;
@@ -617,113 +617,112 @@ void KinematicTree::UpdateJ()
 
 Eigen::MatrixXd KinematicTree::getJointLimits()
 {
-    Eigen::MatrixXd lim(getNumJoints(),2);
-    for(int i=0; i<ControlledJoints.size();i++)
+    Eigen::MatrixXd lim(getNumJoints(), 2);
+    for (int i = 0; i < ControlledJoints.size(); i++)
     {
-        lim(i,0) = ControlledJoints[i]->JointLimits[0];
-        lim(i,1) = ControlledJoints[i]->JointLimits[1];
+        lim(i, 0) = ControlledJoints[i]->JointLimits[0];
+        lim(i, 1) = ControlledJoints[i]->JointLimits[1];
     }
     return lim;
 }
 
 exotica::BASE_TYPE KinematicTree::getModelBaseType()
 {
-  return ModelBaseType;
+    return ModelBaseType;
 }
 
 exotica::BASE_TYPE KinematicTree::getControlledBaseType()
 {
-  return ControlledBaseType;
+    return ControlledBaseType;
 }
 
 std::map<std::string, std::vector<double>> KinematicTree::getUsedJointLimits()
 {
-  std::map<std::string, std::vector<double>> limits;
-  for (std::shared_ptr<KinematicElement> it : ControlledJoints)
-  {
-    limits[it->Segment.getJoint().getName()] = it->JointLimits;
-  }
-  return limits;
+    std::map<std::string, std::vector<double>> limits;
+    for (std::shared_ptr<KinematicElement> it : ControlledJoints)
+    {
+        limits[it->Segment.getJoint().getName()] = it->JointLimits;
+    }
+    return limits;
 }
 
 void KinematicTree::setFloatingBaseLimitsPosXYZEulerZYX(
-    const std::vector<double> & lower, const std::vector<double> & upper)
+    const std::vector<double>& lower, const std::vector<double>& upper)
 {
-  if (ControlledBaseType != BASE_TYPE::FLOATING)
-  {
-    throw_pretty("This is not a floating joint!");
-  }
-  if (lower.size() != 6 || upper.size() != 6)
-  {
-    throw_pretty("Wrong limit data size!");
-  }
-  for (int i = 0; i < 6; i++)
-  {
-    ControlledJoints[i]->JointLimits = {lower[i], upper[i]};
-  }
+    if (ControlledBaseType != BASE_TYPE::FLOATING)
+    {
+        throw_pretty("This is not a floating joint!");
+    }
+    if (lower.size() != 6 || upper.size() != 6)
+    {
+        throw_pretty("Wrong limit data size!");
+    }
+    for (int i = 0; i < 6; i++)
+    {
+        ControlledJoints[i]->JointLimits = {lower[i], upper[i]};
+    }
 }
 void KinematicTree::setJointLimits()
 {
-  srdf::Model::VirtualJoint virtual_joint =  Model->getSRDF()->getVirtualJoints()[0];
-  std::vector<std::string> vars = Model->getVariableNames();
-  for (int i = 0; i < vars.size(); i++)
-  {
-    if (ControlledJointsMap.find(vars[i]) != ControlledJointsMap.end())
+    srdf::Model::VirtualJoint virtual_joint = Model->getSRDF()->getVirtualJoints()[0];
+    std::vector<std::string> vars = Model->getVariableNames();
+    for (int i = 0; i < vars.size(); i++)
     {
-      int index = ControlledJointsMap.at(vars[i])->ControlId;
-      ControlledJoints[index]->JointLimits = {Model->getVariableBounds(vars[i]).min_position_, Model->getVariableBounds(vars[i]).max_position_};
+        if (ControlledJointsMap.find(vars[i]) != ControlledJointsMap.end())
+        {
+            int index = ControlledJointsMap.at(vars[i])->ControlId;
+            ControlledJoints[index]->JointLimits = {Model->getVariableBounds(vars[i]).min_position_, Model->getVariableBounds(vars[i]).max_position_};
+        }
     }
-  }
 
-///	Manually defined floating base limits
-///	Should be done more systematically with robot model class
-  if (ControlledBaseType == BASE_TYPE::FLOATING)
-  {
-    ControlledJoints[0]->JointLimits = {-0.05, 0.05};
+    ///	Manually defined floating base limits
+    ///	Should be done more systematically with robot model class
+    if (ControlledBaseType == BASE_TYPE::FLOATING)
+    {
+        ControlledJoints[0]->JointLimits = {-0.05, 0.05};
 
-    ControlledJoints[1]->JointLimits = {-0.05, 0.05};
+        ControlledJoints[1]->JointLimits = {-0.05, 0.05};
 
-    ControlledJoints[2]->JointLimits = {0.875, 1.075};
+        ControlledJoints[2]->JointLimits = {0.875, 1.075};
 
-    ControlledJoints[3]->JointLimits = {-0.087 / 2, 0.087 / 2};
+        ControlledJoints[3]->JointLimits = {-0.087 / 2, 0.087 / 2};
 
-    ControlledJoints[4]->JointLimits = {-0.087 / 2, 0.2617 / 2};
+        ControlledJoints[4]->JointLimits = {-0.087 / 2, 0.2617 / 2};
 
-    ControlledJoints[5]->JointLimits = {-M_PI / 8, M_PI / 8};
-  }
-  else if (ControlledBaseType == BASE_TYPE::PLANAR)
-  {
-    ControlledJoints[0]->JointLimits = {-10, 10};
+        ControlledJoints[5]->JointLimits = {-M_PI / 8, M_PI / 8};
+    }
+    else if (ControlledBaseType == BASE_TYPE::PLANAR)
+    {
+        ControlledJoints[0]->JointLimits = {-10, 10};
 
-    ControlledJoints[1]->JointLimits = {-10, 10};
+        ControlledJoints[1]->JointLimits = {-10, 10};
 
-    ControlledJoints[2]->JointLimits = {-1.57, 1.57};
-  }
+        ControlledJoints[2]->JointLimits = {-1.57, 1.57};
+    }
 }
 
 std::string KinematicTree::getRootFrameName()
 {
-  return Tree[0]->Segment.getName();
+    return Tree[0]->Segment.getName();
 }
 
 std::string KinematicTree::getRootJointName()
 {
-  return Model->getRootJoint()->getName();
+    return Model->getRootJoint()->getName();
 }
 
 int KinematicTree::getEffSize()
 {
-  return Solution->Frame.size();
+    return Solution->Frame.size();
 }
-
 
 Eigen::VectorXd KinematicTree::getModelState()
 {
     Eigen::VectorXd ret(ModelJointsNames.size());
 
-    for(int i=0; i<ModelJointsNames.size(); i++)
+    for (int i = 0; i < ModelJointsNames.size(); i++)
     {
-        ret(i) =  TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id);
+        ret(i) = TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id);
     }
     return ret;
 }
@@ -731,17 +730,17 @@ Eigen::VectorXd KinematicTree::getModelState()
 std::map<std::string, double> KinematicTree::getModelStateMap()
 {
     std::map<std::string, double> ret;
-    for(std::string& jointName : ModelJointsNames)
+    for (std::string& jointName : ModelJointsNames)
     {
-        ret[jointName] =  TreeState(ModelJointsMap.at(jointName)->Id);
+        ret[jointName] = TreeState(ModelJointsMap.at(jointName)->Id);
     }
     return ret;
 }
 
 void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
 {
-    if(x.rows()!=ModelJointsNames.size()) throw_pretty("Model state vector has wrong size, expected " << ModelJointsNames.size() << " got " << x.rows());
-    for(int i=0; i<ModelJointsNames.size(); i++)
+    if (x.rows() != ModelJointsNames.size()) throw_pretty("Model state vector has wrong size, expected " << ModelJointsNames.size() << " got " << x.rows());
+    for (int i = 0; i < ModelJointsNames.size(); i++)
     {
         TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id) = x(i);
     }
@@ -753,7 +752,7 @@ void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
 
 void KinematicTree::setModelState(std::map<std::string, double> x)
 {
-    for(auto& joint : x)
+    for (auto& joint : x)
     {
         try
         {
@@ -761,7 +760,7 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
         }
         catch (const std::out_of_range& e)
         {
-            throw_pretty("Robot model does not contain joint '"<<joint.first<<"'");
+            throw_pretty("Robot model does not contain joint '" << joint.first << "'");
         }
     }
 
@@ -773,11 +772,10 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
 Eigen::VectorXd KinematicTree::getControlledState()
 {
     Eigen::VectorXd x(NumControlledJoints);
-    for(int i=0; i<ControlledJoints.size(); i++)
+    for (int i = 0; i < ControlledJoints.size(); i++)
     {
         x(i) = TreeState(ControlledJoints[i]->Id);
     }
     return x;
 }
-
 }

--- a/exotica/src/Loaders/XMLLoader.cpp
+++ b/exotica/src/Loaders/XMLLoader.cpp
@@ -1,203 +1,219 @@
 #include <exotica/Loaders/XMLLoader.h>
-#include <tinyxml2/tinyxml2.h>
 #include <exotica/Setup.h>
+#include <tinyxml2/tinyxml2.h>
 
 namespace exotica
 {
+std::shared_ptr<XMLLoader> XMLLoader::instance_ = nullptr;
 
-    std::shared_ptr<XMLLoader> XMLLoader::instance_ = nullptr;
+XMLLoader::XMLLoader()
+{
+}
 
-    XMLLoader::XMLLoader()
+bool parseXML(tinyxml2::XMLHandle& tag, Initializer& parent, const std::string& prefix);
+
+void appendChildXML(Initializer& parent, std::string& name, bool isAttribute, tinyxml2::XMLHandle& tag, const std::string& prefix)
+{
+    if (isAttribute)
     {
-
+        // Attributes are always a regular property
+        std::string value = tag.ToElement()->Attribute(name.c_str());
+        parent.addProperty(Property(name, true, value));
     }
-
-    bool parseXML(tinyxml2::XMLHandle& tag, Initializer& parent, const std::string& prefix);
-
-    void appendChildXML(Initializer& parent, std::string& name, bool isAttribute, tinyxml2::XMLHandle& tag, const std::string& prefix)
+    else
     {
-        if(isAttribute)
+        int count = 0;
+        for (tinyxml2::XMLHandle child = tag.FirstChild(); child.ToNode(); child = child.NextSibling())
+            if (child.ToElement() != nullptr) count++;
+        if (count == 0)
         {
-            // Attributes are always a regular property
-            std::string value = tag.ToElement()->Attribute(name.c_str());
-            parent.addProperty(Property(name,true,value));
+            if (tag.ToElement() == nullptr) return;
+
+            if (!tag.ToElement()->GetText())
+            {
+                // No child tags = this is an empty vector of properties
+                return;
+            }
+            std::string value = tag.ToElement()->GetText();
+            parent.addProperty(Property(name, true, value));
         }
         else
         {
-            int count = 0;
-            for( tinyxml2::XMLHandle child = tag.FirstChild(); child.ToNode(); child = child.NextSibling() ) if(child.ToElement() != nullptr) count++;
-            if(count==0)
+            // Child tags found = this is an initializer
+            // All initializers are treated as a vector
+            std::vector<Initializer> ret;
+            tinyxml2::XMLHandle child_tag = tag.FirstChild();
+            while (child_tag.ToNode())
             {
-                if(tag.ToElement() == nullptr) return;
-
-                if (!tag.ToElement()->GetText())
+                if (child_tag.ToElement() == nullptr)
                 {
-                    // No child tags = this is an empty vector of properties
-                    return;
-                }
-                std::string value = tag.ToElement()->GetText();
-                parent.addProperty(Property(name,true,value));
-            }
-            else
-            {
-                // Child tags found = this is an initializer
-                // All initializers are treated as a vector
-                std::vector<Initializer> ret;
-                tinyxml2::XMLHandle child_tag = tag.FirstChild();
-                while(child_tag.ToNode())
-                {
-                    if(child_tag.ToElement() == nullptr)
-                    {
-                        child_tag = child_tag.NextSibling();
-                        continue;
-                    }
-                    ret.push_back(Initializer("New"+name));
-                    if(!parseXML(child_tag,ret[ret.size()-1],prefix+"- "))
-                    {
-                        ret.pop_back();
-                    }
-                    else
-                    {
-                        //HIGHLIGHT(prefix<<". Adding parsed vector element "<<name<<" to " << parent.getName());
-                    }
                     child_tag = child_tag.NextSibling();
+                    continue;
                 }
-                parent.addProperty(Property(name,true,ret));
+                ret.push_back(Initializer("New" + name));
+                if (!parseXML(child_tag, ret[ret.size() - 1], prefix + "- "))
+                {
+                    ret.pop_back();
+                }
+                else
+                {
+                    //HIGHLIGHT(prefix<<". Adding parsed vector element "<<name<<" to " << parent.getName());
+                }
+                child_tag = child_tag.NextSibling();
             }
+            parent.addProperty(Property(name, true, ret));
         }
     }
+}
 
-    // Parses an Initializer parameters from ints attributes and child tags
-    bool parseXML(tinyxml2::XMLHandle& tag, Initializer& parent, const std::string& prefix)
+// Parses an Initializer parameters from ints attributes and child tags
+bool parseXML(tinyxml2::XMLHandle& tag, Initializer& parent, const std::string& prefix)
+{
+    // Get the name
+    std::string name = std::string(tag.ToElement()->Name());
+    //HIGHLIGHT(prefix<<name<<" added");
+    parent.setName("exotica/" + name);
+
+    // Parse values stored in attributes
+    tinyxml2::XMLAttribute* attr = const_cast<tinyxml2::XMLAttribute*>(tag.ToElement()->FirstAttribute());
+    while (attr)
     {
-        // Get the name
-        std::string name = std::string(tag.ToElement()->Name());
-        //HIGHLIGHT(prefix<<name<<" added");
-        parent.setName("exotica/"+name);
+        std::string member_name = attr->Name();
+        appendChildXML(parent, member_name, true, tag, prefix + "- ");
+        attr = const_cast<tinyxml2::XMLAttribute*>(attr->Next());
+    }
 
-        // Parse values stored in attributes
-        tinyxml2::XMLAttribute* attr = const_cast<tinyxml2::XMLAttribute*>(tag.ToElement()->FirstAttribute());
-        while(attr)
+    // Parse values stored in tags
+    tinyxml2::XMLHandle member_tag = tag.FirstChild();
+    while (member_tag.ToNode())
+    {
+        if (member_tag.ToElement() == nullptr)
         {
-            std::string member_name = attr->Name();
-            appendChildXML(parent,member_name,true,tag,prefix+"- ");
-            attr = const_cast<tinyxml2::XMLAttribute*>(attr->Next());
-        }
-
-        // Parse values stored in tags
-        tinyxml2::XMLHandle member_tag = tag.FirstChild();
-        while(member_tag.ToNode())
-        {
-            if(member_tag.ToElement() == nullptr)
-            {
-                member_tag = member_tag.NextSibling();
-                continue;
-            }
-            std::string member_name = std::string(member_tag.ToElement()->Name());
-            appendChildXML(parent,member_name,false,member_tag,prefix+"- ");
             member_tag = member_tag.NextSibling();
+            continue;
         }
-        //HIGHLIGHT(prefix<<name<<" finished parsing");
-        return true;
+        std::string member_name = std::string(member_tag.ToElement()->Name());
+        appendChildXML(parent, member_name, false, member_tag, prefix + "- ");
+        member_tag = member_tag.NextSibling();
+    }
+    //HIGHLIGHT(prefix<<name<<" finished parsing");
+    return true;
+}
+
+Initializer XMLLoader::loadXML(std::string file_name, bool parsePathAsXML)
+{
+    tinyxml2::XMLDocument xml_file;
+    if (parsePathAsXML)
+    {
+        if (xml_file.Parse(file_name.c_str(), file_name.size()) != tinyxml2::XML_NO_ERROR)
+        {
+            throw_pretty("Can't load file!\nFile: '" + file_name + "'");
+        }
+    }
+    else
+    {
+        std::string xml = loadFile(file_name);
+        if (xml_file.Parse(xml.c_str(), xml.size()) != tinyxml2::XML_NO_ERROR)
+        {
+            throw_pretty("Can't load file!\nFile: '" + parsePath(file_name) + "'");
+        }
     }
 
-    Initializer XMLLoader::loadXML(std::string file_name, bool parsePathAsXML)
+    Initializer ret("TopLevel");
+    tinyxml2::XMLHandle root_tag(xml_file.RootElement()->FirstChildElement());
+    if (!parseXML(root_tag, ret, ""))
     {
-        tinyxml2::XMLDocument xml_file;
-        if(parsePathAsXML)
-        {
-            if (xml_file.Parse(file_name.c_str(),file_name.size()) != tinyxml2::XML_NO_ERROR)
-            {
-              throw_pretty("Can't load file!\nFile: '"+file_name+"'");
-            }
-        }
-        else
-        {
-            std::string xml = loadFile(file_name);
-            if (xml_file.Parse(xml.c_str(),xml.size()) != tinyxml2::XML_NO_ERROR)
-            {
-              throw_pretty("Can't load file!\nFile: '"+parsePath(file_name)+"'");
-            }
-        }
+        throw_pretty("Can't parse XML!\nFile: '" + file_name + "'");
+    }
+    return ret;
+}
 
-        Initializer ret("TopLevel");
-        tinyxml2::XMLHandle root_tag(xml_file.RootElement()->FirstChildElement());
-        if(!parseXML(root_tag,ret, ""))
+void XMLLoader::loadXML(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name, const std::string& problem_name, bool parsePathAsXML)
+{
+    tinyxml2::XMLDocument xml_file;
+    if (parsePathAsXML)
+    {
+        if (xml_file.Parse(file_name.c_str(), file_name.size()) != tinyxml2::XML_NO_ERROR)
         {
-            throw_pretty("Can't parse XML!\nFile: '"+file_name+"'");
+            throw_pretty("Can't load file!\nFile: '" + file_name + "'");
         }
-        return ret;
+    }
+    else
+    {
+        std::string xml = loadFile(file_name);
+        if (xml_file.Parse(xml.c_str(), xml.size()) != tinyxml2::XML_NO_ERROR)
+        {
+            throw_pretty("Can't load file!\nFile: '" + parsePath(file_name) + "'");
+        }
     }
 
-    void XMLLoader::loadXML(std::string file_name, Initializer& solver, Initializer& problem, const std::string& solver_name, const std::string& problem_name, bool parsePathAsXML)
+    std::vector<Initializer> initializers;
+    tinyxml2::XMLHandle root_tag = xml_file.RootElement()->FirstChild();
+    while (root_tag.ToNode())
     {
-        tinyxml2::XMLDocument xml_file;
-        if(parsePathAsXML)
+        if (root_tag.ToElement() == nullptr)
         {
-            if (xml_file.Parse(file_name.c_str(),file_name.size()) != tinyxml2::XML_NO_ERROR)
-            {
-              throw_pretty("Can't load file!\nFile: '"+file_name+"'");
-            }
-        }
-        else
-        {
-            std::string xml = loadFile(file_name);
-            if (xml_file.Parse(xml.c_str(),xml.size()) != tinyxml2::XML_NO_ERROR)
-            {
-              throw_pretty("Can't load file!\nFile: '"+parsePath(file_name)+"'");
-            }
-        }
-
-        std::vector<Initializer> initializers;
-        tinyxml2::XMLHandle root_tag = xml_file.RootElement()->FirstChild();
-        while (root_tag.ToNode())
-        {
-            if(root_tag.ToElement() == nullptr)
-            {
-                root_tag = root_tag.NextSibling();
-                continue;
-            }
-            initializers.push_back(Initializer("TopLevel"));
-            if(!parseXML(root_tag,initializers[initializers.size()-1], ""))
-            {
-                initializers.pop_back();
-            }
             root_tag = root_tag.NextSibling();
+            continue;
         }
-        bool foundSolver = false;
-        bool foundProblem = false;
-        if (solver_name=="" || solver_name=="")
+        initializers.push_back(Initializer("TopLevel"));
+        if (!parseXML(root_tag, initializers[initializers.size() - 1], ""))
         {
-            for(Initializer& i : initializers)
-            {
-                std::string initializer_type = i.getName();
-                if(!foundSolver)
-                {
-                    for(std::string known_type : Setup::getSolvers())
-                    {
-                        if(known_type==initializer_type) {solver = i; foundSolver=true; break;}
-                    }
-                }
-                if(!foundProblem)
-                {
-                    for(std::string known_type : Setup::getProblems())
-                    {
-                        if(known_type==initializer_type) {problem = i; foundProblem=true; break;}
-                    }
-                }
-            }
+            initializers.pop_back();
         }
-        else
-        {
-            for(Initializer& i : initializers)
-            {
-                std::string name = boost::any_cast<std::string>(i.getProperty("Name"));
-                if(name==solver_name) {solver = i; foundSolver=true;}
-                if(name==problem_name) {problem = i; foundProblem=true;}
-            }
-        }
-        if(!foundSolver) throw_pretty("Can't find solver '"+solver_name+"' in '"+file_name+"'!");
-        if(!foundProblem) throw_pretty("Can't find problem '"+problem_name+"' in '"+file_name+"'!");
+        root_tag = root_tag.NextSibling();
     }
-
+    bool foundSolver = false;
+    bool foundProblem = false;
+    if (solver_name == "" || solver_name == "")
+    {
+        for (Initializer& i : initializers)
+        {
+            std::string initializer_type = i.getName();
+            if (!foundSolver)
+            {
+                for (std::string known_type : Setup::getSolvers())
+                {
+                    if (known_type == initializer_type)
+                    {
+                        solver = i;
+                        foundSolver = true;
+                        break;
+                    }
+                }
+            }
+            if (!foundProblem)
+            {
+                for (std::string known_type : Setup::getProblems())
+                {
+                    if (known_type == initializer_type)
+                    {
+                        problem = i;
+                        foundProblem = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        for (Initializer& i : initializers)
+        {
+            std::string name = boost::any_cast<std::string>(i.getProperty("Name"));
+            if (name == solver_name)
+            {
+                solver = i;
+                foundSolver = true;
+            }
+            if (name == problem_name)
+            {
+                problem = i;
+                foundProblem = true;
+            }
+        }
+    }
+    if (!foundSolver) throw_pretty("Can't find solver '" + solver_name + "' in '" + file_name + "'!");
+    if (!foundProblem) throw_pretty("Can't find problem '" + problem_name + "' in '" + file_name + "'!");
+}
 }

--- a/exotica/src/Loaders/tinyxml2.cpp
+++ b/exotica/src/Loaders/tinyxml2.cpp
@@ -23,16 +23,16 @@
 
 #include "tinyxml2/tinyxml2.h"
 
-#include <new>		// yes, this one new style header, is in the Android SDK.
-#   ifdef ANDROID_NDK
-#   include <stddef.h>
+#include <new>  // yes, this one new style header, is in the Android SDK.
+#ifdef ANDROID_NDK
+#include <stddef.h>
 #else
-#   include <cstddef>
+#include <cstddef>
 #endif
 
-static const char LINE_FEED = (char) 0x0a;// all line endings are normalized to LF
+static const char LINE_FEED = (char)0x0a;  // all line endings are normalized to LF
 static const char LF = LINE_FEED;
-static const char CARRIAGE_RETURN = (char) 0x0d;			// CR gets filtered out
+static const char CARRIAGE_RETURN = (char)0x0d;  // CR gets filtered out
 static const char CR = CARRIAGE_RETURN;
 static const char SINGLE_QUOTE = '\'';
 static const char DOUBLE_QUOTE = '\"';
@@ -45,282 +45,280 @@ static const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
 static const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
 static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
 
-#define DELETE_NODE( node )	{			\
-        if ( node ) {						\
-            MemPool* pool = node->_memPool;	\
-            node->~XMLNode();				\
-            pool->Free( node );				\
-        }									\
+#define DELETE_NODE(node)                   \
+    {                                       \
+        if (node)                           \
+        {                                   \
+            MemPool* pool = node->_memPool; \
+            node->~XMLNode();               \
+            pool->Free(node);               \
+        }                                   \
     }
-#define DELETE_ATTRIBUTE( attrib ) {		\
-        if ( attrib ) {							\
-            MemPool* pool = attrib->_memPool;	\
-            attrib->~XMLAttribute();			\
-            pool->Free( attrib );				\
-        }										\
+#define DELETE_ATTRIBUTE(attrib)              \
+    {                                         \
+        if (attrib)                           \
+        {                                     \
+            MemPool* pool = attrib->_memPool; \
+            attrib->~XMLAttribute();          \
+            pool->Free(attrib);               \
+        }                                     \
     }
 
 namespace tinyxml2
 {
+struct Entity
+{
+    const char* pattern;
+    int length;
+    char value;
+};
 
-  struct Entity
-  {
-      const char* pattern;
-      int length;
-      char value;
-  };
+static const int NUM_ENTITIES = 5;
+static const Entity entities[NUM_ENTITIES] = {{"quot", 4, DOUBLE_QUOTE}, {"amp", 3, '&'}, {"apos", 4, SINGLE_QUOTE}, {"lt", 2, '<'}, {"gt", 2, '>'}};
 
-  static const int NUM_ENTITIES = 5;
-  static const Entity entities[NUM_ENTITIES] = { { "quot", 4, DOUBLE_QUOTE }, {
-      "amp", 3, '&' }, { "apos", 4, SINGLE_QUOTE }, { "lt", 2, '<' }, { "gt", 2,
-      '>' } };
-
-  StrPair::~StrPair()
-  {
+StrPair::~StrPair()
+{
     Reset();
-  }
+}
 
-  void StrPair::Reset()
-  {
+void StrPair::Reset()
+{
     if (_flags & NEEDS_DELETE)
     {
-      delete[] _start;
+        delete[] _start;
     }
     _flags = 0;
     _start = 0;
     _end = 0;
-  }
+}
 
-  void StrPair::SetStr(const char* str, int flags)
-  {
+void StrPair::SetStr(const char* str, int flags)
+{
     Reset();
     size_t len = strlen(str);
     _start = new char[len + 1];
     memcpy(_start, str, len + 1);
     _end = _start + len;
     _flags = flags | NEEDS_DELETE;
-  }
+}
 
-  char* StrPair::ParseText(char* p, const char* endTag, int strFlags)
-  {
+char* StrPair::ParseText(char* p, const char* endTag, int strFlags)
+{
     TIXMLASSERT(endTag && *endTag);
 
-    char* start = p;	// fixme: hides a member
+    char* start = p;  // fixme: hides a member
     char endChar = *endTag;
     size_t length = strlen(endTag);
 
     // Inner loop of text parsing.
     while (*p)
     {
-      if (*p == endChar && strncmp(p, endTag, length) == 0)
-      {
-        Set(start, p, strFlags);
-        return p + length;
-      }
-      ++p;
+        if (*p == endChar && strncmp(p, endTag, length) == 0)
+        {
+            Set(start, p, strFlags);
+            return p + length;
+        }
+        ++p;
     }
     return 0;
-  }
+}
 
-  char* StrPair::ParseName(char* p)
-  {
+char* StrPair::ParseName(char* p)
+{
     char* start = p;
 
     if (!start || !(*start))
     {
-      return 0;
+        return 0;
     }
 
-    while (*p
-        && (p == start ? XMLUtil::IsNameStartChar(*p) : XMLUtil::IsNameChar(*p)))
+    while (*p && (p == start ? XMLUtil::IsNameStartChar(*p) : XMLUtil::IsNameChar(*p)))
     {
-      ++p;
+        ++p;
     }
 
     if (p > start)
     {
-      Set(start, p, 0);
-      return p;
+        Set(start, p, 0);
+        return p;
     }
     return 0;
-  }
+}
 
-  void StrPair::CollapseWhitespace()
-  {
+void StrPair::CollapseWhitespace()
+{
     // Trim leading space.
     _start = XMLUtil::SkipWhiteSpace(_start);
 
     if (_start && *_start)
     {
-      char* p = _start;	// the read pointer
-      char* q = _start;	// the write pointer
+        char* p = _start;  // the read pointer
+        char* q = _start;  // the write pointer
 
-      while (*p)
-      {
-        if (XMLUtil::IsWhiteSpace(*p))
+        while (*p)
         {
-          p = XMLUtil::SkipWhiteSpace(p);
-          if (*p == 0)
-          {
-            break;    // don't write to q; this trims the trailing space.
-          }
-          *q = ' ';
-          ++q;
-        }
-        *q = *p;
-        ++q;
-        ++p;
-      }
-      *q = 0;
-    }
-  }
-
-  const char* StrPair::GetStr()
-  {
-    if (_flags & NEEDS_FLUSH)
-    {
-      *_end = 0;
-      _flags ^= NEEDS_FLUSH;
-
-      if (_flags)
-      {
-        char* p = _start;	// the read pointer
-        char* q = _start;	// the write pointer
-
-        while (p < _end)
-        {
-          if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR)
-          {
-            // CR-LF pair becomes LF
-            // CR alone becomes LF
-            // LF-CR becomes LF
-            if (*(p + 1) == LF)
+            if (XMLUtil::IsWhiteSpace(*p))
             {
-              p += 2;
-            }
-            else
-            {
-              ++p;
-            }
-            *q++ = LF;
-          }
-          else if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF)
-          {
-            if (*(p + 1) == CR)
-            {
-              p += 2;
-            }
-            else
-            {
-              ++p;
-            }
-            *q++ = LF;
-          }
-          else if ((_flags & NEEDS_ENTITY_PROCESSING) && *p == '&')
-          {
-            // Entities handled by tinyXML2:
-            // - special entities in the entity table [in/out]
-            // - numeric character reference [in]
-            //   &#20013; or &#x4e2d;
-
-            if (*(p + 1) == '#')
-            {
-              char buf[10] = { 0 };
-              int len;
-              p = const_cast<char*>(XMLUtil::GetCharacterRef(p, buf, &len));
-              for (int i = 0; i < len; ++i)
-              {
-                *q++ = buf[i];
-              }
-              TIXMLASSERT(q <= p);
-            }
-            else
-            {
-              int i = 0;
-              for (; i < NUM_ENTITIES; ++i)
-              {
-                if (strncmp(p + 1, entities[i].pattern, entities[i].length) == 0
-                    && *(p + entities[i].length + 1) == ';')
+                p = XMLUtil::SkipWhiteSpace(p);
+                if (*p == 0)
                 {
-                  // Found an entity convert;
-                  *q = entities[i].value;
-                  ++q;
-                  p += entities[i].length + 2;
-                  break;
+                    break;  // don't write to q; this trims the trailing space.
                 }
-              }
-              if (i == NUM_ENTITIES)
-              {
-                // fixme: treat as error?
-                ++p;
+                *q = ' ';
                 ++q;
-              }
             }
-          }
-          else
-          {
             *q = *p;
-            ++p;
             ++q;
-          }
+            ++p;
         }
         *q = 0;
-      }
-      // The loop below has plenty going on, and this
-      // is a less useful mode. Break it out.
-      if (_flags & COLLAPSE_WHITESPACE)
-      {
-        CollapseWhitespace();
-      }
-      _flags = (_flags & NEEDS_DELETE);
+    }
+}
+
+const char* StrPair::GetStr()
+{
+    if (_flags & NEEDS_FLUSH)
+    {
+        *_end = 0;
+        _flags ^= NEEDS_FLUSH;
+
+        if (_flags)
+        {
+            char* p = _start;  // the read pointer
+            char* q = _start;  // the write pointer
+
+            while (p < _end)
+            {
+                if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR)
+                {
+                    // CR-LF pair becomes LF
+                    // CR alone becomes LF
+                    // LF-CR becomes LF
+                    if (*(p + 1) == LF)
+                    {
+                        p += 2;
+                    }
+                    else
+                    {
+                        ++p;
+                    }
+                    *q++ = LF;
+                }
+                else if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF)
+                {
+                    if (*(p + 1) == CR)
+                    {
+                        p += 2;
+                    }
+                    else
+                    {
+                        ++p;
+                    }
+                    *q++ = LF;
+                }
+                else if ((_flags & NEEDS_ENTITY_PROCESSING) && *p == '&')
+                {
+                    // Entities handled by tinyXML2:
+                    // - special entities in the entity table [in/out]
+                    // - numeric character reference [in]
+                    //   &#20013; or &#x4e2d;
+
+                    if (*(p + 1) == '#')
+                    {
+                        char buf[10] = {0};
+                        int len;
+                        p = const_cast<char*>(XMLUtil::GetCharacterRef(p, buf, &len));
+                        for (int i = 0; i < len; ++i)
+                        {
+                            *q++ = buf[i];
+                        }
+                        TIXMLASSERT(q <= p);
+                    }
+                    else
+                    {
+                        int i = 0;
+                        for (; i < NUM_ENTITIES; ++i)
+                        {
+                            if (strncmp(p + 1, entities[i].pattern, entities[i].length) == 0 && *(p + entities[i].length + 1) == ';')
+                            {
+                                // Found an entity convert;
+                                *q = entities[i].value;
+                                ++q;
+                                p += entities[i].length + 2;
+                                break;
+                            }
+                        }
+                        if (i == NUM_ENTITIES)
+                        {
+                            // fixme: treat as error?
+                            ++p;
+                            ++q;
+                        }
+                    }
+                }
+                else
+                {
+                    *q = *p;
+                    ++p;
+                    ++q;
+                }
+            }
+            *q = 0;
+        }
+        // The loop below has plenty going on, and this
+        // is a less useful mode. Break it out.
+        if (_flags & COLLAPSE_WHITESPACE)
+        {
+            CollapseWhitespace();
+        }
+        _flags = (_flags & NEEDS_DELETE);
     }
     return _start;
-  }
+}
 
 // --------- XMLUtil ----------- //
 
-  const char* XMLUtil::ReadBOM(const char* p, bool* bom)
-  {
+const char* XMLUtil::ReadBOM(const char* p, bool* bom)
+{
     *bom = false;
     const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
     // Check for BOM:
-    if (*(pu + 0) == TIXML_UTF_LEAD_0 && *(pu + 1) == TIXML_UTF_LEAD_1
-        && *(pu + 2) == TIXML_UTF_LEAD_2)
+    if (*(pu + 0) == TIXML_UTF_LEAD_0 && *(pu + 1) == TIXML_UTF_LEAD_1 && *(pu + 2) == TIXML_UTF_LEAD_2)
     {
-      *bom = true;
-      p += 3;
+        *bom = true;
+        p += 3;
     }
     return p;
-  }
+}
 
-  void XMLUtil::ConvertUTF32ToUTF8(unsigned long input, char* output,
-      int* length)
-  {
+void XMLUtil::ConvertUTF32ToUTF8(unsigned long input, char* output,
+                                 int* length)
+{
     const unsigned long BYTE_MASK = 0xBF;
     const unsigned long BYTE_MARK = 0x80;
-    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0,
-        0xF8, 0xFC };
+    const unsigned long FIRST_BYTE_MARK[7] = {0x00, 0x00, 0xC0, 0xE0, 0xF0,
+                                              0xF8, 0xFC};
 
     if (input < 0x80)
     {
-      *length = 1;
+        *length = 1;
     }
     else if (input < 0x800)
     {
-      *length = 2;
+        *length = 2;
     }
     else if (input < 0x10000)
     {
-      *length = 3;
+        *length = 3;
     }
     else if (input < 0x200000)
     {
-      *length = 4;
+        *length = 4;
     }
     else
     {
-      *length = 0;    // This code won't covert this correctly anyway.
-      return;
+        *length = 0;  // This code won't covert this correctly anyway.
+        return;
     }
 
     output += *length;
@@ -328,221 +326,221 @@ namespace tinyxml2
     // Scary scary fall throughs.
     switch (*length)
     {
-    case 4:
-      --output;
-      *output = (char) ((input | BYTE_MARK) & BYTE_MASK);
-      input >>= 6;
-    case 3:
-      --output;
-      *output = (char) ((input | BYTE_MARK) & BYTE_MASK);
-      input >>= 6;
-    case 2:
-      --output;
-      *output = (char) ((input | BYTE_MARK) & BYTE_MASK);
-      input >>= 6;
-    case 1:
-      --output;
-      *output = (char) (input | FIRST_BYTE_MARK[*length]);
-    default:
-      break;
+        case 4:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 3:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 2:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 1:
+            --output;
+            *output = (char)(input | FIRST_BYTE_MARK[*length]);
+        default:
+            break;
     }
-  }
+}
 
-  const char* XMLUtil::GetCharacterRef(const char* p, char* value, int* length)
-  {
+const char* XMLUtil::GetCharacterRef(const char* p, char* value, int* length)
+{
     // Presume an entity, and pull it out.
     *length = 0;
 
     if (*(p + 1) == '#' && *(p + 2))
     {
-      unsigned long ucs = 0;
-      ptrdiff_t delta = 0;
-      unsigned mult = 1;
+        unsigned long ucs = 0;
+        ptrdiff_t delta = 0;
+        unsigned mult = 1;
 
-      if (*(p + 2) == 'x')
-      {
-        // Hexadecimal.
-        if (!*(p + 3))
+        if (*(p + 2) == 'x')
         {
-          return 0;
+            // Hexadecimal.
+            if (!*(p + 3))
+            {
+                return 0;
+            }
+
+            const char* q = p + 3;
+            q = strchr(q, ';');
+
+            if (!q || !*q)
+            {
+                return 0;
+            }
+
+            delta = q - p;
+            --q;
+
+            while (*q != 'x')
+            {
+                if (*q >= '0' && *q <= '9')
+                {
+                    ucs += mult * (*q - '0');
+                }
+                else if (*q >= 'a' && *q <= 'f')
+                {
+                    ucs += mult * (*q - 'a' + 10);
+                }
+                else if (*q >= 'A' && *q <= 'F')
+                {
+                    ucs += mult * (*q - 'A' + 10);
+                }
+                else
+                {
+                    return 0;
+                }
+                mult *= 16;
+                --q;
+            }
         }
-
-        const char* q = p + 3;
-        q = strchr(q, ';');
-
-        if (!q || !*q)
+        else
         {
-          return 0;
+            // Decimal.
+            if (!*(p + 2))
+            {
+                return 0;
+            }
+
+            const char* q = p + 2;
+            q = strchr(q, ';');
+
+            if (!q || !*q)
+            {
+                return 0;
+            }
+
+            delta = q - p;
+            --q;
+
+            while (*q != '#')
+            {
+                if (*q >= '0' && *q <= '9')
+                {
+                    ucs += mult * (*q - '0');
+                }
+                else
+                {
+                    return 0;
+                }
+                mult *= 10;
+                --q;
+            }
         }
-
-        delta = q - p;
-        --q;
-
-        while (*q != 'x')
-        {
-          if (*q >= '0' && *q <= '9')
-          {
-            ucs += mult * (*q - '0');
-          }
-          else if (*q >= 'a' && *q <= 'f')
-          {
-            ucs += mult * (*q - 'a' + 10);
-          }
-          else if (*q >= 'A' && *q <= 'F')
-          {
-            ucs += mult * (*q - 'A' + 10);
-          }
-          else
-          {
-            return 0;
-          }
-          mult *= 16;
-          --q;
-        }
-      }
-      else
-      {
-        // Decimal.
-        if (!*(p + 2))
-        {
-          return 0;
-        }
-
-        const char* q = p + 2;
-        q = strchr(q, ';');
-
-        if (!q || !*q)
-        {
-          return 0;
-        }
-
-        delta = q - p;
-        --q;
-
-        while (*q != '#')
-        {
-          if (*q >= '0' && *q <= '9')
-          {
-            ucs += mult * (*q - '0');
-          }
-          else
-          {
-            return 0;
-          }
-          mult *= 10;
-          --q;
-        }
-      }
-      // convert the UCS to UTF-8
-      ConvertUTF32ToUTF8(ucs, value, length);
-      return p + delta + 1;
+        // convert the UCS to UTF-8
+        ConvertUTF32ToUTF8(ucs, value, length);
+        return p + delta + 1;
     }
     return p + 1;
-  }
+}
 
-  void XMLUtil::ToStr(int v, char* buffer, int bufferSize)
-  {
+void XMLUtil::ToStr(int v, char* buffer, int bufferSize)
+{
     TIXML_SNPRINTF(buffer, bufferSize, "%d", v);
-  }
+}
 
-  void XMLUtil::ToStr(unsigned v, char* buffer, int bufferSize)
-  {
+void XMLUtil::ToStr(unsigned v, char* buffer, int bufferSize)
+{
     TIXML_SNPRINTF(buffer, bufferSize, "%u", v);
-  }
+}
 
-  void XMLUtil::ToStr(bool v, char* buffer, int bufferSize)
-  {
+void XMLUtil::ToStr(bool v, char* buffer, int bufferSize)
+{
     TIXML_SNPRINTF(buffer, bufferSize, "%d", v ? 1 : 0);
-  }
+}
 
-  /*
+/*
    ToStr() of a number is a very tricky topic.
    https://github.com/leethomason/tinyxml2/issues/106
    */
-  void XMLUtil::ToStr(float v, char* buffer, int bufferSize)
-  {
+void XMLUtil::ToStr(float v, char* buffer, int bufferSize)
+{
     TIXML_SNPRINTF(buffer, bufferSize, "%.8g", v);
-  }
+}
 
-  void XMLUtil::ToStr(double v, char* buffer, int bufferSize)
-  {
+void XMLUtil::ToStr(double v, char* buffer, int bufferSize)
+{
     TIXML_SNPRINTF(buffer, bufferSize, "%.17g", v);
-  }
+}
 
-  bool XMLUtil::ToInt(const char* str, int* value)
-  {
-    if ( TIXML_SSCANF(str, "%d", value) == 1)
+bool XMLUtil::ToInt(const char* str, int* value)
+{
+    if (TIXML_SSCANF(str, "%d", value) == 1)
     {
-      return true;
+        return true;
     }
     return false;
-  }
+}
 
-  bool XMLUtil::ToUnsigned(const char* str, unsigned *value)
-  {
-    if ( TIXML_SSCANF(str, "%u", value) == 1)
+bool XMLUtil::ToUnsigned(const char* str, unsigned* value)
+{
+    if (TIXML_SSCANF(str, "%u", value) == 1)
     {
-      return true;
+        return true;
     }
     return false;
-  }
+}
 
-  bool XMLUtil::ToBool(const char* str, bool* value)
-  {
+bool XMLUtil::ToBool(const char* str, bool* value)
+{
     int ival = 0;
     if (ToInt(str, &ival))
     {
-      *value = (ival == 0) ? false : true;
-      return true;
+        *value = (ival == 0) ? false : true;
+        return true;
     }
     if (StringEqual(str, "true"))
     {
-      *value = true;
-      return true;
+        *value = true;
+        return true;
     }
     else if (StringEqual(str, "false"))
     {
-      *value = false;
-      return true;
+        *value = false;
+        return true;
     }
     return false;
-  }
+}
 
-  bool XMLUtil::ToFloat(const char* str, float* value)
-  {
-    if ( TIXML_SSCANF(str, "%f", value) == 1)
+bool XMLUtil::ToFloat(const char* str, float* value)
+{
+    if (TIXML_SSCANF(str, "%f", value) == 1)
     {
-      return true;
+        return true;
     }
     return false;
-  }
+}
 
-  bool XMLUtil::ToDouble(const char* str, double* value)
-  {
-    if ( TIXML_SSCANF(str, "%lf", value) == 1)
+bool XMLUtil::ToDouble(const char* str, double* value)
+{
+    if (TIXML_SSCANF(str, "%lf", value) == 1)
     {
-      return true;
+        return true;
     }
     return false;
-  }
+}
 
-  char* XMLDocument::Identify(char* p, XMLNode** node)
-  {
+char* XMLDocument::Identify(char* p, XMLNode** node)
+{
     XMLNode* returnNode = 0;
     char* start = p;
     p = XMLUtil::SkipWhiteSpace(p);
     if (!p || !*p)
     {
-      return p;
+        return p;
     }
 
     // What is this thing?
     // These strings define the matching patters:
-    static const char* xmlHeader = { "<?" };
-    static const char* commentHeader = { "<!--" };
-    static const char* dtdHeader = { "<!" };
-    static const char* cdataHeader = { "<![CDATA[" };
-    static const char* elementHeader = { "<" };	// and a header for everything else; check last.
+    static const char* xmlHeader = {"<?"};
+    static const char* commentHeader = {"<!--"};
+    static const char* dtdHeader = {"<!"};
+    static const char* cdataHeader = {"<![CDATA["};
+    static const char* elementHeader = {"<"};  // and a header for everything else; check last.
 
     static const int xmlHeaderLen = 2;
     static const int commentHeaderLen = 4;
@@ -551,297 +549,294 @@ namespace tinyxml2
     static const int elementHeaderLen = 1;
 
 #if defined(_MSC_VER)
-#pragma warning ( push )
-#pragma warning ( disable : 4127 )
+#pragma warning(push)
+#pragma warning(disable : 4127)
 #endif
-    TIXMLASSERT(sizeof( XMLComment ) == sizeof( XMLUnknown ));// use same memory pool
-    TIXMLASSERT(sizeof( XMLComment ) == sizeof( XMLDeclaration ));// use same memory pool
+    TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLUnknown));      // use same memory pool
+    TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLDeclaration));  // use same memory pool
 #if defined(_MSC_VER)
-#pragma warning (pop)
+#pragma warning(pop)
 #endif
     if (XMLUtil::StringEqual(p, xmlHeader, xmlHeaderLen))
     {
-      returnNode = new (_commentPool.Alloc()) XMLDeclaration(this);
-      returnNode->_memPool = &_commentPool;
-      p += xmlHeaderLen;
+        returnNode = new (_commentPool.Alloc()) XMLDeclaration(this);
+        returnNode->_memPool = &_commentPool;
+        p += xmlHeaderLen;
     }
     else if (XMLUtil::StringEqual(p, commentHeader, commentHeaderLen))
     {
-      returnNode = new (_commentPool.Alloc()) XMLComment(this);
-      returnNode->_memPool = &_commentPool;
-      p += commentHeaderLen;
+        returnNode = new (_commentPool.Alloc()) XMLComment(this);
+        returnNode->_memPool = &_commentPool;
+        p += commentHeaderLen;
     }
     else if (XMLUtil::StringEqual(p, cdataHeader, cdataHeaderLen))
     {
-      XMLText* text = new (_textPool.Alloc()) XMLText(this);
-      returnNode = text;
-      returnNode->_memPool = &_textPool;
-      p += cdataHeaderLen;
-      text->SetCData(true);
+        XMLText* text = new (_textPool.Alloc()) XMLText(this);
+        returnNode = text;
+        returnNode->_memPool = &_textPool;
+        p += cdataHeaderLen;
+        text->SetCData(true);
     }
     else if (XMLUtil::StringEqual(p, dtdHeader, dtdHeaderLen))
     {
-      returnNode = new (_commentPool.Alloc()) XMLUnknown(this);
-      returnNode->_memPool = &_commentPool;
-      p += dtdHeaderLen;
+        returnNode = new (_commentPool.Alloc()) XMLUnknown(this);
+        returnNode->_memPool = &_commentPool;
+        p += dtdHeaderLen;
     }
     else if (XMLUtil::StringEqual(p, elementHeader, elementHeaderLen))
     {
-      returnNode = new (_elementPool.Alloc()) XMLElement(this);
-      returnNode->_memPool = &_elementPool;
-      p += elementHeaderLen;
+        returnNode = new (_elementPool.Alloc()) XMLElement(this);
+        returnNode->_memPool = &_elementPool;
+        p += elementHeaderLen;
     }
     else
     {
-      returnNode = new (_textPool.Alloc()) XMLText(this);
-      returnNode->_memPool = &_textPool;
-      p = start;	// Back it up, all the text counts.
+        returnNode = new (_textPool.Alloc()) XMLText(this);
+        returnNode->_memPool = &_textPool;
+        p = start;  // Back it up, all the text counts.
     }
 
     *node = returnNode;
     return p;
-  }
+}
 
-  bool XMLDocument::Accept(XMLVisitor* visitor) const
-  {
+bool XMLDocument::Accept(XMLVisitor* visitor) const
+{
     if (visitor->VisitEnter(*this))
     {
-      for (const XMLNode* node = FirstChild(); node; node = node->NextSibling())
-      {
-        if (!node->Accept(visitor))
+        for (const XMLNode* node = FirstChild(); node; node = node->NextSibling())
         {
-          break;
+            if (!node->Accept(visitor))
+            {
+                break;
+            }
         }
-      }
     }
     return visitor->VisitExit(*this);
-  }
+}
 
 // --------- XMLNode ----------- //
 
-  XMLNode::XMLNode(XMLDocument* doc)
-      : _document(doc), _parent(0), _firstChild(0), _lastChild(0), _prev(0), _next(
-          0), _memPool(0)
-  {
-  }
+XMLNode::XMLNode(XMLDocument* doc)
+    : _document(doc), _parent(0), _firstChild(0), _lastChild(0), _prev(0), _next(0), _memPool(0)
+{
+}
 
-  XMLNode::~XMLNode()
-  {
+XMLNode::~XMLNode()
+{
     DeleteChildren();
     if (_parent)
     {
-      _parent->Unlink(this);
+        _parent->Unlink(this);
     }
-  }
+}
 
-  const char* XMLNode::Value() const
-  {
+const char* XMLNode::Value() const
+{
     return _value.GetStr();
-  }
+}
 
-  void XMLNode::SetValue(const char* str, bool staticMem)
-  {
+void XMLNode::SetValue(const char* str, bool staticMem)
+{
     if (staticMem)
     {
-      _value.SetInternedStr(str);
+        _value.SetInternedStr(str);
     }
     else
     {
-      _value.SetStr(str);
+        _value.SetStr(str);
     }
-  }
+}
 
-  void XMLNode::DeleteChildren()
-  {
+void XMLNode::DeleteChildren()
+{
     while (_firstChild)
     {
-      XMLNode* node = _firstChild;
-      Unlink(node);
+        XMLNode* node = _firstChild;
+        Unlink(node);
 
-      DELETE_NODE(node);
+        DELETE_NODE(node);
     }
     _firstChild = _lastChild = 0;
-  }
+}
 
-  void XMLNode::Unlink(XMLNode* child)
-  {
+void XMLNode::Unlink(XMLNode* child)
+{
     if (child == _firstChild)
     {
-      _firstChild = _firstChild->_next;
+        _firstChild = _firstChild->_next;
     }
     if (child == _lastChild)
     {
-      _lastChild = _lastChild->_prev;
+        _lastChild = _lastChild->_prev;
     }
 
     if (child->_prev)
     {
-      child->_prev->_next = child->_next;
+        child->_prev->_next = child->_next;
     }
     if (child->_next)
     {
-      child->_next->_prev = child->_prev;
+        child->_next->_prev = child->_prev;
     }
     child->_parent = 0;
-  }
+}
 
-  void XMLNode::DeleteChild(XMLNode* node)
-  {
+void XMLNode::DeleteChild(XMLNode* node)
+{
     TIXMLASSERT(node->_parent == this);
     DELETE_NODE(node);
-  }
+}
 
-  XMLNode* XMLNode::InsertEndChild(XMLNode* addThis)
-  {
+XMLNode* XMLNode::InsertEndChild(XMLNode* addThis)
+{
     if (addThis->_document != _document) return 0;
 
     if (addThis->_parent)
-      addThis->_parent->Unlink(addThis);
+        addThis->_parent->Unlink(addThis);
     else
-      addThis->_memPool->SetTracked();
+        addThis->_memPool->SetTracked();
 
     if (_lastChild)
     {
-      TIXMLASSERT(_firstChild);
-      TIXMLASSERT(_lastChild->_next == 0);
-      _lastChild->_next = addThis;
-      addThis->_prev = _lastChild;
-      _lastChild = addThis;
+        TIXMLASSERT(_firstChild);
+        TIXMLASSERT(_lastChild->_next == 0);
+        _lastChild->_next = addThis;
+        addThis->_prev = _lastChild;
+        _lastChild = addThis;
 
-      addThis->_next = 0;
+        addThis->_next = 0;
     }
     else
     {
-      TIXMLASSERT(_firstChild == 0);
-      _firstChild = _lastChild = addThis;
+        TIXMLASSERT(_firstChild == 0);
+        _firstChild = _lastChild = addThis;
 
-      addThis->_prev = 0;
-      addThis->_next = 0;
+        addThis->_prev = 0;
+        addThis->_next = 0;
     }
     addThis->_parent = this;
     return addThis;
-  }
+}
 
-  XMLNode* XMLNode::InsertFirstChild(XMLNode* addThis)
-  {
+XMLNode* XMLNode::InsertFirstChild(XMLNode* addThis)
+{
     if (addThis->_document != _document) return 0;
 
     if (addThis->_parent)
-      addThis->_parent->Unlink(addThis);
+        addThis->_parent->Unlink(addThis);
     else
-      addThis->_memPool->SetTracked();
+        addThis->_memPool->SetTracked();
 
     if (_firstChild)
     {
-      TIXMLASSERT(_lastChild);
-      TIXMLASSERT(_firstChild->_prev == 0);
+        TIXMLASSERT(_lastChild);
+        TIXMLASSERT(_firstChild->_prev == 0);
 
-      _firstChild->_prev = addThis;
-      addThis->_next = _firstChild;
-      _firstChild = addThis;
+        _firstChild->_prev = addThis;
+        addThis->_next = _firstChild;
+        _firstChild = addThis;
 
-      addThis->_prev = 0;
+        addThis->_prev = 0;
     }
     else
     {
-      TIXMLASSERT(_lastChild == 0);
-      _firstChild = _lastChild = addThis;
+        TIXMLASSERT(_lastChild == 0);
+        _firstChild = _lastChild = addThis;
 
-      addThis->_prev = 0;
-      addThis->_next = 0;
+        addThis->_prev = 0;
+        addThis->_next = 0;
     }
     addThis->_parent = this;
     return addThis;
-  }
+}
 
-  XMLNode* XMLNode::InsertAfterChild(XMLNode* afterThis, XMLNode* addThis)
-  {
+XMLNode* XMLNode::InsertAfterChild(XMLNode* afterThis, XMLNode* addThis)
+{
     if (addThis->_document != _document) return 0;
 
     TIXMLASSERT(afterThis->_parent == this);
 
     if (afterThis->_parent != this)
     {
-      return 0;
+        return 0;
     }
 
     if (afterThis->_next == 0)
     {
-      // The last node or the only node.
-      return InsertEndChild(addThis);
+        // The last node or the only node.
+        return InsertEndChild(addThis);
     }
     if (addThis->_parent)
-      addThis->_parent->Unlink(addThis);
+        addThis->_parent->Unlink(addThis);
     else
-      addThis->_memPool->SetTracked();
+        addThis->_memPool->SetTracked();
     addThis->_prev = afterThis;
     addThis->_next = afterThis->_next;
     afterThis->_next->_prev = addThis;
     afterThis->_next = addThis;
     addThis->_parent = this;
     return addThis;
-  }
+}
 
-  const XMLElement* XMLNode::FirstChildElement(const char* value) const
-  {
+const XMLElement* XMLNode::FirstChildElement(const char* value) const
+{
     for (XMLNode* node = _firstChild; node; node = node->_next)
     {
-      XMLElement* element = node->ToElement();
-      if (element)
-      {
-        if (!value || XMLUtil::StringEqual(element->Name(), value))
+        XMLElement* element = node->ToElement();
+        if (element)
         {
-          return element;
+            if (!value || XMLUtil::StringEqual(element->Name(), value))
+            {
+                return element;
+            }
         }
-      }
     }
     return 0;
-  }
+}
 
-  const XMLElement* XMLNode::LastChildElement(const char* value) const
-  {
+const XMLElement* XMLNode::LastChildElement(const char* value) const
+{
     for (XMLNode* node = _lastChild; node; node = node->_prev)
     {
-      XMLElement* element = node->ToElement();
-      if (element)
-      {
-        if (!value || XMLUtil::StringEqual(element->Name(), value))
+        XMLElement* element = node->ToElement();
+        if (element)
         {
-          return element;
+            if (!value || XMLUtil::StringEqual(element->Name(), value))
+            {
+                return element;
+            }
         }
-      }
     }
     return 0;
-  }
+}
 
-  const XMLElement* XMLNode::NextSiblingElement(const char* value) const
-  {
+const XMLElement* XMLNode::NextSiblingElement(const char* value) const
+{
     for (XMLNode* element = this->_next; element; element = element->_next)
     {
-      if (element->ToElement()
-          && (!value || XMLUtil::StringEqual(value, element->Value())))
-      {
-        return element->ToElement();
-      }
+        if (element->ToElement() && (!value || XMLUtil::StringEqual(value, element->Value())))
+        {
+            return element->ToElement();
+        }
     }
     return 0;
-  }
+}
 
-  const XMLElement* XMLNode::PreviousSiblingElement(const char* value) const
-  {
+const XMLElement* XMLNode::PreviousSiblingElement(const char* value) const
+{
     for (XMLNode* element = _prev; element; element = element->_prev)
     {
-      if (element->ToElement()
-          && (!value || XMLUtil::StringEqual(value, element->Value())))
-      {
-        return element->ToElement();
-      }
+        if (element->ToElement() && (!value || XMLUtil::StringEqual(value, element->Value())))
+        {
+            return element->ToElement();
+        }
     }
     return 0;
-  }
+}
 
-  char* XMLNode::ParseDeep(char* p, StrPair* parentEnd)
-  {
+char* XMLNode::ParseDeep(char* p, StrPair* parentEnd)
+{
     // This is a recursive method, but thinking about it "at the current level"
     // it is a pretty simple flat list:
     //		<foo/>
@@ -861,712 +856,705 @@ namespace tinyxml2
 
     while (p && *p)
     {
-      XMLNode* node = 0;
+        XMLNode* node = 0;
 
-      p = _document->Identify(p, &node);
-      if (p == 0 || node == 0)
-      {
-        break;
-      }
+        p = _document->Identify(p, &node);
+        if (p == 0 || node == 0)
+        {
+            break;
+        }
 
-      StrPair endTag;
-      p = node->ParseDeep(p, &endTag);
-      if (!p)
-      {
-        DELETE_NODE(node);
-        node = 0;
-        if (!_document->Error())
+        StrPair endTag;
+        p = node->ParseDeep(p, &endTag);
+        if (!p)
         {
-          _document->SetError(XML_ERROR_PARSING, 0, 0);
+            DELETE_NODE(node);
+            node = 0;
+            if (!_document->Error())
+            {
+                _document->SetError(XML_ERROR_PARSING, 0, 0);
+            }
+            break;
         }
-        break;
-      }
 
-      // We read the end tag. Return it to the parent.
-      if (node->ToElement()
-          && node->ToElement()->ClosingType() == XMLElement::CLOSING)
-      {
-        if (parentEnd)
+        // We read the end tag. Return it to the parent.
+        if (node->ToElement() && node->ToElement()->ClosingType() == XMLElement::CLOSING)
         {
-          *parentEnd = static_cast<XMLElement*>(node)->_value;
+            if (parentEnd)
+            {
+                *parentEnd = static_cast<XMLElement*>(node)->_value;
+            }
+            node->_memPool->SetTracked();  // created and then immediately deleted.
+            DELETE_NODE(node);
+            return p;
         }
-        node->_memPool->SetTracked();	// created and then immediately deleted.
-        DELETE_NODE(node);
-        return p;
-      }
 
-      // Handle an end tag returned to this level.
-      // And handle a bunch of annoying errors.
-      XMLElement* ele = node->ToElement();
-      if (ele)
-      {
-        if (endTag.Empty() && ele->ClosingType() == XMLElement::OPEN)
+        // Handle an end tag returned to this level.
+        // And handle a bunch of annoying errors.
+        XMLElement* ele = node->ToElement();
+        if (ele)
         {
-          _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
-          p = 0;
+            if (endTag.Empty() && ele->ClosingType() == XMLElement::OPEN)
+            {
+                _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
+                p = 0;
+            }
+            else if (!endTag.Empty() && ele->ClosingType() != XMLElement::OPEN)
+            {
+                _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
+                p = 0;
+            }
+            else if (!endTag.Empty())
+            {
+                if (!XMLUtil::StringEqual(endTag.GetStr(), node->Value()))
+                {
+                    _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
+                    p = 0;
+                }
+            }
         }
-        else if (!endTag.Empty() && ele->ClosingType() != XMLElement::OPEN)
+        if (p == 0)
         {
-          _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
-          p = 0;
+            DELETE_NODE(node);
+            node = 0;
         }
-        else if (!endTag.Empty())
+        if (node)
         {
-          if (!XMLUtil::StringEqual(endTag.GetStr(), node->Value()))
-          {
-            _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0);
-            p = 0;
-          }
+            this->InsertEndChild(node);
         }
-      }
-      if (p == 0)
-      {
-        DELETE_NODE(node);
-        node = 0;
-      }
-      if (node)
-      {
-        this->InsertEndChild(node);
-      }
     }
     return 0;
-  }
+}
 
 // --------- XMLText ---------- //
-  char* XMLText::ParseDeep(char* p, StrPair*)
-  {
+char* XMLText::ParseDeep(char* p, StrPair*)
+{
     const char* start = p;
     if (this->CData())
     {
-      p = _value.ParseText(p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION);
-      if (!p)
-      {
-        _document->SetError(XML_ERROR_PARSING_CDATA, start, 0);
-      }
-      return p;
+        p = _value.ParseText(p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION);
+        if (!p)
+        {
+            _document->SetError(XML_ERROR_PARSING_CDATA, start, 0);
+        }
+        return p;
     }
     else
     {
-      int flags =
-          _document->ProcessEntities() ?
-              StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
-      if (_document->WhitespaceMode() == COLLAPSE_WHITESPACE)
-      {
-        flags |= StrPair::COLLAPSE_WHITESPACE;
-      }
+        int flags =
+            _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+        if (_document->WhitespaceMode() == COLLAPSE_WHITESPACE)
+        {
+            flags |= StrPair::COLLAPSE_WHITESPACE;
+        }
 
-      p = _value.ParseText(p, "<", flags);
-      if (!p)
-      {
-        _document->SetError(XML_ERROR_PARSING_TEXT, start, 0);
-      }
-      if (p && *p)
-      {
-        return p - 1;
-      }
+        p = _value.ParseText(p, "<", flags);
+        if (!p)
+        {
+            _document->SetError(XML_ERROR_PARSING_TEXT, start, 0);
+        }
+        if (p && *p)
+        {
+            return p - 1;
+        }
     }
     return 0;
-  }
+}
 
-  XMLNode* XMLText::ShallowClone(XMLDocument* doc) const
-  {
+XMLNode* XMLText::ShallowClone(XMLDocument* doc) const
+{
     if (!doc)
     {
-      doc = _document;
+        doc = _document;
     }
-    XMLText* text = doc->NewText(Value());// fixme: this will always allocate memory. Intern?
+    XMLText* text = doc->NewText(Value());  // fixme: this will always allocate memory. Intern?
     text->SetCData(this->CData());
     return text;
-  }
+}
 
-  bool XMLText::ShallowEqual(const XMLNode* compare) const
-  {
-    return (compare->ToText()
-        && XMLUtil::StringEqual(compare->ToText()->Value(), Value()));
-  }
+bool XMLText::ShallowEqual(const XMLNode* compare) const
+{
+    return (compare->ToText() && XMLUtil::StringEqual(compare->ToText()->Value(), Value()));
+}
 
-  bool XMLText::Accept(XMLVisitor* visitor) const
-  {
+bool XMLText::Accept(XMLVisitor* visitor) const
+{
     return visitor->Visit(*this);
-  }
+}
 
 // --------- XMLComment ---------- //
 
-  XMLComment::XMLComment(XMLDocument* doc)
-      : XMLNode(doc)
-  {
-  }
+XMLComment::XMLComment(XMLDocument* doc)
+    : XMLNode(doc)
+{
+}
 
-  XMLComment::~XMLComment()
-  {
-  }
+XMLComment::~XMLComment()
+{
+}
 
-  char* XMLComment::ParseDeep(char* p, StrPair*)
-  {
+char* XMLComment::ParseDeep(char* p, StrPair*)
+{
     // Comment parses as text.
     const char* start = p;
     p = _value.ParseText(p, "-->", StrPair::COMMENT);
     if (p == 0)
     {
-      _document->SetError(XML_ERROR_PARSING_COMMENT, start, 0);
+        _document->SetError(XML_ERROR_PARSING_COMMENT, start, 0);
     }
     return p;
-  }
+}
 
-  XMLNode* XMLComment::ShallowClone(XMLDocument* doc) const
-  {
+XMLNode* XMLComment::ShallowClone(XMLDocument* doc) const
+{
     if (!doc)
     {
-      doc = _document;
+        doc = _document;
     }
-    XMLComment* comment = doc->NewComment(Value());	// fixme: this will always allocate memory. Intern?
+    XMLComment* comment = doc->NewComment(Value());  // fixme: this will always allocate memory. Intern?
     return comment;
-  }
+}
 
-  bool XMLComment::ShallowEqual(const XMLNode* compare) const
-  {
-    return (compare->ToComment()
-        && XMLUtil::StringEqual(compare->ToComment()->Value(), Value()));
-  }
+bool XMLComment::ShallowEqual(const XMLNode* compare) const
+{
+    return (compare->ToComment() && XMLUtil::StringEqual(compare->ToComment()->Value(), Value()));
+}
 
-  bool XMLComment::Accept(XMLVisitor* visitor) const
-  {
+bool XMLComment::Accept(XMLVisitor* visitor) const
+{
     return visitor->Visit(*this);
-  }
+}
 
 // --------- XMLDeclaration ---------- //
 
-  XMLDeclaration::XMLDeclaration(XMLDocument* doc)
-      : XMLNode(doc)
-  {
-  }
+XMLDeclaration::XMLDeclaration(XMLDocument* doc)
+    : XMLNode(doc)
+{
+}
 
-  XMLDeclaration::~XMLDeclaration()
-  {
+XMLDeclaration::~XMLDeclaration()
+{
     //printf( "~XMLDeclaration\n" );
-  }
+}
 
-  char* XMLDeclaration::ParseDeep(char* p, StrPair*)
-  {
+char* XMLDeclaration::ParseDeep(char* p, StrPair*)
+{
     // Declaration parses as text.
     const char* start = p;
     p = _value.ParseText(p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION);
     if (p == 0)
     {
-      _document->SetError(XML_ERROR_PARSING_DECLARATION, start, 0);
+        _document->SetError(XML_ERROR_PARSING_DECLARATION, start, 0);
     }
     return p;
-  }
+}
 
-  XMLNode* XMLDeclaration::ShallowClone(XMLDocument* doc) const
-  {
+XMLNode* XMLDeclaration::ShallowClone(XMLDocument* doc) const
+{
     if (!doc)
     {
-      doc = _document;
+        doc = _document;
     }
-    XMLDeclaration* dec = doc->NewDeclaration(Value());	// fixme: this will always allocate memory. Intern?
+    XMLDeclaration* dec = doc->NewDeclaration(Value());  // fixme: this will always allocate memory. Intern?
     return dec;
-  }
+}
 
-  bool XMLDeclaration::ShallowEqual(const XMLNode* compare) const
-  {
-    return (compare->ToDeclaration()
-        && XMLUtil::StringEqual(compare->ToDeclaration()->Value(), Value()));
-  }
+bool XMLDeclaration::ShallowEqual(const XMLNode* compare) const
+{
+    return (compare->ToDeclaration() && XMLUtil::StringEqual(compare->ToDeclaration()->Value(), Value()));
+}
 
-  bool XMLDeclaration::Accept(XMLVisitor* visitor) const
-  {
+bool XMLDeclaration::Accept(XMLVisitor* visitor) const
+{
     return visitor->Visit(*this);
-  }
+}
 
 // --------- XMLUnknown ---------- //
 
-  XMLUnknown::XMLUnknown(XMLDocument* doc)
-      : XMLNode(doc)
-  {
-  }
+XMLUnknown::XMLUnknown(XMLDocument* doc)
+    : XMLNode(doc)
+{
+}
 
-  XMLUnknown::~XMLUnknown()
-  {
-  }
+XMLUnknown::~XMLUnknown()
+{
+}
 
-  char* XMLUnknown::ParseDeep(char* p, StrPair*)
-  {
+char* XMLUnknown::ParseDeep(char* p, StrPair*)
+{
     // Unknown parses as text.
     const char* start = p;
 
     p = _value.ParseText(p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION);
     if (!p)
     {
-      _document->SetError(XML_ERROR_PARSING_UNKNOWN, start, 0);
+        _document->SetError(XML_ERROR_PARSING_UNKNOWN, start, 0);
     }
     return p;
-  }
+}
 
-  XMLNode* XMLUnknown::ShallowClone(XMLDocument* doc) const
-  {
+XMLNode* XMLUnknown::ShallowClone(XMLDocument* doc) const
+{
     if (!doc)
     {
-      doc = _document;
+        doc = _document;
     }
-    XMLUnknown* text = doc->NewUnknown(Value());// fixme: this will always allocate memory. Intern?
+    XMLUnknown* text = doc->NewUnknown(Value());  // fixme: this will always allocate memory. Intern?
     return text;
-  }
+}
 
-  bool XMLUnknown::ShallowEqual(const XMLNode* compare) const
-  {
-    return (compare->ToUnknown()
-        && XMLUtil::StringEqual(compare->ToUnknown()->Value(), Value()));
-  }
+bool XMLUnknown::ShallowEqual(const XMLNode* compare) const
+{
+    return (compare->ToUnknown() && XMLUtil::StringEqual(compare->ToUnknown()->Value(), Value()));
+}
 
-  bool XMLUnknown::Accept(XMLVisitor* visitor) const
-  {
+bool XMLUnknown::Accept(XMLVisitor* visitor) const
+{
     return visitor->Visit(*this);
-  }
+}
 
 // --------- XMLAttribute ---------- //
 
-  const char* XMLAttribute::Name() const
-  {
+const char* XMLAttribute::Name() const
+{
     return _name.GetStr();
-  }
+}
 
-  const char* XMLAttribute::Value() const
-  {
+const char* XMLAttribute::Value() const
+{
     return _value.GetStr();
-  }
+}
 
-  char* XMLAttribute::ParseDeep(char* p, bool processEntities)
-  {
+char* XMLAttribute::ParseDeep(char* p, bool processEntities)
+{
     // Parse using the name rules: bug fix, was using ParseText before
     p = _name.ParseName(p);
     if (!p || !*p)
     {
-      return 0;
+        return 0;
     }
 
     // Skip white space before =
     p = XMLUtil::SkipWhiteSpace(p);
     if (!p || *p != '=')
     {
-      return 0;
+        return 0;
     }
 
-    ++p;	// move up to opening quote
+    ++p;  // move up to opening quote
     p = XMLUtil::SkipWhiteSpace(p);
     if (*p != '\"' && *p != '\'')
     {
-      return 0;
+        return 0;
     }
 
-    char endTag[2] = { *p, 0 };
-    ++p;	// move past opening quote
+    char endTag[2] = {*p, 0};
+    ++p;  // move past opening quote
 
     p = _value.ParseText(p, endTag,
-        processEntities ?
-            StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES);
+                         processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES);
     return p;
-  }
+}
 
-  void XMLAttribute::SetName(const char* n)
-  {
+void XMLAttribute::SetName(const char* n)
+{
     _name.SetStr(n);
-  }
+}
 
-  XMLError XMLAttribute::QueryIntValue(int* value) const
-  {
+XMLError XMLAttribute::QueryIntValue(int* value) const
+{
     if (XMLUtil::ToInt(Value(), value))
     {
-      return XML_NO_ERROR;
+        return XML_NO_ERROR;
     }
     return XML_WRONG_ATTRIBUTE_TYPE;
-  }
+}
 
-  XMLError XMLAttribute::QueryUnsignedValue(unsigned int* value) const
-  {
+XMLError XMLAttribute::QueryUnsignedValue(unsigned int* value) const
+{
     if (XMLUtil::ToUnsigned(Value(), value))
     {
-      return XML_NO_ERROR;
+        return XML_NO_ERROR;
     }
     return XML_WRONG_ATTRIBUTE_TYPE;
-  }
+}
 
-  XMLError XMLAttribute::QueryBoolValue(bool* value) const
-  {
+XMLError XMLAttribute::QueryBoolValue(bool* value) const
+{
     if (XMLUtil::ToBool(Value(), value))
     {
-      return XML_NO_ERROR;
+        return XML_NO_ERROR;
     }
     return XML_WRONG_ATTRIBUTE_TYPE;
-  }
+}
 
-  XMLError XMLAttribute::QueryFloatValue(float* value) const
-  {
+XMLError XMLAttribute::QueryFloatValue(float* value) const
+{
     if (XMLUtil::ToFloat(Value(), value))
     {
-      return XML_NO_ERROR;
+        return XML_NO_ERROR;
     }
     return XML_WRONG_ATTRIBUTE_TYPE;
-  }
+}
 
-  XMLError XMLAttribute::QueryDoubleValue(double* value) const
-  {
+XMLError XMLAttribute::QueryDoubleValue(double* value) const
+{
     if (XMLUtil::ToDouble(Value(), value))
     {
-      return XML_NO_ERROR;
+        return XML_NO_ERROR;
     }
     return XML_WRONG_ATTRIBUTE_TYPE;
-  }
+}
 
-  void XMLAttribute::SetAttribute(const char* v)
-  {
+void XMLAttribute::SetAttribute(const char* v)
+{
     _value.SetStr(v);
-  }
+}
 
-  void XMLAttribute::SetAttribute(int v)
-  {
+void XMLAttribute::SetAttribute(int v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     _value.SetStr(buf);
-  }
+}
 
-  void XMLAttribute::SetAttribute(unsigned v)
-  {
+void XMLAttribute::SetAttribute(unsigned v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     _value.SetStr(buf);
-  }
+}
 
-  void XMLAttribute::SetAttribute(bool v)
-  {
+void XMLAttribute::SetAttribute(bool v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     _value.SetStr(buf);
-  }
+}
 
-  void XMLAttribute::SetAttribute(double v)
-  {
+void XMLAttribute::SetAttribute(double v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     _value.SetStr(buf);
-  }
+}
 
-  void XMLAttribute::SetAttribute(float v)
-  {
+void XMLAttribute::SetAttribute(float v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     _value.SetStr(buf);
-  }
+}
 
 // --------- XMLElement ---------- //
-  XMLElement::XMLElement(XMLDocument* doc)
-      : XMLNode(doc), _closingType(0), _rootAttribute(0)
-  {
-  }
+XMLElement::XMLElement(XMLDocument* doc)
+    : XMLNode(doc), _closingType(0), _rootAttribute(0)
+{
+}
 
-  XMLElement::~XMLElement()
-  {
+XMLElement::~XMLElement()
+{
     while (_rootAttribute)
     {
-      XMLAttribute* next = _rootAttribute->_next;
-      DELETE_ATTRIBUTE(_rootAttribute);
-      _rootAttribute = next;
+        XMLAttribute* next = _rootAttribute->_next;
+        DELETE_ATTRIBUTE(_rootAttribute);
+        _rootAttribute = next;
     }
-  }
+}
 
-  XMLAttribute* XMLElement::FindAttribute(const char* name)
-  {
+XMLAttribute* XMLElement::FindAttribute(const char* name)
+{
     XMLAttribute* a = 0;
     for (a = _rootAttribute; a; a = a->_next)
     {
-      if (XMLUtil::StringEqual(a->Name(), name))
-      {
-        return a;
-      }
+        if (XMLUtil::StringEqual(a->Name(), name))
+        {
+            return a;
+        }
     }
     return 0;
-  }
+}
 
-  const XMLAttribute* XMLElement::FindAttribute(const char* name) const
-  {
+const XMLAttribute* XMLElement::FindAttribute(const char* name) const
+{
     XMLAttribute* a = 0;
     for (a = _rootAttribute; a; a = a->_next)
     {
-      if (XMLUtil::StringEqual(a->Name(), name))
-      {
-        return a;
-      }
+        if (XMLUtil::StringEqual(a->Name(), name))
+        {
+            return a;
+        }
     }
     return 0;
-  }
+}
 
-  const char* XMLElement::Attribute(const char* name, const char* value) const
-  {
+const char* XMLElement::Attribute(const char* name, const char* value) const
+{
     const XMLAttribute* a = FindAttribute(name);
     if (!a)
     {
-      return 0;
+        return 0;
     }
     if (!value || XMLUtil::StringEqual(a->Value(), value))
     {
-      return a->Value();
+        return a->Value();
     }
     return 0;
-  }
+}
 
-  const char* XMLElement::GetText() const
-  {
+const char* XMLElement::GetText() const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      return FirstChild()->ToText()->Value();
+        return FirstChild()->ToText()->Value();
     }
     return 0;
-  }
+}
 
-  void XMLElement::SetText(const char* inText)
-  {
+void XMLElement::SetText(const char* inText)
+{
     if (FirstChild() && FirstChild()->ToText())
-      FirstChild()->SetValue(inText);
+        FirstChild()->SetValue(inText);
     else
     {
-      XMLText* theText = GetDocument()->NewText(inText);
-      InsertFirstChild(theText);
+        XMLText* theText = GetDocument()->NewText(inText);
+        InsertFirstChild(theText);
     }
-  }
+}
 
-  void XMLElement::SetText(int v)
-  {
+void XMLElement::SetText(int v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     SetText(buf);
-  }
+}
 
-  void XMLElement::SetText(unsigned v)
-  {
+void XMLElement::SetText(unsigned v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     SetText(buf);
-  }
+}
 
-  void XMLElement::SetText(bool v)
-  {
+void XMLElement::SetText(bool v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     SetText(buf);
-  }
+}
 
-  void XMLElement::SetText(float v)
-  {
+void XMLElement::SetText(float v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     SetText(buf);
-  }
+}
 
-  void XMLElement::SetText(double v)
-  {
+void XMLElement::SetText(double v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     SetText(buf);
-  }
+}
 
-  XMLError XMLElement::QueryIntText(int* ival) const
-  {
+XMLError XMLElement::QueryIntText(int* ival) const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      const char* t = FirstChild()->ToText()->Value();
-      if (XMLUtil::ToInt(t, ival))
-      {
-        return XML_SUCCESS;
-      }
-      return XML_CAN_NOT_CONVERT_TEXT;
+        const char* t = FirstChild()->ToText()->Value();
+        if (XMLUtil::ToInt(t, ival))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
     }
     return XML_NO_TEXT_NODE;
-  }
+}
 
-  XMLError XMLElement::QueryUnsignedText(unsigned* uval) const
-  {
+XMLError XMLElement::QueryUnsignedText(unsigned* uval) const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      const char* t = FirstChild()->ToText()->Value();
-      if (XMLUtil::ToUnsigned(t, uval))
-      {
-        return XML_SUCCESS;
-      }
-      return XML_CAN_NOT_CONVERT_TEXT;
+        const char* t = FirstChild()->ToText()->Value();
+        if (XMLUtil::ToUnsigned(t, uval))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
     }
     return XML_NO_TEXT_NODE;
-  }
+}
 
-  XMLError XMLElement::QueryBoolText(bool* bval) const
-  {
+XMLError XMLElement::QueryBoolText(bool* bval) const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      const char* t = FirstChild()->ToText()->Value();
-      if (XMLUtil::ToBool(t, bval))
-      {
-        return XML_SUCCESS;
-      }
-      return XML_CAN_NOT_CONVERT_TEXT;
+        const char* t = FirstChild()->ToText()->Value();
+        if (XMLUtil::ToBool(t, bval))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
     }
     return XML_NO_TEXT_NODE;
-  }
+}
 
-  XMLError XMLElement::QueryDoubleText(double* dval) const
-  {
+XMLError XMLElement::QueryDoubleText(double* dval) const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      const char* t = FirstChild()->ToText()->Value();
-      if (XMLUtil::ToDouble(t, dval))
-      {
-        return XML_SUCCESS;
-      }
-      return XML_CAN_NOT_CONVERT_TEXT;
+        const char* t = FirstChild()->ToText()->Value();
+        if (XMLUtil::ToDouble(t, dval))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
     }
     return XML_NO_TEXT_NODE;
-  }
+}
 
-  XMLError XMLElement::QueryFloatText(float* fval) const
-  {
+XMLError XMLElement::QueryFloatText(float* fval) const
+{
     if (FirstChild() && FirstChild()->ToText())
     {
-      const char* t = FirstChild()->ToText()->Value();
-      if (XMLUtil::ToFloat(t, fval))
-      {
-        return XML_SUCCESS;
-      }
-      return XML_CAN_NOT_CONVERT_TEXT;
+        const char* t = FirstChild()->ToText()->Value();
+        if (XMLUtil::ToFloat(t, fval))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
     }
     return XML_NO_TEXT_NODE;
-  }
+}
 
-  XMLAttribute* XMLElement::FindOrCreateAttribute(const char* name)
-  {
+XMLAttribute* XMLElement::FindOrCreateAttribute(const char* name)
+{
     XMLAttribute* last = 0;
     XMLAttribute* attrib = 0;
     for (attrib = _rootAttribute; attrib; last = attrib, attrib = attrib->_next)
     {
-      if (XMLUtil::StringEqual(attrib->Name(), name))
-      {
-        break;
-      }
+        if (XMLUtil::StringEqual(attrib->Name(), name))
+        {
+            break;
+        }
     }
     if (!attrib)
     {
-      attrib = new (_document->_attributePool.Alloc()) XMLAttribute();
-      attrib->_memPool = &_document->_attributePool;
-      if (last)
-      {
-        last->_next = attrib;
-      }
-      else
-      {
-        _rootAttribute = attrib;
-      }
-      attrib->SetName(name);
-      attrib->_memPool->SetTracked(); // always created and linked.
-    }
-    return attrib;
-  }
-
-  void XMLElement::DeleteAttribute(const char* name)
-  {
-    XMLAttribute* prev = 0;
-    for (XMLAttribute* a = _rootAttribute; a; a = a->_next)
-    {
-      if (XMLUtil::StringEqual(name, a->Name()))
-      {
-        if (prev)
+        attrib = new (_document->_attributePool.Alloc()) XMLAttribute();
+        attrib->_memPool = &_document->_attributePool;
+        if (last)
         {
-          prev->_next = a->_next;
+            last->_next = attrib;
         }
         else
         {
-          _rootAttribute = a->_next;
+            _rootAttribute = attrib;
         }
-        DELETE_ATTRIBUTE(a);
-        break;
-      }
-      prev = a;
+        attrib->SetName(name);
+        attrib->_memPool->SetTracked();  // always created and linked.
     }
-  }
+    return attrib;
+}
 
-  char* XMLElement::ParseAttributes(char* p)
-  {
+void XMLElement::DeleteAttribute(const char* name)
+{
+    XMLAttribute* prev = 0;
+    for (XMLAttribute* a = _rootAttribute; a; a = a->_next)
+    {
+        if (XMLUtil::StringEqual(name, a->Name()))
+        {
+            if (prev)
+            {
+                prev->_next = a->_next;
+            }
+            else
+            {
+                _rootAttribute = a->_next;
+            }
+            DELETE_ATTRIBUTE(a);
+            break;
+        }
+        prev = a;
+    }
+}
+
+char* XMLElement::ParseAttributes(char* p)
+{
     const char* start = p;
     XMLAttribute* prevAttribute = 0;
 
     // Read the attributes.
     while (p)
     {
-      p = XMLUtil::SkipWhiteSpace(p);
-      if (!p || !(*p))
-      {
-        _document->SetError(XML_ERROR_PARSING_ELEMENT, start, Name());
-        return 0;
-      }
-
-      // attribute.
-      if (XMLUtil::IsNameStartChar(*p))
-      {
-        XMLAttribute* attrib =
-            new (_document->_attributePool.Alloc()) XMLAttribute();
-        attrib->_memPool = &_document->_attributePool;
-        attrib->_memPool->SetTracked();
-
-        p = attrib->ParseDeep(p, _document->ProcessEntities());
-        if (!p || Attribute(attrib->Name()))
+        p = XMLUtil::SkipWhiteSpace(p);
+        if (!p || !(*p))
         {
-          DELETE_ATTRIBUTE(attrib);
-          _document->SetError(XML_ERROR_PARSING_ATTRIBUTE, start, p);
-          return 0;
+            _document->SetError(XML_ERROR_PARSING_ELEMENT, start, Name());
+            return 0;
         }
-        // There is a minor bug here: if the attribute in the source xml
-        // document is duplicated, it will not be detected and the
-        // attribute will be doubly added. However, tracking the 'prevAttribute'
-        // avoids re-scanning the attribute list. Preferring performance for
-        // now, may reconsider in the future.
-        if (prevAttribute)
+
+        // attribute.
+        if (XMLUtil::IsNameStartChar(*p))
         {
-          prevAttribute->_next = attrib;
+            XMLAttribute* attrib =
+                new (_document->_attributePool.Alloc()) XMLAttribute();
+            attrib->_memPool = &_document->_attributePool;
+            attrib->_memPool->SetTracked();
+
+            p = attrib->ParseDeep(p, _document->ProcessEntities());
+            if (!p || Attribute(attrib->Name()))
+            {
+                DELETE_ATTRIBUTE(attrib);
+                _document->SetError(XML_ERROR_PARSING_ATTRIBUTE, start, p);
+                return 0;
+            }
+            // There is a minor bug here: if the attribute in the source xml
+            // document is duplicated, it will not be detected and the
+            // attribute will be doubly added. However, tracking the 'prevAttribute'
+            // avoids re-scanning the attribute list. Preferring performance for
+            // now, may reconsider in the future.
+            if (prevAttribute)
+            {
+                prevAttribute->_next = attrib;
+            }
+            else
+            {
+                _rootAttribute = attrib;
+            }
+            prevAttribute = attrib;
+        }
+        // end of the tag
+        else if (*p == '/' && *(p + 1) == '>')
+        {
+            _closingType = CLOSED;
+            return p + 2;  // done; sealed element.
+        }
+        // end of the tag
+        else if (*p == '>')
+        {
+            ++p;
+            break;
         }
         else
         {
-          _rootAttribute = attrib;
+            _document->SetError(XML_ERROR_PARSING_ELEMENT, start, p);
+            return 0;
         }
-        prevAttribute = attrib;
-      }
-      // end of the tag
-      else if (*p == '/' && *(p + 1) == '>')
-      {
-        _closingType = CLOSED;
-        return p + 2;	// done; sealed element.
-      }
-      // end of the tag
-      else if (*p == '>')
-      {
-        ++p;
-        break;
-      }
-      else
-      {
-        _document->SetError(XML_ERROR_PARSING_ELEMENT, start, p);
-        return 0;
-      }
     }
     return p;
-  }
+}
 
 //
 //	<ele></ele>
 //	<ele>foo<b>bar</b></ele>
 //
-  char* XMLElement::ParseDeep(char* p, StrPair* strPair)
-  {
+char* XMLElement::ParseDeep(char* p, StrPair* strPair)
+{
     // Read the element name.
     p = XMLUtil::SkipWhiteSpace(p);
     if (!p)
     {
-      return 0;
+        return 0;
     }
 
     // The closing element is the </element> form. It is
@@ -1574,94 +1562,91 @@ namespace tinyxml2
     // the DOM.
     if (*p == '/')
     {
-      _closingType = CLOSING;
-      ++p;
+        _closingType = CLOSING;
+        ++p;
     }
 
     p = _value.ParseName(p);
     if (_value.Empty())
     {
-      return 0;
+        return 0;
     }
 
     p = ParseAttributes(p);
     if (!p || !*p || _closingType)
     {
-      return p;
+        return p;
     }
 
     p = XMLNode::ParseDeep(p, strPair);
     return p;
-  }
+}
 
-  XMLNode* XMLElement::ShallowClone(XMLDocument* doc) const
-  {
+XMLNode* XMLElement::ShallowClone(XMLDocument* doc) const
+{
     if (!doc)
     {
-      doc = _document;
+        doc = _document;
     }
-    XMLElement* element = doc->NewElement(Value());	// fixme: this will always allocate memory. Intern?
+    XMLElement* element = doc->NewElement(Value());  // fixme: this will always allocate memory. Intern?
     for (const XMLAttribute* a = FirstAttribute(); a; a = a->Next())
     {
-      element->SetAttribute(a->Name(), a->Value());	// fixme: this will always allocate memory. Intern?
+        element->SetAttribute(a->Name(), a->Value());  // fixme: this will always allocate memory. Intern?
     }
     return element;
-  }
+}
 
-  bool XMLElement::ShallowEqual(const XMLNode* compare) const
-  {
+bool XMLElement::ShallowEqual(const XMLNode* compare) const
+{
     const XMLElement* other = compare->ToElement();
     if (other && XMLUtil::StringEqual(other->Value(), Value()))
     {
+        const XMLAttribute* a = FirstAttribute();
+        const XMLAttribute* b = other->FirstAttribute();
 
-      const XMLAttribute* a = FirstAttribute();
-      const XMLAttribute* b = other->FirstAttribute();
-
-      while (a && b)
-      {
-        if (!XMLUtil::StringEqual(a->Value(), b->Value()))
+        while (a && b)
         {
-          return false;
+            if (!XMLUtil::StringEqual(a->Value(), b->Value()))
+            {
+                return false;
+            }
+            a = a->Next();
+            b = b->Next();
         }
-        a = a->Next();
-        b = b->Next();
-      }
-      if (a || b)
-      {
-        // different count
-        return false;
-      }
-      return true;
+        if (a || b)
+        {
+            // different count
+            return false;
+        }
+        return true;
     }
     return false;
-  }
+}
 
-  bool XMLElement::Accept(XMLVisitor* visitor) const
-  {
+bool XMLElement::Accept(XMLVisitor* visitor) const
+{
     if (visitor->VisitEnter(*this, _rootAttribute))
     {
-      for (const XMLNode* node = FirstChild(); node; node = node->NextSibling())
-      {
-        if (!node->Accept(visitor))
+        for (const XMLNode* node = FirstChild(); node; node = node->NextSibling())
         {
-          break;
+            if (!node->Accept(visitor))
+            {
+                break;
+            }
         }
-      }
     }
     return visitor->VisitExit(*this);
-  }
+}
 
 // --------- XMLDocument ----------- //
-  XMLDocument::XMLDocument(bool processEntities, Whitespace whitespace)
-      : XMLNode(0), _writeBOM(false), _processEntities(processEntities), _errorID(
-          XML_NO_ERROR), _whitespace(whitespace), _errorStr1(0), _errorStr2(0), _charBuffer(
-          0)
-  {
-    _document = this;	// avoid warning about 'this' in initializer list
-  }
+XMLDocument::XMLDocument(bool processEntities, Whitespace whitespace)
+    : XMLNode(0), _writeBOM(false), _processEntities(processEntities), _errorID(XML_NO_ERROR), _whitespace(whitespace), _errorStr1(0), _errorStr2(0), _charBuffer(0)
+{
+    _document = this;  // avoid warning about 'this' in initializer list
+}
 
-  XMLDocument::~XMLDocument()
-  {
+XMLDocument::~XMLDocument()
+{
     DeleteChildren();
     delete[] _charBuffer;
 
@@ -1673,18 +1658,18 @@ namespace tinyxml2
 #endif
 
 #ifdef DEBUG
-    if ( Error() == false )
+    if (Error() == false)
     {
-      TIXMLASSERT( _elementPool.CurrentAllocs() == _elementPool.Untracked() );
-      TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
-      TIXMLASSERT( _textPool.CurrentAllocs() == _textPool.Untracked() );
-      TIXMLASSERT( _commentPool.CurrentAllocs() == _commentPool.Untracked() );
+        TIXMLASSERT(_elementPool.CurrentAllocs() == _elementPool.Untracked());
+        TIXMLASSERT(_attributePool.CurrentAllocs() == _attributePool.Untracked());
+        TIXMLASSERT(_textPool.CurrentAllocs() == _textPool.Untracked());
+        TIXMLASSERT(_commentPool.CurrentAllocs() == _commentPool.Untracked());
     }
 #endif
-  }
+}
 
-  void XMLDocument::Clear()
-  {
+void XMLDocument::Clear()
+{
     DeleteChildren();
 
     _errorID = XML_NO_ERROR;
@@ -1693,80 +1678,80 @@ namespace tinyxml2
 
     delete[] _charBuffer;
     _charBuffer = 0;
-  }
+}
 
-  XMLElement* XMLDocument::NewElement(const char* name)
-  {
+XMLElement* XMLDocument::NewElement(const char* name)
+{
     XMLElement* ele = new (_elementPool.Alloc()) XMLElement(this);
     ele->_memPool = &_elementPool;
     ele->SetName(name);
     return ele;
-  }
+}
 
-  XMLComment* XMLDocument::NewComment(const char* str)
-  {
+XMLComment* XMLDocument::NewComment(const char* str)
+{
     XMLComment* comment = new (_commentPool.Alloc()) XMLComment(this);
     comment->_memPool = &_commentPool;
     comment->SetValue(str);
     return comment;
-  }
+}
 
-  XMLText* XMLDocument::NewText(const char* str)
-  {
+XMLText* XMLDocument::NewText(const char* str)
+{
     XMLText* text = new (_textPool.Alloc()) XMLText(this);
     text->_memPool = &_textPool;
     text->SetValue(str);
     return text;
-  }
+}
 
-  XMLDeclaration* XMLDocument::NewDeclaration(const char* str)
-  {
+XMLDeclaration* XMLDocument::NewDeclaration(const char* str)
+{
     XMLDeclaration* dec = new (_commentPool.Alloc()) XMLDeclaration(this);
     dec->_memPool = &_commentPool;
     dec->SetValue(str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"");
     return dec;
-  }
+}
 
-  XMLUnknown* XMLDocument::NewUnknown(const char* str)
-  {
+XMLUnknown* XMLDocument::NewUnknown(const char* str)
+{
     XMLUnknown* unk = new (_commentPool.Alloc()) XMLUnknown(this);
     unk->_memPool = &_commentPool;
     unk->SetValue(str);
     return unk;
-  }
+}
 
-  XMLError XMLDocument::LoadFile(const char* filename)
-  {
+XMLError XMLDocument::LoadFile(const char* filename)
+{
     Clear();
     FILE* fp = 0;
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
-    errno_t err = fopen_s(&fp, filename, "rb" );
-    if ( !fp || err)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+    errno_t err = fopen_s(&fp, filename, "rb");
+    if (!fp || err)
     {
 #else
     fp = fopen(filename, "rb");
     if (!fp)
     {
 #endif
-      SetError(XML_ERROR_FILE_NOT_FOUND, filename, 0);
-      return _errorID;
+        SetError(XML_ERROR_FILE_NOT_FOUND, filename, 0);
+        return _errorID;
     }
     LoadFile(fp);
     fclose(fp);
     return _errorID;
-  }
+}
 
-  XMLError XMLDocument::LoadFile(FILE* fp)
-  {
+XMLError XMLDocument::LoadFile(FILE* fp)
+{
     Clear();
 
     fseek(fp, 0, SEEK_SET);
     fgetc(fp);
     if (ferror(fp) != 0)
     {
-      SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+        return _errorID;
     }
 
     fseek(fp, 0, SEEK_END);
@@ -1775,16 +1760,16 @@ namespace tinyxml2
 
     if (size == 0)
     {
-      SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+        return _errorID;
     }
 
     _charBuffer = new char[size + 1];
     size_t read = fread(_charBuffer, 1, size, fp);
     if (read != size)
     {
-      SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+        return _errorID;
     }
 
     _charBuffer[size] = 0;
@@ -1794,60 +1779,60 @@ namespace tinyxml2
     p = XMLUtil::ReadBOM(p, &_writeBOM);
     if (!p || !*p)
     {
-      SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+        return _errorID;
     }
 
     ParseDeep(_charBuffer + (p - _charBuffer), 0);
     return _errorID;
-  }
+}
 
-  XMLError XMLDocument::SaveFile(const char* filename, bool compact)
-  {
+XMLError XMLDocument::SaveFile(const char* filename, bool compact)
+{
     FILE* fp = 0;
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
-    errno_t err = fopen_s(&fp, filename, "w" );
-    if ( !fp || err)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+    errno_t err = fopen_s(&fp, filename, "w");
+    if (!fp || err)
     {
 #else
     fp = fopen(filename, "w");
     if (!fp)
     {
 #endif
-      SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, filename, 0);
-      return _errorID;
+        SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, filename, 0);
+        return _errorID;
     }
     SaveFile(fp, compact);
     fclose(fp);
     return _errorID;
-  }
+}
 
-  XMLError XMLDocument::SaveFile(FILE* fp, bool compact)
-  {
+XMLError XMLDocument::SaveFile(FILE* fp, bool compact)
+{
     XMLPrinter stream(fp, compact);
     Print(&stream);
     return _errorID;
-  }
+}
 
-  XMLError XMLDocument::Parse(const char* p, size_t len)
-  {
+XMLError XMLDocument::Parse(const char* p, size_t len)
+{
     const char* start = p;
     Clear();
 
     if (len == 0)
     {
-      SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+        return _errorID;
     }
 
     if (!p || !*p)
     {
-      SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+        return _errorID;
     }
-    if (len == (size_t) (-1))
+    if (len == (size_t)(-1))
     {
-      len = strlen(p);
+        len = strlen(p);
     }
     _charBuffer = new char[len + 1];
     memcpy(_charBuffer, p, len);
@@ -1857,428 +1842,426 @@ namespace tinyxml2
     p = XMLUtil::ReadBOM(p, &_writeBOM);
     if (!p || !*p)
     {
-      SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
-      return _errorID;
+        SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+        return _errorID;
     }
 
-    ptrdiff_t delta = p - start;	// skip initial whitespace, BOM, etc.
+    ptrdiff_t delta = p - start;  // skip initial whitespace, BOM, etc.
     ParseDeep(_charBuffer + delta, 0);
     return _errorID;
-  }
+}
 
-  void XMLDocument::Print(XMLPrinter* streamer) const
-  {
-    XMLPrinter stdStreamer( stdout);
+void XMLDocument::Print(XMLPrinter* streamer) const
+{
+    XMLPrinter stdStreamer(stdout);
     if (!streamer)
     {
-      streamer = &stdStreamer;
+        streamer = &stdStreamer;
     }
     Accept(streamer);
-  }
+}
 
-  void XMLDocument::SetError(XMLError error, const char* str1, const char* str2)
-  {
+void XMLDocument::SetError(XMLError error, const char* str1, const char* str2)
+{
     _errorID = error;
     _errorStr1 = str1;
     _errorStr2 = str2;
-  }
+}
 
-  void XMLDocument::PrintError() const
-  {
+void XMLDocument::PrintError() const
+{
     if (_errorID)
     {
-      static const int LEN = 20;
-      char buf1[LEN] = { 0 };
-      char buf2[LEN] = { 0 };
+        static const int LEN = 20;
+        char buf1[LEN] = {0};
+        char buf2[LEN] = {0};
 
-      if (_errorStr1)
-      {
-        TIXML_SNPRINTF(buf1, LEN, "%s", _errorStr1);
-      }
-      if (_errorStr2)
-      {
-        TIXML_SNPRINTF(buf2, LEN, "%s", _errorStr2);
-      }
+        if (_errorStr1)
+        {
+            TIXML_SNPRINTF(buf1, LEN, "%s", _errorStr1);
+        }
+        if (_errorStr2)
+        {
+            TIXML_SNPRINTF(buf2, LEN, "%s", _errorStr2);
+        }
 
-      printf("XMLDocument error id=%d str1=%s str2=%s\n", _errorID, buf1, buf2);
+        printf("XMLDocument error id=%d str1=%s str2=%s\n", _errorID, buf1, buf2);
     }
-  }
+}
 
-  XMLPrinter::XMLPrinter(FILE* file, bool compact, int depth)
-      : _elementJustOpened(false), _firstElement(true), _fp(file), _depth(
-          depth), _textDepth(-1), _processEntities(true), _compactMode(compact)
-  {
+XMLPrinter::XMLPrinter(FILE* file, bool compact, int depth)
+    : _elementJustOpened(false), _firstElement(true), _fp(file), _depth(depth), _textDepth(-1), _processEntities(true), _compactMode(compact)
+{
     for (int i = 0; i < ENTITY_RANGE; ++i)
     {
-      _entityFlag[i] = false;
-      _restrictedEntityFlag[i] = false;
+        _entityFlag[i] = false;
+        _restrictedEntityFlag[i] = false;
     }
     for (int i = 0; i < NUM_ENTITIES; ++i)
     {
-      TIXMLASSERT(entities[i].value < ENTITY_RANGE);
-      if (entities[i].value < ENTITY_RANGE)
-      {
-        _entityFlag[(int) entities[i].value] = true;
-      }
+        TIXMLASSERT(entities[i].value < ENTITY_RANGE);
+        if (entities[i].value < ENTITY_RANGE)
+        {
+            _entityFlag[(int)entities[i].value] = true;
+        }
     }
-    _restrictedEntityFlag[(int) '&'] = true;
-    _restrictedEntityFlag[(int) '<'] = true;
-    _restrictedEntityFlag[(int) '>'] = true;// not required, but consistency is nice
+    _restrictedEntityFlag[(int)'&'] = true;
+    _restrictedEntityFlag[(int)'<'] = true;
+    _restrictedEntityFlag[(int)'>'] = true;  // not required, but consistency is nice
     _buffer.Push(0);
-  }
+}
 
-  void XMLPrinter::Print(const char* format, ...)
-  {
+void XMLPrinter::Print(const char* format, ...)
+{
     va_list va;
     va_start(va, format);
 
     if (_fp)
     {
-      vfprintf(_fp, format, va);
+        vfprintf(_fp, format, va);
     }
     else
     {
-      // This seems brutally complex. Haven't figured out a better
-      // way on windows.
+// This seems brutally complex. Haven't figured out a better
+// way on windows.
 #ifdef _MSC_VER
-      int len = -1;
-      int expand = 1000;
-      while ( len < 0 )
-      {
-        len = vsnprintf_s( _accumulator.Mem(), _accumulator.Capacity(), _TRUNCATE, format, va );
-        if ( len < 0 )
+        int len = -1;
+        int expand = 1000;
+        while (len < 0)
         {
-          expand *= 3/2;
-          _accumulator.PushArr( expand );
+            len = vsnprintf_s(_accumulator.Mem(), _accumulator.Capacity(), _TRUNCATE, format, va);
+            if (len < 0)
+            {
+                expand *= 3 / 2;
+                _accumulator.PushArr(expand);
+            }
         }
-      }
-      char* p = _buffer.PushArr( len ) - 1;
-      memcpy( p, _accumulator.Mem(), len+1 );
+        char* p = _buffer.PushArr(len) - 1;
+        memcpy(p, _accumulator.Mem(), len + 1);
 #else
-      int len = vsnprintf(0, 0, format, va);
-      // Close out and re-start the va-args
-      va_end(va);
-      va_start(va, format);
-      char* p = _buffer.PushArr(len) - 1;
-      vsnprintf(p, len + 1, format, va);
+        int len = vsnprintf(0, 0, format, va);
+        // Close out and re-start the va-args
+        va_end(va);
+        va_start(va, format);
+        char* p = _buffer.PushArr(len) - 1;
+        vsnprintf(p, len + 1, format, va);
 #endif
     }
     va_end(va);
-  }
+}
 
-  void XMLPrinter::PrintSpace(int depth)
-  {
+void XMLPrinter::PrintSpace(int depth)
+{
     for (int i = 0; i < depth; ++i)
     {
-      Print("    ");
+        Print("    ");
     }
-  }
+}
 
-  void XMLPrinter::PrintString(const char* p, bool restricted)
-  {
+void XMLPrinter::PrintString(const char* p, bool restricted)
+{
     // Look for runs of bytes between entities to print.
     const char* q = p;
     const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
 
     if (_processEntities)
     {
-      while (*q)
-      {
-        // Remember, char is sometimes signed. (How many times has that bitten me?)
-        if (*q > 0 && *q < ENTITY_RANGE)
+        while (*q)
         {
-          // Check for entities. If one is found, flush
-          // the stream up until the entity, write the
-          // entity, and keep looking.
-          if (flag[(unsigned) (*q)])
-          {
-            while (p < q)
+            // Remember, char is sometimes signed. (How many times has that bitten me?)
+            if (*q > 0 && *q < ENTITY_RANGE)
             {
-              Print("%c", *p);
-              ++p;
+                // Check for entities. If one is found, flush
+                // the stream up until the entity, write the
+                // entity, and keep looking.
+                if (flag[(unsigned)(*q)])
+                {
+                    while (p < q)
+                    {
+                        Print("%c", *p);
+                        ++p;
+                    }
+                    for (int i = 0; i < NUM_ENTITIES; ++i)
+                    {
+                        if (entities[i].value == *q)
+                        {
+                            Print("&%s;", entities[i].pattern);
+                            break;
+                        }
+                    }
+                    ++p;
+                }
             }
-            for (int i = 0; i < NUM_ENTITIES; ++i)
-            {
-              if (entities[i].value == *q)
-              {
-                Print("&%s;", entities[i].pattern);
-                break;
-              }
-            }
-            ++p;
-          }
+            ++q;
         }
-        ++q;
-      }
     }
     // Flush the remaining string. This will be the entire
     // string if an entity wasn't found.
     if (!_processEntities || (q - p > 0))
     {
-      Print("%s", p);
+        Print("%s", p);
     }
-  }
+}
 
-  void XMLPrinter::PushHeader(bool writeBOM, bool writeDec)
-  {
+void XMLPrinter::PushHeader(bool writeBOM, bool writeDec)
+{
     if (writeBOM)
     {
-      static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1,
-          TIXML_UTF_LEAD_2, 0 };
-      Print("%s", bom);
+        static const unsigned char bom[] = {TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1,
+                                            TIXML_UTF_LEAD_2, 0};
+        Print("%s", bom);
     }
     if (writeDec)
     {
-      PushDeclaration("xml version=\"1.0\"");
+        PushDeclaration("xml version=\"1.0\"");
     }
-  }
+}
 
-  void XMLPrinter::OpenElement(const char* name)
-  {
+void XMLPrinter::OpenElement(const char* name)
+{
     if (_elementJustOpened)
     {
-      SealElement();
+        SealElement();
     }
     _stack.Push(name);
 
     if (_textDepth < 0 && !_firstElement && !_compactMode)
     {
-      Print("\n");
+        Print("\n");
     }
     if (!_compactMode)
     {
-      PrintSpace(_depth);
+        PrintSpace(_depth);
     }
 
     Print("<%s", name);
     _elementJustOpened = true;
     _firstElement = false;
     ++_depth;
-  }
+}
 
-  void XMLPrinter::PushAttribute(const char* name, const char* value)
-  {
+void XMLPrinter::PushAttribute(const char* name, const char* value)
+{
     TIXMLASSERT(_elementJustOpened);
     Print(" %s=\"", name);
     PrintString(value, false);
     Print("\"");
-  }
+}
 
-  void XMLPrinter::PushAttribute(const char* name, int v)
-  {
+void XMLPrinter::PushAttribute(const char* name, int v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     PushAttribute(name, buf);
-  }
+}
 
-  void XMLPrinter::PushAttribute(const char* name, unsigned v)
-  {
+void XMLPrinter::PushAttribute(const char* name, unsigned v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     PushAttribute(name, buf);
-  }
+}
 
-  void XMLPrinter::PushAttribute(const char* name, bool v)
-  {
+void XMLPrinter::PushAttribute(const char* name, bool v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     PushAttribute(name, buf);
-  }
+}
 
-  void XMLPrinter::PushAttribute(const char* name, double v)
-  {
+void XMLPrinter::PushAttribute(const char* name, double v)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(v, buf, BUF_SIZE);
     PushAttribute(name, buf);
-  }
+}
 
-  void XMLPrinter::CloseElement()
-  {
+void XMLPrinter::CloseElement()
+{
     --_depth;
     const char* name = _stack.Pop();
 
     if (_elementJustOpened)
     {
-      Print("/>");
+        Print("/>");
     }
     else
     {
-      if (_textDepth < 0 && !_compactMode)
-      {
-        Print("\n");
-        PrintSpace(_depth);
-      }
-      Print("</%s>", name);
+        if (_textDepth < 0 && !_compactMode)
+        {
+            Print("\n");
+            PrintSpace(_depth);
+        }
+        Print("</%s>", name);
     }
 
     if (_textDepth == _depth)
     {
-      _textDepth = -1;
+        _textDepth = -1;
     }
     if (_depth == 0 && !_compactMode)
     {
-      Print("\n");
+        Print("\n");
     }
     _elementJustOpened = false;
-  }
+}
 
-  void XMLPrinter::SealElement()
-  {
+void XMLPrinter::SealElement()
+{
     _elementJustOpened = false;
     Print(">");
-  }
+}
 
-  void XMLPrinter::PushText(const char* text, bool cdata)
-  {
+void XMLPrinter::PushText(const char* text, bool cdata)
+{
     _textDepth = _depth - 1;
 
     if (_elementJustOpened)
     {
-      SealElement();
+        SealElement();
     }
     if (cdata)
     {
-      Print("<![CDATA[");
-      Print("%s", text);
-      Print("]]>");
+        Print("<![CDATA[");
+        Print("%s", text);
+        Print("]]>");
     }
     else
     {
-      PrintString(text, true);
+        PrintString(text, true);
     }
-  }
+}
 
-  void XMLPrinter::PushText(int value)
-  {
+void XMLPrinter::PushText(int value)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(value, buf, BUF_SIZE);
     PushText(buf, false);
-  }
+}
 
-  void XMLPrinter::PushText(unsigned value)
-  {
+void XMLPrinter::PushText(unsigned value)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(value, buf, BUF_SIZE);
     PushText(buf, false);
-  }
+}
 
-  void XMLPrinter::PushText(bool value)
-  {
+void XMLPrinter::PushText(bool value)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(value, buf, BUF_SIZE);
     PushText(buf, false);
-  }
+}
 
-  void XMLPrinter::PushText(float value)
-  {
+void XMLPrinter::PushText(float value)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(value, buf, BUF_SIZE);
     PushText(buf, false);
-  }
+}
 
-  void XMLPrinter::PushText(double value)
-  {
+void XMLPrinter::PushText(double value)
+{
     char buf[BUF_SIZE];
     XMLUtil::ToStr(value, buf, BUF_SIZE);
     PushText(buf, false);
-  }
+}
 
-  void XMLPrinter::PushComment(const char* comment)
-  {
+void XMLPrinter::PushComment(const char* comment)
+{
     if (_elementJustOpened)
     {
-      SealElement();
+        SealElement();
     }
     if (_textDepth < 0 && !_firstElement && !_compactMode)
     {
-      Print("\n");
-      PrintSpace(_depth);
+        Print("\n");
+        PrintSpace(_depth);
     }
     _firstElement = false;
     Print("<!--%s-->", comment);
-  }
+}
 
-  void XMLPrinter::PushDeclaration(const char* value)
-  {
+void XMLPrinter::PushDeclaration(const char* value)
+{
     if (_elementJustOpened)
     {
-      SealElement();
+        SealElement();
     }
     if (_textDepth < 0 && !_firstElement && !_compactMode)
     {
-      Print("\n");
-      PrintSpace(_depth);
+        Print("\n");
+        PrintSpace(_depth);
     }
     _firstElement = false;
     Print("<?%s?>", value);
-  }
+}
 
-  void XMLPrinter::PushUnknown(const char* value)
-  {
+void XMLPrinter::PushUnknown(const char* value)
+{
     if (_elementJustOpened)
     {
-      SealElement();
+        SealElement();
     }
     if (_textDepth < 0 && !_firstElement && !_compactMode)
     {
-      Print("\n");
-      PrintSpace(_depth);
+        Print("\n");
+        PrintSpace(_depth);
     }
     _firstElement = false;
     Print("<!%s>", value);
-  }
+}
 
-  bool XMLPrinter::VisitEnter(const XMLDocument& doc)
-  {
+bool XMLPrinter::VisitEnter(const XMLDocument& doc)
+{
     _processEntities = doc.ProcessEntities();
     if (doc.HasBOM())
     {
-      PushHeader(true, false);
+        PushHeader(true, false);
     }
     return true;
-  }
+}
 
-  bool XMLPrinter::VisitEnter(const XMLElement& element,
-      const XMLAttribute* attribute)
-  {
+bool XMLPrinter::VisitEnter(const XMLElement& element,
+                            const XMLAttribute* attribute)
+{
     OpenElement(element.Name());
     while (attribute)
     {
-      PushAttribute(attribute->Name(), attribute->Value());
-      attribute = attribute->Next();
+        PushAttribute(attribute->Name(), attribute->Value());
+        attribute = attribute->Next();
     }
     return true;
-  }
+}
 
-  bool XMLPrinter::VisitExit(const XMLElement&)
-  {
+bool XMLPrinter::VisitExit(const XMLElement&)
+{
     CloseElement();
     return true;
-  }
+}
 
-  bool XMLPrinter::Visit(const XMLText& text)
-  {
+bool XMLPrinter::Visit(const XMLText& text)
+{
     PushText(text.Value(), text.CData());
     return true;
-  }
+}
 
-  bool XMLPrinter::Visit(const XMLComment& comment)
-  {
+bool XMLPrinter::Visit(const XMLComment& comment)
+{
     PushComment(comment.Value());
     return true;
-  }
+}
 
-  bool XMLPrinter::Visit(const XMLDeclaration& declaration)
-  {
+bool XMLPrinter::Visit(const XMLDeclaration& declaration)
+{
     PushDeclaration(declaration.Value());
     return true;
-  }
+}
 
-  bool XMLPrinter::Visit(const XMLUnknown& unknown)
-  {
+bool XMLPrinter::Visit(const XMLUnknown& unknown)
+{
     PushUnknown(unknown.Value());
     return true;
-  }
+}
 
-}   // namespace tinyxml2
-
+}  // namespace tinyxml2

--- a/exotica/src/MotionSolver.cpp
+++ b/exotica/src/MotionSolver.cpp
@@ -34,26 +34,25 @@
 
 namespace exotica
 {
-
-  void MotionSolver::InstantiateBase(const Initializer& init)
-  {
+void MotionSolver::InstantiateBase(const Initializer& init)
+{
     Object::InstatiateObject(init);
-  }
+}
 
-  MotionSolver::MotionSolver()
-  {
-  }
+MotionSolver::MotionSolver()
+{
+}
 
-  void MotionSolver::specifyProblem(PlanningProblem_ptr pointer)
-  {
+void MotionSolver::specifyProblem(PlanningProblem_ptr pointer)
+{
     problem_ = pointer;
-  }
+}
 
-  std::string MotionSolver::print(std::string prepend)
-  {
+std::string MotionSolver::print(std::string prepend)
+{
     std::string ret = Object::print(prepend);
     ret += "\n" + prepend + "  Problem:";
     if (problem_) ret += "\n" + problem_->print(prepend + "    ");
     return ret;
-  }
+}
 }

--- a/exotica/src/Property.cpp
+++ b/exotica/src/Property.cpp
@@ -2,23 +2,22 @@
 
 namespace exotica
 {
-
 // //////////////////////////////// Property //////////////////////////////////////
 
-boost::any Property::get() const {return value;}
+boost::any Property::get() const { return value; }
 Property::Property(std::string prop_name) : name(prop_name), required(true) {}
 Property::Property(std::string prop_name, bool isRequired) : name(prop_name), required(isRequired) {}
-Property::Property(std::string prop_name, bool isRequired, boost::any val) : name(prop_name), required(isRequired) {value = val;}
-bool Property::isRequired() const {return required;}
-bool Property::isSet() const {return !value.empty();}
-bool Property::isStringType() const {return value.type()==typeid(std::string);}
-bool Property::isInitializerVectorType() const {return value.type()==typeid(std::vector<exotica::Initializer>);}
-std::string Property::getName() const {return name;}
-std::string Property::getType() const {return getTypeName(value.type());}
+Property::Property(std::string prop_name, bool isRequired, boost::any val) : name(prop_name), required(isRequired) { value = val; }
+bool Property::isRequired() const { return required; }
+bool Property::isSet() const { return !value.empty(); }
+bool Property::isStringType() const { return value.type() == typeid(std::string); }
+bool Property::isInitializerVectorType() const { return value.type() == typeid(std::vector<exotica::Initializer>); }
+std::string Property::getName() const { return name; }
+std::string Property::getType() const { return getTypeName(value.type()); }
 Property::Property(std::initializer_list<boost::any> val_)
 {
     std::vector<boost::any> val(val_);
-    if(val.size()!=2 || val[0].type()!=typeid(std::string)) throw_pretty("Invalid property initialization!");
+    if (val.size() != 2 || val[0].type() != typeid(std::string)) throw_pretty("Invalid property initialization!");
     name = boost::any_cast<std::string>(val[0]);
     value = val[1];
 }
@@ -26,18 +25,17 @@ Property::Property(std::initializer_list<boost::any> val_)
 // //////////////////////////// InitializerBase ///////////////////////////////////
 Initializer::Initializer()
 {
-
 }
 
 Initializer::Initializer(std::string name_) : name(name_)
 {
 }
 
-Initializer::Initializer(std::string name_, std::map<std::string,boost::any> properties_) : name(name_)
+Initializer::Initializer(std::string name_, std::map<std::string, boost::any> properties_) : name(name_)
 {
-    for(auto& prop : properties_)
+    for (auto& prop : properties_)
     {
-        properties.emplace(prop.first,Property(prop.first,true,prop.second));
+        properties.emplace(prop.first, Property(prop.first, true, prop.second));
     }
 }
 
@@ -53,7 +51,7 @@ void Initializer::addProperty(const Property& prop)
 
 bool Initializer::hasProperty(std::string name_) const
 {
-    if(properties.find( name_ ) != properties.end())
+    if (properties.find(name_) != properties.end())
     {
         return true;
     }
@@ -82,7 +80,4 @@ std::vector<std::string> Initializer::getPropertyNames() const
 {
     return getKeys(properties);
 }
-
 }
-
-

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -31,13 +31,13 @@
  */
 
 #include "exotica/Scene.h"
-#include <exotica/Setup.h>
-#include <iostream>
-#include <fstream>
-#include <string>
 #include <eigen_conversions/eigen_kdl.h>
 #include <exotica/LinkInitializer.h>
+#include <exotica/Setup.h>
 #include <exotica/TrajectoryInitializer.h>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 namespace exotica
 {
@@ -45,440 +45,437 @@ namespace exotica
 /////////////////////// EXOTica Scene ///////////////////////
 ///////////////////////////////////////////////////////////////
 
-  Scene::Scene() : name_("Unnamed")
-  {
+Scene::Scene() : name_("Unnamed")
+{
+}
 
-  }
-
-  Scene::Scene(const std::string & name) : name_(name)
-  {
+Scene::Scene(const std::string& name) : name_(name)
+{
     object_name_ = name_;
-  }
+}
 
-  Scene::~Scene()
-  {
-//TODO
-  }
+Scene::~Scene()
+{
+    //TODO
+}
 
-  robot_model::RobotModelPtr Scene::getRobotModel()
-  {
+robot_model::RobotModelPtr Scene::getRobotModel()
+{
     return model_;
+}
 
-  }
-
-  std::string Scene::getName()
-  {
+std::string Scene::getName()
+{
     return name_;
-  }
+}
 
-  void Scene::Instantiate(SceneInitializer& init)
-  {
-      Object::InstatiateObject(init);
-      name_ = object_name_;
-      kinematica_.Debug = debug_;
-      force_collision_ = init.AlwaysUpdateCollisionScene;
-      if(init.URDF=="" || init.SRDF=="")
-      {
-          Server::Instance()->getModel(init.RobotDescription, model_);
-      }
-      else
-      {
-          Server::Instance()->getModel(init.URDF, model_, init.URDF, init.SRDF);
-      }
-      kinematica_.Instantiate(init.JointGroup, model_, name_);
-      group = model_->getJointModelGroup(init.JointGroup);
-      ps_.reset(new planning_scene::PlanningScene(model_));
+void Scene::Instantiate(SceneInitializer& init)
+{
+    Object::InstatiateObject(init);
+    name_ = object_name_;
+    kinematica_.Debug = debug_;
+    force_collision_ = init.AlwaysUpdateCollisionScene;
+    if (init.URDF == "" || init.SRDF == "")
+    {
+        Server::Instance()->getModel(init.RobotDescription, model_);
+    }
+    else
+    {
+        Server::Instance()->getModel(init.URDF, model_, init.URDF, init.SRDF);
+    }
+    kinematica_.Instantiate(init.JointGroup, model_, name_);
+    group = model_->getJointModelGroup(init.JointGroup);
+    ps_.reset(new planning_scene::PlanningScene(model_));
 
-      BaseType = kinematica_.getControlledBaseType();
+    BaseType = kinematica_.getControlledBaseType();
 
-      if (Server::isRos()) {
-        ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(name_ +(name_==""?"":"/")+"PlanningScene", 100, true);
-        proxy_pub_ = Server::advertise<visualization_msgs::Marker>(name_ +(name_==""?"":"/")+"CollisionProxies", 100, true);
+    if (Server::isRos())
+    {
+        ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(name_ + (name_ == "" ? "" : "/") + "PlanningScene", 100, true);
+        proxy_pub_ = Server::advertise<visualization_msgs::Marker>(name_ + (name_ == "" ? "" : "/") + "CollisionProxies", 100, true);
         if (debug_)
-          HIGHLIGHT_NAMED(
-              name_,
-              "Running in debug mode, planning scene will be published to '"
-                  << Server::Instance()->getName() << "/" << name_
-                  << "/PlanningScene'");
-      }
+            HIGHLIGHT_NAMED(
+                name_,
+                "Running in debug mode, planning scene will be published to '"
+                    << Server::Instance()->getName() << "/" << name_
+                    << "/PlanningScene'");
+    }
 
-      if(init.LoadScene!="")
-      {
-          std::vector<std::string> files = parseList(init.LoadScene, ';');
-          for(const std::string& file : files) loadSceneFile(file, false);
-      }
+    if (init.LoadScene != "")
+    {
+        std::vector<std::string> files = parseList(init.LoadScene, ';');
+        for (const std::string& file : files) loadSceneFile(file, false);
+    }
 
-      for(const exotica::Initializer& linkInit : init.Links)
-      {
-          LinkInitializer link(linkInit);
-          addObject(link.Name, getFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, getFrame(link.CoM).p), false);
-      }
+    for (const exotica::Initializer& linkInit : init.Links)
+    {
+        LinkInitializer link(linkInit);
+        addObject(link.Name, getFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, getFrame(link.CoM).p), false);
+    }
 
-      kinematica_.UpdateModel();
+    kinematica_.UpdateModel();
 
-      collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
-      collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
+    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
 
-      AllowedCollisionMatrix acm;
-      std::vector<std::string> acm_names;
-      ps_->getAllowedCollisionMatrix().getAllEntryNames(acm_names);
-      for(auto& name1 : acm_names)
-      {
-          for(auto& name2 : acm_names)
-          {
-              collision_detection::AllowedCollision::Type type = collision_detection::AllowedCollision::Type::ALWAYS;
-              ps_->getAllowedCollisionMatrix().getAllowedCollision(name1, name2, type);
-              if(type == collision_detection::AllowedCollision::Type::ALWAYS)
-              {
-                  acm.setEntry(name1, name2);
-              }
-          }
-      }
-      collision_scene_->setACM(acm);
+    AllowedCollisionMatrix acm;
+    std::vector<std::string> acm_names;
+    ps_->getAllowedCollisionMatrix().getAllEntryNames(acm_names);
+    for (auto& name1 : acm_names)
+    {
+        for (auto& name2 : acm_names)
+        {
+            collision_detection::AllowedCollision::Type type = collision_detection::AllowedCollision::Type::ALWAYS;
+            ps_->getAllowedCollisionMatrix().getAllowedCollision(name1, name2, type);
+            if (type == collision_detection::AllowedCollision::Type::ALWAYS)
+            {
+                acm.setEntry(name1, name2);
+            }
+        }
+    }
+    collision_scene_->setACM(acm);
 
-      for(const exotica::Initializer& it : init.Trajectories)
-      {
-          TrajectoryInitializer trajInit(it);
-          if(trajInit.File!="")
-          {
-              addTrajectoryFromFile(trajInit.Link, trajInit.File);
-          }
-          else
-          {
-              addTrajectory(trajInit.Link, trajInit.Trajectory);
-          }
-      }
+    for (const exotica::Initializer& it : init.Trajectories)
+    {
+        TrajectoryInitializer trajInit(it);
+        if (trajInit.File != "")
+        {
+            addTrajectoryFromFile(trajInit.Link, trajInit.File);
+        }
+        else
+        {
+            addTrajectory(trajInit.Link, trajInit.Trajectory);
+        }
+    }
 
-      if (debug_) INFO_NAMED(name_, "Exotica Scene initialized");
-  }
+    if (debug_) INFO_NAMED(name_, "Exotica Scene initialized");
+}
 
-  std::shared_ptr<KinematicResponse> Scene::RequestKinematics(KinematicsRequest& Request)
-  {
-      return kinematica_.RequestFrames(Request);
-  }
+std::shared_ptr<KinematicResponse> Scene::RequestKinematics(KinematicsRequest& Request)
+{
+    return kinematica_.RequestFrames(Request);
+}
 
-  void Scene::updateTrajectoryGenerators(double t)
-  {
-      for(auto& it : trajectory_generators_)
-      {
-          it.second.first->GeneratedOffset = it.second.second->getPosition(t);
-      }
-  }
+void Scene::updateTrajectoryGenerators(double t)
+{
+    for (auto& it : trajectory_generators_)
+    {
+        it.second.first->GeneratedOffset = it.second.second->getPosition(t);
+    }
+}
 
-  void Scene::Update(Eigen::VectorXdRefConst x, double t)
-  {
-      updateTrajectoryGenerators(t);
-      kinematica_.Update(x);
-      if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
-      if (debug_) publishScene();
-  }
+void Scene::Update(Eigen::VectorXdRefConst x, double t)
+{
+    updateTrajectoryGenerators(t);
+    kinematica_.Update(x);
+    if (force_collision_) collision_scene_->updateCollisionObjectTransforms();
+    if (debug_) publishScene();
+}
 
-  void Scene::publishScene()
-  {
-    if(Server::isRos())
+void Scene::publishScene()
+{
+    if (Server::isRos())
     {
         moveit_msgs::PlanningScene msg;
         ps_->getPlanningSceneMsg(msg);
         ps_pub_.publish(msg);
     }
-  }
+}
 
-  void Scene::publishProxies(const std::vector<CollisionProxy>& proxies)
-  {
-      if(Server::isRos())
-      {
-          proxy_pub_.publish(proxyToMarker(proxies, kinematica_.getRootFrameName()));
-      }
-  }
+void Scene::publishProxies(const std::vector<CollisionProxy>& proxies)
+{
+    if (Server::isRos())
+    {
+        proxy_pub_.publish(proxyToMarker(proxies, kinematica_.getRootFrameName()));
+    }
+}
 
-  visualization_msgs::Marker Scene::proxyToMarker(const std::vector<CollisionProxy>& proxies, const std::string& frame)
-  {
-      visualization_msgs::Marker ret;
-      ret.header.frame_id = "exotica/"+frame;
-      ret.action = visualization_msgs::Marker::ADD;
-      ret.frame_locked = false;
-      ret.ns = "Proxies";
-      ret.color.a=1.0;
-      ret.id=0;
-      ret.type = visualization_msgs::Marker::LINE_LIST;
-      ret.points.resize(proxies.size()*6);
-      ret.colors.resize(proxies.size()*6);
-      ret.scale.x = 0.005;
-      double normalLength = 0.01;
-      std_msgs::ColorRGBA normal = getColor(0.8,0.8,0.8);
-      std_msgs::ColorRGBA far = getColor(0.5,0.5,0.5);
-      std_msgs::ColorRGBA colliding = getColor(1,0,0);
-      for(int i=0; i<proxies.size();i++)
-      {
-          KDL::Vector c1 = KDL::Vector(proxies[i].contact1(0), proxies[i].contact1(1), proxies[i].contact1(2));
-          KDL::Vector c2 = KDL::Vector(proxies[i].contact2(0), proxies[i].contact2(1), proxies[i].contact2(2));
-          KDL::Vector n1 = KDL::Vector(proxies[i].normal1(0), proxies[i].normal1(1), proxies[i].normal1(2));
-          KDL::Vector n2 = KDL::Vector(proxies[i].normal2(0), proxies[i].normal2(1), proxies[i].normal2(2));
-          tf::pointKDLToMsg(c1, ret.points[i*6]);
-          tf::pointKDLToMsg(c2, ret.points[i*6+1]);
-          tf::pointKDLToMsg(c1, ret.points[i*6+2]);
-          tf::pointKDLToMsg(c1+n1*normalLength, ret.points[i*6+3]);
-          tf::pointKDLToMsg(c2, ret.points[i*6+4]);
-          tf::pointKDLToMsg(c2+n2*normalLength, ret.points[i*6+5]);
-          ret.colors[i*6] = ret.colors[i*6+1] = proxies[i].distance>0?far:colliding;
-          ret.colors[i*6+2]=ret.colors[i*6+3]=ret.colors[i*6+4]=ret.colors[i*6+5]=normal;
-      }
-      return ret;
-  }
+visualization_msgs::Marker Scene::proxyToMarker(const std::vector<CollisionProxy>& proxies, const std::string& frame)
+{
+    visualization_msgs::Marker ret;
+    ret.header.frame_id = "exotica/" + frame;
+    ret.action = visualization_msgs::Marker::ADD;
+    ret.frame_locked = false;
+    ret.ns = "Proxies";
+    ret.color.a = 1.0;
+    ret.id = 0;
+    ret.type = visualization_msgs::Marker::LINE_LIST;
+    ret.points.resize(proxies.size() * 6);
+    ret.colors.resize(proxies.size() * 6);
+    ret.scale.x = 0.005;
+    double normalLength = 0.01;
+    std_msgs::ColorRGBA normal = getColor(0.8, 0.8, 0.8);
+    std_msgs::ColorRGBA far = getColor(0.5, 0.5, 0.5);
+    std_msgs::ColorRGBA colliding = getColor(1, 0, 0);
+    for (int i = 0; i < proxies.size(); i++)
+    {
+        KDL::Vector c1 = KDL::Vector(proxies[i].contact1(0), proxies[i].contact1(1), proxies[i].contact1(2));
+        KDL::Vector c2 = KDL::Vector(proxies[i].contact2(0), proxies[i].contact2(1), proxies[i].contact2(2));
+        KDL::Vector n1 = KDL::Vector(proxies[i].normal1(0), proxies[i].normal1(1), proxies[i].normal1(2));
+        KDL::Vector n2 = KDL::Vector(proxies[i].normal2(0), proxies[i].normal2(1), proxies[i].normal2(2));
+        tf::pointKDLToMsg(c1, ret.points[i * 6]);
+        tf::pointKDLToMsg(c2, ret.points[i * 6 + 1]);
+        tf::pointKDLToMsg(c1, ret.points[i * 6 + 2]);
+        tf::pointKDLToMsg(c1 + n1 * normalLength, ret.points[i * 6 + 3]);
+        tf::pointKDLToMsg(c2, ret.points[i * 6 + 4]);
+        tf::pointKDLToMsg(c2 + n2 * normalLength, ret.points[i * 6 + 5]);
+        ret.colors[i * 6] = ret.colors[i * 6 + 1] = proxies[i].distance > 0 ? far : colliding;
+        ret.colors[i * 6 + 2] = ret.colors[i * 6 + 3] = ret.colors[i * 6 + 4] = ret.colors[i * 6 + 5] = normal;
+    }
+    return ret;
+}
 
-  void Scene::setCollisionScene(const moveit_msgs::PlanningSceneConstPtr & scene)
-  {
+void Scene::setCollisionScene(const moveit_msgs::PlanningSceneConstPtr& scene)
+{
     updateSceneFrames();
     collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-  }
+}
 
-  void Scene::updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world)
-  {
-      updateSceneFrames();
-      collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-  }
+void Scene::updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world)
+{
+    updateSceneFrames();
+    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+}
 
-  CollisionScene_ptr & Scene::getCollisionScene()
-  {
+CollisionScene_ptr& Scene::getCollisionScene()
+{
     return collision_scene_;
-  }
+}
 
-  std::string Scene::getRootFrameName()
-  {
+std::string Scene::getRootFrameName()
+{
     return kinematica_.getRootFrameName();
-  }
+}
 
-  std::string Scene::getRootJointName()
-  {
+std::string Scene::getRootJointName()
+{
     return kinematica_.getRootJointName();
-  }
+}
 
-  std::string Scene::getModelRootLinkName()
-  {
+std::string Scene::getModelRootLinkName()
+{
     return model_->getRootLinkName();
-  }
+}
 
-  planning_scene::PlanningScenePtr Scene::getPlanningScene()
-  {
+planning_scene::PlanningScenePtr Scene::getPlanningScene()
+{
     return ps_;
-  }
+}
 
-  exotica::KinematicTree & Scene::getSolver()
-  {
+exotica::KinematicTree& Scene::getSolver()
+{
     return kinematica_;
-  }
+}
 
-  void Scene::getJointNames(std::vector<std::string> & joints)
-  {
+void Scene::getJointNames(std::vector<std::string>& joints)
+{
     joints = kinematica_.getJointNames();
-  }
+}
 
-  std::vector<std::string> Scene::getJointNames()
-  {
+std::vector<std::string> Scene::getJointNames()
+{
     return kinematica_.getJointNames();
-  }
+}
 
-  std::vector<std::string> Scene::getModelJointNames()
-  {
+std::vector<std::string> Scene::getModelJointNames()
+{
     return kinematica_.getModelJointNames();
-  }
+}
 
-  Eigen::VectorXd Scene::getModelState()
-  {
+Eigen::VectorXd Scene::getModelState()
+{
     return kinematica_.getModelState();
-  }
+}
 
-  std::map<std::string, double> Scene::getModelStateMap()
-  {
+std::map<std::string, double> Scene::getModelStateMap()
+{
     return kinematica_.getModelStateMap();
-  }
+}
 
-  void Scene::setModelState(Eigen::VectorXdRefConst x, double t)
-  {
+void Scene::setModelState(Eigen::VectorXdRefConst x, double t)
+{
     updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
-    if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
+    if (force_collision_) collision_scene_->updateCollisionObjectTransforms();
 
     if (debug_) publishScene();
-  }
+}
 
-  void Scene::setModelState(std::map<std::string, double> x, double t)
-  {
+void Scene::setModelState(std::map<std::string, double> x, double t)
+{
     updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
-    if(force_collision_) collision_scene_->updateCollisionObjectTransforms();
+    if (force_collision_) collision_scene_->updateCollisionObjectTransforms();
 
     if (debug_) publishScene();
-  }
+}
 
-  Eigen::VectorXd Scene::getControlledState()
-  {
-      return kinematica_.getControlledState();
-  }
+Eigen::VectorXd Scene::getControlledState()
+{
+    return kinematica_.getControlledState();
+}
 
-  std::string Scene::getGroupName()
-  {
-      return group->getName();
-  }
+std::string Scene::getGroupName()
+{
+    return group->getName();
+}
 
-  void Scene::loadScene(const std::string& scene, bool updateCollisionScene)
-  {
-      std::stringstream ss(scene);
-      ps_->loadGeometryFromStream(ss);
-      updateSceneFrames();
-      if(updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-  }
+void Scene::loadScene(const std::string& scene, bool updateCollisionScene)
+{
+    std::stringstream ss(scene);
+    ps_->loadGeometryFromStream(ss);
+    updateSceneFrames();
+    if (updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+}
 
-  void Scene::loadSceneFile(const std::string& file_name, bool updateCollisionScene)
-  {
-      std::ifstream ss(parsePath(file_name));
-      ps_->loadGeometryFromStream(ss);
-      updateSceneFrames();
-      if(updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-  }
+void Scene::loadSceneFile(const std::string& file_name, bool updateCollisionScene)
+{
+    std::ifstream ss(parsePath(file_name));
+    ps_->loadGeometryFromStream(ss);
+    updateSceneFrames();
+    if (updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+}
 
-  std::string Scene::getScene()
-  {
-      std::stringstream ss;
-      ps_->saveGeometryToStream(ss);
-      return ss.str();
-  }
+std::string Scene::getScene()
+{
+    std::stringstream ss;
+    ps_->saveGeometryToStream(ss);
+    return ss.str();
+}
 
-  void Scene::cleanScene()
-  {
-      ps_->removeAllCollisionObjects();
-      updateSceneFrames();
-      collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-  }
+void Scene::cleanScene()
+{
+    ps_->removeAllCollisionObjects();
+    updateSceneFrames();
+    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+}
 
-  void Scene::updateSceneFrames()
-  {
-      kinematica_.resetModel();
+void Scene::updateSceneFrames()
+{
+    kinematica_.resetModel();
 
-      // Add world objects
-      for(auto& object : *ps_->getWorld())
-      {
-          if(object.second->shapes_.size())
-          {
-              // Use the first collision shape as the origin of the object
-              Eigen::Affine3d objTransform = object.second->shape_poses_[0];
-              kinematica_.AddElement(object.first, objTransform);
-              for(int i=0; i<object.second->shape_poses_.size();i++)
-              {
-                  Eigen::Affine3d trans = objTransform.inverse()*object.second->shape_poses_[i];
-                  kinematica_.AddElement(object.first+"_collision_"+std::to_string(i), trans, object.first, object.second->shapes_[i]);
-              }
-          }
-          else
-          {
-            HIGHLIGHT("Object with no shapes ('"<<object.first<<"')");
-          }
-      }
+    // Add world objects
+    for (auto& object : *ps_->getWorld())
+    {
+        if (object.second->shapes_.size())
+        {
+            // Use the first collision shape as the origin of the object
+            Eigen::Affine3d objTransform = object.second->shape_poses_[0];
+            kinematica_.AddElement(object.first, objTransform);
+            for (int i = 0; i < object.second->shape_poses_.size(); i++)
+            {
+                Eigen::Affine3d trans = objTransform.inverse() * object.second->shape_poses_[i];
+                kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
+            }
+        }
+        else
+        {
+            HIGHLIGHT("Object with no shapes ('" << object.first << "')");
+        }
+    }
 
-      // Add robot collision objects
-      ps_->getCurrentStateNonConst().update(true);
-      const std::vector<const robot_model::LinkModel*>& links =
-          ps_->getCollisionRobot()->getRobotModel()->getLinkModelsWithCollisionGeometry();
-      for (int i = 0; i < links.size(); ++i)
-      {
-          Eigen::Affine3d objTransform = ps_->getCurrentState().getGlobalLinkTransform(links[i]);
+    // Add robot collision objects
+    ps_->getCurrentStateNonConst().update(true);
+    const std::vector<const robot_model::LinkModel*>& links =
+        ps_->getCollisionRobot()->getRobotModel()->getLinkModelsWithCollisionGeometry();
+    for (int i = 0; i < links.size(); ++i)
+    {
+        Eigen::Affine3d objTransform = ps_->getCurrentState().getGlobalLinkTransform(links[i]);
 
-          for (int j = 0; j < links[i]->getShapes().size(); ++j)
-          {
-              Eigen::Affine3d trans = objTransform.inverse()*ps_->getCurrentState().getCollisionBodyTransform(links[i], j);
-              kinematica_.AddElement(links[i]->getName()+"_collision_"+std::to_string(j), trans, links[i]->getName(), links[i]->getShapes()[j]);
-          }
-      }
+        for (int j = 0; j < links[i]->getShapes().size(); ++j)
+        {
+            Eigen::Affine3d trans = objTransform.inverse() * ps_->getCurrentState().getCollisionBodyTransform(links[i], j);
+            kinematica_.AddElement(links[i]->getName() + "_collision_" + std::to_string(j), trans, links[i]->getName(), links[i]->getShapes()[j]);
+        }
+    }
 
-      for(auto& it : custom_links_)
-      {
-          Eigen::Affine3d pose;
-          tf::transformKDLToEigen(it.second->Segment.getFrameToTip(), pose);
-          it.second = kinematica_.AddElement(it.first, pose,  it.second->Parent->Segment.getName(), it.second->Shape, it.second->Segment.getInertia());
-      }
+    for (auto& it : custom_links_)
+    {
+        Eigen::Affine3d pose;
+        tf::transformKDLToEigen(it.second->Segment.getFrameToTip(), pose);
+        it.second = kinematica_.AddElement(it.first, pose, it.second->Parent->Segment.getName(), it.second->Shape, it.second->Segment.getInertia());
+    }
 
-      kinematica_.UpdateModel();
-  }
+    kinematica_.UpdateModel();
+}
 
-  void Scene::addObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, bool updateCollisionScene)
-  {
-      const std::map<std::string, std::shared_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
-      if(links.find(name)!=links.end()) throw_pretty("Link '"<<name<<"' already exists in the scene!");
-      std::string parent_name = parent==""?kinematica_.getRootFrameName():parent;
-      if(links.find(parent_name)==links.end()) throw_pretty("Can't find parent '"<<parent_name<<"'!");
-      Eigen::Affine3d pose;
-      tf::transformKDLToEigen(transform, pose);
-      custom_links_[name] = kinematica_.AddElement(name, pose, parent_name, shape, inertia);
-      if(updateCollisionScene)
-      {
-          collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-      }
-  }
+void Scene::addObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, bool updateCollisionScene)
+{
+    const std::map<std::string, std::shared_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
+    if (links.find(name) != links.end()) throw_pretty("Link '" << name << "' already exists in the scene!");
+    std::string parent_name = parent == "" ? kinematica_.getRootFrameName() : parent;
+    if (links.find(parent_name) == links.end()) throw_pretty("Can't find parent '" << parent_name << "'!");
+    Eigen::Affine3d pose;
+    tf::transformKDLToEigen(transform, pose);
+    custom_links_[name] = kinematica_.AddElement(name, pose, parent_name, shape, inertia);
+    if (updateCollisionScene)
+    {
+        collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    }
+}
 
-  void Scene::attachObject(const std::string& name, const std::string& parent)
-  {
-      kinematica_.changeParent(name, parent, KDL::Frame(), false);
-      attached_objects_[name] = AttachedObject(parent);
-  }
+void Scene::attachObject(const std::string& name, const std::string& parent)
+{
+    kinematica_.changeParent(name, parent, KDL::Frame(), false);
+    attached_objects_[name] = AttachedObject(parent);
+}
 
-  void Scene::attachObjectLocal(const std::string& name, const std::string& parent, const KDL::Frame& pose)
-  {
-      kinematica_.changeParent(name, parent, pose, true);
-      attached_objects_[name] = AttachedObject(parent, pose);
-  }
+void Scene::attachObjectLocal(const std::string& name, const std::string& parent, const KDL::Frame& pose)
+{
+    kinematica_.changeParent(name, parent, pose, true);
+    attached_objects_[name] = AttachedObject(parent, pose);
+}
 
-  void Scene::detachObject(const std::string& name)
-  {
-      if(!hasAttachedObject(name)) throw_pretty("'"<<name<<"' is not attached to the robot!");
-      auto object = attached_objects_.find(name);
-      kinematica_.changeParent(name, "", KDL::Frame(), false);
-      attached_objects_.erase(object);
-  }
+void Scene::detachObject(const std::string& name)
+{
+    if (!hasAttachedObject(name)) throw_pretty("'" << name << "' is not attached to the robot!");
+    auto object = attached_objects_.find(name);
+    kinematica_.changeParent(name, "", KDL::Frame(), false);
+    attached_objects_.erase(object);
+}
 
-  bool Scene::hasAttachedObject(const std::string& name)
-  {
-      return attached_objects_.find(name)!=attached_objects_.end();
-  }
+bool Scene::hasAttachedObject(const std::string& name)
+{
+    return attached_objects_.find(name) != attached_objects_.end();
+}
 
-  void Scene::addTrajectoryFromFile(const std::string& link, const std::string& traj)
-  {
-      addTrajectory(link, loadFile(traj));
-  }
+void Scene::addTrajectoryFromFile(const std::string& link, const std::string& traj)
+{
+    addTrajectory(link, loadFile(traj));
+}
 
-  void Scene::addTrajectory(const std::string& link, const std::string& traj)
-  {
-      addTrajectory(link, std::shared_ptr<Trajectory>(new Trajectory(traj)));
-  }
+void Scene::addTrajectory(const std::string& link, const std::string& traj)
+{
+    addTrajectory(link, std::shared_ptr<Trajectory>(new Trajectory(traj)));
+}
 
-  void Scene::addTrajectory(const std::string& link, std::shared_ptr<Trajectory> traj)
-  {
-      const auto& tree = kinematica_.getTreeMap();
-      const auto& it = tree.find(link);
-      if(it==tree.end()) throw_pretty("Can't find link '"<<link<<"'!");
-      if(traj->getDuration()==0.0) throw_pretty("The trajectory is empty!");
-      trajectory_generators_[link] = std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>(it->second, traj);
-      it->second->IsTrajectoryGenerated = true;
-  }
+void Scene::addTrajectory(const std::string& link, std::shared_ptr<Trajectory> traj)
+{
+    const auto& tree = kinematica_.getTreeMap();
+    const auto& it = tree.find(link);
+    if (it == tree.end()) throw_pretty("Can't find link '" << link << "'!");
+    if (traj->getDuration() == 0.0) throw_pretty("The trajectory is empty!");
+    trajectory_generators_[link] = std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>(it->second, traj);
+    it->second->IsTrajectoryGenerated = true;
+}
 
-  std::shared_ptr<Trajectory> Scene::getTrajectory(const std::string& link)
-  {
-      const auto& it = trajectory_generators_.find(link);
-      if(it==trajectory_generators_.end()) throw_pretty("No trajectory generator defined for link '"<<link<<"'!");
-      return it->second.second;
-  }
+std::shared_ptr<Trajectory> Scene::getTrajectory(const std::string& link)
+{
+    const auto& it = trajectory_generators_.find(link);
+    if (it == trajectory_generators_.end()) throw_pretty("No trajectory generator defined for link '" << link << "'!");
+    return it->second.second;
+}
 
-  void Scene::removeTrajectory(const std::string& link)
-  {
-      const auto& it = trajectory_generators_.find(link);
-      if(it==trajectory_generators_.end()) throw_pretty("No trajectory generator defined for link '"<<link<<"'!");
-      it->second.first->IsTrajectoryGenerated = false;
-      trajectory_generators_.erase(it);
-  }
-
+void Scene::removeTrajectory(const std::string& link)
+{
+    const auto& it = trajectory_generators_.find(link);
+    if (it == trajectory_generators_.end()) throw_pretty("No trajectory generator defined for link '" << link << "'!");
+    it->second.first->IsTrajectoryGenerated = false;
+    trajectory_generators_.erase(it);
+}
 }
 //  namespace exotica
-

--- a/exotica/src/Setup.cpp
+++ b/exotica/src/Setup.cpp
@@ -30,88 +30,84 @@
  *
  */
 
+#include <exotica/Scene.h>
 #include <exotica/Setup.h>
 #include <type_traits>
-#include <exotica/Scene.h>
 
 namespace exotica
 {
-  Setup_ptr Setup::singleton_initialiser_ = nullptr;
+Setup_ptr Setup::singleton_initialiser_ = nullptr;
 
-  void Setup::printSupportedClasses()
-  {
-      HIGHLIGHT("Registered solvers:");
-      std::vector<std::string> solvers =  Instance()->solvers_.getDeclaredClasses();
-      for(std::string s : solvers)
-      {
-          HIGHLIGHT(" '"<<s<<"'");
-      }
-      HIGHLIGHT("Registered problems:");
-      std::vector<std::string> problems =  Instance()->problems_.getDeclaredClasses();
-      for(std::string s : problems)
-      {
-          HIGHLIGHT(" '"<<s<<"'");
-      }
-      HIGHLIGHT("Registered task maps:");
-      std::vector<std::string> maps =  Instance()->maps_.getDeclaredClasses();
-      for(std::string s : maps)
-      {
-          HIGHLIGHT(" '"<<s<<"'");
-      }
-      HIGHLIGHT("Registered collision scenes:");
-      std::vector<std::string> scenes =  Instance()->scenes_.getDeclaredClasses();
-      for(std::string s : scenes)
-      {
-          HIGHLIGHT(" '"<<s<<"'");
-      }
-  }
+void Setup::printSupportedClasses()
+{
+    HIGHLIGHT("Registered solvers:");
+    std::vector<std::string> solvers = Instance()->solvers_.getDeclaredClasses();
+    for (std::string s : solvers)
+    {
+        HIGHLIGHT(" '" << s << "'");
+    }
+    HIGHLIGHT("Registered problems:");
+    std::vector<std::string> problems = Instance()->problems_.getDeclaredClasses();
+    for (std::string s : problems)
+    {
+        HIGHLIGHT(" '" << s << "'");
+    }
+    HIGHLIGHT("Registered task maps:");
+    std::vector<std::string> maps = Instance()->maps_.getDeclaredClasses();
+    for (std::string s : maps)
+    {
+        HIGHLIGHT(" '" << s << "'");
+    }
+    HIGHLIGHT("Registered collision scenes:");
+    std::vector<std::string> scenes = Instance()->scenes_.getDeclaredClasses();
+    for (std::string s : scenes)
+    {
+        HIGHLIGHT(" '" << s << "'");
+    }
+}
 
-  void appendInit(std::shared_ptr<InstantiableBase> it, std::vector<Initializer>& ret)
-  {
-      std::vector<Initializer> temps = it->getAllTemplates();
-      for(Initializer& i : temps)
-      {
-          bool found = false;
-          for(Initializer& j : ret)
-          {
-              if(i.name==j.name)
-              {
-                  found = true;
-                  break;
-              }
-          }
-          if(!found)
-          {
-              ret.push_back(i);
-          }
-      }
-  }
+void appendInit(std::shared_ptr<InstantiableBase> it, std::vector<Initializer>& ret)
+{
+    std::vector<Initializer> temps = it->getAllTemplates();
+    for (Initializer& i : temps)
+    {
+        bool found = false;
+        for (Initializer& j : ret)
+        {
+            if (i.name == j.name)
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+        {
+            ret.push_back(i);
+        }
+    }
+}
 
-  std::vector<Initializer> Setup::getInitializers()
-  {
-      std::vector<Initializer> ret = Scene().getAllTemplates();
-      std::vector<std::string> solvers =  Instance()->solvers_.getDeclaredClasses();
-      for(std::string s : solvers)
-      {
-          appendInit(std::static_pointer_cast<InstantiableBase>(createSolver(s, false)), ret);
-      }
-      std::vector<std::string> maps =  Instance()->maps_.getDeclaredClasses();
-      for(std::string s : maps)
-      {
-          appendInit(std::static_pointer_cast<InstantiableBase>(createMap(s, false)), ret);
-      }
-      return ret;
-  }
+std::vector<Initializer> Setup::getInitializers()
+{
+    std::vector<Initializer> ret = Scene().getAllTemplates();
+    std::vector<std::string> solvers = Instance()->solvers_.getDeclaredClasses();
+    for (std::string s : solvers)
+    {
+        appendInit(std::static_pointer_cast<InstantiableBase>(createSolver(s, false)), ret);
+    }
+    std::vector<std::string> maps = Instance()->maps_.getDeclaredClasses();
+    for (std::string s : maps)
+    {
+        appendInit(std::static_pointer_cast<InstantiableBase>(createMap(s, false)), ret);
+    }
+    return ret;
+}
 
-  std::vector<std::string> Setup::getSolvers() {return Instance()->solvers_.getDeclaredClasses();}
-  std::vector<std::string> Setup::getProblems() {return Instance()->problems_.getDeclaredClasses();}
-  std::vector<std::string> Setup::getMaps() {return Instance()->maps_.getDeclaredClasses();}
-  std::vector<std::string> Setup::getCollisionScenes() {return Instance()->scenes_.getDeclaredClasses();}
-
-  Setup::Setup() : solvers_("exotica","exotica::MotionSolver"), maps_("exotica","exotica::TaskMap"),
-      problems_(PlanningProblem_fac::Instance()), scenes_("exotica","exotica::CollisionScene")
-  {
-
-  }
-
+std::vector<std::string> Setup::getSolvers() { return Instance()->solvers_.getDeclaredClasses(); }
+std::vector<std::string> Setup::getProblems() { return Instance()->problems_.getDeclaredClasses(); }
+std::vector<std::string> Setup::getMaps() { return Instance()->maps_.getDeclaredClasses(); }
+std::vector<std::string> Setup::getCollisionScenes() { return Instance()->scenes_.getDeclaredClasses(); }
+Setup::Setup() : solvers_("exotica", "exotica::MotionSolver"), maps_("exotica", "exotica::TaskMap"), problems_(PlanningProblem_fac::Instance()), scenes_("exotica", "exotica::CollisionScene")
+{
+}
 }

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -30,46 +30,44 @@
  *
  */
 
-#include <exotica/TaskMap.h>
-#include <exotica/PlanningProblem.h>
-#include <exotica/TaskMapInitializer.h>
 #include <exotica/FrameInitializer.h>
+#include <exotica/PlanningProblem.h>
+#include <exotica/TaskMap.h>
+#include <exotica/TaskMapInitializer.h>
 
 namespace exotica
 {
+TaskMap::TaskMap() : Id(-1), Start(-1), Length(-1), StartJ(-1), LengthJ(-1)
+{
+}
 
-  TaskMap::TaskMap() : Id(-1), Start(-1), Length(-1), StartJ(-1), LengthJ(-1)
-  {
-
-  }
-
-  std::string TaskMap::print(std::string prepend)
-  {
+std::string TaskMap::print(std::string prepend)
+{
     std::string ret = Object::print(prepend);
     return ret;
-  }
+}
 
-  void TaskMap::InstantiateBase(const Initializer& init)
-  {
+void TaskMap::InstantiateBase(const Initializer& init)
+{
     Object::InstatiateObject(init);
     TaskMapInitializer MapInitializer(init);
 
     Frames.clear();
 
-    for(Initializer& eff : MapInitializer.EndEffector)
+    for (Initializer& eff : MapInitializer.EndEffector)
     {
         FrameInitializer frame(eff);
         Frames.push_back(KinematicFrameRequest(frame.Link, getFrame(frame.LinkOffset), frame.Base, getFrame(frame.BaseOffset)));
     }
-  }
+}
 
-  std::vector<KinematicFrameRequest> TaskMap::GetFrames()
-  {
-      return Frames;
-  }
+std::vector<KinematicFrameRequest> TaskMap::GetFrames()
+{
+    return Frames;
+}
 
-  void TaskMap::taskSpaceDim(int & task_dim)
-  {
-      task_dim = taskSpaceDim();
-  }
+void TaskMap::taskSpaceDim(int& task_dim)
+{
+    task_dim = taskSpaceDim();
+}
 }

--- a/exotica/src/TaskSpaceVector.cpp
+++ b/exotica/src/TaskSpaceVector.cpp
@@ -34,73 +34,66 @@
 
 namespace exotica
 {
+TaskVectorEntry::TaskVectorEntry(int inId_, RotationType type_) : inId(inId_), type(type_)
+{
+}
 
-    TaskVectorEntry::TaskVectorEntry(int inId_, RotationType type_) :
-        inId(inId_), type(type_)
+TaskVectorEntry::TaskVectorEntry() : inId(0), type(RotationType::RPY)
+{
+}
+
+TaskSpaceVector::TaskSpaceVector()
+{
+}
+
+TaskSpaceVector& TaskSpaceVector::operator=(std::initializer_list<double> other)
+{
+    if (other.size() != data.rows()) throw_pretty("Wrong initializer size: " << other.size() << " expecting " << data.rows());
+    int i = 0;
+    for (double val : other)
     {
-
+        data(i) = val;
+        i++;
     }
+    return *this;
+}
 
-    TaskVectorEntry::TaskVectorEntry() :
-        inId(0), type(RotationType::RPY)
+void TaskSpaceVector::setZero(int N)
+{
+    data = Eigen::VectorXd::Zero(N);
+    for (const TaskVectorEntry& id : map)
     {
-
+        int len = getRotationTypeLength(id.type);
+        data.segment(id.inId, len) = setRotation(KDL::Rotation(), id.type);
     }
+}
 
-    TaskSpaceVector::TaskSpaceVector()
+Eigen::VectorXd TaskSpaceVector::operator-(const TaskSpaceVector& other)
+{
+    if (data.rows() != other.data.rows()) throw_pretty("Task space vector sizes do not match!");
+    int entrySize = 0;
+    for (const TaskVectorEntry& id : map) entrySize += getRotationTypeLength(id.type);
+    Eigen::VectorXd ret(data.rows() + map.size() * 3 - entrySize);
+    int iIn = 0;
+    int iOut = 0;
+    for (const TaskVectorEntry& id : map)
     {
+        if (iIn < id.inId) ret.segment(iOut, id.inId - iIn) = data.segment(iIn, id.inId - iIn) - other.data.segment(iIn, id.inId - iIn);
+        iOut += id.inId - iIn;
+        iIn += id.inId - iIn;
+        int len = getRotationTypeLength(id.type);
 
+        KDL::Rotation M1 = getRotation(data.segment(id.inId, len), id.type);
+        KDL::Rotation M2 = getRotation(other.data.segment(id.inId, len), id.type);
+        KDL::Rotation M = M2.Inverse() * M1;
+        KDL::Vector rotvec = M1 * (M.GetRot());
+        ret(iOut) = rotvec[0];
+        ret(iOut + 1) = rotvec[1];
+        ret(iOut + 2) = rotvec[2];
+        iOut += 3;
+        iIn += len;
     }
-
-    TaskSpaceVector& TaskSpaceVector::operator=(std::initializer_list<double> other)
-    {
-        if(other.size()!=data.rows()) throw_pretty("Wrong initializer size: " << other.size() << " expecting " << data.rows());
-        int i = 0;
-        for(double val : other)
-        {
-            data(i) = val;
-            i++;
-        }
-        return *this;
-    }
-
-    void TaskSpaceVector::setZero(int N)
-    {
-
-        data = Eigen::VectorXd::Zero(N);
-        for(const TaskVectorEntry& id : map)
-        {
-            int len = getRotationTypeLength(id.type);
-            data.segment(id.inId,len) = setRotation(KDL::Rotation(), id.type);
-        }
-    }
-
-    Eigen::VectorXd TaskSpaceVector::operator-(const TaskSpaceVector& other)
-    {
-        if(data.rows() != other.data.rows()) throw_pretty("Task space vector sizes do not match!");
-        int entrySize = 0;
-        for(const TaskVectorEntry& id : map) entrySize += getRotationTypeLength(id.type);
-        Eigen::VectorXd ret(data.rows()+map.size()*3-entrySize);
-        int iIn=0;
-        int iOut=0;
-        for(const TaskVectorEntry& id : map)
-        {
-            if(iIn<id.inId) ret.segment(iOut, id.inId-iIn) = data.segment(iIn, id.inId-iIn) - other.data.segment(iIn, id.inId-iIn);
-            iOut += id.inId-iIn;
-            iIn += id.inId-iIn;
-            int len = getRotationTypeLength(id.type);
-
-            KDL::Rotation M1 = getRotation(data.segment(id.inId, len), id.type);
-            KDL::Rotation M2 = getRotation(other.data.segment(id.inId, len), id.type);
-            KDL::Rotation M = M2.Inverse()*M1;
-            KDL::Vector rotvec = M1*(M.GetRot());
-            ret(iOut) = rotvec[0];
-            ret(iOut+1) = rotvec[1];
-            ret(iOut+2) = rotvec[2];
-            iOut+=3;
-            iIn+=len;
-        }
-        if(iIn<data.rows()) ret.segment(iOut, data.rows()-iIn) = data.segment(iIn, data.rows()-iIn) - other.data.segment(iIn, data.rows()-iIn);
-        return ret;
-    }
+    if (iIn < data.rows()) ret.segment(iOut, data.rows() - iIn) = data.segment(iIn, data.rows() - iIn) - other.data.segment(iIn, data.rows() - iIn);
+    return ret;
+}
 }

--- a/exotica/src/Tools.cpp
+++ b/exotica/src/Tools.cpp
@@ -31,50 +31,50 @@
  */
 
 #include "exotica/Tools.h"
-#include <fstream>
-#include <boost/algorithm/string.hpp>
-#include <random>
-#include <iostream>
-#include <typeinfo> //!< The RTTI Functionality of C++
-#include <cxxabi.h> //!< The demangler for gcc... this makes this system dependent!
-#include <regex>
+#include <cxxabi.h>  //!< The demangler for gcc... this makes this system dependent!
 #include <ros/package.h>
+#include <boost/algorithm/string.hpp>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <regex>
+#include <typeinfo>  //!< The RTTI Functionality of C++
 
 namespace exotica
 {
-    std_msgs::ColorRGBA randomColor()
-    {
-        std_msgs::ColorRGBA ret;
-        ret.a = 1.0;
-        std::random_device rd;
-        std::mt19937 gen(rd());
-        std::uniform_real_distribution<> dis(0.0, 1.0);
-        ret.r = dis(gen);
-        ret.g = dis(gen);
-        ret.b = dis(gen);
-        return ret;
-    }
+std_msgs::ColorRGBA randomColor()
+{
+    std_msgs::ColorRGBA ret;
+    ret.a = 1.0;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+    ret.r = dis(gen);
+    ret.g = dis(gen);
+    ret.b = dis(gen);
+    return ret;
+}
 
-  void saveMatrix(std::string file_name,
-      const Eigen::Ref<const Eigen::MatrixXd> mat)
-  {
+void saveMatrix(std::string file_name,
+                const Eigen::Ref<const Eigen::MatrixXd> mat)
+{
     std::ofstream myfile;
     myfile.open(file_name);
     if (myfile.good())
     {
-      myfile << mat;
-      myfile.close();
+        myfile << mat;
+        myfile.close();
     }
     else
     {
-      myfile.close();
-      throw_pretty("Can't open file!");
+        myfile.close();
+        throw_pretty("Can't open file!");
     }
-  }
+}
 
-  void loadOBJ(const std::string & data, Eigen::VectorXi& tri,
-      Eigen::VectorXd& vert)
-  {
+void loadOBJ(const std::string& data, Eigen::VectorXi& tri,
+             Eigen::VectorXd& vert)
+{
     std::stringstream ss(data);
     std::string line;
     tri.resize(0, 1);
@@ -84,111 +84,109 @@ namespace exotica
     int vv[9];
     while (std::getline(ss, line))
     {
-      if (line.compare(0, 2, "v ") == 0)
-      {
-
-        vert.conservativeResize((vn + 1) * 3);
-        std::stringstream sss(line.substr(2));
-        sss >> v[0] >> v[1] >> v[2];
-        vert(vn * 3) = v[0];
-        vert(vn * 3 + 1) = v[1];
-        vert(vn * 3 + 2) = v[2];
-        vn++;
-      }
-      else if (line.compare(0, 2, "f ") == 0)
-      {
-        std::stringstream sss(line.substr(2));
-        int i;
-        for (i = 0; i < 9 && sss >> vv[i]; i++)
+        if (line.compare(0, 2, "v ") == 0)
         {
-          while (sss.peek() == '/' || sss.peek() == ' ')
-            sss.ignore();
+            vert.conservativeResize((vn + 1) * 3);
+            std::stringstream sss(line.substr(2));
+            sss >> v[0] >> v[1] >> v[2];
+            vert(vn * 3) = v[0];
+            vert(vn * 3 + 1) = v[1];
+            vert(vn * 3 + 2) = v[2];
+            vn++;
         }
-        if (i < 8)
+        else if (line.compare(0, 2, "f ") == 0)
         {
-          throw_pretty("Invalid format!");
+            std::stringstream sss(line.substr(2));
+            int i;
+            for (i = 0; i < 9 && sss >> vv[i]; i++)
+            {
+                while (sss.peek() == '/' || sss.peek() == ' ')
+                    sss.ignore();
+            }
+            if (i < 8)
+            {
+                throw_pretty("Invalid format!");
+            }
+            tri.conservativeResize((tn + 1) * 3);
+            tri(tn * 3) = vv[0] - 1;
+            tri(tn * 3 + 1) = vv[3] - 1;
+            tri(tn * 3 + 2) = vv[6] - 1;
+            tn++;
         }
-        tri.conservativeResize((tn + 1) * 3);
-        tri(tn * 3) = vv[0] - 1;
-        tri(tn * 3 + 1) = vv[3] - 1;
-        tri(tn * 3 + 2) = vv[6] - 1;
-        tn++;
-      }
     }
-  }
+}
 
-  void getText(std::string& txt, KDL::Frame& ret)
-  {
-      std::vector<std::string> strs;
-      boost::split(strs, txt, boost::is_any_of(" "));
-      if(strs.size()!=7)
-      {
-          throw_pretty("Not a frame! " <<txt);
-      }
+void getText(std::string& txt, KDL::Frame& ret)
+{
+    std::vector<std::string> strs;
+    boost::split(strs, txt, boost::is_any_of(" "));
+    if (strs.size() != 7)
+    {
+        throw_pretty("Not a frame! " << txt);
+    }
 
-      std::vector<double> doubleVector(strs.size());
-      std::transform(strs.begin(), strs.end(), doubleVector.begin(), [](const std::string& val)
-      {
-          return std::stod(val);
-      });
+    std::vector<double> doubleVector(strs.size());
+    std::transform(strs.begin(), strs.end(), doubleVector.begin(), [](const std::string& val) {
+        return std::stod(val);
+    });
 
-      ret.p = KDL::Vector(doubleVector[0],doubleVector[1],doubleVector[2]);
-      ret.M = KDL::Rotation::Quaternion(doubleVector[4],doubleVector[5],doubleVector[6],doubleVector[3]);
-  }
+    ret.p = KDL::Vector(doubleVector[0], doubleVector[1], doubleVector[2]);
+    ret.M = KDL::Rotation::Quaternion(doubleVector[4], doubleVector[5], doubleVector[6], doubleVector[3]);
+}
 
-  std::string getTypeName(const std::type_info& type)
-  {
-      int status;
-      std::string name;
-      char * temp; //!< We need to store this to free the memory!
+std::string getTypeName(const std::type_info& type)
+{
+    int status;
+    std::string name;
+    char* temp;  //!< We need to store this to free the memory!
 
-      temp = abi::__cxa_demangle(type.name(), 0, 0, &status);
-      name = std::string(temp);
-      free(temp);
-      return name;
-  }
+    temp = abi::__cxa_demangle(type.name(), 0, 0, &status);
+    name = std::string(temp);
+    free(temp);
+    return name;
+}
 
-  std::string parsePath(const std::string& path)
-  {
-      std::string ret = path;
-      std::smatch matches;
-      std::regex_search(ret, matches, std::regex("\\{([^\\}]+){1,}\\}"));
-      for(auto& match : matches)
-      {
-          std::string package = match.str();
-          if (package[0] == '{' || package == "") continue;
-          std::string package_path = ros::package::getPath(package);
-          if(package_path=="") throw_pretty("Unknown package '"<<package<<"'");
-          try
-          {
-              ret = std::regex_replace(ret, std::regex("\\{"+package+"\\}"), package_path, std::regex_constants::match_any);
-          }
-          catch(const std::regex_error& e)
-          {
-              throw_pretty("Package name resolution failed (regex error "<<e.code()<<")");
-          }
-      }
-      return ret;
-  }
+std::string parsePath(const std::string& path)
+{
+    std::string ret = path;
+    std::smatch matches;
+    std::regex_search(ret, matches, std::regex("\\{([^\\}]+){1,}\\}"));
+    for (auto& match : matches)
+    {
+        std::string package = match.str();
+        if (package[0] == '{' || package == "") continue;
+        std::string package_path = ros::package::getPath(package);
+        if (package_path == "") throw_pretty("Unknown package '" << package << "'");
+        try
+        {
+            ret = std::regex_replace(ret, std::regex("\\{" + package + "\\}"), package_path, std::regex_constants::match_any);
+        }
+        catch (const std::regex_error& e)
+        {
+            throw_pretty("Package name resolution failed (regex error " << e.code() << ")");
+        }
+    }
+    return ret;
+}
 
-  std::string loadFile(const std::string& path)
-  {
-      std::string file_name = parsePath(path);
-      std::ifstream fstream(file_name);
-      if(!fstream) throw_pretty("File does not exist '" << file_name << "'");
-      try
-      {
-          return std::string((std::istreambuf_iterator<char>(fstream)), std::istreambuf_iterator<char>());
-      }
-      catch (const std::ifstream::failure& e)
-      {
-          throw_pretty("Can't read file '"<<file_name<<"'");
-      }
-  }
+std::string loadFile(const std::string& path)
+{
+    std::string file_name = parsePath(path);
+    std::ifstream fstream(file_name);
+    if (!fstream) throw_pretty("File does not exist '" << file_name << "'");
+    try
+    {
+        return std::string((std::istreambuf_iterator<char>(fstream)), std::istreambuf_iterator<char>());
+    }
+    catch (const std::ifstream::failure& e)
+    {
+        throw_pretty("Can't read file '" << file_name << "'");
+    }
+}
 
-  bool pathExists(const std::string& path)
-  {
+bool pathExists(const std::string& path)
+{
     std::ifstream file(parsePath(path));
     return (bool)file;
-  }
+}
 }

--- a/exotica/src/Tools/Conversions.cpp
+++ b/exotica/src/Tools/Conversions.cpp
@@ -4,85 +4,85 @@
 
 namespace Eigen
 {
-    Eigen::VectorXd VectorTransform(double px, double py, double pz, double qx, double qy, double qz, double qw)
-    {
-        Eigen::VectorXd ret((Eigen::VectorXd(7) << px,py,pz,qx,qy,qz,qw).finished());
-        return ret;
-    }
+Eigen::VectorXd VectorTransform(double px, double py, double pz, double qx, double qy, double qz, double qw)
+{
+    Eigen::VectorXd ret((Eigen::VectorXd(7) << px, py, pz, qx, qy, qz, qw).finished());
+    return ret;
+}
 
-    Eigen::VectorXd IdentityTransform()
-    {
-        return VectorTransform();
-    }
+Eigen::VectorXd IdentityTransform()
+{
+    return VectorTransform();
+}
 }
 
 namespace exotica
 {
-    KDL::Frame getFrame(Eigen::VectorXdRefConst val)
+KDL::Frame getFrame(Eigen::VectorXdRefConst val)
+{
+    switch (val.rows())
     {
-        switch(val.rows())
-        {
         case 7:
-            {
-                double norm = val.tail(4).norm();
-                if(!(norm>0.0)) throw_pretty("Invalid quaternion!");
-                return KDL::Frame(KDL::Rotation::Quaternion(val(3)/norm, val(4)/norm, val(5)/norm, val(6)/norm), KDL::Vector(val(0),val(1),val(2)));
-            }
-        case 6:
-            return KDL::Frame(KDL::Rotation::RPY(val(3),val(4),val(5)),KDL::Vector(val(0),val(1),val(2)));
-        case 3:
-            return KDL::Frame(KDL::Vector(val(0),val(1),val(2)));
-        default:
-            throw_pretty("Eigen vector has incorrect length! ("+std::to_string(val.rows())+")");
-        }
-    }
-
-    KDL::Frame getFrameFromMatrix(Eigen::MatrixXdRefConst val)
-    {
-        switch(val.cols())
         {
+            double norm = val.tail(4).norm();
+            if (!(norm > 0.0)) throw_pretty("Invalid quaternion!");
+            return KDL::Frame(KDL::Rotation::Quaternion(val(3) / norm, val(4) / norm, val(5) / norm, val(6) / norm), KDL::Vector(val(0), val(1), val(2)));
+        }
+        case 6:
+            return KDL::Frame(KDL::Rotation::RPY(val(3), val(4), val(5)), KDL::Vector(val(0), val(1), val(2)));
+        case 3:
+            return KDL::Frame(KDL::Vector(val(0), val(1), val(2)));
+        default:
+            throw_pretty("Eigen vector has incorrect length! (" + std::to_string(val.rows()) + ")");
+    }
+}
+
+KDL::Frame getFrameFromMatrix(Eigen::MatrixXdRefConst val)
+{
+    switch (val.cols())
+    {
         case 1:
             return getFrame(val);
         case 4:
-            switch(val.rows())
+            switch (val.rows())
             {
-            case 3:
-            case 4:
-                return KDL::Frame(KDL::Rotation(val(0,0),val(0,1),val(0,2),val(1,0),val(1,1),val(1,2),val(2,0),val(2,1),val(2,2)),KDL::Vector(val(0,3),val(1,3),val(2,3)));
-            default:
-                throw_pretty("Eigen matrix has incorrect number of rows! ("+std::to_string(val.rows())+")");
+                case 3:
+                case 4:
+                    return KDL::Frame(KDL::Rotation(val(0, 0), val(0, 1), val(0, 2), val(1, 0), val(1, 1), val(1, 2), val(2, 0), val(2, 1), val(2, 2)), KDL::Vector(val(0, 3), val(1, 3), val(2, 3)));
+                default:
+                    throw_pretty("Eigen matrix has incorrect number of rows! (" + std::to_string(val.rows()) + ")");
             }
         default:
-            throw_pretty("Eigen matrix has incorrect number of columns! ("+std::to_string(val.cols())+")");
-        }
+            throw_pretty("Eigen matrix has incorrect number of columns! (" + std::to_string(val.cols()) + ")");
     }
+}
 
-    Eigen::MatrixXd getFrame(const KDL::Frame& val)
-    {
-        Eigen::MatrixXd ret = Eigen::MatrixXd::Identity(4,4);
-        ret(0,3) = val.p(0);
-        ret(1,3) = val.p(1);
-        ret(2,3) = val.p(2);
-        ret.block(0,0,3,3) = Eigen::Map<const Eigen::Matrix3d>(val.M.data);
-        return ret;
-    }
+Eigen::MatrixXd getFrame(const KDL::Frame& val)
+{
+    Eigen::MatrixXd ret = Eigen::MatrixXd::Identity(4, 4);
+    ret(0, 3) = val.p(0);
+    ret(1, 3) = val.p(1);
+    ret(2, 3) = val.p(2);
+    ret.block(0, 0, 3, 3) = Eigen::Map<const Eigen::Matrix3d>(val.M.data);
+    return ret;
+}
 
-    Eigen::VectorXd getFrameAsVector(const KDL::Frame& val, RotationType type)
-    {
-        Eigen::VectorXd ret(3+getRotationTypeLength(type));
-        ret(0) = val.p[0];
-        ret(1) = val.p[1];
-        ret(2) = val.p[2];
-        ret.segment(3,getRotationTypeLength(type)) = setRotation(val.M, type);
-        return ret;
-    }
+Eigen::VectorXd getFrameAsVector(const KDL::Frame& val, RotationType type)
+{
+    Eigen::VectorXd ret(3 + getRotationTypeLength(type));
+    ret(0) = val.p[0];
+    ret(1) = val.p[1];
+    ret(2) = val.p[2];
+    ret.segment(3, getRotationTypeLength(type)) = setRotation(val.M, type);
+    return ret;
+}
 
-    KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type)
+KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type)
+{
+    switch (type)
     {
-        switch(type)
-        {
         case RotationType::QUATERNION:
-            if(data.sum()==0.0) throw_pretty("Invalid quaternion transform!");
+            if (data.sum() == 0.0) throw_pretty("Invalid quaternion transform!");
             return KDL::Rotation::Quaternion(data(0), data(1), data(2), data(3));
         case RotationType::RPY:
             return KDL::Rotation::RPY(data(0), data(1), data(2));
@@ -91,32 +91,32 @@ namespace exotica
         case RotationType::ZYZ:
             return KDL::Rotation::EulerZYZ(data(0), data(1), data(2));
         case RotationType::ANGLE_AXIS:
+        {
+            KDL::Vector axis(data(0), data(1), data(2));
+            double angle = axis.Norm();
+            if (fabs(angle) > 1e-10)
             {
-                KDL::Vector axis(data(0), data(1), data(2));
-                double angle = axis.Norm();
-                if(fabs(angle)>1e-10)
-                {
-                    return KDL::Rotation::Rot(axis, angle);
-                }
-                else
-                {
-                    return KDL::Rotation();
-                }
+                return KDL::Rotation::Rot(axis, angle);
             }
+            else
+            {
+                return KDL::Rotation();
+            }
+        }
         case RotationType::MATRIX:
-            if(data.sum()==0.0) throw_pretty("Invalid matrix transform!");
+            if (data.sum() == 0.0) throw_pretty("Invalid matrix transform!");
             return KDL::Rotation(data(0), data(1), data(2),
                                  data(3), data(4), data(5),
                                  data(6), data(7), data(8));
-        }
-        throw_pretty("Unknown rotation represntation type!");
     }
+    throw_pretty("Unknown rotation represntation type!");
+}
 
-    Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type)
+Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type)
+{
+    Eigen::VectorXd ret;
+    switch (type)
     {
-        Eigen::VectorXd ret;
-        switch(type)
-        {
         case RotationType::QUATERNION:
             ret.resize(4);
             data.GetQuaternion(ret(0), ret(1), ret(2), ret(3));
@@ -139,66 +139,65 @@ namespace exotica
         case RotationType::MATRIX:
             ret = Eigen::Map<const Eigen::VectorXd>(data.data, 9);
             return ret;
-        }
-        throw_pretty("Unknown rotation represntation type!");
     }
+    throw_pretty("Unknown rotation represntation type!");
+}
 
-    bool contains(std::string key, const std::vector<std::string>& vec)
-    {
+bool contains(std::string key, const std::vector<std::string>& vec)
+{
+    if (std::find(vec.begin(), vec.end(), key) == vec.end()) return false;
+    return true;
+}
 
-        if(std::find(vec.begin(),vec.end(),key)==vec.end()) return false;
-        return true;
-    }
-
-    void vectorExoticaToEigen(const exotica::Vector & exotica,
-        Eigen::VectorXd & eigen)
-    {
-      eigen.resize(exotica.data.size());
-      for (int i = 0; i < exotica.data.size(); i++)
+void vectorExoticaToEigen(const exotica::Vector& exotica,
+                          Eigen::VectorXd& eigen)
+{
+    eigen.resize(exotica.data.size());
+    for (int i = 0; i < exotica.data.size(); i++)
         eigen(i) = exotica.data[i];
-    }
+}
 
-    void vectorEigenToExotica(Eigen::VectorXd eigen, exotica::Vector & exotica)
-    {
-      exotica.data.resize(eigen.rows());
-      for (int i = 0; i < eigen.rows(); i++)
+void vectorEigenToExotica(Eigen::VectorXd eigen, exotica::Vector& exotica)
+{
+    exotica.data.resize(eigen.rows());
+    for (int i = 0; i < eigen.rows(); i++)
         exotica.data[i] = eigen(i);
-    }
+}
 
-    void matrixExoticaToEigen(const exotica::Matrix & exotica,
-        Eigen::MatrixXd & eigen)
+void matrixExoticaToEigen(const exotica::Matrix& exotica,
+                          Eigen::MatrixXd& eigen)
+{
+    if (exotica.col == 0 || exotica.row == 0 || exotica.data.size() == 0)
     {
-      if (exotica.col == 0 || exotica.row == 0 || exotica.data.size() == 0)
-      {
         throw_pretty("Matrix conversion failed, no data in the matrix.");
-      }
-      if (exotica.col * exotica.row != exotica.data.size())
-      {
-        throw_pretty(
-            "Matrix conversion failed, size mismatch."<<exotica.col<<" * "<<exotica.row<<" != "<<exotica.data.size());
-      }
-      eigen.resize(exotica.row, exotica.col);
-      int cnt = 0;
-      for (int r = 0; r < exotica.row; r++)
-        for (int c = 0; c < exotica.col; c++)
-        {
-          eigen(r, c) = exotica.data[cnt];
-          cnt++;
-        }
     }
-
-    void matrixEigenToExotica(const Eigen::MatrixXd & eigen,
-        exotica::Matrix & exotica)
+    if (exotica.col * exotica.row != exotica.data.size())
     {
-      exotica.row = eigen.rows();
-      exotica.col = eigen.cols();
-      exotica.data.resize(exotica.col * exotica.row);
-      int cnt = 0;
-      for (int r = 0; r < exotica.row; r++)
+        throw_pretty(
+            "Matrix conversion failed, size mismatch." << exotica.col << " * " << exotica.row << " != " << exotica.data.size());
+    }
+    eigen.resize(exotica.row, exotica.col);
+    int cnt = 0;
+    for (int r = 0; r < exotica.row; r++)
         for (int c = 0; c < exotica.col; c++)
         {
-          exotica.data[cnt] = eigen(r, c);
-          cnt++;
+            eigen(r, c) = exotica.data[cnt];
+            cnt++;
         }
-    }
+}
+
+void matrixEigenToExotica(const Eigen::MatrixXd& eigen,
+                          exotica::Matrix& exotica)
+{
+    exotica.row = eigen.rows();
+    exotica.col = eigen.cols();
+    exotica.data.resize(exotica.col * exotica.row);
+    int cnt = 0;
+    for (int r = 0; r < exotica.row; r++)
+        for (int c = 0; c < exotica.col; c++)
+        {
+            exotica.data[cnt] = eigen(r, c);
+            cnt++;
+        }
+}
 }

--- a/exotica/src/Tools/Exception.cpp
+++ b/exotica/src/Tools/Exception.cpp
@@ -2,34 +2,28 @@
 
 namespace exotica
 {
-
 Exception::ReportingType Exception::reporting_ = Exception::Message | Exception::FileName | Exception::FunctionName | Exception::LineNumber | Exception::ObjectName;
 
 Exception::Exception()
 {
 }
 
-Exception::Exception(const std::string &msg, const char *file, const char *func, int line) :
-    msg_(msg), file_(file), func_(func), line_(std::to_string(line))
+Exception::Exception(const std::string &msg, const char *file, const char *func, int line) : msg_(msg), file_(file), func_(func), line_(std::to_string(line))
 {
-
 }
 
-Exception::Exception(const std::string &msg, const char *file, const char *func, int line, const std::string& object) :
-    msg_(msg), file_(file), func_(func), line_(std::to_string(line)), object_(object)
+Exception::Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object) : msg_(msg), file_(file), func_(func), line_(std::to_string(line)), object_(object)
 {
-
 }
 
-const char* Exception::what() const noexcept
+const char *Exception::what() const noexcept
 {
     std::string tmp;
-    if(Exception::reporting_ | FileName) tmp += "In "+file_+"\n";
-    if(Exception::reporting_ | FunctionName) tmp += func_+" ";
-    if(Exception::reporting_ | LineNumber) tmp += line_+"\n";
-    if(Exception::reporting_ | ObjectName) tmp += "Object: "+object_+": ";
-    if(Exception::reporting_ | Message) tmp += msg_;
+    if (Exception::reporting_ | FileName) tmp += "In " + file_ + "\n";
+    if (Exception::reporting_ | FunctionName) tmp += func_ + " ";
+    if (Exception::reporting_ | LineNumber) tmp += line_ + "\n";
+    if (Exception::reporting_ | ObjectName) tmp += "Object: " + object_ + ": ";
+    if (Exception::reporting_ | Message) tmp += msg_;
     return tmp.c_str();
 }
-
 }

--- a/exotica/src/Tools/Printable.cpp
+++ b/exotica/src/Tools/Printable.cpp
@@ -1,15 +1,15 @@
 
 #include <exotica/Tools/Printable.h>
 
-std::ostream& operator<< (std::ostream& os, const Printable& s)
+std::ostream& operator<<(std::ostream& os, const Printable& s)
 {
-  s.print(os);
-  return os;
+    s.print(os);
+    return os;
 }
 
 std::string toString(const KDL::Frame& s)
 {
-    double x,y,z,w;
-    s.M.GetQuaternion(x,y,z,w);
-    return "(["+  std::to_string(s.p.data[0]) + " " +  std::to_string(s.p.data[1]) + " " +  std::to_string(s.p.data[2]) + "] [" +  std::to_string(x) + " " +  std::to_string(y) + " " +  std::to_string(z) + " " +  std::to_string(w) + "])";
+    double x, y, z, w;
+    s.M.GetQuaternion(x, y, z, w);
+    return "([" + std::to_string(s.p.data[0]) + " " + std::to_string(s.p.data[1]) + " " + std::to_string(s.p.data[2]) + "] [" + std::to_string(x) + " " + std::to_string(y) + " " + std::to_string(z) + " " + std::to_string(w) + "])";
 }

--- a/exotica/src/Trajectory.cpp
+++ b/exotica/src/Trajectory.cpp
@@ -6,7 +6,6 @@ namespace exotica
 {
 Trajectory::Trajectory() : radius_(1.0), trajectory_(nullptr)
 {
-
 }
 
 Trajectory::Trajectory(const std::string& data)
@@ -18,13 +17,13 @@ Trajectory::Trajectory(const std::string& data)
     ss >> m;
     data_.resize(n, m);
 
-    for(int i=0;i<n;i++)
+    for (int i = 0; i < n; i++)
     {
-        for(int j=0;j<m;j++)
+        for (int j = 0; j < m; j++)
         {
             double val;
             ss >> val;
-            data_(i,j) = val;
+            data_(i, j) = val;
         }
     }
     constructFromData(data_, radius_);
@@ -76,15 +75,15 @@ std::string Trajectory::toString()
 
 void Trajectory::constructFromData(Eigen::MatrixXdRefConst data, double radius)
 {
-    if(!(data.cols()==4 || data.cols()==7 || data.cols()==8) || data.rows()<2) throw_pretty("Invalid trajectory data size!");
+    if (!(data.cols() == 4 || data.cols() == 7 || data.cols() == 8) || data.rows() < 2) throw_pretty("Invalid trajectory data size!");
     trajectory_.reset(new KDL::Trajectory_Composite());
-    for(int i=0;i<data.rows()-1;i++)
+    for (int i = 0; i < data.rows() - 1; i++)
     {
-        KDL::Frame f1 = getFrame(data.row(i).tail(data.cols()-1).transpose());
-        KDL::Frame f2 = getFrame(data.row(i+1).tail(data.cols()-1).transpose());
-        double dt = data(i+1,0) - data(i,0);
-        if(dt<=0) throw_pretty("Time indices must be monotonically increasing! "<<i<<" ("<<dt<<")");
-        if(KDL::Equal(f1, f2, 1e-6))
+        KDL::Frame f1 = getFrame(data.row(i).tail(data.cols() - 1).transpose());
+        KDL::Frame f2 = getFrame(data.row(i + 1).tail(data.cols() - 1).transpose());
+        double dt = data(i + 1, 0) - data(i, 0);
+        if (dt <= 0) throw_pretty("Time indices must be monotonically increasing! " << i << " (" << dt << ")");
+        if (KDL::Equal(f1, f2, 1e-6))
         {
             trajectory_->Add(new KDL::Trajectory_Stationary(dt, f1));
         }
@@ -100,5 +99,4 @@ void Trajectory::constructFromData(Eigen::MatrixXdRefConst data, double radius)
     data_ = data;
     radius_ = radius;
 }
-
 }

--- a/exotica/tests/test_initializers.cpp
+++ b/exotica/tests/test_initializers.cpp
@@ -34,40 +34,50 @@
 
 using namespace exotica;
 
-std::string urdf_string="<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"continuous\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /></joint><joint name=\"joint2\" type=\"continuous\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /></joint><joint name=\"joint3\" type=\"continuous\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
-std::string srdf_string="<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
+std::string urdf_string = "<robot name=\"test_robot\"><link name=\"base\"><visual><geometry><cylinder length=\"0.3\" radius=\"0.2\"/></geometry><origin xyz=\"0 0 0.15\"/></visual></link><link name=\"link1\"> <visual><geometry><cylinder length=\"0.15\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.075\"/></visual> </link><link name=\"link2\"><visual><geometry><cylinder length=\"0.35\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.175\"/></visual> </link><link name=\"link3\"><visual><geometry><cylinder length=\"0.45\" radius=\"0.05\"/></geometry><origin xyz=\"0 0 0.225\"/></visual></link><link name=\"endeff\"><visual><geometry><cylinder length=\"0.05\" radius=\"0.1\"/></geometry><origin xyz=\"0 0 -0.025\"/></visual></link><joint name=\"joint1\" type=\"continuous\"><parent link=\"base\"/><child link=\"link1\"/><origin xyz=\"0 0 0.3\" rpy=\"0 0 0\" /><axis xyz=\"0 0 1\" /></joint><joint name=\"joint2\" type=\"continuous\"><parent link=\"link1\"/><child link=\"link2\"/><origin xyz=\"0 0 0.15\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /></joint><joint name=\"joint3\" type=\"continuous\"><parent link=\"link2\"/><child link=\"link3\"/><origin xyz=\"0 0 0.35\" rpy=\"0 0 0\" /><axis xyz=\"0 1 0\" /></joint><joint name=\"joint4\" type=\"fixed\"><parent link=\"link3\"/><child link=\"endeff\"/><origin xyz=\"0 0 0.45\" rpy=\"0 0 0\" /></joint></robot>";
+std::string srdf_string = "<robot name=\"test_robot\"><group name=\"arm\"><chain base_link=\"base\" tip_link=\"endeff\" /></group><virtual_joint name=\"world_joint\" type=\"fixed\" parent_frame=\"world_frame\" child_link=\"base\" /><group_state name=\"zero\" group=\"arm\"><joint name=\"joint1\" value=\"0\" /><joint name=\"joint2\" value=\"0.3\" /><joint name=\"joint3\" value=\"0.55\" /></group_state><disable_collisions link1=\"base\" link2=\"link1\" reason=\"Adjacent\" /><disable_collisions link1=\"endeff\" link2=\"link3\" reason=\"Adjacent\" /><disable_collisions link1=\"link1\" link2=\"link2\" reason=\"Adjacent\" /><disable_collisions link1=\"link2\" link2=\"link3\" reason=\"Adjacent\" /></robot>";
 
 bool testCore()
 {
-    if(Setup::getSolvers().size()==0) {HIGHLIGHT_NAMED("EXOTica","Failed to find any solvers."); return false;}
-    if(Setup::getProblems().size()==0) {HIGHLIGHT_NAMED("EXOTica","Failed to find any problems."); return false;}
-    if(Setup::getMaps().size()==0) {HIGHLIGHT_NAMED("EXOTica","Failed to find any maps."); return false;}
+    if (Setup::getSolvers().size() == 0)
+    {
+        HIGHLIGHT_NAMED("EXOTica", "Failed to find any solvers.");
+        return false;
+    }
+    if (Setup::getProblems().size() == 0)
+    {
+        HIGHLIGHT_NAMED("EXOTica", "Failed to find any problems.");
+        return false;
+    }
+    if (Setup::getMaps().size() == 0)
+    {
+        HIGHLIGHT_NAMED("EXOTica", "Failed to find any maps.");
+        return false;
+    }
     return true;
 }
 
 bool testGenericInit()
 {
-    Initializer scene("Scene",{{"Name",std::string("MyScene")},{"JointGroup",std::string("arm")}});
-    Initializer map("exotica/EffPosition",{
-                        {"Name",std::string("Position")},
-                        {"Scene",std::string("MyScene")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("endeff")}})
-                                        }) } });
-    Eigen::VectorXd W(3);W << 3,2,1;
-    Initializer problem("exotica/UnconstrainedEndPoseProblem",{
-                            {"Name",std::string("MyProblem")},
-                            {"PlanningScene",scene},
-                            {"Maps",std::vector<Initializer>({map})},
-                            {"W",W},
-                        });
-    Initializer solver("exotica/IKsolver",{
-                            {"Name",std::string("MySolver")},
-                            {"MaxIt",1},
-                            {"MaxStep",0.1},
-                            {"C",1e-3},
-                        });
-    Server::Instance()->getModel("robot_description",urdf_string,srdf_string);
+    Initializer scene("Scene", {{"Name", std::string("MyScene")}, {"JointGroup", std::string("arm")}});
+    Initializer map("exotica/EffPosition", {{"Name", std::string("Position")},
+                                            {"Scene", std::string("MyScene")},
+                                            {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
+    Eigen::VectorXd W(3);
+    W << 3, 2, 1;
+    Initializer problem("exotica/UnconstrainedEndPoseProblem", {
+                                                                   {"Name", std::string("MyProblem")},
+                                                                   {"PlanningScene", scene},
+                                                                   {"Maps", std::vector<Initializer>({map})},
+                                                                   {"W", W},
+                                                               });
+    Initializer solver("exotica/IKsolver", {
+                                               {"Name", std::string("MySolver")},
+                                               {"MaxIt", 1},
+                                               {"MaxStep", 0.1},
+                                               {"C", 1e-3},
+                                           });
+    Server::Instance()->getModel("robot_description", urdf_string, srdf_string);
     PlanningProblem_ptr any_problem = Setup::createProblem(problem);
     MotionSolver_ptr any_solver = Setup::createSolver(solver);
     return true;
@@ -77,7 +87,7 @@ bool testXMLInit()
 {
     std::string XMLstring = "<IKSolverDemoConfig><IKsolver Name=\"MySolver\"><MaxIt>1</MaxIt><MaxStep>0.1</MaxStep><C>1e-3</C></IKsolver><UnconstrainedEndPoseProblem Name=\"MyProblem\"><PlanningScene><Scene Name=\"MyScene\"><JointGroup>arm</JointGroup></Scene></PlanningScene><Maps><EffPosition Name=\"Position\"><Scene>MyScene</Scene><EndEffector><Frame Link=\"endeff\" /></EndEffector></EffPosition></Maps><W> 3 2 1 </W></UnconstrainedEndPoseProblem></IKSolverDemoConfig>";
     Initializer solver, problem;
-    XMLLoader::load(XMLstring,solver, problem,"","",true);
+    XMLLoader::load(XMLstring, solver, problem, "", "", true);
     PlanningProblem_ptr any_problem = Setup::createProblem(problem);
     MotionSolver_ptr any_solver = Setup::createSolver(solver);
     return true;
@@ -90,15 +100,15 @@ bool testRos()
         std::string path1 = ros::package::getPath("exotica");
         std::string path2 = parsePath("{exotica}");
         if (path1 != path2)
-          throw_pretty("Failed when parsing paths:\n"
-                       << path1 << "\n"
-                       << path2);
+            throw_pretty("Failed when parsing paths:\n"
+                         << path1 << "\n"
+                         << path2);
     }
 
     // Reset server
     Server::destroy();
 
-    if(Server::isRos()) throw_pretty("ROS node initialized, but it shouldn't have been!");
+    if (Server::isRos()) throw_pretty("ROS node initialized, but it shouldn't have been!");
 
     // Fail when ROS node has not been initialized
     try
@@ -106,21 +116,19 @@ bool testRos()
         Server::Instance()->getNodeHandle();
         return false;
     }
-    catch(Exception& e)
+    catch (Exception& e)
     {
-
     }
 
-    if(Server::hasParam("/rosdistro")) throw_pretty("ROS param retrieved, but shouldn't have!");
+    if (Server::hasParam("/rosdistro")) throw_pretty("ROS param retrieved, but shouldn't have!");
     try
     {
         std::string param;
         Server::getParam("/rosdistro", param);
         return false;
     }
-    catch(Exception& e)
+    catch (Exception& e)
     {
-
     }
 
     // Load robot model into cache from a file
@@ -136,20 +144,23 @@ bool testRos()
         Server::Instance()->getModel("robot_description");
         return false;
     }
-    catch(Exception& e)
+    catch (Exception& e)
     {
-
     }
     return true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    if(!testRos()) exit(2); HIGHLIGHT_NAMED("EXOTica","ROS test passed.");
+    if (!testRos()) exit(2);
+    HIGHLIGHT_NAMED("EXOTica", "ROS test passed.");
     ros::init(argc, argv, "EXOTica_test_initializers");
-    if(!testCore()) exit(2); HIGHLIGHT_NAMED("EXOTica","Core test passed.");
-    if(!testGenericInit()) exit(2); HIGHLIGHT_NAMED("EXOTica","Generic initialization test passed.");
-    if(!testXMLInit()) exit(2); HIGHLIGHT_NAMED("EXOTica","XML initialization test passed.");
+    if (!testCore()) exit(2);
+    HIGHLIGHT_NAMED("EXOTica", "Core test passed.");
+    if (!testGenericInit()) exit(2);
+    HIGHLIGHT_NAMED("EXOTica", "Generic initialization test passed.");
+    if (!testXMLInit()) exit(2);
+    HIGHLIGHT_NAMED("EXOTica", "XML initialization test passed.");
     Setup::Destroy();
     return 0;
 }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1,17 +1,17 @@
 #include <exotica/Exotica.h>
 #undef NDEBUG
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/eigen.h>
 #include <ros/package.h>
 
-#if PY_MAJOR_VERSION<3
+#if PY_MAJOR_VERSION < 3
 #define PY_OLDSTANDARD
 #endif
 
 #ifndef PY_OLDSTANDARD
-bool PyInt_Check(PyObject* value_py) {return PyLong_Check(value_py);}
-long PyInt_AsLong(PyObject* value_py) {return PyLong_AsLong(value_py);}
+bool PyInt_Check(PyObject* value_py) { return PyLong_Check(value_py); }
+long PyInt_AsLong(PyObject* value_py) { return PyLong_AsLong(value_py); }
 #endif
 
 bool isPyString(PyObject* value_py)
@@ -38,7 +38,7 @@ std::string pyAsString(PyObject* value_py)
 PyObject* stringAsPy(std::string value)
 {
 #ifndef PY_OLDSTANDARD
-    return PyUnicode_DecodeASCII(value.c_str(),value.size(), "");
+    return PyUnicode_DecodeASCII(value.c_str(), value.size(), "");
 #else
     return PyString_FromString(value.c_str());
 #endif
@@ -49,64 +49,70 @@ namespace py = pybind11;
 
 std::map<std::string, Initializer> knownInitializers;
 
-PyObject* createStringIOObject() {
+PyObject* createStringIOObject()
+{
 #if PY_MAJOR_VERSION <= 2
-  PyObject* module = PyImport_ImportModule("StringIO");
-  if (!module) throw_pretty("Can't load StringIO module.");
-  PyObject* cls = PyObject_GetAttrString(module, "StringIO");
-  if (!cls) throw_pretty("Can't load StringIO class.");
+    PyObject* module = PyImport_ImportModule("StringIO");
+    if (!module) throw_pretty("Can't load StringIO module.");
+    PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+    if (!cls) throw_pretty("Can't load StringIO class.");
 #else
-  PyObject* module = PyImport_ImportModule("io");
-  if (!module) throw_pretty("Can't load io module.");
-  PyObject* cls = PyObject_GetAttrString(module, "BytesIO");
-  if (!cls) throw_pretty("Can't load BytesIO class.");
+    PyObject* module = PyImport_ImportModule("io");
+    if (!module) throw_pretty("Can't load io module.");
+    PyObject* cls = PyObject_GetAttrString(module, "BytesIO");
+    if (!cls) throw_pretty("Can't load BytesIO class.");
 #endif
-  PyObject* stringio = PyObject_CallObject(cls, NULL);
-  if (!stringio) throw_pretty("Can't create StringIO object.");
-  Py_DECREF(module);
-  Py_DECREF(cls);
-  return stringio;
+    PyObject* stringio = PyObject_CallObject(cls, NULL);
+    if (!stringio) throw_pretty("Can't create StringIO object.");
+    Py_DECREF(module);
+    Py_DECREF(cls);
+    return stringio;
 }
 
-#define ROS_MESSAGE_WRAPPER(MessageType)                                      \
-  namespace pybind11 {                                                        \
-  namespace detail {                                                          \
-  template <>                                                                 \
-  struct type_caster<MessageType> {                                           \
-   public:                                                                    \
-    PYBIND11_TYPE_CASTER(MessageType, _("genpy.Message"));                    \
-                                                                              \
-    bool load(handle src, bool) {                                             \
-      PyObject* stringio = createStringIOObject();                            \
-      if (!stringio) throw_pretty("Can't create StringIO instance.");         \
-      PyObject* result =                                                      \
-          PyObject_CallMethod(src.ptr(), "serialize", "O", stringio);         \
-      if (!result) throw_pretty("Can't serialize.");                          \
-      result = PyObject_CallMethod(stringio, "getvalue", nullptr);            \
-      if (!result) throw_pretty("Can't get buffer.");                         \
-      char* data = PyByteArray_AsString(PyByteArray_FromObject(result));      \
-      int len = PyByteArray_Size(result);                                     \
-      unsigned char* udata = new unsigned char[len];                          \
-      for (int i = 0; i < len; i++)                                           \
-        udata[i] = static_cast<unsigned char>(data[i]);                       \
-      ros::serialization::IStream stream(udata, len);                         \
-      ros::serialization::deserialize<MessageType>(stream, value);            \
-      delete[] udata;                                                         \
-      delete[] data;                                                          \
-      Py_DECREF(stringio);                                                    \
-      Py_DECREF(result);                                                      \
-      return !PyErr_Occurred();                                               \
-    }                                                                         \
-                                                                              \
-    static handle cast(MessageType src,                                       \
-                       return_value_policy /* policy /, handle / parent */) { \
-      ros::message_traits::DataType<MessageType::Type> type;                  \
-      throw_pretty("Can't create python object from message of type '"        \
-                   << type.value() << "'!");                                  \
-    }                                                                         \
-  };                                                                          \
-  }                                                                           \
-  }
+#define ROS_MESSAGE_WRAPPER(MessageType)                                        \
+    namespace pybind11                                                          \
+    {                                                                           \
+    namespace detail                                                            \
+    {                                                                           \
+    template <>                                                                 \
+    struct type_caster<MessageType>                                             \
+    {                                                                           \
+    public:                                                                     \
+        PYBIND11_TYPE_CASTER(MessageType, _("genpy.Message"));                  \
+                                                                                \
+        bool load(handle src, bool)                                             \
+        {                                                                       \
+            PyObject* stringio = createStringIOObject();                        \
+            if (!stringio) throw_pretty("Can't create StringIO instance.");     \
+            PyObject* result =                                                  \
+                PyObject_CallMethod(src.ptr(), "serialize", "O", stringio);     \
+            if (!result) throw_pretty("Can't serialize.");                      \
+            result = PyObject_CallMethod(stringio, "getvalue", nullptr);        \
+            if (!result) throw_pretty("Can't get buffer.");                     \
+            char* data = PyByteArray_AsString(PyByteArray_FromObject(result));  \
+            int len = PyByteArray_Size(result);                                 \
+            unsigned char* udata = new unsigned char[len];                      \
+            for (int i = 0; i < len; i++)                                       \
+                udata[i] = static_cast<unsigned char>(data[i]);                 \
+            ros::serialization::IStream stream(udata, len);                     \
+            ros::serialization::deserialize<MessageType>(stream, value);        \
+            delete[] udata;                                                     \
+            delete[] data;                                                      \
+            Py_DECREF(stringio);                                                \
+            Py_DECREF(result);                                                  \
+            return !PyErr_Occurred();                                           \
+        }                                                                       \
+                                                                                \
+        static handle cast(MessageType src,                                     \
+                           return_value_policy /* policy /, handle / parent */) \
+        {                                                                       \
+            ros::message_traits::DataType<MessageType::Type> type;              \
+            throw_pretty("Can't create python object from message of type '"    \
+                         << type.value() << "'!");                              \
+        }                                                                       \
+    };                                                                          \
+    }                                                                           \
+    }
 #include <moveit_msgs/PlanningScene.h>
 #include <moveit_msgs/PlanningSceneWorld.h>
 ROS_MESSAGE_WRAPPER(moveit_msgs::PlanningScene);
@@ -142,7 +148,7 @@ Initializer createInitializer(const Initializer& init)
     return Initializer(init);
 }
 
-std::pair<Initializer, Initializer> loadFromXML(std::string file_name, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML=false)
+std::pair<Initializer, Initializer> loadFromXML(std::string file_name, const std::string& solver_name = "", const std::string& problem_name = "", bool parsePathAsXML = false)
 {
     Initializer solver, problem;
     XMLLoader::load(file_name, solver, problem, solver_name, problem_name, parsePathAsXML);
@@ -151,20 +157,19 @@ std::pair<Initializer, Initializer> loadFromXML(std::string file_name, const std
 
 void addInitializers(py::module& module)
 {
-    py::module inits = module.def_submodule("Initializers","Initializers for core EXOTica classes.");
+    py::module inits = module.def_submodule("Initializers", "Initializers for core EXOTica classes.");
     inits.def("Initializer", &createInitializer);
     std::vector<Initializer> initializers = Setup::getInitializers();
-    for(Initializer& i : initializers)
+    for (Initializer& i : initializers)
     {
-
         std::string full_name = i.getName();
         std::string name = full_name.substr(8);
         knownInitializers[full_name] = createInitializer(i);
-        inits.def((name+"Initializer").c_str(), [i](){return createInitializer(i);}, (name+"Initializer constructor.").c_str());
+        inits.def((name + "Initializer").c_str(), [i]() { return createInitializer(i); }, (name + "Initializer constructor.").c_str());
     }
 
-    inits.def("loadXML", (Initializer (*)(std::string, bool)) &XMLLoader::load, "Loads initializer from XML", py::arg("xml"), py::arg("parseAsXMLString")=false);
-    inits.def("loadXMLFull", &loadFromXML, "Loads initializer from XML", py::arg("xml"), py::arg("solver_name")=std::string(""), py::arg("problem_name")=std::string(""), py::arg("parseAsXMLString")=false);
+    inits.def("loadXML", (Initializer(*)(std::string, bool)) & XMLLoader::load, "Loads initializer from XML", py::arg("xml"), py::arg("parseAsXMLString") = false);
+    inits.def("loadXMLFull", &loadFromXML, "Loads initializer from XML", py::arg("xml"), py::arg("solver_name") = std::string(""), py::arg("problem_name") = std::string(""), py::arg("parseAsXMLString") = false);
 }
 
 Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
@@ -174,245 +179,247 @@ Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
     return ret;
 }
 
-namespace pybind11 {
-namespace detail {
-    template <> struct type_caster<Initializer>
+namespace pybind11
+{
+namespace detail
+{
+template <>
+struct type_caster<Initializer>
+{
+public:
+    PYBIND11_TYPE_CASTER(Initializer, _("Initializer"));
+
+    bool addPropertyFromDict(Property& target, PyObject* value_py)
     {
-    public:
-
-        PYBIND11_TYPE_CASTER(Initializer, _("Initializer"));
-
-        bool addPropertyFromDict(Property& target, PyObject* value_py)
+        if (target.getType() == "std::string" || target.getType() == getTypeName(typeid(std::string)))
         {
-            if(target.getType()=="std::string" || target.getType()==getTypeName(typeid(std::string)))
+            target.set(pyAsString(value_py));
+            return true;
+        }
+        else if (target.getType() == "int")
+        {
+            if (isPyString(value_py))
             {
-                target.set(pyAsString(value_py));
+                target.set(parseInt(pyAsString(value_py)));
                 return true;
             }
-            else if(target.getType()=="int")
+            else if (PyInt_Check(value_py))
             {
-                if(isPyString(value_py))
-                {
-                    target.set(parseInt(pyAsString(value_py)));
-                    return true;
-                }
-                else if(PyInt_Check(value_py))
-                {
-                    target.set((int)PyInt_AsLong(value_py));
-                    return true;
-                }
-            }
-            else if(target.getType()=="long")
-            {
-                if(isPyString(value_py))
-                {
-                    target.set((long)parseInt(pyAsString(value_py)));
-                    return true;
-                }
-                else if(PyInt_Check(value_py))
-                {
-                    target.set(PyInt_AsLong(value_py));
-                    return true;
-                }
-            }
-            else if(target.getType()=="double")
-            {
-                if(isPyString(value_py))
-                {
-                    target.set(parseDouble(pyAsString(value_py)));
-                    return true;
-                }
-                else if(PyFloat_Check(value_py))
-                {
-                    target.set(PyFloat_AsDouble(value_py));
-                    return true;
-                }
-            }
-            else if(target.getType()=="Eigen::Matrix<double, -1, 1, 0, -1, 1>")
-            {
-                if(isPyString(value_py))
-                {
-                    target.set(parseVector(pyAsString(value_py)));
-                }
-                else
-                {
-                    target.set(py::cast<Eigen::VectorXd>(value_py));
-                }
+                target.set((int)PyInt_AsLong(value_py));
                 return true;
             }
-            else if(target.getType()=="bool")
+        }
+        else if (target.getType() == "long")
+        {
+            if (isPyString(value_py))
             {
-                if(isPyString(value_py))
-                {
-                    target.set(parseBool(pyAsString(value_py)));
-                    return true;
-                }
-                else if(PyBool_Check(value_py))
-                {
-                    target.set(PyObject_IsTrue(value_py)==1);
-                    return true;
-                }
-            }
-            else if(target.getType()=="exotica::Initializer")
-            {
-                if(PyList_Check(value_py))
-                {
-                    Initializer tmp;
-                    int n = PyList_Size(value_py);
-                    if(n==1)
-                    {
-                        if(!PyToInit(PyList_GetItem(value_py, 0), tmp))
-                        {
-                            return false;
-                        }
-                    }
-                    target.set(tmp);
-                }
-                else
-                {
-                    Initializer tmp;
-                    if(!PyToInit(value_py, tmp))
-                    {
-                        return false;
-                    }
-                    target.set(tmp);
-                }
+                target.set((long)parseInt(pyAsString(value_py)));
                 return true;
             }
-            else if(target.isInitializerVectorType())
+            else if (PyInt_Check(value_py))
             {
-                if(PyList_Check(value_py))
-                {
-                    int n = PyList_Size(value_py);
-                    std::vector<Initializer> vec(n);
-                    for(int i=0;i<n;i++)
-                    {
-                        if(!PyToInit(PyList_GetItem(value_py, i), vec[i]))
-                        {
-                            return false;
-                        }
-                    }
-                    target.set(vec);
-                    return true;
-                }
+                target.set(PyInt_AsLong(value_py));
+                return true;
+            }
+        }
+        else if (target.getType() == "double")
+        {
+            if (isPyString(value_py))
+            {
+                target.set(parseDouble(pyAsString(value_py)));
+                return true;
+            }
+            else if (PyFloat_Check(value_py))
+            {
+                target.set(PyFloat_AsDouble(value_py));
+                return true;
+            }
+        }
+        else if (target.getType() == "Eigen::Matrix<double, -1, 1, 0, -1, 1>")
+        {
+            if (isPyString(value_py))
+            {
+                target.set(parseVector(pyAsString(value_py)));
             }
             else
             {
-                HIGHLIGHT("Skipping unsupported type '"<<target.getType()<<"'");
-            }
-
-            return false;
-        }
-
-        bool PyToInit(PyObject *source, Initializer& ret)
-        {
-            if(!PyTuple_CheckExact(source)) return false;
-
-            int sz = PyTuple_Size(source);
-
-            if(sz<1 || sz>2) return false;
-
-            PyObject* name_py = PyTuple_GetItem(source, 0);
-            if(!isPyString(name_py)) return false;
-            std::string name = pyAsString(name_py);
-
-            ret = Initializer(knownInitializers.at(name));
-
-            if(sz==2)
-            {
-                PyObject* dict = PyTuple_GetItem(source, 1);
-                if(!PyDict_Check(dict)) return false;
-
-                PyObject *key, *value_py;
-                Py_ssize_t pos = 0;
-
-                while (PyDict_Next(dict, &pos, &key, &value_py))
-                {
-                     std::string key_str = pyAsString(key);
-                     if(ret.properties.find( key_str ) == ret.properties.end())
-                     {
-                         ret.addProperty(Property(key_str, false, boost::any(pyAsString(value_py))));
-                     }
-                     else
-                     {
-                        if(!addPropertyFromDict(ret.properties.at(key_str), value_py))
-                        {
-                            HIGHLIGHT("Failed to add property '"<<key_str<<"'");
-                            return false;
-                        }
-                     }
-                }
+                target.set(py::cast<Eigen::VectorXd>(value_py));
             }
             return true;
         }
-
-        bool load(handle src, bool)
+        else if (target.getType() == "bool")
         {
-            return PyToInit(src.ptr(), value);
+            if (isPyString(value_py))
+            {
+                target.set(parseBool(pyAsString(value_py)));
+                return true;
+            }
+            else if (PyBool_Check(value_py))
+            {
+                target.set(PyObject_IsTrue(value_py) == 1);
+                return true;
+            }
         }
-
-        static PyObject* InitializerToTuple(const Initializer& src)
+        else if (target.getType() == "exotica::Initializer")
         {
-            PyObject* dict = PyDict_New();
-            for(auto& prop : src.properties)
+            if (PyList_Check(value_py))
             {
-                addPropertyToDict(dict, prop.first, prop.second);
-            }
-            return PyTuple_Pack(2,stringAsPy(src.getName()), dict);
-        }
-
-        static void addPropertyToDict(PyObject* dict, const std::string& name, const Property& prop)
-        {
-            if(prop.getType()=="std::string" || prop.getType()==getTypeName(typeid(std::string)))
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<std::string>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="int")
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<int>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="long")
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<long>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="double")
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<double>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="Eigen::Matrix<double, -1, 1, 0, -1, 1>")
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<Eigen::VectorXd>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="bool")
-            {
-                PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<bool>(prop.get())).ptr());
-            }
-            else if(prop.getType()=="exotica::Initializer")
-            {
-                PyDict_SetItemString(dict, name.c_str(), InitializerToTuple(boost::any_cast<Initializer>(prop.get())));
-            }
-            else if(prop.isInitializerVectorType())
-            {
-                PyObject* vec = PyList_New(0);
-                for(Initializer& i : boost::any_cast<std::vector<Initializer>>(prop.get()))
+                Initializer tmp;
+                int n = PyList_Size(value_py);
+                if (n == 1)
                 {
-                    PyList_Append(vec, InitializerToTuple(i));
+                    if (!PyToInit(PyList_GetItem(value_py, 0), tmp))
+                    {
+                        return false;
+                    }
                 }
-                PyDict_SetItemString(dict, name.c_str(), vec);
+                target.set(tmp);
             }
             else
             {
-                HIGHLIGHT("Skipping unsupported type '"<<prop.getType()<<"'");
+                Initializer tmp;
+                if (!PyToInit(value_py, tmp))
+                {
+                    return false;
+                }
+                target.set(tmp);
             }
-        }        
-
-        static handle cast(Initializer src, return_value_policy /* policy */, handle /* parent */)
-        {
-            return handle(InitializerToTuple(src));
+            return true;
         }
-    };
-}}
+        else if (target.isInitializerVectorType())
+        {
+            if (PyList_Check(value_py))
+            {
+                int n = PyList_Size(value_py);
+                std::vector<Initializer> vec(n);
+                for (int i = 0; i < n; i++)
+                {
+                    if (!PyToInit(PyList_GetItem(value_py, i), vec[i]))
+                    {
+                        return false;
+                    }
+                }
+                target.set(vec);
+                return true;
+            }
+        }
+        else
+        {
+            HIGHLIGHT("Skipping unsupported type '" << target.getType() << "'");
+        }
 
+        return false;
+    }
+
+    bool PyToInit(PyObject* source, Initializer& ret)
+    {
+        if (!PyTuple_CheckExact(source)) return false;
+
+        int sz = PyTuple_Size(source);
+
+        if (sz < 1 || sz > 2) return false;
+
+        PyObject* name_py = PyTuple_GetItem(source, 0);
+        if (!isPyString(name_py)) return false;
+        std::string name = pyAsString(name_py);
+
+        ret = Initializer(knownInitializers.at(name));
+
+        if (sz == 2)
+        {
+            PyObject* dict = PyTuple_GetItem(source, 1);
+            if (!PyDict_Check(dict)) return false;
+
+            PyObject *key, *value_py;
+            Py_ssize_t pos = 0;
+
+            while (PyDict_Next(dict, &pos, &key, &value_py))
+            {
+                std::string key_str = pyAsString(key);
+                if (ret.properties.find(key_str) == ret.properties.end())
+                {
+                    ret.addProperty(Property(key_str, false, boost::any(pyAsString(value_py))));
+                }
+                else
+                {
+                    if (!addPropertyFromDict(ret.properties.at(key_str), value_py))
+                    {
+                        HIGHLIGHT("Failed to add property '" << key_str << "'");
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    bool load(handle src, bool)
+    {
+        return PyToInit(src.ptr(), value);
+    }
+
+    static PyObject* InitializerToTuple(const Initializer& src)
+    {
+        PyObject* dict = PyDict_New();
+        for (auto& prop : src.properties)
+        {
+            addPropertyToDict(dict, prop.first, prop.second);
+        }
+        return PyTuple_Pack(2, stringAsPy(src.getName()), dict);
+    }
+
+    static void addPropertyToDict(PyObject* dict, const std::string& name, const Property& prop)
+    {
+        if (prop.getType() == "std::string" || prop.getType() == getTypeName(typeid(std::string)))
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<std::string>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "int")
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<int>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "long")
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<long>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "double")
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<double>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "Eigen::Matrix<double, -1, 1, 0, -1, 1>")
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<Eigen::VectorXd>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "bool")
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<bool>(prop.get())).ptr());
+        }
+        else if (prop.getType() == "exotica::Initializer")
+        {
+            PyDict_SetItemString(dict, name.c_str(), InitializerToTuple(boost::any_cast<Initializer>(prop.get())));
+        }
+        else if (prop.isInitializerVectorType())
+        {
+            PyObject* vec = PyList_New(0);
+            for (Initializer& i : boost::any_cast<std::vector<Initializer>>(prop.get()))
+            {
+                PyList_Append(vec, InitializerToTuple(i));
+            }
+            PyDict_SetItemString(dict, name.c_str(), vec);
+        }
+        else
+        {
+            HIGHLIGHT("Skipping unsupported type '" << prop.getType() << "'");
+        }
+    }
+
+    static handle cast(Initializer src, return_value_policy /* policy */, handle /* parent */)
+    {
+        return handle(InitializerToTuple(src));
+    }
+};
+}
+}
 
 PYBIND11_MODULE(_pyexotica, module)
 {
@@ -421,18 +428,18 @@ PYBIND11_MODULE(_pyexotica, module)
     module.doc() = "Exotica Python wrapper";
 
     py::class_<Setup, std::unique_ptr<Setup, py::nodelete>> setup(module, "Setup");
-    setup.def("__init__",[](Setup* instance){instance=Setup::Instance().get();});
+    setup.def("__init__", [](Setup* instance) { instance = Setup::Instance().get(); });
     setup.def_static("getSolvers", &Setup::getSolvers);
-    setup.def_static("getProblems",&Setup::getProblems);
-    setup.def_static("getMaps",&Setup::getMaps);
-    setup.def_static("getCollisionScenes",&Setup::getCollisionScenes);
+    setup.def_static("getProblems", &Setup::getProblems);
+    setup.def_static("getMaps", &Setup::getMaps);
+    setup.def_static("getCollisionScenes", &Setup::getCollisionScenes);
     setup.def_static("createSolver", &createSolver, py::return_value_policy::take_ownership);
-    setup.def_static("createMap",&createMap, py::return_value_policy::take_ownership);
-    setup.def_static("createProblem",&createProblem, py::return_value_policy::take_ownership);
-    setup.def_static("printSupportedClasses",&Setup::printSupportedClasses);
-    setup.def_static("getInitializers",&Setup::getInitializers, py::return_value_policy::copy);
-    setup.def_static("getPackagePath",&ros::package::getPath);
-    setup.def_static("initRos",[](const std::string& name){int argc = 0; ros::init(argc, nullptr, name); Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));}, py::arg("name") = "exotica");
+    setup.def_static("createMap", &createMap, py::return_value_policy::take_ownership);
+    setup.def_static("createProblem", &createProblem, py::return_value_policy::take_ownership);
+    setup.def_static("printSupportedClasses", &Setup::printSupportedClasses);
+    setup.def_static("getInitializers", &Setup::getInitializers, py::return_value_policy::copy);
+    setup.def_static("getPackagePath", &ros::package::getPath);
+    setup.def_static("initRos", [](const std::string& name) {int argc = 0; ros::init(argc, nullptr, name); Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~"))); }, py::arg("name") = "exotica");
     setup.def_static("loadSolver", &XMLLoader::loadSolver);
 
     py::module tools = module.def_submodule("Tools");
@@ -443,17 +450,17 @@ PYBIND11_MODULE(_pyexotica, module)
     tools.def("parseList", &parseList);
     tools.def("parseInt", &parseInt);
     tools.def("parseIntList", &parseIntList);
-    tools.def("loadOBJ", [](const std::string& path){ Eigen::VectorXi tri; Eigen::VectorXd vert; loadOBJ(loadFile(path), tri, vert); return py::make_tuple(tri, vert);});
+    tools.def("loadOBJ", [](const std::string& path) { Eigen::VectorXi tri; Eigen::VectorXd vert; loadOBJ(loadFile(path), tri, vert); return py::make_tuple(tri, vert); });
     tools.def("getText", &getText);
     tools.def("saveMatrix", &saveMatrix);
     tools.def("VectorTransform", &Eigen::VectorTransform);
     tools.def("IdentityTransform", &Eigen::IdentityTransform);
     tools.def("loadFile", &loadFile);
     tools.def("pathExists", &pathExists);
-    tools.def("createCompositeTrajectory", [](Eigen::MatrixXdRefConst data, double radius)
-    {
+    tools.def("createCompositeTrajectory", [](Eigen::MatrixXdRefConst data, double radius) {
         return Trajectory(data, radius).toString();
-    }, py::arg("data"), py::arg("maxradius")=1.0);
+    },
+              py::arg("data"), py::arg("maxradius") = 1.0);
 
     py::class_<Timer, std::shared_ptr<Timer>> timer(module, "Timer");
     timer.def(py::init());
@@ -463,7 +470,7 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<Object, std::shared_ptr<Object>> object(module, "Object");
     object.def("getType", &Object::type, "Object type");
     object.def("getName", &Object::getObjectName, "Object name");
-    object.def("__repr__", &Object::print, "String representation of the object", py::arg("prepend")=std::string(""));
+    object.def("__repr__", &Object::print, "String representation of the object", py::arg("prepend") = std::string(""));
     object.def_readwrite("namespace", &Object::ns_);
     object.def_readwrite("debugMode", &Object::debug_);
 
@@ -488,7 +495,7 @@ PYBIND11_MODULE(_pyexotica, module)
     taskMap.def_readonly("length", &TaskMap::Length);
     taskMap.def_readonly("startJ", &TaskMap::StartJ);
     taskMap.def_readonly("lengthJ", &TaskMap::LengthJ);
-    taskMap.def("taskSpaceDim", (int (TaskMap::*)()) &TaskMap::taskSpaceDim);
+    taskMap.def("taskSpaceDim", (int (TaskMap::*)()) & TaskMap::taskSpaceDim);
     taskMap.def("taskSpaceJacobianDim", &TaskMap::taskSpaceJacobianDim);
     taskMap.def("debug", &TaskMap::debug);
 
@@ -496,7 +503,7 @@ PYBIND11_MODULE(_pyexotica, module)
     taskSpaceVector.def("setZero", &TaskSpaceVector::setZero);
     taskSpaceVector.def_readwrite("data", &TaskSpaceVector::data);
     taskSpaceVector.def("__sub__", &TaskSpaceVector::operator-, py::is_operator());
-    taskSpaceVector.def("__repr__", [](TaskSpaceVector* instance){return ((std::ostringstream&)(std::ostringstream("")<<"TaskSpaceVector ("<<instance->data.transpose()<<")")).str();});
+    taskSpaceVector.def("__repr__", [](TaskSpaceVector* instance) { return ((std::ostringstream&)(std::ostringstream("") << "TaskSpaceVector (" << instance->data.transpose() << ")")).str(); });
 
     py::class_<MotionSolver, std::shared_ptr<MotionSolver>, Object> motionSolver(module, "MotionSolver");
     motionSolver.def("specifyProblem", &MotionSolver::specifyProblem, "Assign problem to the solver", py::arg("planningProblem"));
@@ -508,11 +515,11 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<PlanningProblem, std::shared_ptr<PlanningProblem>, Object> planningProblem(module, "PlanningProblem");
     planningProblem.def("getTasks", &PlanningProblem::getTasks, py::return_value_policy::reference_internal);
     planningProblem.def("getScene", &PlanningProblem::getScene, py::return_value_policy::reference_internal);
-    planningProblem.def("__repr__", &PlanningProblem::print, "String representation of the object", py::arg("prepend")=std::string(""));
+    planningProblem.def("__repr__", &PlanningProblem::print, "String representation of the object", py::arg("prepend") = std::string(""));
     planningProblem.def_property("startState", &PlanningProblem::getStartState, &PlanningProblem::setStartState);
 
     // Problem types
-    py::module prob = module.def_submodule("Problems","Problem types");
+    py::module prob = module.def_submodule("Problems", "Problem types");
     py::class_<UnconstrainedTimeIndexedProblem, std::shared_ptr<UnconstrainedTimeIndexedProblem>, PlanningProblem> unconstrainedTimeIndexedProblem(prob, "UnconstrainedTimeIndexedProblem");
     unconstrainedTimeIndexedProblem.def("getDuration", &UnconstrainedTimeIndexedProblem::getDuration);
     unconstrainedTimeIndexedProblem.def("update", &UnconstrainedTimeIndexedProblem::Update);
@@ -573,23 +580,23 @@ PYBIND11_MODULE(_pyexotica, module)
     proxy.def_readonly("Normal1", &CollisionProxy::normal1);
     proxy.def_readonly("Normal2", &CollisionProxy::normal2);
     proxy.def_readonly("Distance", &CollisionProxy::distance);
-    proxy.def_property_readonly("Object1", [](CollisionProxy* instance){ return (instance->e1 && instance->e2)?instance->e1->Segment.getName():std::string("");});
-    proxy.def_property_readonly("Object2", [](CollisionProxy* instance){ return (instance->e1 && instance->e2)?instance->e2->Segment.getName():std::string("");});
-    proxy.def_property_readonly("Transform1", [](CollisionProxy* instance){ return (instance->e1 && instance->e2)?instance->e1->Frame:KDL::Frame();});
-    proxy.def_property_readonly("Transform2", [](CollisionProxy* instance){ return (instance->e1 && instance->e2)?instance->e2->Frame:KDL::Frame();});
+    proxy.def_property_readonly("Object1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Segment.getName() : std::string(""); });
+    proxy.def_property_readonly("Object2", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Segment.getName() : std::string(""); });
+    proxy.def_property_readonly("Transform1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Frame : KDL::Frame(); });
+    proxy.def_property_readonly("Transform2", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Frame : KDL::Frame(); });
     proxy.def("__repr__", &CollisionProxy::print);
 
     py::class_<Scene, std::shared_ptr<Scene>, Object> scene(module, "Scene");
-    scene.def("Update", &Scene::Update, py::arg("x"), py::arg("t")=0.0);
+    scene.def("Update", &Scene::Update, py::arg("x"), py::arg("t") = 0.0);
     scene.def("getBaseType", &Scene::getBaseType);
     scene.def("getGroupName", &Scene::getGroupName);
-    scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) &Scene::getJointNames);
+    scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) & Scene::getJointNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
     scene.def("getModelJointNames", &Scene::getModelJointNames);
     scene.def("getModelState", &Scene::getModelState);
     scene.def("getModelStateMap", &Scene::getModelStateMap);
-    scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst, double)) &Scene::setModelState, py::arg("x"), py::arg("t")=0.0);
-    scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>, double)) &Scene::setModelState, py::arg("x"), py::arg("t")=0.0);
+    scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst, double)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0);
+    scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>, double)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0);
     scene.def("publishScene", &Scene::publishScene);
     scene.def("publishProxies", &Scene::publishProxies);
     scene.def("setCollisionScene", [](Scene* instance, moveit_msgs::PlanningScene& ps) {
@@ -600,13 +607,13 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("loadSceneFile", &Scene::loadSceneFile);
     scene.def("getScene", &Scene::getScene);
     scene.def("cleanScene", &Scene::cleanScene);
-    scene.def("isStateValid", [](Scene* instance, bool self, double safe_distance) {return instance->getCollisionScene()->isStateValid(self, safe_distance);}, py::arg("self")=true, py::arg("SafeDistance")=0.0);
-    scene.def("isCollisionFree", [](Scene* instance, const std::string& o1, const std::string& o2, double safe_distance) {return instance->getCollisionScene()->isCollisionFree(o1, o2, safe_distance);}, py::arg("Object1"), py::arg("Object2"), py::arg("SafeDistance")=0.0);
-    scene.def("getCollisionDistance", [](Scene* instance, bool self) {return instance->getCollisionScene()->getCollisionDistance(self);}, py::arg("self")=true);
-    scene.def("getCollisionDistance", [](Scene* instance, const std::string& o1, const std::string& o2) {return instance->getCollisionScene()->getCollisionDistance(o1, o2);}, py::arg("Object1"), py::arg("Object2"));
+    scene.def("isStateValid", [](Scene* instance, bool self, double safe_distance) { return instance->getCollisionScene()->isStateValid(self, safe_distance); }, py::arg("self") = true, py::arg("SafeDistance") = 0.0);
+    scene.def("isCollisionFree", [](Scene* instance, const std::string& o1, const std::string& o2, double safe_distance) { return instance->getCollisionScene()->isCollisionFree(o1, o2, safe_distance); }, py::arg("Object1"), py::arg("Object2"), py::arg("SafeDistance") = 0.0);
+    scene.def("getCollisionDistance", [](Scene* instance, bool self) { return instance->getCollisionScene()->getCollisionDistance(self); }, py::arg("self") = true);
+    scene.def("getCollisionDistance", [](Scene* instance, const std::string& o1, const std::string& o2) { return instance->getCollisionScene()->getCollisionDistance(o1, o2); }, py::arg("Object1"), py::arg("Object2"));
     scene.def("updateWorld", &Scene::updateWorld);
-    scene.def("getCollisionRobotLinks", [](Scene* instance) {return instance->getCollisionScene()->getCollisionRobotLinks();});
-    scene.def("getCollisionWorldLinks", [](Scene* instance) {return instance->getCollisionScene()->getCollisionWorldLinks();});
+    scene.def("getCollisionRobotLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionRobotLinks(); });
+    scene.def("getCollisionWorldLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionWorldLinks(); });
     scene.def("getRootFrameName", &Scene::getRootFrameName);
     scene.def("getRootJointName", &Scene::getRootJointName);
     scene.def("getModelRootLinkName", &Scene::getModelRootLinkName);
@@ -614,18 +621,18 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("attachObjectLocal", &Scene::attachObjectLocal);
     scene.def("detachObject", &Scene::detachObject);
     scene.def("hasAttachedObject", &Scene::hasAttachedObject);
-    scene.def("fk", [](Scene* instance, const std::string& e1, const KDL::Frame& o1, const std::string& e2, const KDL::Frame& o2) {return instance->getSolver().FK(e1, o1, e2, o2);});
-    scene.def("fk", [](Scene* instance, const std::string& e1, const std::string& e2) {return instance->getSolver().FK(e1, KDL::Frame(), e2, KDL::Frame());});
-    scene.def("fk", [](Scene* instance, const std::string& e1) {return instance->getSolver().FK(e1, KDL::Frame(), "", KDL::Frame());});
-    scene.def("jacobian", [](Scene* instance, const std::string& e1, const KDL::Frame& o1, const std::string& e2, const KDL::Frame& o2) {return instance->getSolver().Jacobian(e1, o1, e2, o2);});
-    scene.def("jacobian", [](Scene* instance, const std::string& e1, const std::string& e2) {return instance->getSolver().Jacobian(e1, KDL::Frame(), e2, KDL::Frame());});
-    scene.def("jacobian", [](Scene* instance, const std::string& e1) {return instance->getSolver().Jacobian(e1, KDL::Frame(), "", KDL::Frame());});
+    scene.def("fk", [](Scene* instance, const std::string& e1, const KDL::Frame& o1, const std::string& e2, const KDL::Frame& o2) { return instance->getSolver().FK(e1, o1, e2, o2); });
+    scene.def("fk", [](Scene* instance, const std::string& e1, const std::string& e2) { return instance->getSolver().FK(e1, KDL::Frame(), e2, KDL::Frame()); });
+    scene.def("fk", [](Scene* instance, const std::string& e1) { return instance->getSolver().FK(e1, KDL::Frame(), "", KDL::Frame()); });
+    scene.def("jacobian", [](Scene* instance, const std::string& e1, const KDL::Frame& o1, const std::string& e2, const KDL::Frame& o2) { return instance->getSolver().Jacobian(e1, o1, e2, o2); });
+    scene.def("jacobian", [](Scene* instance, const std::string& e1, const std::string& e2) { return instance->getSolver().Jacobian(e1, KDL::Frame(), e2, KDL::Frame()); });
+    scene.def("jacobian", [](Scene* instance, const std::string& e1) { return instance->getSolver().Jacobian(e1, KDL::Frame(), "", KDL::Frame()); });
     scene.def("addTrajectoryFromFile", &Scene::addTrajectoryFromFile);
-    scene.def("addTrajectory", (void (Scene::*)(const std::string&, const std::string&)) &Scene::addTrajectory);
-    scene.def("getTrajectory", [](Scene* instance, const std::string& link){return instance->getTrajectory(link)->toString();});
+    scene.def("addTrajectory", (void (Scene::*)(const std::string&, const std::string&)) & Scene::addTrajectory);
+    scene.def("getTrajectory", [](Scene* instance, const std::string& link) { return instance->getTrajectory(link)->toString(); });
     scene.def("removeTrajectory", &Scene::removeTrajectory);
 
-    py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
+    py::module kin = module.def_submodule("Kinematics", "Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");
     kinematicTree.def("publishFrames", &KinematicTree::publishFrames);
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);
@@ -635,19 +642,19 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getModelBaseType", &KinematicTree::getModelBaseType);
     kinematicTree.def("getControlledBaseType", &KinematicTree::getControlledBaseType);
 
-    py::class_<KDL::Frame> kdlFrame (module, "KDLFrame");
+    py::class_<KDL::Frame> kdlFrame(module, "KDLFrame");
     kdlFrame.def(py::init());
-    kdlFrame.def("__init__", [](KDL::Frame &me, Eigen::MatrixXd other) {me = getFrameFromMatrix(other);});
-    kdlFrame.def("__init__", [](KDL::Frame &me, Eigen::VectorXd other) {me = getFrame(other);});
-    kdlFrame.def("__repr__", [](KDL::Frame* me){return "KDL::Frame "+toString(*me);});
-    kdlFrame.def("getRPY", [](KDL::Frame* me){return getFrameAsVector(*me, RotationType::RPY);});
-    kdlFrame.def("getZYZ", [](KDL::Frame* me){return getFrameAsVector(*me, RotationType::ZYZ);});
-    kdlFrame.def("getZYX", [](KDL::Frame* me){return getFrameAsVector(*me, RotationType::ZYX);});
-    kdlFrame.def("getAngleAxis", [](KDL::Frame* me){return getFrameAsVector(*me, RotationType::ANGLE_AXIS);});
-    kdlFrame.def("getQuaternion", [](KDL::Frame* me){return getFrameAsVector(*me, RotationType::QUATERNION);});
-    kdlFrame.def("get", [](KDL::Frame* me){return getFrame(*me);});
-    kdlFrame.def("inverse", (KDL::Frame (KDL::Frame::*)() const) &KDL::Frame::Inverse);
-    kdlFrame.def("__mul__", [](const KDL::Frame& A, const KDL::Frame& B){return A*B;}, py::is_operator());
+    kdlFrame.def("__init__", [](KDL::Frame& me, Eigen::MatrixXd other) { me = getFrameFromMatrix(other); });
+    kdlFrame.def("__init__", [](KDL::Frame& me, Eigen::VectorXd other) { me = getFrame(other); });
+    kdlFrame.def("__repr__", [](KDL::Frame* me) { return "KDL::Frame " + toString(*me); });
+    kdlFrame.def("getRPY", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::RPY); });
+    kdlFrame.def("getZYZ", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::ZYZ); });
+    kdlFrame.def("getZYX", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::ZYX); });
+    kdlFrame.def("getAngleAxis", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::ANGLE_AXIS); });
+    kdlFrame.def("getQuaternion", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::QUATERNION); });
+    kdlFrame.def("get", [](KDL::Frame* me) { return getFrame(*me); });
+    kdlFrame.def("inverse", (KDL::Frame (KDL::Frame::*)() const) & KDL::Frame::Inverse);
+    kdlFrame.def("__mul__", [](const KDL::Frame& A, const KDL::Frame& B) { return A * B; }, py::is_operator());
     py::implicitly_convertible<Eigen::MatrixXd, KDL::Frame>();
     py::implicitly_convertible<Eigen::VectorXd, KDL::Frame>();
 
@@ -656,8 +663,7 @@ PYBIND11_MODULE(_pyexotica, module)
 
     addInitializers(module);
 
-    auto cleanup_exotica = []()
-    {
+    auto cleanup_exotica = []() {
         Setup::Destroy();
     };
     module.add_object("_cleanup", py::capsule(cleanup_exotica));


### PR DESCRIPTION
Proposal to address #131 

- Command used: ``find -name '*.cpp' -o -name '*.h' | xargs clang-format-3.8 -style=google -i``, committed under neutral author Exotica Dev Team
- On top of a hotfix required for it to work: https://github.com/ipab-slmc/exotica/commit/18254951cd523eeb7c9e453b5ea690df36a1bcf6
- Will add an automatic pre-commit-hook that runs ``clang-format-3.8`` before any commit in a follow-up PR (i.e. with clang-format install no further user action required)