### PR TITLE
KinematicTree: Fix setModelState (broken in the last ~3 weeks?)

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -200,7 +200,7 @@ private:
     void BuildTree(const KDL::Tree& RobotKinematics);
     void AddElement(KDL::SegmentMap::const_iterator segment, std::shared_ptr<KinematicElement> parent);
     int IsControlled(std::shared_ptr<KinematicElement> Joint);
-    void UpdateTree(Eigen::VectorXdRefConst x);
+    void UpdateTree();
     void UpdateFK();
     void UpdateJ();
     void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -447,18 +447,18 @@ std::shared_ptr<KinematicResponse> KinematicTree::RequestFrames(const Kinematics
 void KinematicTree::Update(Eigen::VectorXdRefConst x)
 {
     if (x.rows() != StateSize) throw_pretty("Wrong state vector size! Got " << x.rows() << " expected " << StateSize);
-    UpdateTree(x);
+
+    for (int i = 0; i < ControlledJoints.size(); i++)
+        TreeState(ControlledJoints[i]->Id) = x(i);
+
+    UpdateTree();
     UpdateFK();
     if (Flags & KIN_J) UpdateJ();
     if (Debug) publishFrames();
 }
 
-void KinematicTree::UpdateTree(Eigen::VectorXdRefConst x)
+void KinematicTree::UpdateTree()
 {
-    for (int i = 0; i < ControlledJoints.size(); i++)
-    {
-        TreeState(ControlledJoints[i]->Id) = x(i);
-    }
     for (std::shared_ptr<KinematicElement> element : Tree)
     {
         KDL::Frame ParentFrame;
@@ -744,7 +744,7 @@ void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
     {
         TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id) = x(i);
     }
-
+    UpdateTree();
     UpdateFK();
     if (Flags & KIN_J) UpdateJ();
     if (Debug) publishFrames();
@@ -763,7 +763,7 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
             throw_pretty("Robot model does not contain joint '" << joint.first << "'");
         }
     }
-
+    UpdateTree();
     UpdateFK();
     if (Flags & KIN_J) UpdateJ();
     if (Debug) publishFrames();


### PR DESCRIPTION
This PR fixes the ``setModelState(Map)`` methods. It was broken some time in the last 3-4 weeks and resulted in all frame transforms being messed up as soon as an unactuated joint was set (e.g. with subgroups on Valkyrie) - or the ``setModelState`` method was used instead of ``Update`` (which only allows for updating controlled joints):

![image](https://user-images.githubusercontent.com/1664508/31628758-969e38a2-b2a9-11e7-9d2e-eefdb45d2e0b.png)

We should not make any more changes that were solely tested on the simplified LWR - I keep spending time fixing bugs every single time I pick up an updated revision.