### PR TITLE
Fix of nearest contact points and work-around for primitive-vs-mesh collisions

### DIFF
--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -80,7 +80,7 @@ public:
     /**
        * \brief Check if the whole robot is valid (collision only).
        * @param self Indicate if self collision check is required.
-       * @return True, if the state is collision free..
+       * @return True, if the state is collision free.
        */
     virtual bool isStateValid(bool self = true, double safe_distance = 0.0);
     virtual bool isCollisionFree(const std::string& o1, const std::string& o2, double safe_distance = 0.0);
@@ -88,8 +88,7 @@ public:
     ///
     /// \brief Computes collision distances.
     /// \param self Indicate if self collision check is required.
-    /// \param computePenetrationDepth If set to true, accurate penetration depth is computed.
-    /// \return Collision proximity objectects for all colliding pairs of objects.
+    /// \return Collision proximity objects for all colliding pairs of objects.
     ///
     virtual std::vector<CollisionProxy> getCollisionDistance(bool self);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2);

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -57,7 +57,7 @@ public:
 
     struct DistanceData
     {
-        DistanceData(CollisionSceneFCLLatest* scene) : Scene(scene), Self(true), Distance{1e300} {}
+        DistanceData(CollisionSceneFCLLatest* scene) : Scene(scene), Self(true), Distance(1e300) {}
         fcl::DistanceRequestd Request;
         fcl::DistanceResultd Result;
         CollisionSceneFCLLatest* Scene;

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -250,9 +250,29 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     data->Request.enable_nearest_points = true;
     data->Request.enable_signed_distance = true;  // Added in FCL 0.6.0
     // GST_LIBCCD produces incorrect contacts. Probably due to incompatible version of libccd.
+    // However, FCL code comments suggest INDEP producing incorrect contact points, cf.
+    // https://github.com/flexible-collision-library/fcl/blob/master/test/test_fcl_signed_distance.cpp#L85-L86
+    // data->Request.gjk_solver_type = fcl::GST_LIBCCD;
     data->Request.gjk_solver_type = fcl::GST_INDEP;
     data->Result.clear();
-    fcl::distance(o1, o2, data->Request, data->Result);
+
+    // Nearest point calculation is broken when o1 is a primitive and o2 a mesh,
+    // works however for o1 being a mesh and o2 being a primitive. Due to this,
+    // we will flip the order of o1 and o2 in the request and then later on swap
+    // the contact points and normals.
+    // Cf. Issue #184:
+    // https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
+    bool flipO1AndO2 = false;
+    if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM && o2->getObjectType() == fcl::OBJECT_TYPE::OT_BVH)
+    {
+        // HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "Flipping o1 and o2");
+        flipO1AndO2 = true;
+        fcl::distance(o2, o1, data->Request, data->Result);
+    }
+    else
+    {
+        fcl::distance(o1, o2, data->Request, data->Result);
+    }
 
     CollisionProxy p;
     p.e1 = data->Scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())];
@@ -265,15 +285,51 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
         // for primitive shapes - thus, we need to work around this.
         // Cf. https://github.com/flexible-collision-library/fcl/issues/171
         KDL::Vector c1, c2;
-        if (p.e1->Shape->type == shapes::ShapeType::MESH)
-            c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-        else
-            c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
 
-        if (p.e2->Shape->type == shapes::ShapeType::MESH)
+        // Case 1: Mesh vs Mesh - already in world frame
+        if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+        {
+            c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
             c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        else
+        }
+        // Case 2: Primitive vs Primitive - convert from both local frames to world frame
+        else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+        {
+            c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
             c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        // Case 3: Primitive vs Mesh - primitive returned in flipped local frame (tbc), mesh returned in global frame
+        else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+        {
+            // Flipping contacts is a workaround for issue #184
+            // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
+            if (!flipO1AndO2)
+                throw_pretty("We got the broken case but aren't flipping, why?");
+            // Not e1 and e2 are swapped, i.e. c1 on e2, c2 on e1
+            c1 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+            c2 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        // Case 4: Mesh vs Primitive - both are returned in the local frame (works with both LIBCCD and INDEP)
+        else if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+        {
+            c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+            c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        // Unknown case - what's up?
+        else
+        {
+            throw_pretty("e1: " << p.e1->Shape->type << " vs e2: " << p.e2->Shape->type);
+        }
+
+        if (flipO1AndO2)
+        {
+            // Flipping contacts is a workaround for issue #184
+            // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
+            KDL::Vector tmp_c1 = KDL::Vector(c1);
+            KDL::Vector tmp_c2 = KDL::Vector(c2);
+            c1 = tmp_c2;
+            c2 = tmp_c1;
+        }
 
         KDL::Vector n1 = c2 - c1;
         KDL::Vector n2 = c1 - c2;

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -252,8 +252,17 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     // GST_LIBCCD produces incorrect contacts. Probably due to incompatible version of libccd.
     // However, FCL code comments suggest INDEP producing incorrect contact points, cf.
     // https://github.com/flexible-collision-library/fcl/blob/master/test/test_fcl_signed_distance.cpp#L85-L86
-    // data->Request.gjk_solver_type = fcl::GST_LIBCCD;
-    data->Request.gjk_solver_type = fcl::GST_INDEP;
+
+    // INDEP better for primitives, CCD better for when there's a mesh
+    if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM && o2->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM)
+    {
+        data->Request.gjk_solver_type = fcl::GST_INDEP;
+    }
+    else
+    {
+        data->Request.gjk_solver_type = fcl::GST_LIBCCD;
+    }
+
     data->Result.clear();
 
     // Nearest point calculation is broken when o1 is a primitive and o2 a mesh,
@@ -279,81 +288,99 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     p.e2 = data->Scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())];
 
     p.distance = data->Result.min_distance;
-    if (p.distance > 0)
-    {
-        // FCL uses world coordinates for meshes while local coordinates are used
-        // for primitive shapes - thus, we need to work around this.
-        // Cf. https://github.com/flexible-collision-library/fcl/issues/171
-        KDL::Vector c1, c2;
 
-        // Case 1: Mesh vs Mesh - already in world frame
-        if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
-        {
-            c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-            c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        }
-        // Case 2: Primitive vs Primitive - convert from both local frames to world frame
-        else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
-        {
-            c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-            c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        }
-        // Case 3: Primitive vs Mesh - primitive returned in flipped local frame (tbc), mesh returned in global frame
-        else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
-        {
-            // Flipping contacts is a workaround for issue #184
-            // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
-            if (!flipO1AndO2)
-                throw_pretty("We got the broken case but aren't flipping, why?");
-            // Not e1 and e2 are swapped, i.e. c1 on e2, c2 on e1
-            c1 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
-            c2 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
-        }
-        // Case 4: Mesh vs Primitive - both are returned in the local frame (works with both LIBCCD and INDEP)
-        else if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+    // FCL uses world coordinates for meshes while local coordinates are used
+    // for primitive shapes - thus, we need to work around this.
+    // Cf. https://github.com/flexible-collision-library/fcl/issues/171
+    //
+    // Additionally, when in penetration (distance < 0), for meshes, contact
+    // points are reasonably accurate. Contact points for primitives are not
+    // reliable (FCL bug), use shape centres instead.
+    KDL::Vector c1, c2;
+
+    // Case 1: Mesh vs Mesh - already in world frame
+    if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+    {
+        c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+        c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+    }
+    // Case 2: Primitive vs Primitive - convert from both local frames to world frame
+    else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+    {
+        // Use shape centres as nearest point when in penetration - otherwise use the nearest point.
+        if (p.distance > 0)
         {
             c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
             c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
         }
-        // Unknown case - what's up?
         else
         {
-            throw_pretty("e1: " << p.e1->Shape->type << " vs e2: " << p.e2->Shape->type);
+            c1 = p.e1->Frame.p;
+            c2 = p.e2->Frame.p;
         }
-
-        if (flipO1AndO2)
-        {
-            // Flipping contacts is a workaround for issue #184
-            // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
-            KDL::Vector tmp_c1 = KDL::Vector(c1);
-            KDL::Vector tmp_c2 = KDL::Vector(c2);
-            c1 = tmp_c2;
-            c2 = tmp_c1;
-        }
-
-        KDL::Vector n1 = c2 - c1;
-        KDL::Vector n2 = c1 - c2;
-        n1.Normalize();
-        n2.Normalize();
-        tf::vectorKDLToEigen(c1, p.contact1);
-        tf::vectorKDLToEigen(c2, p.contact2);
-        tf::vectorKDLToEigen(n1, p.normal1);
-        tf::vectorKDLToEigen(n2, p.normal2);
     }
+    // Case 3: Primitive vs Mesh - primitive returned in flipped local frame (tbc), mesh returned in global frame
+    else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+    {
+        // Flipping contacts is a workaround for issue #184
+        // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
+        if (!flipO1AndO2) throw_pretty("We got the broken case but aren't flipping, why?");
+
+        // Note: e1 and e2 are swapped, i.e. c1 on e2, c2 on e1
+        // e2 is a mesh, always fine
+        c1 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+
+        // e1 is a primitive, i.e. use shape centres as nearest point when in penetration
+        if (p.distance > 0)
+        {
+            c2 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        else
+        {
+            c2 = p.e1->Frame.p;
+        }
+    }
+    // Case 4: Mesh vs Primitive - both are returned in the local frame (works with both LIBCCD and INDEP)
+    else if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+    {
+        // e1 is mesh, i.e. nearest points are fine
+        c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
+
+        // e2 is a primitive, i.e. use shape centres as nearest point when in penetration
+        if (p.distance > 0)
+        {
+            c2 = p.e2->Frame * KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
+        }
+        else
+        {
+            c2 = p.e2->Frame.p;
+        }
+    }
+    // Unknown case - what's up?
     else
     {
-        // Contact points are not reliable (FCL bug), use shape centres instead.
-        KDL::Vector c1 = p.e1->Frame.p;
-        KDL::Vector c2 = p.e2->Frame.p;
-        KDL::Vector n1 = c2 - c1;
-        KDL::Vector n2 = c1 - c2;
-        n1.Normalize();
-        n2.Normalize();
-        tf::vectorKDLToEigen(c1, p.contact1);
-        tf::vectorKDLToEigen(c2, p.contact2);
-        tf::vectorKDLToEigen(n1, p.normal1);
-        tf::vectorKDLToEigen(n2, p.normal2);
+        throw_pretty("e1: " << p.e1->Shape->type << " vs e2: " << p.e2->Shape->type);
     }
+
+    if (flipO1AndO2)
+    {
+        // Flipping contacts is a workaround for issue #184
+        // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
+        KDL::Vector tmp_c1 = KDL::Vector(c1);
+        KDL::Vector tmp_c2 = KDL::Vector(c2);
+        c1 = tmp_c2;
+        c2 = tmp_c1;
+    }
+
+    KDL::Vector n1 = c2 - c1;
+    KDL::Vector n2 = c1 - c2;
+    n1.Normalize();
+    n2.Normalize();
+    tf::vectorKDLToEigen(c1, p.contact1);
+    tf::vectorKDLToEigen(c2, p.contact2);
+    tf::vectorKDLToEigen(n1, p.normal1);
+    tf::vectorKDLToEigen(n2, p.normal2);
+
     data->Distance = std::min(data->Distance, p.distance);
     data->Proxies.push_back(p);
 }

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -58,7 +58,7 @@ struct CollisionProxy
         std::stringstream ss;
         if (e1 && e2)
         {
-            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c1: " << contact2.transpose() << " d: " << distance;
+            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " d: " << distance;
         }
         else
         {


### PR DESCRIPTION
- Splits the collision types into four pairs and fixes contact points for each of the four cases.
- As highlighted in #184, primitive-vs-mesh can't be fixed right now. Thus, a work-around flipping the order internally to mesh-vs-primitive and changing return values is implemented. 
- Validated with both LIBCCD and INDEP for primitive-sphere vs mesh-sphere and mesh-cube.

However, while this works fine for the simple use cases it doesn't yet work with the more complex meshes used for experiments.

Resolves #184 