### PR TITLE
Optimisation problem improvements

### DIFF
--- a/examples/exotica_examples/resources/configs/ik_solver_demo.xml
+++ b/examples/exotica_examples/resources/configs/ik_solver_demo.xml
@@ -26,6 +26,8 @@
         </EndEffector>
       </EffFrame>
     </Maps>
+    <StartState>0 0 0 0 0 0 0</StartState>
+    <NominalState>0 0 0 0 0 0 0</NominalState>
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedEndPoseProblem>
 

--- a/examples/exotica_examples/resources/rviz-distance.rviz
+++ b/examples/exotica_examples/resources/rviz-distance.rviz
@@ -130,7 +130,7 @@ Visualization Manager:
   Global Options:
     Background Color: 48; 48; 48
     Fixed Frame: exotica/world_frame
-    Frame Rate: 100
+    Frame Rate: 30
   Name: root
   Tools:
     - Class: rviz/Interact
@@ -162,10 +162,10 @@ Visualization Manager:
         Z: 0.658301
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.484798
+      Pitch: 0.269798
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 1.64594
+      Yaw: 1.98094
     Saved: ~
 Window Geometry:
   Displays:

--- a/examples/exotica_examples/resources/rviz.rviz
+++ b/examples/exotica_examples/resources/rviz.rviz
@@ -114,14 +114,14 @@ Visualization Manager:
       Marker Topic: /exotica/CollisionShapes
       Name: SceneObjects
       Namespaces:
-        CollisionObjects: true
+        {}
       Queue Size: 100
       Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
     Fixed Frame: exotica/world_frame
-    Frame Rate: 100
+    Frame Rate: 30
   Name: root
   Tools:
     - Class: rviz/Interact

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -504,8 +504,8 @@ double AICOsolver::getTaskCosts(int t)
                 Jt = prob_->J[t].middleRows(start, len).transpose();
                 C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
-                r[t] += prec * Jt * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
-                rhat[t] += prec * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
+                r[t] += prec * Jt * (-prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
+                rhat[t] += prec * (-prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
             }
         }
     }
@@ -527,8 +527,8 @@ double AICOsolver::getTaskCosts(int t)
                 Jt = prob_->J[t].middleRows(start, len).transpose();
                 C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t].topLeftCorner(n2, n2) += prec * Jt * prob_->J[t].middleRows(start, len);
-                r[t].head(n2) += prec * Jt * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
-                rhat[t] += prec * (prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
+                r[t].head(n2) += prec * Jt * (-prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]);
+                rhat[t] += prec * (-prob_->ydiff[t].segment(start, len) + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
             }
         }
     }

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -164,7 +164,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
         ScaleToStepSize(qd);
 
-        q = q + qd * parameters_.Alpha;
+        q = q - qd * parameters_.Alpha;
 
         if (qd.norm() < parameters_.Convergence)
         {

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -141,15 +141,6 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
     bool UseNullspace = prob_->qNominal.rows() == prob_->N;
 
-    Eigen::MatrixXd S = Eigen::MatrixXd::Identity(prob_->JN, prob_->JN);
-    for (TaskMap_ptr task : prob_->getTasks())
-    {
-        for (int i = 0; i < task->Length; i++)
-        {
-            S(i + task->Start, i + task->Start) = prob_->Rho(task->Id);
-        }
-    }
-
     solution.resize(1, prob_->N);
 
     Eigen::VectorXd q = q0;
@@ -158,7 +149,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
     for (i = 0; i < parameters_.MaxIt; i++)
     {
         prob_->Update(q);
-        Eigen::VectorXd yd = S * (prob_->y - prob_->Phi);
+        Eigen::VectorXd yd = prob_->S * prob_->ydiff;
 
         error = yd.dot(yd);
 
@@ -167,9 +158,9 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
             break;
         }
 
-        Eigen::MatrixXd Jinv = PseudoInverse(S * prob_->J);
+        Eigen::MatrixXd Jinv = PseudoInverse(prob_->S * prob_->J);
         Eigen::VectorXd qd = Jinv * yd;
-        if (UseNullspace) qd += (Eigen::MatrixXd::Identity(prob_->N, prob_->N) - Jinv * S * prob_->J) * (prob_->qNominal - q);
+        if (UseNullspace) qd += (Eigen::MatrixXd::Identity(prob_->N, prob_->N) - Jinv * prob_->S * prob_->J) * (prob_->qNominal - q);
 
         ScaleToStepSize(qd);
 

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -160,7 +160,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
         Eigen::MatrixXd Jinv = PseudoInverse(prob_->S * prob_->J);
         Eigen::VectorXd qd = Jinv * yd;
-        if (UseNullspace) qd += (Eigen::MatrixXd::Identity(prob_->N, prob_->N) - Jinv * prob_->S * prob_->J) * (prob_->qNominal - q);
+        if (UseNullspace) qd += (Eigen::MatrixXd::Identity(prob_->N, prob_->N) - Jinv * prob_->S * prob_->J) * (q - prob_->qNominal);
 
         ScaleToStepSize(qd);
 

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -47,7 +47,6 @@ CoM::~CoM()
 void CoM::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != dim_) throw_named("Wrong size of phi!");
-    phi.setZero();
     double M = mass_.sum();
     if (M == 0.0) return;
 
@@ -82,7 +81,6 @@ void CoM::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::Matri
 {
     if (phi.rows() != dim_) throw_named("Wrong size of phi!");
     if (J.rows() != dim_ || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
-    phi.setZero();
     J.setZero();
     KDL::Vector com;
     double M = mass_.sum();

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -56,13 +56,19 @@ public:
     double getRho(const std::string& task_name);
     Eigen::VectorXd getNominalPose();
     void setNominalPose(Eigen::VectorXdRefConst qNominal_in);
+    virtual void preupdate();
+
+    double getScalarCost();
+    Eigen::VectorXd getScalarJacobian();
 
     Eigen::VectorXd Rho;
     TaskSpaceVector y;
+    Eigen::VectorXd ydiff;
     Eigen::MatrixXd W;
     TaskSpaceVector Phi;
     Eigen::MatrixXd J;
     Eigen::VectorXd qNominal;
+    Eigen::MatrixXd S;
 
     int PhiN;
     int JN;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -59,6 +59,10 @@ public:
     double getRho(const std::string& task_name, int t = 0);
     std::vector<Eigen::VectorXd> getInitialTrajectory();
     void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
+    virtual void preupdate();
+
+    double getScalarCost(int t);
+    Eigen::VectorXd getScalarJacobian(int t);
 
     int T;          //!< Number of time steps
     double tau;     //!< Time step duration
@@ -74,6 +78,7 @@ public:
     std::vector<TaskSpaceVector> Phi;
     std::vector<Eigen::VectorXd> ydiff;
     std::vector<Eigen::MatrixXd> J;
+    std::vector<Eigen::MatrixXd> S;
 
     int PhiN;
     int JN;

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -114,6 +114,8 @@ Eigen::VectorXd UnconstrainedEndPoseProblem::getScalarJacobian()
 void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x);
+    Phi.setZero(PhiN);
+    J.setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         if (Rho(i) != 0)

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -183,11 +183,27 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x, int t)
 
 double UnconstrainedTimeIndexedProblem::getScalarCost(int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     return ydiff[t].transpose()*S[t]*ydiff[t];
 }
 
 Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarJacobian(int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     return J[t].transpose()*S[t]*ydiff[t]*2.0;
 }
 

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -176,7 +176,7 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x, int t)
         if (Rho[t](i) != 0)
             Tasks[i]->update(x, Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
     }
-    ydiff[t] = y[t] - Phi[t];
+    ydiff[t] = Phi[t] - y[t];
 }
 
 double UnconstrainedTimeIndexedProblem::getScalarCost(int t)

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -122,7 +122,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
 void UnconstrainedTimeIndexedProblem::preupdate()
 {
     PlanningProblem::preupdate();
-    for(int t; t=0; t<T)
+    for(int t=0; t<T; t++)
     {
         for (TaskMap_ptr task : Tasks)
         {

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -170,6 +170,8 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x, int t)
     }
 
     scene_->Update(x, static_cast<double>(t) * tau);
+    Phi[t].setZero(PhiN);
+    J[t].setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         // Only update TaskMap if Rho is not 0

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -554,6 +554,8 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def_readonly("Phi", &UnconstrainedTimeIndexedProblem::Phi);
     unconstrainedTimeIndexedProblem.def_readonly("ydiff", &UnconstrainedTimeIndexedProblem::ydiff);
     unconstrainedTimeIndexedProblem.def_readonly("J", &UnconstrainedTimeIndexedProblem::J);
+    unconstrainedTimeIndexedProblem.def("getScalarCost", &UnconstrainedTimeIndexedProblem::getScalarCost);
+    unconstrainedTimeIndexedProblem.def("getScalarJacobian", &UnconstrainedTimeIndexedProblem::getScalarJacobian);
     py::class_<UnconstrainedEndPoseProblem, std::shared_ptr<UnconstrainedEndPoseProblem>, PlanningProblem> unconstrainedEndPoseProblem(prob, "UnconstrainedEndPoseProblem");
     unconstrainedEndPoseProblem.def("update", &UnconstrainedEndPoseProblem::Update);
     unconstrainedEndPoseProblem.def("setGoal", &UnconstrainedEndPoseProblem::setGoal);
@@ -570,6 +572,8 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedEndPoseProblem.def_readonly("Phi", &UnconstrainedEndPoseProblem::Phi);
     unconstrainedEndPoseProblem.def_readonly("J", &UnconstrainedEndPoseProblem::J);
     unconstrainedEndPoseProblem.def_property("qNominal", &UnconstrainedEndPoseProblem::getNominalPose, &UnconstrainedEndPoseProblem::setNominalPose);
+    unconstrainedEndPoseProblem.def("getScalarCost", &UnconstrainedEndPoseProblem::getScalarCost);
+    unconstrainedEndPoseProblem.def("getScalarJacobian", &UnconstrainedEndPoseProblem::getScalarJacobian);
     py::class_<SamplingProblem, std::shared_ptr<SamplingProblem>, PlanningProblem> samplingProblem(prob, "SamplingProblem");
     samplingProblem.def("update", &SamplingProblem::Update);
     samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);


### PR DESCRIPTION
- Seths RViz to 30FPS
- Resets Phi and Jacobian to zero before problem update (fixes NaN issues).
- Fixed pre-update callback in time-indexed problem. The call was not propagated correctly.
- Changed the sign on ```ydiff```. This didn't affect IK and AICO because they always computed the squared error (removing the sign).
- Moved setting up the S matrix into the problem(s) (diagonal matrix made out of Rho for each task).
- Added a scalar cost and scalar cost Jacobian methods for end-pose and time-indexed problems.