### PR TITLE
Enable Valkyrie collision checking tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 - cd ..
 script:
 - catkin config --init --install
-- catkin build -i
+- catkin build -i -j4
 # Run tests
 - source /opt/ros/indigo/setup.bash
 - source install/setup.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 cache:
 - apt
-#- ccache
+- ccache
 language: generic
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC
 - git clone --depth 1 https://github.com/openhumanoids/val_description.git # could also get from SRCSIM PPA
+- rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 - catkin_init_workspace
 - cd ..
 - catkin config --init --install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_install:
 - sudo add-apt-repository -y ppa:libccd-debs/ppa
 - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+- sudo sh -c 'echo "deb http://srcsim.gazebosim.org/src trusty main" \ > /etc/apt/sources.list.d/src-latest.list'
+- wget -O - http://srcsim.gazebosim.org/src/src.key | sudo apt-key add -
+- wget -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
 - sudo apt-get update -qq
 install:
 - export PATH=/usr/bin/:$PATH # work-around Travis PYTHONPATH bug, cf. https://github.com/travis-ci/travis-ci/issues/8048
@@ -27,17 +30,16 @@ install:
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
-- sudo apt-get install -qq -y ros-$CI_ROS_DISTRO-rosbash
+- sudo apt-get install -qq -y ros-$CI_ROS_DISTRO-rosbash val-description
 - sudo pip install -U sphinx sphinx_rtd_theme
-script:
 - source /opt/ros/$CI_ROS_DISTRO/setup.bash
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC
-- git clone --depth 1 https://github.com/openhumanoids/val_description.git # could also get from SRCSIM PPA
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 - catkin_init_workspace
 - cd ..
+script:
 - catkin config --init --install
 - catkin build -i
 # Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC
+- git clone --depth 1 https://github.com/openhumanoids/val_description.git # could also get from SRCSIM PPA
 - catkin_init_workspace
 - cd ..
 - catkin config --init --install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
 - sudo add-apt-repository -y ppa:libccd-debs/ppa
 - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-- sudo sh -c 'echo "deb http://srcsim.gazebosim.org/src trusty main" \ > /etc/apt/sources.list.d/src-latest.list'
-- wget -O - http://srcsim.gazebosim.org/src/src.key | sudo apt-key add -
-- wget -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
 - sudo apt-get update -qq
 install:
 - export PATH=/usr/bin/:$PATH # work-around Travis PYTHONPATH bug, cf. https://github.com/travis-ci/travis-ci/issues/8048
@@ -30,12 +27,13 @@ install:
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
-- sudo apt-get install -qq -y ros-$CI_ROS_DISTRO-rosbash val-description
+- sudo apt-get install -qq -y ros-$CI_ROS_DISTRO-rosbash
 - sudo pip install -U sphinx sphinx_rtd_theme
 - source /opt/ros/$CI_ROS_DISTRO/setup.bash
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC
+- git clone https://github.com/wxmerkt/oh_val_description.git
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 - catkin_init_workspace
 - cd ..

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -324,7 +324,7 @@ public:
         std::string name = pyAsString(name_py);
 
         const auto& it = knownInitializers.find(name);
-        if(it==knownInitializers.end())
+        if (it == knownInitializers.end())
         {
             HIGHLIGHT("Unknown initializer type '" << name << "'");
             return false;

--- a/exotica_python/tests/runtest.py
+++ b/exotica_python/tests/runtest.py
@@ -7,9 +7,9 @@ import os
 import sys
 
 tests = ['core.py',
-         'valkyrie_com.py' #,
-        # 'valkyrie_collision_check_fcl_default.py',
-        # 'valkyrie_collision_check_fcl_latest.py'
+         'valkyrie_com.py',
+         'valkyrie_collision_check_fcl_default.py',
+         'valkyrie_collision_check_fcl_latest.py'
         ]
 
 for test in tests:


### PR DESCRIPTION
- Clones minimal val_description package into CI workspace for meshes.
- Enables Valkyrie collision checking tests for CollisionScene and CollisionSceneFCL added in #158 - these are currently minimal and should be expanded.