### PR TITLE
KinematicTree: Call UpdateTree in UpdateModel to fix #175

### DIFF
--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -296,6 +296,7 @@ void KinematicTree::UpdateModel()
         TreeMap[Joint->Segment.getName()] = Joint;
     }
     debugTree.resize(Tree.size() - 1);
+    UpdateTree();
     debugSceneChanged = true;
 }
 


### PR DESCRIPTION
After updating the model, the tree transforms where not being updated. The only way to fix this was to update the problem, thus updating the scene, thus updating the KinematicTree. This fix updates the tree very time the model is updated, e.g. upon adding or removing scene objects.

Fixes #175 