### PR TITLE
Add colour support for CollisionShapes and Scenes

### DIFF
--- a/exotica/include/exotica/KinematicElement.h
+++ b/exotica/include/exotica/KinematicElement.h
@@ -54,6 +54,7 @@ public:
     std::vector<double> JointLimits;
     shapes::ShapeConstPtr Shape;
     bool isRobotLink;
+    Eigen::Vector4d Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0);
 
 private:
     inline void setChildrenClosestRobotLink()

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -172,7 +172,8 @@ public:
     Eigen::MatrixXd Jacobian(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB);
 
     void resetModel();
-    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero());
+    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const std_msgs::ColorRGBA& colorMsg);
+    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);
 

--- a/exotica/include/exotica/Tools.h
+++ b/exotica/include/exotica/Tools.h
@@ -64,7 +64,7 @@ inline std_msgs::ColorRGBA getColor(double r, double g, double b, double a = 1.0
     ret.r = r;
     ret.g = g;
     ret.b = b;
-    ret.a = 1;
+    ret.a = a;
     return ret;
 }
 

--- a/exotica/include/exotica/Tools.h
+++ b/exotica/include/exotica/Tools.h
@@ -68,6 +68,16 @@ inline std_msgs::ColorRGBA getColor(double r, double g, double b, double a = 1.0
     return ret;
 }
 
+inline std_msgs::ColorRGBA getColor(Eigen::Vector4d rgba)
+{
+    std_msgs::ColorRGBA ret;
+    ret.r = rgba(0);
+    ret.g = rgba(1);
+    ret.b = rgba(2);
+    ret.a = rgba(3);
+    return ret;
+}
+
 /**
    * @brief loadOBJ Loads mesh data from an OBJ file
    * @param file_name File name

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -416,7 +416,10 @@ void Scene::updateSceneFrames()
             for (int i = 0; i < object.second->shape_poses_.size(); i++)
             {
                 Eigen::Affine3d trans = objTransform.inverse() * object.second->shape_poses_[i];
-                kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
+                if (ps_->hasObjectColor(object.first))
+                    kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i], ps_->getObjectColor(object.first));
+                else
+                    kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
             }
         }
         else


### PR DESCRIPTION
Adds colour support for collision objects that are published to the ``CollisionShapes`` topic. It works both for scenes set from MoveIt planning scene messages and the ``loadScene``/``loadSceneFile`` methods.