### PR TITLE
KinematicTree: Fix computation of Jacobians for frames with offsets

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -99,10 +99,10 @@ public:
 
 struct KinematicFrame
 {
-    std::shared_ptr<KinematicElement> FrameA = nullptr;
-    KDL::Frame FrameAOffset = KDL::Frame();
-    std::shared_ptr<KinematicElement> FrameB = nullptr;
-    KDL::Frame FrameBOffset = KDL::Frame();
+    std::shared_ptr<KinematicElement> FrameA;
+    KDL::Frame FrameAOffset;
+    std::shared_ptr<KinematicElement> FrameB;
+    KDL::Frame FrameBOffset;
     KDL::Frame TempAB;
     KDL::Frame TempA;
     KDL::Frame TempB;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -99,10 +99,10 @@ public:
 
 struct KinematicFrame
 {
-    std::shared_ptr<KinematicElement> FrameA;
-    KDL::Frame FrameAOffset;
-    std::shared_ptr<KinematicElement> FrameB;
-    KDL::Frame FrameBOffset;
+    std::shared_ptr<KinematicElement> FrameA = nullptr;
+    KDL::Frame FrameAOffset = KDL::Frame();
+    std::shared_ptr<KinematicElement> FrameB = nullptr;
+    KDL::Frame FrameBOffset = KDL::Frame();
     KDL::Frame TempAB;
     KDL::Frame TempA;
     KDL::Frame TempB;
@@ -194,7 +194,7 @@ private:
     void UpdateTree();
     void UpdateFK();
     void UpdateJ();
-    void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);
+    void ComputeJ(KinematicFrame& frame, KDL::Jacobian& J);
 
     BASE_TYPE ModelBaseType;
     BASE_TYPE ControlledBaseType = BASE_TYPE::FIXED;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -584,9 +584,10 @@ Eigen::MatrixXd KinematicTree::Jacobian(const std::string& elementA, const KDL::
     return Jacobian(A->second, offsetA, B->second, offsetB);
 }
 
-void KinematicTree::ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J)
+void KinematicTree::ComputeJ(KinematicFrame& frame, KDL::Jacobian& J)
 {
     J.data.setZero();
+    KDL::Frame tmp = FK(frame);  // Create temporary offset frames
     std::shared_ptr<KinematicElement> it = frame.FrameA;
     while (it != nullptr)
     {
@@ -614,7 +615,7 @@ void KinematicTree::ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J)
 void KinematicTree::UpdateJ()
 {
     int i = 0;
-    for (const KinematicFrame& frame : Solution->Frame)
+    for (KinematicFrame& frame : Solution->Frame)
     {
         ComputeJ(frame, Solution->J(i));
         i++;


### PR DESCRIPTION
The issue in #181 was caused by the temporary frames for the desired offsets (in-link/in-frame positions) not being created when computing Jacobians. This PR adds an explicit update of the internal temporary offset frames when computing Jacobians.

Fixes #181 