### PR TITLE
Add link/object scale and padding to CollisionScene

### DIFF
--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -96,6 +96,27 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
     // Maybe use cache here?
 
     shapes::ShapeConstPtr shape = element->Shape;
+
+    // Apply scaling and padding
+    if (element->isRobotLink || element->ClosestRobotLink)
+    {
+        if (robotLinkScale_ != 1.0 || robotLinkPadding_ > 0.0)
+        {
+            shapes::ShapePtr scaled_shape(shape->clone());
+            scaled_shape->scaleAndPadd(robotLinkScale_, robotLinkPadding_);
+            shape = scaled_shape;
+        }
+    }
+    else
+    {
+        if (worldLinkScale_ != 1.0 || worldLinkPadding_ > 0.0)
+        {
+            shapes::ShapePtr scaled_shape(shape->clone());
+            scaled_shape->scaleAndPadd(worldLinkScale_, worldLinkPadding_);
+            shape = scaled_shape;
+        }
+    }
+
 #ifdef ROS_KINETIC
     std::shared_ptr<fcl::CollisionGeometry> geometry;
 #else

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -99,6 +99,27 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
     // Maybe use cache here?
 
     shapes::ShapeConstPtr shape = element->Shape;
+
+    // Apply scaling and padding
+    if (element->isRobotLink || element->ClosestRobotLink)
+    {
+        if (robotLinkScale_ != 1.0 || robotLinkPadding_ > 0.0)
+        {
+            shapes::ShapePtr scaled_shape(shape->clone());
+            scaled_shape->scaleAndPadd(robotLinkScale_, robotLinkPadding_);
+            shape = scaled_shape;
+        }
+    }
+    else
+    {
+        if (worldLinkScale_ != 1.0 || worldLinkPadding_ > 0.0)
+        {
+            shapes::ShapePtr scaled_shape(shape->clone());
+            scaled_shape->scaleAndPadd(worldLinkScale_, worldLinkPadding_);
+            shape = scaled_shape;
+        }
+    }
+
     std::shared_ptr<fcl::CollisionGeometryd> geometry;
     switch (shape->type)
     {

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -135,6 +135,34 @@ public:
         alwaysExternallyUpdatedCollisionScene_ = value;
     }
 
+    inline void setRobotLinkScale(const double& scale)
+    {
+        if (scale < 0.0)
+            throw_pretty("Link scaling needs to be greater than or equal to 0");
+        robotLinkScale_ = scale;
+    }
+
+    inline void setWorldLinkScale(const double& scale)
+    {
+        if (scale < 0.0)
+            throw_pretty("Link scaling needs to be greater than or equal to 0");
+        worldLinkScale_ = scale;
+    }
+
+    inline void setRobotLinkPadding(const double& padding)
+    {
+        if (padding < 0.0)
+            HIGHLIGHT_NAMED("setRobotLinkPadding", "Generally, padding should be positive.");
+        robotLinkPadding_ = padding;
+    }
+
+    inline void setWorldLinkPadding(const double& padding)
+    {
+        if (padding < 0.0)
+            HIGHLIGHT_NAMED("setRobotLinkPadding", "Generally, padding should be positive.");
+        worldLinkPadding_ = padding;
+    }
+
     ///
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
@@ -152,6 +180,18 @@ protected:
 
     /// Whether the collision scene is automatically updated - if not, update on queries
     bool alwaysExternallyUpdatedCollisionScene_ = false;
+
+    /// Robot link scaling
+    double robotLinkScale_ = 1.0;
+
+    /// World link scaling
+    double worldLinkScale_ = 1.0;
+
+    /// Robot link padding
+    double robotLinkPadding_ = 0.0;
+
+    /// World link padding
+    double worldLinkPadding_ = 0.0;
 };
 
 typedef exotica::Factory<exotica::CollisionScene> CollisionScene_fac;

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -130,11 +130,13 @@ public:
         acm_ = acm;
     }
 
+    inline bool getAlwaysExternallyUpdatedCollisionScene() { return alwaysExternallyUpdatedCollisionScene_; }
     inline void setAlwaysExternallyUpdatedCollisionScene(const bool& value)
     {
         alwaysExternallyUpdatedCollisionScene_ = value;
     }
 
+    inline double getRobotLinkScale() { return robotLinkScale_; }
     inline void setRobotLinkScale(const double& scale)
     {
         if (scale < 0.0)
@@ -142,6 +144,7 @@ public:
         robotLinkScale_ = scale;
     }
 
+    inline double getWorldLinkScale() { return worldLinkScale_; }
     inline void setWorldLinkScale(const double& scale)
     {
         if (scale < 0.0)
@@ -149,6 +152,7 @@ public:
         worldLinkScale_ = scale;
     }
 
+    inline double getRobotLinkPadding() { return robotLinkPadding_; }
     inline void setRobotLinkPadding(const double& padding)
     {
         if (padding < 0.0)
@@ -156,6 +160,7 @@ public:
         robotLinkPadding_ = padding;
     }
 
+    inline double getWorldLinkPadding() { return worldLinkPadding_; }
     inline void setWorldLinkPadding(const double& padding)
     {
         if (padding < 0.0)

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -121,6 +121,8 @@ public:
        */
     void updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
 
+    void updateCollisionObjects();
+
     BASE_TYPE getBaseType()
     {
         return BaseType;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -116,7 +116,7 @@ void Scene::Instantiate(SceneInitializer& init)
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
     updateSceneFrames();
-    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    updateCollisionObjects();
 
     AllowedCollisionMatrix acm;
     std::vector<std::string> acm_names;
@@ -271,13 +271,18 @@ void Scene::setCollisionScene(const moveit_msgs::PlanningScene& scene)
 {
     ps_->usePlanningSceneMsg(scene);
     updateSceneFrames();
-    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    updateCollisionObjects();
 }
 
 void Scene::updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world)
 {
     ps_->processPlanningSceneWorldMsg(*world);
     updateSceneFrames();
+    updateCollisionObjects();
+}
+
+void Scene::updateCollisionObjects()
+{
     collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
 }
 
@@ -371,7 +376,7 @@ void Scene::loadScene(const std::string& scene, bool updateCollisionScene)
     std::stringstream ss(scene);
     ps_->loadGeometryFromStream(ss);
     updateSceneFrames();
-    if (updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    if (updateCollisionScene) updateCollisionObjects();
 }
 
 void Scene::loadSceneFile(const std::string& file_name, bool updateCollisionScene)
@@ -379,7 +384,7 @@ void Scene::loadSceneFile(const std::string& file_name, bool updateCollisionScen
     std::ifstream ss(parsePath(file_name));
     ps_->loadGeometryFromStream(ss);
     updateSceneFrames();
-    if (updateCollisionScene) collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    if (updateCollisionScene) updateCollisionObjects();
 }
 
 std::string Scene::getScene()
@@ -393,7 +398,7 @@ void Scene::cleanScene()
 {
     ps_->removeAllCollisionObjects();
     updateSceneFrames();
-    collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
+    updateCollisionObjects();
 }
 
 void Scene::updateSceneFrames()
@@ -456,10 +461,7 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
     Eigen::Affine3d pose;
     tf::transformKDLToEigen(transform, pose);
     custom_links_.push_back(kinematica_.AddElement(name, pose, parent_name, shape, inertia));
-    if (updateCollisionScene)
-    {
-        collision_scene_->updateCollisionObjects(kinematica_.getCollisionTreeMap());
-    }
+    if (updateCollisionScene) updateCollisionObjects();
 }
 
 void Scene::attachObject(const std::string& name, const std::string& parent)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -626,6 +626,7 @@ PYBIND11_MODULE(_pyexotica, module)
                       new moveit_msgs::PlanningSceneWorld(world));
                   instance->updateWorld(myPtr);
               });
+    scene.def("updateCollisionObjects", &Scene::updateCollisionObjects);
     scene.def("getCollisionRobotLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionRobotLinks(); });
     scene.def("getCollisionWorldLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionWorldLinks(); });
     scene.def("getRootFrameName", &Scene::getRootFrameName);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -598,6 +598,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getGroupName", &Scene::getGroupName);
     scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) & Scene::getJointNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
+    scene.def("getCollisionScene", &Scene::getCollisionScene, py::return_value_policy::reference_internal);
     scene.def("getModelJointNames", &Scene::getModelJointNames);
     scene.def("getModelState", &Scene::getModelState);
     scene.def("getModelStateMap", &Scene::getModelStateMap);
@@ -644,6 +645,15 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("addTrajectory", (void (Scene::*)(const std::string&, const std::string&)) & Scene::addTrajectory);
     scene.def("getTrajectory", [](Scene* instance, const std::string& link) { return instance->getTrajectory(link)->toString(); });
     scene.def("removeTrajectory", &Scene::removeTrajectory);
+
+    py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
+    // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation
+    collisionScene.def_property("alwaysExternallyUpdatedCollisionScene", &CollisionScene::getAlwaysExternallyUpdatedCollisionScene, &CollisionScene::setAlwaysExternallyUpdatedCollisionScene);
+    collisionScene.def_property("robotLinkScale", &CollisionScene::getRobotLinkScale, &CollisionScene::setRobotLinkScale);
+    collisionScene.def_property("worldLinkScale", &CollisionScene::getWorldLinkScale, &CollisionScene::setWorldLinkScale);
+    collisionScene.def_property("robotLinkPadding", &CollisionScene::getRobotLinkPadding, &CollisionScene::setRobotLinkPadding);
+    collisionScene.def_property("worldLinkPadding", &CollisionScene::getWorldLinkPadding, &CollisionScene::setWorldLinkPadding);
+    collisionScene.def("updateCollisionObjectTransforms", &CollisionScene::updateCollisionObjectTransforms);
 
     py::module kin = module.def_submodule("Kinematics", "Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");


### PR DESCRIPTION
This is an alternative to disabling safe distance for robot links which has proven to be much, much more efficient.

E.g. on Valkyrie:

```
Info:    Exotica_Exotica_RRTConnect: Created 1340 states (1316 start + 24 goal)
Info:    Solution found in 6.344722 seconds
```
I.e. one valid state every 4.8ms vs 387ms in #165 

Resolves #165 