### PR TITLE
Fix FCL segfault and add python collision check unit test

### DIFF
--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -30,6 +30,7 @@ public:
             names.push_back(it.first);
         }
     }
+    inline size_t getNumberOfEntries() const { return entries_.size(); }
     inline bool getAllowedCollision(const std::string& name1, const std::string& name2) const
     {
         auto it = entries_.find(name1);
@@ -141,7 +142,7 @@ public:
     virtual void updateCollisionObjectTransforms() = 0;
 
 protected:
-    /// The allowed collisiom matrix
+    /// The allowed collision matrix
     AllowedCollisionMatrix acm_;
 };
 

--- a/exotica/resources/configs/test_valkyrie_collisionscene_fcl.xml
+++ b/exotica/resources/configs/test_valkyrie_collisionscene_fcl.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<ExoticaWholeBodyIKConfig>
+  <IKsolver Name="DummySolver">
+    <MaxIt>100</MaxIt>
+    <MaxStep>0.1</MaxStep>
+    <Tolerance>1e-5</Tolerance>
+    <Alpha>1.0</Alpha>
+    <C>1e-3</C>
+  </IKsolver>
+  
+  <UnconstrainedEndPoseProblem>
+    <PlanningScene>
+      <Scene Name="CoMDebugScene">
+        <PlanningMode>Optimization</PlanningMode>
+        <JointGroup>whole_body</JointGroup>
+        <Debug>0</Debug>
+        <URDF>{exotica}/resources/robots/valkyrie_sim.urdf</URDF>
+        <SRDF>{exotica}/resources/robots/valkyrie_sim.srdf</SRDF>
+        <CollisionScene>CollisionSceneFCL</CollisionScene>
+      </Scene>
+    </PlanningScene>
+    <Maps>
+      <CoM Name="CoM">
+        <Debug>0</Debug>
+        <EnableZ>1</EnableZ>
+      </CoM>
+    </Maps>
+    <NominalState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</NominalState>
+    <StartState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</StartState>
+  </UnconstrainedEndPoseProblem>
+</ExoticaWholeBodyIKConfig>

--- a/exotica/resources/configs/test_valkyrie_collisionscene_fcl_latest.xml
+++ b/exotica/resources/configs/test_valkyrie_collisionscene_fcl_latest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<ExoticaWholeBodyIKConfig>
+  <IKsolver Name="DummySolver">
+    <MaxIt>100</MaxIt>
+    <MaxStep>0.1</MaxStep>
+    <Tolerance>1e-5</Tolerance>
+    <Alpha>1.0</Alpha>
+    <C>1e-3</C>
+  </IKsolver>
+  
+  <UnconstrainedEndPoseProblem>
+    <PlanningScene>
+      <Scene Name="CoMDebugScene">
+        <PlanningMode>Optimization</PlanningMode>
+        <JointGroup>whole_body</JointGroup>
+        <Debug>0</Debug>
+        <URDF>{exotica}/resources/robots/valkyrie_sim.urdf</URDF>
+        <SRDF>{exotica}/resources/robots/valkyrie_sim.srdf</SRDF>
+        <CollisionScene>CollisionSceneFCLLatest</CollisionScene>
+      </Scene>
+    </PlanningScene>
+    <Maps>
+      <CoM Name="CoM">
+        <Debug>0</Debug>
+        <EnableZ>1</EnableZ>
+      </CoM>
+    </Maps>
+    <NominalState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</NominalState>
+    <StartState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</StartState>
+  </UnconstrainedEndPoseProblem>
+</ExoticaWholeBodyIKConfig>

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -116,6 +116,7 @@ void Scene::Instantiate(SceneInitializer& init)
     kinematica_.UpdateModel();
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
+    updateSceneFrames();
     collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
 
     AllowedCollisionMatrix acm;
@@ -147,6 +148,7 @@ void Scene::Instantiate(SceneInitializer& init)
             addTrajectory(trajInit.Link, trajInit.Trajectory);
         }
     }
+
 
     if (debug_) INFO_NAMED(name_, "Exotica Scene initialized");
 }

--- a/exotica_python/tests/runtest.py
+++ b/exotica_python/tests/runtest.py
@@ -6,7 +6,11 @@ import subprocess
 import os
 import sys
 
-tests = ['core.py', 'valkyrie_com.py']
+tests = ['core.py',
+         'valkyrie_com.py' #,
+        # 'valkyrie_collision_check_fcl_default.py',
+        # 'valkyrie_collision_check_fcl_latest.py'
+        ]
 
 for test in tests:
     process=subprocess.Popen(['rosrun', 'exotica_python', test],stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/exotica_python/tests/valkyrie_collision_check_fcl_default.py
+++ b/exotica_python/tests/valkyrie_collision_check_fcl_default.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import numpy as np
+import pyexotica as exo
+
+print(">>>>>>>>>>>>> TESTING DEFAULT FCL")
+
+# Default FCL
+(_, ik_prob) = exo.Initializers.loadXMLFull(
+    '{exotica}/resources/configs/test_valkyrie_collisionscene_fcl.xml')
+ik_problem = exo.Setup.createProblem(ik_prob)
+ik_problem.update(np.zeros(ik_problem.N,))
+ik_scene = ik_problem.getScene()
+
+print("Check number of collision robot links")
+assert (len(ik_scene.getCollisionRobotLinks()) == 84)
+
+print("Check number of collision world links")
+assert (len(ik_scene.getCollisionWorldLinks()) == 0)
+
+print("Testing isStateValid(True, 0.0) - with self-collision")
+assert (ik_scene.isStateValid(True, 0.0) == True)
+
+print("Testing isStateValid(False, 0.0) - without self-collision")
+assert (ik_scene.isStateValid(False, 0.0) == True)
+
+print('>>SUCCESS<<')

--- a/exotica_python/tests/valkyrie_collision_check_fcl_latest.py
+++ b/exotica_python/tests/valkyrie_collision_check_fcl_latest.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import numpy as np
+import pyexotica as exo
+
+print(">>>>>>>>>>>>> TESTING FCL LATEST")
+
+# FCL Latest
+(_, ik_prob) = exo.Initializers.loadXMLFull(
+    '{exotica}/resources/configs/test_valkyrie_collisionscene_fcl_latest.xml')
+ik_problem = exo.Setup.createProblem(ik_prob)
+ik_problem.update(np.zeros(ik_problem.N,))
+ik_scene = ik_problem.getScene()
+
+print("Check number of collision robot links")
+assert (len(ik_scene.getCollisionRobotLinks()) == 84)
+
+print("Check number of collision world links")
+assert (len(ik_scene.getCollisionWorldLinks()) == 0)
+
+print("Testing isStateValid(True, 0.0) - with self-collision")
+assert (ik_scene.isStateValid(True, 0.0) == True)
+
+print("Testing isStateValid(False, 0.0) - without self-collision")
+assert (ik_scene.isStateValid(False, 0.0) == True)
+
+print('>>SUCCESS<<')


### PR DESCRIPTION
- Fixes default-FCL segfault - resolves #157 
- Adds tests demonstrating that the isStateValid is broken (allowed collision matrix issue, described in #156)