### PR TITLE
Scene: Add way to update MoveIt PlanningScene to fix scene publishing

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -172,6 +172,11 @@ private:
     std::map<std::string, std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>> trajectory_generators_;
 
     bool force_collision_;
+
+    /**
+     * @brief      Updates the internal state of the MoveIt PlanningScene from Kinematica.
+     */
+    void updateMoveItPlanningScene();
 };
 typedef std::shared_ptr<Scene> Scene_ptr;
 //  typedef std::map<std::string, Scene_ptr> Scene_map;


### PR DESCRIPTION
- Broken in #125, addresses issue identified in #150 
- Adds method that updates the model state from Kinematica just before publishing
- Does not handle attached objects (addObject/attachObject/detachObject) - this would have to be done separately at a later state [both adding as objects to the MoveIt planning scene and to add as attached object]

I will add a comment in #150 that the attached objects are not supported by this fix, otherwise it works just as it used to (attached objects have never been supported by the PlanningScene messages feature in exotica, apart from via exotica_json which I added there back in 2015).