### PR TITLE
Change CollisionScene to shared_ptr

### DIFF
--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -106,7 +106,7 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-    std::shared_ptr<fcl::CollisionObject> constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element);
+    std::shared_ptr<fcl::CollisionObject> constructFclCollisionObject(long i, std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObject* o1, fcl::CollisionObject* o2, CollisionData* data);
 
     std::map<std::string, std::shared_ptr<fcl::CollisionObject>> fcl_cache_;

--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -34,6 +34,7 @@
 #define COLLISIONSCENEFCL_H
 
 #include <exotica/CollisionScene.h>
+#include <exotica/Tools/Conversions.h>
 #include <fcl/BVH/BVH_model.h>
 #include <fcl/broadphase/broadphase.h>
 #include <fcl/collision.h>
@@ -105,12 +106,13 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-    static std::shared_ptr<fcl::CollisionObject> constructFclCollisionObject(std::shared_ptr<KinematicElement> element);
+    std::shared_ptr<fcl::CollisionObject> constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObject* o1, fcl::CollisionObject* o2, CollisionData* data);
 
     std::map<std::string, std::shared_ptr<fcl::CollisionObject>> fcl_cache_;
 
     std::vector<fcl::CollisionObject*> fcl_objects_;
+    std::vector<std::shared_ptr<KinematicElement>> kinematic_elements_;
 };
 
 typedef std::shared_ptr<CollisionSceneFCL> CollisionSceneFCL_ptr;

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -57,7 +57,7 @@ void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::
 {
     kinematic_elements_ = MapToVec(objects);
     fcl_objects_.resize(objects.size());
-    int i = 0;
+    long i = 0;
     for (const auto& object : objects)
     {
         std::shared_ptr<fcl::CollisionObject> new_object;
@@ -91,7 +91,7 @@ void CollisionSceneFCL::updateCollisionObjectTransforms()
 
 // This function was copied from 'moveit_core/collision_detection_fcl/src/collision_common.cpp'
 // https://github.com/ros-planning/moveit/blob/indigo-devel/moveit_core/collision_detection_fcl/src/collision_common.cpp#L512
-std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element)
+std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionObject(long i, std::shared_ptr<KinematicElement> element)
 {
     // Maybe use cache here?
 

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -55,6 +55,7 @@ CollisionSceneFCL::~CollisionSceneFCL()
 
 void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects)
 {
+    kinematic_elements_ = MapToVec(objects);
     fcl_objects_.resize(objects.size());
     int i = 0;
     for (const auto& object : objects)
@@ -62,9 +63,12 @@ void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::
         std::shared_ptr<fcl::CollisionObject> new_object;
 
         const auto& cache_entry = fcl_cache_.find(object.first);
-        if (cache_entry == fcl_cache_.end())
+        // TODO: There is currently a bug with the caching causing proxies not
+        // to update. The correct fix would be to update the user data, for now
+        // disable use of the cache.
+        if (true)  // (cache_entry == fcl_cache_.end())
         {
-            new_object = constructFclCollisionObject(object.second);
+            new_object = constructFclCollisionObject(i, object.second);
             fcl_cache_[object.first] = new_object;
         }
         else
@@ -79,7 +83,7 @@ void CollisionSceneFCL::updateCollisionObjectTransforms()
 {
     for (fcl::CollisionObject* collision_object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(collision_object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(collision_object->getUserData())];
         collision_object->setTransform(fcl_convert::KDL2fcl(element->Frame));
         collision_object->computeAABB();
     }
@@ -87,7 +91,7 @@ void CollisionSceneFCL::updateCollisionObjectTransforms()
 
 // This function was copied from 'moveit_core/collision_detection_fcl/src/collision_common.cpp'
 // https://github.com/ros-planning/moveit/blob/indigo-devel/moveit_core/collision_detection_fcl/src/collision_common.cpp#L512
-std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionObject(std::shared_ptr<KinematicElement> element)
+std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element)
 {
     // Maybe use cache here?
 
@@ -162,17 +166,17 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
             throw_pretty("This shape type (" << ((int)shape->type) << ") is not supported using FCL yet");
     }
     geometry->computeLocalAABB();
-    geometry->setUserData(reinterpret_cast<void*>(element.get()));
+    geometry->setUserData(reinterpret_cast<void*>(i));
     std::shared_ptr<fcl::CollisionObject> ret(new fcl::CollisionObject(geometry));
-    ret->setUserData(reinterpret_cast<void*>(element.get()));
+    ret->setUserData(reinterpret_cast<void*>(i));
 
     return ret;
 }
 
 bool CollisionSceneFCL::isAllowedToCollide(fcl::CollisionObject* o1, fcl::CollisionObject* o2, bool self, CollisionSceneFCL* scene)
 {
-    KinematicElement* e1 = reinterpret_cast<KinematicElement*>(o1->getUserData());
-    KinematicElement* e2 = reinterpret_cast<KinematicElement*>(o2->getUserData());
+    std::shared_ptr<KinematicElement> e1 = scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())];
+    std::shared_ptr<KinematicElement> e2 = scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())];
 
     bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink;
     bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink;
@@ -241,7 +245,7 @@ bool CollisionSceneFCL::isCollisionFree(const std::string& o1, const std::string
     std::vector<fcl::CollisionObject*> shapes2;
     for (fcl::CollisionObject* o : fcl_objects_)
     {
-        KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
         if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
@@ -264,7 +268,7 @@ Eigen::Vector3d CollisionSceneFCL::getTranslation(const std::string& name)
 {
     for (fcl::CollisionObject* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (element->Segment.getName() == name)
         {
             return Eigen::Map<Eigen::Vector3d>(element->Frame.p.data);
@@ -279,7 +283,7 @@ std::vector<std::string> CollisionSceneFCL::getCollisionWorldLinks()
     std::vector<std::string> tmp;
     for (fcl::CollisionObject* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (!element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
@@ -298,7 +302,7 @@ std::vector<std::string> CollisionSceneFCL::getCollisionRobotLinks()
     std::vector<std::string> tmp;
     for (fcl::CollisionObject* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -123,7 +123,7 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-    std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element);
+    std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(long i, std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, CollisionData* data);
     static void computeDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, DistanceData* data);
 

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -34,6 +34,7 @@
 #define CollisionSceneFCLLatest_H
 
 #include <exotica/CollisionScene.h>
+#include <exotica/Tools/Conversions.h>
 #include <fcl/fcl.h>
 #include <geometric_shapes/mesh_operations.h>
 #include <geometric_shapes/shape_operations.h>
@@ -121,13 +122,13 @@ public:
     virtual void updateCollisionObjectTransforms();
 
 private:
-    static std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(std::shared_ptr<KinematicElement> element);
+    std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, CollisionData* data);
     static void computeDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, DistanceData* data);
 
     std::map<std::string, std::shared_ptr<fcl::CollisionObjectd>> fcl_cache_;
-
     std::vector<fcl::CollisionObjectd*> fcl_objects_;
+    std::vector<std::shared_ptr<KinematicElement>> kinematic_elements_;
 };
 
 typedef std::shared_ptr<CollisionSceneFCLLatest> CollisionSceneFCLLatest_ptr;

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -33,6 +33,7 @@
 #ifndef CollisionSceneFCLLatest_H
 #define CollisionSceneFCLLatest_H
 
+#include <eigen_conversions/eigen_kdl.h>
 #include <exotica/CollisionScene.h>
 #include <exotica/Tools/Conversions.h>
 #include <fcl/fcl.h>

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -60,7 +60,7 @@ void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string,
 {
     kinematic_elements_ = MapToVec(objects);
     fcl_objects_.resize(objects.size());
-    int i = 0;
+    long i = 0;
     for (const auto& object : objects)
     {
         std::shared_ptr<fcl::CollisionObjectd> new_object;
@@ -94,7 +94,7 @@ void CollisionSceneFCLLatest::updateCollisionObjectTransforms()
 
 // This function was copied from 'moveit_core/collision_detection_fcl/src/collision_common.cpp'
 // https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_core/collision_detection_fcl/src/collision_common.cpp#L520
-std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element)
+std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclCollisionObject(long i, std::shared_ptr<KinematicElement> element)
 {
     // Maybe use cache here?
 

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -59,6 +59,7 @@ CollisionSceneFCLLatest::~CollisionSceneFCLLatest()
 
 void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects)
 {
+    kinematic_elements_ = MapToVec(objects);
     fcl_objects_.resize(objects.size());
     int i = 0;
     for (const auto& object : objects)
@@ -71,7 +72,7 @@ void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string,
         // disable use of the cache.
         if (true)  // (cache_entry == fcl_cache_.end())
         {
-            new_object = constructFclCollisionObject(object.second);
+            new_object = constructFclCollisionObject(i, object.second);
             fcl_cache_[object.first] = new_object;
         }
         else
@@ -86,7 +87,7 @@ void CollisionSceneFCLLatest::updateCollisionObjectTransforms()
 {
     for (fcl::CollisionObjectd* collision_object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(collision_object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(collision_object->getUserData())];
         collision_object->setTransform(fcl_convert::KDL2fcl(element->Frame));
         collision_object->computeAABB();
     }
@@ -94,7 +95,7 @@ void CollisionSceneFCLLatest::updateCollisionObjectTransforms()
 
 // This function was copied from 'moveit_core/collision_detection_fcl/src/collision_common.cpp'
 // https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_core/collision_detection_fcl/src/collision_common.cpp#L520
-std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclCollisionObject(std::shared_ptr<KinematicElement> element)
+std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclCollisionObject(int i, std::shared_ptr<KinematicElement> element)
 {
     // Maybe use cache here?
 
@@ -165,17 +166,17 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
             throw_pretty("This shape type (" << ((int)shape->type) << ") is not supported using FCL yet");
     }
     geometry->computeLocalAABB();
-    geometry->setUserData(reinterpret_cast<void*>(element.get()));
+    geometry->setUserData(reinterpret_cast<void*>(i));
     std::shared_ptr<fcl::CollisionObjectd> ret(new fcl::CollisionObjectd(geometry));
-    ret->setUserData(reinterpret_cast<void*>(element.get()));
+    ret->setUserData(reinterpret_cast<void*>(i));
 
     return ret;
 }
 
 bool CollisionSceneFCLLatest::isAllowedToCollide(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, bool self, CollisionSceneFCLLatest* scene)
 {
-    KinematicElement* e1 = reinterpret_cast<KinematicElement*>(o1->getUserData());
-    KinematicElement* e2 = reinterpret_cast<KinematicElement*>(o2->getUserData());
+    std::shared_ptr<KinematicElement> e1 = scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())];
+    std::shared_ptr<KinematicElement> e2 = scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())];
 
     bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink;
     bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink;
@@ -234,8 +235,8 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     fcl::distance(o1, o2, data->Request, data->Result);
 
     CollisionProxy p;
-    p.e1 = reinterpret_cast<KinematicElement*>(o1->getUserData());
-    p.e2 = reinterpret_cast<KinematicElement*>(o2->getUserData());
+    p.e1 = data->Scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())];
+    p.e2 = data->Scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())];
 
     p.distance = data->Result.min_distance;
     if (p.distance > 0)
@@ -311,7 +312,7 @@ bool CollisionSceneFCLLatest::isCollisionFree(const std::string& o1, const std::
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
-        KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
         if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
@@ -350,7 +351,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
-        KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
         if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
     }
@@ -380,7 +381,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     // object o1
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
-        KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1)
             shapes1.push_back(o);
     }
@@ -389,7 +390,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     // with
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
-        KinematicElement* e = reinterpret_cast<KinematicElement*>(o->getUserData());
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         // Collision Object does not belong to o1
         if (e->Segment.getName() != o1 || e->Parent->Segment.getName() != o1)
         {
@@ -421,7 +422,7 @@ Eigen::Vector3d CollisionSceneFCLLatest::getTranslation(const std::string& name)
 {
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (element->Segment.getName() == name)
         {
             return Eigen::Map<Eigen::Vector3d>(element->Frame.p.data);
@@ -436,7 +437,7 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionWorldLinks()
     std::vector<std::string> tmp;
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (!element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());
@@ -455,7 +456,7 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionRobotLinks()
     std::vector<std::string> tmp;
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
-        KinematicElement* element = reinterpret_cast<KinematicElement*>(object->getUserData());
+        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
         if (element->ClosestRobotLink)
         {
             tmp.push_back(element->Segment.getName());

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -31,7 +31,6 @@
  */
 
 #include <collision_scene_fcl_latest/CollisionSceneFCLLatest.h>
-#include <eigen_conversions/eigen_kdl.h>
 #include <exotica/Factory.h>
 
 REGISTER_COLLISION_SCENE_TYPE("CollisionSceneFCLLatest", exotica::CollisionSceneFCLLatest)

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -45,8 +45,8 @@ private:
 struct CollisionProxy
 {
     CollisionProxy() : e1(nullptr), e2(nullptr), distance(0) {}
-    KinematicElement* e1;
-    KinematicElement* e2;
+    std::shared_ptr<KinematicElement> e1;
+    std::shared_ptr<KinematicElement> e2;
     Eigen::Vector3d contact1;
     Eigen::Vector3d normal1;
     Eigen::Vector3d contact2;


### PR DESCRIPTION
As required for the smooth collision cost function, and also to disentangle the performance drop from the safe distance issue in #165. The move definitely results in some slight performance drop, as below. But nothing what we've seen when disabling safe distances for robots.

# Master

121 µs ± 270 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
26.6 µs ± 31.1 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
80.4 µs ± 164 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
26.6 µs ± 86.5 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# Shared Ptr

123 µs ± 433 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
28.7 µs ± 76.2 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
80.6 µs ± 66.6 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
28.5 µs ± 60.2 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

126 µs ± 2.62 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
29.8 µs ± 939 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
80.9 µs ± 168 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
29.1 µs ± 58.9 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
