### PR TITLE
CollisionScene updates from latest work

### DIFF
--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -93,6 +93,7 @@ public:
     virtual std::vector<CollisionProxy> getCollisionDistance(bool self);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1);
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects);
 
     /**
        * @brief      Gets the collision world links.

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -92,8 +92,8 @@ public:
     ///
     virtual std::vector<CollisionProxy> getCollisionDistance(bool self);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2);
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, bool disableCollisionSceneUpdate = false);
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects);
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self = true, const bool& disableCollisionSceneUpdate = false);
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects, const bool& self = true);
 
     /**
        * @brief      Gets the collision world links.

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -92,7 +92,7 @@ public:
     ///
     virtual std::vector<CollisionProxy> getCollisionDistance(bool self);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2);
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self = true, const bool& disableCollisionSceneUpdate = false);
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self = true);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects, const bool& self = true);
 
     /**
@@ -126,6 +126,8 @@ private:
     std::shared_ptr<fcl::CollisionObjectd> constructFclCollisionObject(long i, std::shared_ptr<KinematicElement> element);
     static void checkCollision(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, CollisionData* data);
     static void computeDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, DistanceData* data);
+
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self = true, const bool& disableCollisionSceneUpdate = false);
 
     std::map<std::string, std::shared_ptr<fcl::CollisionObjectd>> fcl_cache_;
     std::vector<fcl::CollisionObjectd*> fcl_objects_;

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -92,7 +92,7 @@ public:
     ///
     virtual std::vector<CollisionProxy> getCollisionDistance(bool self);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const std::string& o2);
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1);
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, bool disableCollisionSceneUpdate = false);
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects);
 
     /**

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -521,6 +521,17 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     return data.Proxies;
 }
 
+std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const std::vector<std::string>& objects)
+{
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
+    std::vector<CollisionProxy> proxies;
+    for (const auto& o1 : objects)
+        appendVector(proxies, getCollisionDistance(o1));
+
+    return proxies;
+}
+
 Eigen::Vector3d CollisionSceneFCLLatest::getTranslation(const std::string& name)
 {
     for (fcl::CollisionObjectd* object : fcl_objects_)

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -472,13 +472,14 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
 }
 
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
-    const std::string& o1, bool disableCollisionSceneUpdate)
+    const std::string& o1, const bool& self, const bool& disableCollisionSceneUpdate)
 {
     if (!alwaysExternallyUpdatedCollisionScene_ && !disableCollisionSceneUpdate) updateCollisionObjectTransforms();
 
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     DistanceData data(this);
+    data.Self = self;
 
     // Iterate over all fcl_objects_ to find all collision links that belong to
     // object o1
@@ -521,13 +522,13 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     return data.Proxies;
 }
 
-std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const std::vector<std::string>& objects)
+std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const std::vector<std::string>& objects, const bool& self)
 {
     if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
 
     std::vector<CollisionProxy> proxies;
     for (const auto& o1 : objects)
-        appendVector(proxies, getCollisionDistance(o1, true));
+        appendVector(proxies, getCollisionDistance(o1, self, true));
 
     return proxies;
 }

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -471,6 +471,11 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
     return data.Proxies;
 }
 
+std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const std::string& o1, const bool& self)
+{
+    return getCollisionDistance(o1, self, false);
+}
+
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     const std::string& o1, const bool& self, const bool& disableCollisionSceneUpdate)
 {

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -472,9 +472,9 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
 }
 
 std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
-    const std::string& o1)
+    const std::string& o1, bool disableCollisionSceneUpdate)
 {
-    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+    if (!alwaysExternallyUpdatedCollisionScene_ && !disableCollisionSceneUpdate) updateCollisionObjectTransforms();
 
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
@@ -527,7 +527,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
 
     std::vector<CollisionProxy> proxies;
     for (const auto& o1 : objects)
-        appendVector(proxies, getCollisionDistance(o1));
+        appendVector(proxies, getCollisionDistance(o1, true));
 
     return proxies;
 }

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(exotica)
 
 set(MSG_DEPS
@@ -19,8 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
   ${MSG_DEPS}
 )
-
-find_package(Boost REQUIRED COMPONENTS python signals)
+find_package(Boost REQUIRED COMPONENTS signals)
 
 set(MSG_FILES
   MeshVertex.msg

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -58,7 +58,7 @@ struct CollisionProxy
         std::stringstream ss;
         if (e1 && e2)
         {
-            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " d: " << distance;
+            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " n1: " << normal1.transpose() << " n2: " << normal2.transpose() << " d: " << distance;
         }
         else
         {

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -110,14 +110,14 @@ public:
    * @param[in]  o1    Name of object 1.
    * @return     Vector of proximity objects.
    */
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1) { throw_pretty("Not implemented!"); }
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self) { throw_pretty("Not implemented!"); }
     /**
    * @brief      Gets the closest distance of any collision object which is
    * allowed to collide with any collision object related to any of the objects.
    * @param[in]  objects    Vector of object names.
    * @return     Vector of proximity objects.
    */
-    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects) { throw_pretty("Not implemented!"); }
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects, const bool& self) { throw_pretty("Not implemented!"); }
     /**
        * @brief      Gets the collision world links.
        * @return     The collision world links.

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -112,6 +112,13 @@ public:
    */
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1) { throw_pretty("Not implemented!"); }
     /**
+   * @brief      Gets the closest distance of any collision object which is
+   * allowed to collide with any collision object related to any of the objects.
+   * @param[in]  objects    Vector of object names.
+   * @return     Vector of proximity objects.
+   */
+    virtual std::vector<CollisionProxy> getCollisionDistance(const std::vector<std::string>& objects) { throw_pretty("Not implemented!"); }
+    /**
        * @brief      Gets the collision world links.
        * @return     The collision world links.
        */

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -159,10 +159,18 @@ public:
     {
         return ControlledJointsNames;
     }
+    std::vector<std::string> getControlledLinkNames()
+    {
+        return ControlledLinkNames;
+    }
 
     std::vector<std::string> getModelJointNames()
     {
         return ModelJointsNames;
+    }
+    std::vector<std::string> getModelLinkNames()
+    {
+        return ControlledLinkNames;
     }
 
     Eigen::VectorXd getControlledLinkMass();
@@ -216,6 +224,8 @@ private:
     std::map<std::string, std::shared_ptr<KinematicElement>> ModelJointsMap;
     std::vector<std::string> ModelJointsNames;
     std::vector<std::string> ControlledJointsNames;
+    std::vector<std::string> ModelLinkNames;
+    std::vector<std::string> ControlledLinkNames;
     std::shared_ptr<KinematicResponse> Solution;
     KinematicRequestFlags Flags;
 

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -170,7 +170,7 @@ public:
     }
     std::vector<std::string> getModelLinkNames()
     {
-        return ControlledLinkNames;
+        return ModelLinkNames;
     }
 
     Eigen::VectorXd getControlledLinkMass();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -198,6 +198,8 @@ public:
     std::map<std::string, std::shared_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
     bool Debug;
 
+    std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();
+
 private:
     void BuildTree(const KDL::Tree& RobotKinematics);
     void AddElement(KDL::SegmentMap::const_iterator segment, std::shared_ptr<KinematicElement> parent);

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -182,7 +182,6 @@ public:
     Eigen::MatrixXd Jacobian(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB);
 
     void resetModel();
-    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const std_msgs::ColorRGBA& colorMsg);
     std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -76,8 +76,10 @@ public:
     void getJointNames(std::vector<std::string>& joints);
     std::vector<std::string> getJointNames();
     std::vector<std::string> getModelJointNames();
-    Eigen::VectorXd getModelState();
+    std::vector<std::string> getControlledLinkNames();
+    std::vector<std::string> getModelLinkNames();
     Eigen::VectorXd getControlledState();
+    Eigen::VectorXd getModelState();
     std::map<std::string, double> getModelStateMap();
     void setModelState(Eigen::VectorXdRefConst x, double t = 0);
     void setModelState(std::map<std::string, double> x, double t = 0);

--- a/exotica/package.xml
+++ b/exotica/package.xml
@@ -6,6 +6,7 @@
 
   <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
   <maintainer email="yiming.yang@ed.ac.uk">Yiming Yang</maintainer>
+  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
   <author email="mcamnadur@gmail.com">Michael Camilleri</author>
   <author email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</author>
 

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -818,4 +818,14 @@ Eigen::VectorXd KinematicTree::getControlledLinkMass()
     }
     return x;
 }
+
+std::map<std::string, shapes::ShapeType> KinematicTree::getCollisionObjectTypes()
+{
+    std::map<std::string, shapes::ShapeType> ret;
+    for (const auto& element : CollisionTreeMap)
+    {
+        ret[element.second->Segment.getName()] = element.second->Shape->type;
+    }
+    return ret;
+}
 }

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -357,12 +357,6 @@ void KinematicTree::changeParent(const std::string& name, const std::string& par
     debugSceneChanged = true;
 }
 
-std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const std_msgs::ColorRGBA& colorMsg)
-{
-    Eigen::Vector4d color = Eigen::Vector4d(colorMsg.r, colorMsg.g, colorMsg.b, colorMsg.a);
-    AddElement(name, transform, parent, shape, KDL::RigidBodyInertia::Zero(), color);
-}
-
 std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color)
 {
     std::shared_ptr<KinematicElement> parent_element;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -136,6 +136,8 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
     Tree.clear();
     TreeMap.clear();
     ModelJointsMap.clear();
+    ModelLinkNames.clear();
+    ControlledLinkNames.clear();
 
     // Handle the root joint
     const robot_model::JointModel* RootJoint = Model->getRootJoint();
@@ -263,11 +265,13 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
         Joint->isRobotLink = true;
         Joint->ControlId = IsControlled(Joint);
         Joint->IsControlled = Joint->ControlId >= 0;
-        if (Joint->IsControlled) ControlledJoints[Joint->ControlId] = Joint;
         ModelJointsMap[Joint->Segment.getJoint().getName()] = Joint;
+        ModelLinkNames.push_back(Joint->Segment.getName());
         if (Joint->IsControlled)
         {
+            ControlledJoints[Joint->ControlId] = Joint;
             ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
+            ControlledLinkNames.push_back(Joint->Segment.getName());
 
             // The ModelBaseType defined above refers to the base type of the
             // overall robot model - not of the set of controlled joints. E.g. a

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -437,9 +437,15 @@ void Scene::updateSceneFrames()
             {
                 Eigen::Affine3d trans = objTransform.inverse() * object.second->shape_poses_[i];
                 if (ps_->hasObjectColor(object.first))
-                    kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i], ps_->getObjectColor(object.first));
+                {
+                    auto colorMsg = ps_->getObjectColor(object.first);
+                    Eigen::Vector4d color = Eigen::Vector4d(colorMsg.r, colorMsg.g, colorMsg.b, colorMsg.a);
+                    kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i], KDL::RigidBodyInertia::Zero(), color);
+                }
                 else
+                {
                     kinematica_.AddElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
+                }
             }
         }
         else

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -336,6 +336,16 @@ std::vector<std::string> Scene::getJointNames()
     return kinematica_.getJointNames();
 }
 
+std::vector<std::string> Scene::getControlledLinkNames()
+{
+    return kinematica_.getControlledLinkNames();
+}
+
+std::vector<std::string> Scene::getModelLinkNames()
+{
+    return kinematica_.getModelLinkNames();
+}
+
 std::vector<std::string> Scene::getModelJointNames()
 {
     return kinematica_.getModelJointNames();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -692,6 +692,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getModelBaseType", &KinematicTree::getModelBaseType);
     kinematicTree.def("getControlledBaseType", &KinematicTree::getControlledBaseType);
     kinematicTree.def("getControlledLinkMass", &KinematicTree::getControlledLinkMass);
+    kinematicTree.def("getCollisionObjectTypes", &KinematicTree::getCollisionObjectTypes);
 
     py::class_<KDL::Frame> kdlFrame(module, "KDLFrame");
     kdlFrame.def(py::init());
@@ -709,6 +710,16 @@ PYBIND11_MODULE(_pyexotica, module)
     kdlFrame.def("__mul__", [](const KDL::Frame& A, const KDL::Frame& B) { return A * B; }, py::is_operator());
     py::implicitly_convertible<Eigen::MatrixXd, KDL::Frame>();
     py::implicitly_convertible<Eigen::VectorXd, KDL::Frame>();
+
+    py::enum_<shapes::ShapeType>(module, "ShapeType")
+        .value("UnknownShape", shapes::ShapeType::UNKNOWN_SHAPE)
+        .value("Sphere", shapes::ShapeType::SPHERE)
+        .value("Cylinder", shapes::ShapeType::CYLINDER)
+        .value("Cone", shapes::ShapeType::CONE)
+        .value("Box", shapes::ShapeType::BOX)
+        .value("Plane", shapes::ShapeType::PLANE)
+        .value("Mesh", shapes::ShapeType::MESH)
+        .value("Octree", shapes::ShapeType::OCTREE);
 
     module.attr("version") = version();
     module.attr("branch") = branch();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -615,6 +615,8 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getBaseType", &Scene::getBaseType);
     scene.def("getGroupName", &Scene::getGroupName);
     scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) & Scene::getJointNames);
+    scene.def("getControlledLinkNames", &Scene::getControlledLinkNames);
+    scene.def("getModelLinkNames", &Scene::getModelLinkNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
     scene.def("getCollisionScene", &Scene::getCollisionScene, py::return_value_policy::reference_internal);
     scene.def("getModelJointNames", &Scene::getModelJointNames);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -637,15 +637,15 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getCollisionDistance", [](Scene* instance, bool self) { return instance->getCollisionScene()->getCollisionDistance(self); }, py::arg("self") = true);
     scene.def("getCollisionDistance", [](Scene* instance, const std::string& o1, const std::string& o2) { return instance->getCollisionScene()->getCollisionDistance(o1, o2); }, py::arg("Object1"), py::arg("Object2"));
     scene.def("getCollisionDistance",
-              [](Scene* instance, const std::string& o1) {
-                  return instance->getCollisionScene()->getCollisionDistance(o1);
+              [](Scene* instance, const std::string& o1, const bool& self) {
+                  return instance->getCollisionScene()->getCollisionDistance(o1, self);
               },
-              py::arg("Object1"));
+              py::arg("Object1"), py::arg("self") = true);
     scene.def("getCollisionDistance",
-              [](Scene* instance, const std::vector<std::string>& objects) {
-                  return instance->getCollisionScene()->getCollisionDistance(objects);
+              [](Scene* instance, const std::vector<std::string>& objects, const bool& self) {
+                  return instance->getCollisionScene()->getCollisionDistance(objects, self);
               },
-              py::arg("Objects"));
+              py::arg("objects"), py::arg("self") = true);
     scene.def("updateWorld",
               [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
                   moveit_msgs::PlanningSceneWorldConstPtr myPtr(

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -641,6 +641,11 @@ PYBIND11_MODULE(_pyexotica, module)
                   return instance->getCollisionScene()->getCollisionDistance(o1);
               },
               py::arg("Object1"));
+    scene.def("getCollisionDistance",
+              [](Scene* instance, const std::vector<std::string>& objects) {
+                  return instance->getCollisionScene()->getCollisionDistance(objects);
+              },
+              py::arg("Objects"));
     scene.def("updateWorld",
               [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
                   moveit_msgs::PlanningSceneWorldConstPtr myPtr(


### PR DESCRIPTION
Many updates from recent work, including:

1. More overloads to get collision distances between objects
2. Methods to retrieve the name of all controlled and model links
3. The ability to query all collision objects and their type (primitive shape vs mesh) in the scene
4. More debugging for CollisionScene (towards verifying contact/penetration points and normals vs paper calculations)
5. A bugfix for a segfault when assigning the colour of collision objects