### PR TITLE
Add documentation on code formatting and documentation

### DIFF
--- a/exotica/doc/Code-Formatting.rst
+++ b/exotica/doc/Code-Formatting.rst
@@ -1,0 +1,17 @@
+***************
+Code Formatting
+***************
+
+We use ``clang-format-3.8`` to automatically format source files and headers _prior_ to committing any files. The format is specified in the ``.clang-format`` file provided in the root of the repository.
+
+You can install ``clang-format-3.8`` e.g. via your package managers:
+
+.. code:: bash
+
+    sudo apt-get install clang-format-3.8
+
+In order to format your changes prior to committing, please run the following from the root of the repository:
+
+.. code:: bash
+
+    find -name '*.cpp' -o -name '*.h' | xargs clang-format-3.8 -style=file -i

--- a/exotica/doc/Code-Formatting.rst
+++ b/exotica/doc/Code-Formatting.rst
@@ -2,7 +2,7 @@
 Code Formatting
 ***************
 
-We use ``clang-format-3.8`` to automatically format source files and headers _prior_ to committing any files. The format is specified in the ``.clang-format`` file provided in the root of the repository.
+We use ``clang-format-3.8`` to automatically format source files and headers *prior* to committing any files. The format is specified in the ``.clang-format`` file provided in the root of the repository.
 
 You can install ``clang-format-3.8`` e.g. via your package managers:
 

--- a/exotica/doc/Documentation.rst
+++ b/exotica/doc/Documentation.rst
@@ -12,9 +12,9 @@ In order to build the documentation offline, you require the ``sphinx`` and ``sp
 
 Navigating to ``exotica/doc``, you can create the documentation by running ``make html``. It can be found in ``_build/html``.
 
-The documentation is written in reStructured Text. A great reference can be found `here <http://www.sphinx-doc.org/en/stable/rest.html>`_.
+The documentation is written in reStructured Text. Sphinx provides a great `reStructured Text reference <http://www.sphinx-doc.org/en/stable/rest.html>`_.
 
-The generated documentation for the current master release can always be found `here <https://ipab-slmc.github.io/exotica/>`_.
+The `generated documentation <https://ipab-slmc.github.io/exotica/>`_ for the current master release is always up to date on GitHub.
 
 
 C++ API Documentation
@@ -22,6 +22,6 @@ C++ API Documentation
 
 In order to build the Doxygen C++ API documentation, you require ``doxygen`` to be installed on your system (e.g. via ``sudo apt-get install doxygen``). After navigating to the exotica package you can then run ``doxygen`` to generate the C++ API documentation. It will be created in ``doc/doxygen_cpp/doxygen_cpp``.
 
-It can also be found `here <https://ipab-slmc.github.io/exotica/doxygen_cpp/>`_ for the current master release.
+The `generated C++ API doxygen <https://ipab-slmc.github.io/exotica/doxygen_cpp/>`_ for the current master release is always up to date on GitHub.
 
 Both the C++ API documentation and the documentation in the ``doc`` subdirectory of the exotica package are generated automatically by our continuous integration services once Pull Requests/branches are merged to master.

--- a/exotica/doc/Documentation.rst
+++ b/exotica/doc/Documentation.rst
@@ -1,0 +1,27 @@
+*************
+Documentation
+*************
+
+Our documentation is built using `Sphinx <http://www.sphinx-doc.org>`_.
+
+In order to build the documentation offline, you require the ``sphinx`` and ``sphinx_rtd_theme`` packages to be installed on your machine:
+
+.. code:: bash
+
+    sudo pip install -U sphinx sphinx_rtd_theme
+
+Navigating to ``exotica/doc``, you can create the documentation by running ``make html``. It can be found in ``_build/html``.
+
+The documentation is written in reStructured Text. A great reference can be found `here <http://www.sphinx-doc.org/en/stable/rest.html>`_.
+
+The generated documentation for the current master release can always be found `here <https://ipab-slmc.github.io/exotica/>`_.
+
+
+C++ API Documentation
+=====================
+
+In order to build the Doxygen C++ API documentation, you require ``doxygen`` to be installed on your system (e.g. via ``sudo apt-get install doxygen``). After navigating to the exotica package you can then run ``doxygen`` to generate the C++ API documentation. It will be created in ``doc/doxygen_cpp/doxygen_cpp``.
+
+It can also be found `here <https://ipab-slmc.github.io/exotica/doxygen_cpp/>`_ for the current master release.
+
+Both the C++ API documentation and the documentation in the ``doc`` subdirectory of the exotica package are generated automatically by our continuous integration services once Pull Requests/branches are merged to master.

--- a/exotica/doc/Python-API.rst
+++ b/exotica/doc/Python-API.rst
@@ -1,0 +1,7 @@
+**********
+Python API
+**********
+
+.. NB: This is deactivated/not included in the toctree until the segfault upon loading the Python module is resolved - this prevents auto-generation.
+
+.. automodule:: pyexotica

--- a/exotica/doc/conf.py
+++ b/exotica/doc/conf.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 extensions = ['sphinx.ext.imgmath',
-    'sphinx.ext.githubpages']
+    'sphinx.ext.githubpages', 'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon']
+
+autosummary_generate = True
 
 templates_path = ['_templates']
 source_suffix = ['.rst', '.md']
@@ -13,7 +18,7 @@ author = u'Vladimir Ivan, Yiming Yang, Wolfgang Merkt, Michael Camilleri, Sethu 
 # The short X.Y version.
 version = u'5.0'
 # The full version, including alpha/beta/rc tags.
-release = u'beta1'
+release = u'5.0-beta1'
 
 language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/exotica/doc/conf.py
+++ b/exotica/doc/conf.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 extensions = ['sphinx.ext.imgmath',
-    'sphinx.ext.githubpages', 'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon']
+              'sphinx.ext.githubpages',
+              'sphinx.ext.autodoc',
+              'sphinx.ext.intersphinx',
+              'sphinx.ext.autosummary',
+              'sphinx.ext.napoleon']
 
 autosummary_generate = True
 
@@ -37,7 +38,6 @@ html_context = {'show_source': False}
 # html_static_path = ['_static']
 
 html_extra_path = ['doxygen_cpp']
-
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/exotica/doc/index.rst
+++ b/exotica/doc/index.rst
@@ -47,6 +47,8 @@ Overview
    Code-Formatting
    Doxygen C++ <./doxygen_cpp/index.html#http://>
 
+.. Python-API
+
 
 .. Indices and tables
     ==================

--- a/exotica/doc/index.rst
+++ b/exotica/doc/index.rst
@@ -43,6 +43,7 @@ Overview
    Quickstart
    Setting-up-ROSlaunch
    Using-EXOTica
+   Code-Formatting
    Doxygen C++ <./doxygen_cpp/index.html#http://>
 
 

--- a/exotica/doc/index.rst
+++ b/exotica/doc/index.rst
@@ -43,6 +43,7 @@ Overview
    Quickstart
    Setting-up-ROSlaunch
    Using-EXOTica
+   Documentation
    Code-Formatting
    Doxygen C++ <./doxygen_cpp/index.html#http://>
 


### PR DESCRIPTION
This resolves #94 

It includes:
- documentation on how the documentation works - cc: @cam586 
- documentation on the code formatting, cf. #141 
- adds the prerequisites for auto-generating the Python API documentation, but deactivates it as it doesn't work with the current segfault in the module