### PR TITLE
Fix collision checking: change to INDEP, update object transforms when in lazy checking mode

### DIFF
--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -222,6 +222,8 @@ bool CollisionSceneFCL::collisionCallback(fcl::CollisionObject* o1, fcl::Collisi
 
 bool CollisionSceneFCL::isStateValid(bool self, double safe_distance)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::shared_ptr<fcl::BroadPhaseCollisionManager> manager(new fcl::DynamicAABBTreeCollisionManager());
     manager->registerObjects(fcl_objects_);
     CollisionData data(this);
@@ -233,6 +235,8 @@ bool CollisionSceneFCL::isStateValid(bool self, double safe_distance)
 
 bool CollisionSceneFCL::isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::vector<fcl::CollisionObject*> shapes1;
     std::vector<fcl::CollisionObject*> shapes2;
     for (fcl::CollisionObject* o : fcl_objects_)

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -240,8 +240,21 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     p.distance = data->Result.min_distance;
     if (p.distance > 0)
     {
-        KDL::Vector c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-        KDL::Vector c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        KDL::Vector c1, c2;
+        if (data->Request.gjk_solver_type == fcl::GST_LIBCCD)
+        {
+            KDL::Vector c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+            KDL::Vector c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        else if (data->Request.gjk_solver_type == fcl::GST_INDEP)
+        {
+            c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+            c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        else
+        {
+            throw_pretty("Unknown solver type");
+        }
         KDL::Vector n1 = c2 - c1;
         KDL::Vector n2 = c1 - c2;
         n1.Normalize();

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -279,6 +279,8 @@ bool CollisionSceneFCLLatest::collisionCallbackDistance(fcl::CollisionObjectd* o
 
 bool CollisionSceneFCLLatest::isStateValid(bool self, double safe_distance)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::shared_ptr<fcl::BroadPhaseCollisionManagerd> manager(new fcl::DynamicAABBTreeCollisionManagerd());
     manager->registerObjects(fcl_objects_);
     CollisionData data(this);
@@ -290,6 +292,8 @@ bool CollisionSceneFCLLatest::isStateValid(bool self, double safe_distance)
 
 bool CollisionSceneFCLLatest::isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
@@ -315,6 +319,8 @@ bool CollisionSceneFCLLatest::isCollisionFree(const std::string& o1, const std::
 
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(bool self)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::shared_ptr<fcl::BroadPhaseCollisionManagerd> manager(new fcl::DynamicAABBTreeCollisionManagerd());
     manager->registerObjects(fcl_objects_);
     DistanceData data(this);
@@ -325,6 +331,8 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(bool s
 
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const std::string& o1, const std::string& o2)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
@@ -349,6 +357,8 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     const std::string& o1)
 {
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     DistanceData data(this);

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -240,21 +240,20 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     p.distance = data->Result.min_distance;
     if (p.distance > 0)
     {
+        // FCL uses world coordinates for meshes while local coordinates are used
+        // for primitive shapes - thus, we need to work around this.
+        // Cf. https://github.com/flexible-collision-library/fcl/issues/171
         KDL::Vector c1, c2;
-        if (data->Request.gjk_solver_type == fcl::GST_LIBCCD)
-        {
-            KDL::Vector c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-            KDL::Vector c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        }
-        else if (data->Request.gjk_solver_type == fcl::GST_INDEP)
-        {
+        if (p.e1->Shape->type == shapes::ShapeType::MESH)
             c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-            c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        }
         else
-        {
-            throw_pretty("Unknown solver type");
-        }
+            c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+
+        if (p.e2->Shape->type == shapes::ShapeType::MESH)
+            c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        else
+            c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+
         KDL::Vector n1 = c2 - c1;
         KDL::Vector n2 = c1 - c2;
         n1.Normalize();

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -69,7 +69,7 @@ void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string,
         // TODO: There is currently a bug with the caching causing proxies not
         // to update. The correct fix would be to update the user data, for now
         // disable use of the cache.
-        if (true) // (cache_entry == fcl_cache_.end())
+        if (true)  // (cache_entry == fcl_cache_.end())
         {
             new_object = constructFclCollisionObject(object.second);
             fcl_cache_[object.first] = new_object;

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -200,6 +200,7 @@ bool CollisionSceneFCLLatest::isAllowedToCollide(fcl::CollisionObjectd* o1, fcl:
 void CollisionSceneFCLLatest::checkCollision(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, CollisionData* data)
 {
     data->Request.num_max_contacts = 1000;
+    data->Request.gjk_solver_type = fcl::GST_INDEP;  // CCD returns wrong points
     data->Result.clear();
     fcl::collide(o1, o2, data->Request, data->Result);
     if (data->SafeDistance > 0.0 && o1->getAABB().distance(o2->getAABB()) < data->SafeDistance)

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -43,7 +43,7 @@ CollisionCheck::CollisionCheck()
 void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != 1) throw_named("Wrong size of phi!");
-    cscene_->updateCollisionObjectTransforms();
+    if (!scene_->alwaysUpdatesCollisionScene()) cscene_->updateCollisionObjectTransforms();
     phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance) ? -1.0 : 0.0;
 }
 

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -130,6 +130,11 @@ public:
         acm_ = acm;
     }
 
+    inline void setAlwaysExternallyUpdatedCollisionScene(const bool& value)
+    {
+        alwaysExternallyUpdatedCollisionScene_ = value;
+    }
+
     ///
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
@@ -144,6 +149,9 @@ public:
 protected:
     /// The allowed collision matrix
     AllowedCollisionMatrix acm_;
+
+    /// Whether the collision scene is automatically updated - if not, update on queries
+    bool alwaysExternallyUpdatedCollisionScene_ = false;
 };
 
 typedef exotica::Factory<exotica::CollisionScene> CollisionScene_fac;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -136,6 +136,11 @@ public:
     std::string getScene();
     void cleanScene();
 
+    /**
+     * @brief      Whether the collision scene transforms get updated on every scene update.
+     * @return     Whether collision scene transforms are force updated on every scene update.
+     */
+    bool alwaysUpdatesCollisionScene() { return force_collision_; }
 private:
     /// The name of the scene
     std::string name_;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -148,7 +148,6 @@ void Scene::Instantiate(SceneInitializer& init)
         }
     }
 
-
     if (debug_) INFO_NAMED(name_, "Exotica Scene initialized");
 }
 
@@ -354,7 +353,6 @@ void Scene::setModelState(std::map<std::string, double> x, double t)
     kinematica_.setModelState(x);
 
     if (force_collision_) collision_scene_->updateCollisionObjectTransforms();
-
     if (debug_) publishScene();
 }
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -115,6 +115,7 @@ void Scene::Instantiate(SceneInitializer& init)
 
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
+    collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
     updateSceneFrames();
     collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -113,7 +113,6 @@ void Scene::Instantiate(SceneInitializer& init)
         addObject(link.Name, getFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, getFrame(link.CoM).p), false);
     }
 
-
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
     updateSceneFrames();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -615,9 +615,9 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("Object1"));
     scene.def("updateWorld",
               [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
-                moveit_msgs::PlanningSceneWorldConstPtr myPtr(
-                    new moveit_msgs::PlanningSceneWorld(world));
-                instance->updateWorld(myPtr);
+                  moveit_msgs::PlanningSceneWorldConstPtr myPtr(
+                      new moveit_msgs::PlanningSceneWorld(world));
+                  instance->updateWorld(myPtr);
               });
     scene.def("getCollisionRobotLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionRobotLinks(); });
     scene.def("getCollisionWorldLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionWorldLinks(); });


### PR DESCRIPTION
- Passes information on whether the collision scene is updated lazily to the CollisionScene
- Uses that information to force an object transform update when queried and it has not been externally updated
- This is e.g. of relevance when using multiple task maps that query the CollisionScene - in that case only one update would be required for multiple queries (and that update would be from AlwaysUpdateCollisionScene, i.e. forced from Scene)
- Switches to INDEP for collision queries in addition to distance queries as per recommendation/tests from Vlad
- Adds method to Scene to allow querying whether the Scene is updated lazily (also used in another branch). This may be replaced with checking it directly from CollisionScene in the future
- The tests for collision checking are *not* enabled yet due to missing meshes. We should add tests e.g. using the ur_description with meshes that can be apt-get install'ed
- Relates to #158 

- Resolves #155, #156