### PR TITLE
Fix wrongly initialised and unchecked inputs into SamplingProblem and UnconstrainedEndPoseProblem

### DIFF
--- a/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
+++ b/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
@@ -57,7 +57,7 @@ void DMeshROS::assignScene(Scene_ptr scene)
 
 void DMeshROS::Initialize()
 {
-    q_size_ = scene_->getSolver().getNumJoints();
+    q_size_ = scene_->getSolver().getNumControlledJoints();
     if (init_.Size > 0)
     {
         size_ = init_.Size;

--- a/exotations/task_maps/task_map/src/Identity.cpp
+++ b/exotations/task_maps/task_map/src/Identity.cpp
@@ -90,7 +90,7 @@ void Identity::assignScene(Scene_ptr scene)
 
 void Identity::Initialize()
 {
-    N = std::max(scene_->getSolver().getNumJoints(), (int)init_.JointMap.size());
+    N = std::max(scene_->getSolver().getNumControlledJoints(), (int)init_.JointMap.size());
     if (init_.JointMap.size() > 0)
     {
         jointMap = init_.JointMap;

--- a/exotica/doc/Using-EXOTica.rst
+++ b/exotica/doc/Using-EXOTica.rst
@@ -17,7 +17,7 @@ complete:
 
         // Continued from initialisation
         // Create the initial configuration
-        Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->getScene()->getNumJoints());
+        Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->getScene()->getNumControlledJoints());
         Eigen::MatrixXd solution;
 
 
@@ -64,10 +64,10 @@ into the solver. Here we initialise the joints to zero angles:
 
 .. code:: c++
 
-        Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->getScene()->getNumJoints());
+        Eigen::VectorXd q = Eigen::VectorXd::Zero(any_problem->getScene()->getNumControlledJoints());
 
 Here we use the kinematic description of the robot to determine the size
-of the vector (``any_problem->getScene()->getNumJoints()``). This vector
+of the vector (``any_problem->getScene()->getNumControlledJoints()``). This vector
 can naturally be changed to whatever joint configuration is required for
 your motion planning purposes. for example, after instantiating ``q``:
 

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -151,7 +151,8 @@ public:
     void setFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> getUsedJointLimits();
     int getEffSize();
-    int getNumJoints();
+    int getNumJoints(); // to be renamed
+    int getNumModelJoints();
     void publishFrames();
     Eigen::MatrixXd getJointLimits();
     std::vector<std::string> getJointNames()

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -151,7 +151,7 @@ public:
     void setFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> getUsedJointLimits();
     int getEffSize();
-    int getNumJoints(); // to be renamed
+    int getNumControlledJoints();
     int getNumModelJoints();
     void publishFrames();
     Eigen::MatrixXd getJointLimits();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -90,9 +90,14 @@ void KinematicSolution::Create(std::shared_ptr<KinematicResponse> solution)
     if (solution->Flags & KIN_J_DOT) new (&JDot) Eigen::Map<ArrayJacobian>(solution->JDot.data() + Start, Length);
 }
 
-int KinematicTree::getNumJoints()
+int KinematicTree::getNumJoints() // to be renamed
 {
     return NumControlledJoints;
+}
+
+int KinematicTree::getNumModelJoints()
+{
+    return NumJoints;
 }
 
 KinematicTree::KinematicTree() : StateSize(-1), Debug(false)

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -90,7 +90,7 @@ void KinematicSolution::Create(std::shared_ptr<KinematicResponse> solution)
     if (solution->Flags & KIN_J_DOT) new (&JDot) Eigen::Map<ArrayJacobian>(solution->JDot.data() + Start, Length);
 }
 
-int KinematicTree::getNumJoints() // to be renamed
+int KinematicTree::getNumControlledJoints()
 {
     return NumControlledJoints;
 }
@@ -622,7 +622,7 @@ void KinematicTree::UpdateJ()
 
 Eigen::MatrixXd KinematicTree::getJointLimits()
 {
-    Eigen::MatrixXd lim(getNumJoints(), 2);
+    Eigen::MatrixXd lim(getNumControlledJoints(), 2);
     for (int i = 0; i < ControlledJoints.size(); i++)
     {
         lim(i, 0) = ControlledJoints[i]->JointLimits[0];

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -62,7 +62,7 @@ void PlanningProblem::preupdate()
 
 void PlanningProblem::setStartState(Eigen::VectorXdRefConst x)
 {
-    if (x.rows() == startState.rows())
+    if (x.rows() == scene_->getSolver().getNumModelJoints())
     {
         startState = x;
     }
@@ -80,7 +80,7 @@ void PlanningProblem::setStartState(Eigen::VectorXdRefConst x)
     }
     else
     {
-        throw_named("Wrong start state vector size, expected " << startState.rows() << " got " << x.rows());
+        throw_named("Wrong start state vector size, expected " << scene_->getSolver().getNumModelJoints() << ", got " << x.rows());
     }
 }
 

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -66,7 +66,7 @@ void PlanningProblem::setStartState(Eigen::VectorXdRefConst x)
     {
         startState = x;
     }
-    else if (x.rows() == scene_->getSolver().getNumJoints())
+    else if (x.rows() == scene_->getSolver().getNumControlledJoints())
     {
         std::vector<std::string> jointNames = scene_->getJointNames();
         std::vector<std::string> modelNames = scene_->getModelJointNames();
@@ -101,7 +101,7 @@ void PlanningProblem::InstantiateBase(const Initializer& init_)
     scene_.reset(new Scene());
     scene_->InstantiateInternal(SceneInitializer(init.PlanningScene));
     startState = Eigen::VectorXd::Zero(scene_->getModelJointNames().size());
-    N = scene_->getSolver().getNumJoints();
+    N = scene_->getSolver().getNumControlledJoints();
 
     if (init.StartState.rows() > 0)
     {

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -114,6 +114,8 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
 
 void SamplingProblem::setGoalState(Eigen::VectorXdRefConst qT)
 {
+    if (qT.rows() != N)
+        throw_pretty("Dimensionality of goal state wrong: Got " << qT.rows() << ", expected " << N);
     goal_ = qT;
 }
 

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -76,7 +76,8 @@ void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitial
     Phi = y;
     J = Eigen::MatrixXd(JN, N);
 
-    qNominal = init.NominalState;
+    if (init.NominalState.rows() > 0 && init.NominalState.rows() != N) throw_named("Invalid size of NominalState (" << init.NominalState.rows() << "), expected: " << N);
+    if (init.NominalState.rows() == N) qNominal = init.NominalState;
 
     if (init.Rho.rows() > 0 && init.Rho.rows() != NumTasks) throw_named("Invalid size of Rho (" << init.Rho.rows() << ") expected: " << NumTasks);
     if (init.Goal.rows() > 0 && init.Goal.rows() != PhiN) throw_named("Invalid size of Goal (" << init.Goal.rows() << ") expected: " << PhiN);

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -71,7 +71,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
         JN += Tasks[i]->LengthJ;
     }
 
-    N = scene_->getSolver().getNumJoints();
+    N = scene_->getSolver().getNumControlledJoints();
 
     W = Eigen::MatrixXd::Identity(N, N) * W_rate;
     if (init.W.rows() > 0)


### PR DESCRIPTION
- Makes a clear distinction between number of model and controlled joints: ``getNumJoints`` is now renamed to ``getNumControlledJoints`` and ``getNumModelJoints`` is added.
- Fixes the setter for StartState to correctly check the dimensionality, and also to correctly initialise. A wrong vector size in the Initializer/XML could block correct usage down the line!
- Adds a check for the dimensionality in the setter for the goal state of the ``SamplingProblem`` - without this any arbitrary sized vector could be set as a goal state and sampling would obviously fail...
- Adds a check for the NominalState dimensionality in the ``UnconstrainedEndPoseProblem``

Resolves #163 