### PR TITLE
Fix TimeIndexedRRTConnect on Kinetic

### DIFF
--- a/exotations/solvers/time_indexed_rrt_connect/CMakeLists.txt
+++ b/exotations/solvers/time_indexed_rrt_connect/CMakeLists.txt
@@ -7,6 +7,10 @@ find_package(catkin REQUIRED COMPONENTS
   exotica
 )
 
+if($ENV{ROS_DISTRO} MATCHES "(kinetic|lunar)")
+  add_definitions(-DROS_KINETIC)
+endif()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES time_indexed_rrt_connect

--- a/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
+++ b/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
@@ -34,6 +34,8 @@
 #ifndef TIME_INDEXED_RRT_CONNECT_TIMEINDEXEDRRTCONNECT_H_
 #define TIME_INDEXED_RRT_CONNECT_TIMEINDEXEDRRTCONNECT_H_
 
+#include <memory>
+
 #include <exotica/Problems/TimeIndexedSamplingProblem.h>
 #include <ompl/base/SpaceInformation.h>
 #include <ompl/base/StateSpace.h>

--- a/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
+++ b/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
@@ -205,7 +205,7 @@ protected:
     };
 
     /** \brief A nearest-neighbor datastructure representing a tree of motions */
-    typedef boost::shared_ptr<NearestNeighbors<Motion *> > TreeData;
+    typedef std::shared_ptr<NearestNeighbors<Motion *> > TreeData;
 
     /** \brief Information attached to growing a tree of motions (used internally) */
     struct TreeGrowingInfo

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -283,10 +283,17 @@ void OMPLTimeIndexedRRTConnect::setup()
     tools::SelfConfig sc(si_, getName());
     sc.configurePlannerRange(maxDistance_);
 
+#ifdef ROS_KINETIC
+    if (!tStart_)
+        tStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
+    if (!tGoal_)
+        tGoal_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
+#else
     if (!tStart_)
         tStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(si_->getStateSpace()));
     if (!tGoal_)
         tGoal_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(si_->getStateSpace()));
+#endif
     tStart_->setDistanceFunction(boost::bind(&OMPLTimeIndexedRRTConnect::reverseTimeDistance, this, _1, _2));
     tGoal_->setDistanceFunction(boost::bind(&OMPLTimeIndexedRRTConnect::forwardTimeDistance, this, _1, _2));
 }


### PR DESCRIPTION
The underlying OMPL API changed and the ROS_KINETIC definition wasn't set.