### PR TITLE
Fix stale CollisionProxies

### DIFF
--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -66,7 +66,10 @@ void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string,
         std::shared_ptr<fcl::CollisionObjectd> new_object;
 
         const auto& cache_entry = fcl_cache_.find(object.first);
-        if (cache_entry == fcl_cache_.end())
+        // TODO: There is currently a bug with the caching causing proxies not
+        // to update. The correct fix would be to update the user data, for now
+        // disable use of the cache.
+        if (true) // (cache_entry == fcl_cache_.end())
         {
             new_object = constructFclCollisionObject(object.second);
             fcl_cache_[object.first] = new_object;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -113,7 +113,6 @@ void Scene::Instantiate(SceneInitializer& init)
         addObject(link.Name, getFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, getFrame(link.CoM).p), false);
     }
 
-    kinematica_.UpdateModel();
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     updateSceneFrames();

--- a/exotica_python/scripts/example_distance.py
+++ b/exotica_python/scripts/example_distance.py
@@ -6,8 +6,8 @@ import math
 
 exo.Setup.initRos()
 ompl=exo.Setup.loadSolver('{exotica}/resources/configs/example_distance.xml')
-ompl.getProblem().getScene().loadSceneFile('{exotica}/resources/scenes/example_distance.scene')
 sc=ompl.getProblem().getScene()
+sc.loadSceneFile('{exotica}/resources/scenes/example_distance.scene')
 
 dt=0.01
 t=0.0
@@ -15,6 +15,6 @@ while not is_shutdown():
     sc.Update([math.sin(t/2.0)*0.5]*7)
     p=sc.getCollisionDistance(False)
     sc.getSolver().publishFrames()
-    sc.publishProxies(sc.getCollisionDistance(False))
+    sc.publishProxies(p)
     t=t+dt
     sleep(dt)


### PR DESCRIPTION
- Disables FCL cache to avoid stale collision distance proxies
- Fixes the distance example test - it was broken for a while now, only the XML Initialisation worked with the loadScene and loadSceneFile methods broken - they are fixed after this PR
- Relates to #156 