### PR TITLE
UnconstrainedTimeIndexedProblem: Move cost computation to problem, normalise trajectory cost to compare solvers

### DIFF
--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -174,7 +174,7 @@ private:
     std::vector<Eigen::VectorXd> q;      //!< Configuration space trajectory
     std::vector<Eigen::VectorXd> qhat;   //!< Point of linearisation
     Eigen::VectorXd costControl;         //!< Control cost for each time step
-    Eigen::MatrixXd costTask;            //!< Task cost for each task for each time step
+    Eigen::VectorXd costTask;            //!< Task cost for each task for each time step
     std::vector<std::string> taskNames;  //!< Task names (only used for printing debug info)
 
     std::vector<Eigen::VectorXd> phiBar_old;  //!< Task cost mappings (last most optimal value)

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -135,7 +135,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     prob_->applyStartState();
 
     Timer timer;
-    ROS_WARN_STREAM("AICO: Setting up the solver");
+    if (debug_) ROS_WARN_STREAM("AICO: Setting up the solver");
     updateCount = 0;
     sweep = -1;
     damping = damping_init;
@@ -146,7 +146,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     }
     initTrajectory(q_init);
     sweep = 0;
-    ROS_WARN_STREAM("AICO: Solving");
+    if (debug_) ROS_WARN_STREAM("AICO: Solving");
     for (int k = 0; k < max_iterations && !(Server::isRos() && !ros::ok()); k++)
     {
         d = step();
@@ -584,7 +584,7 @@ void AICOsolver::updateTimeStepGaussNewton(int t, bool updateFwd,
 double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
                                       bool skipUpdate)
 {
-    ROS_WARN_STREAM("Evaluating, sweep " << sweep);
+    if (debug_) ROS_WARN_STREAM("Evaluating, sweep " << sweep);
     Timer timer;
     double dSet, dPre, dUpd, dCtrl, dTask;
     // double tau = prob_->tau;
@@ -604,7 +604,7 @@ double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
     dSet = timer.getDuration();
     if (preupdateTrajectory_)
     {
-        ROS_WARN_STREAM("Pre-update, sweep " << sweep);
+        if (debug_) ROS_WARN_STREAM("Pre-update, sweep " << sweep);
         for (int t = 0; t < T; t++)
         {
             if (Server::isRos() && !ros::ok()) return -1.0;
@@ -722,7 +722,7 @@ double AICOsolver::step()
     // q is set inside of evaluateTrajectory() function
     cost = evaluateTrajectory(b);
     prob_->setCostEvolution(sweep, cost);
-    HIGHLIGHT("Sweep: " << sweep << ", updates: " << updateCount << ", cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << " (dq=" << b_step << ", damping=" << damping << ")");
+    if (debug_) HIGHLIGHT("Sweep: " << sweep << ", updates: " << updateCount << ", cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << " (dq=" << b_step << ", damping=" << damping << ")");
     if (cost < 0) return -1.0;
 
     if (sweep && damping) perhapsUndoStep();

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -496,8 +496,8 @@ double AICOsolver::getTaskCosts(int t)
             prec = prob_->Rho[t](i);
             if (prec > 0)
             {
-                int start = prob_->getTasks()[i]->StartJ;
-                int len = prob_->getTasks()[i]->LengthJ;
+                int& start = prob_->getTasks()[i]->StartJ;
+                int& len = prob_->getTasks()[i]->LengthJ;
                 Jt = prob_->J[t].middleRows(start, len).transpose();
                 C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
@@ -519,8 +519,8 @@ double AICOsolver::getTaskCosts(int t)
             prec = prob_->Rho[t](i);
             if (prec > 0)
             {
-                int start = prob_->getTasks()[i]->StartJ;
-                int len = prob_->getTasks()[i]->LengthJ;
+                int& start = prob_->getTasks()[i]->StartJ;
+                int& len = prob_->getTasks()[i]->LengthJ;
                 Jt = prob_->J[t].middleRows(start, len).transpose();
                 C += prec * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t].topLeftCorner(n2, n2) += prec * Jt * prob_->J[t].middleRows(start, len);
@@ -529,7 +529,7 @@ double AICOsolver::getTaskCosts(int t)
             }
         }
     }
-    return C;
+    return prob_->ct * C;
 }
 
 void AICOsolver::updateTimeStep(int t, bool updateFwd, bool updateBwd,

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -70,8 +70,25 @@ public:
     unsigned int getNumberOfProblemUpdates() { return numberOfProblemUpdates; }
     void resetNumberOfProblemUpdates() { numberOfProblemUpdates = 0; }
     std::vector<double> getCostEvolution() { return costEvolution; }
+    double getCostEvolution(int index) {
+        if (index > -1 && index < costEvolution.size()) {
+            return costEvolution[index];
+        } else if (index == -1) {
+            return costEvolution[costEvolution.size() - 1];
+        } else {
+            throw_pretty("Out of range");
+        }
+    }
     void resetCostEvolution(unsigned int size) { costEvolution.resize(size, NAN); }
-    void setCostEvolution(unsigned int index, double value) { costEvolution[index] = value; }
+    void setCostEvolution(int index, double value) {
+        if (index > -1 && index < costEvolution.size()) {
+            costEvolution[index] = value;
+        } else if (index == -1) {
+            costEvolution[costEvolution.size() - 1] = value;
+        } else {
+            throw_pretty("Out of range: " << index << " where length=" << costEvolution.size());
+        }
+    }
 protected:
     Scene_ptr scene_;
     TaskMap_map TaskMaps;

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -41,6 +41,8 @@
 #include <exotica/TaskSpaceVector.h>
 #include <exotica/Tools.h>
 
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -69,26 +71,11 @@ public:
     virtual void preupdate();
     unsigned int getNumberOfProblemUpdates() { return numberOfProblemUpdates; }
     void resetNumberOfProblemUpdates() { numberOfProblemUpdates = 0; }
-    std::vector<double> getCostEvolution() { return costEvolution; }
-    double getCostEvolution(int index) {
-        if (index > -1 && index < costEvolution.size()) {
-            return costEvolution[index];
-        } else if (index == -1) {
-            return costEvolution[costEvolution.size() - 1];
-        } else {
-            throw_pretty("Out of range");
-        }
-    }
-    void resetCostEvolution(unsigned int size) { costEvolution.resize(size, NAN); }
-    void setCostEvolution(int index, double value) {
-        if (index > -1 && index < costEvolution.size()) {
-            costEvolution[index] = value;
-        } else if (index == -1) {
-            costEvolution[costEvolution.size() - 1] = value;
-        } else {
-            throw_pretty("Out of range: " << index << " where length=" << costEvolution.size());
-        }
-    }
+    std::vector<double> getCostEvolution();
+    double getCostEvolution(int index);
+    void resetCostEvolution(unsigned int size);
+    void setCostEvolution(int index, double value);
+
 protected:
     Scene_ptr scene_;
     TaskMap_map TaskMaps;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -52,7 +52,7 @@ public:
     virtual ~UnconstrainedTimeIndexedProblem();
     virtual void Instantiate(UnconstrainedTimeIndexedProblemInitializer& init);
     double getDuration();
-    void Update(Eigen::VectorXdRefConst x, int t);
+    void Update(Eigen::VectorXdRefConst x_in, int t);
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t = 0);
     void setRho(const std::string& task_name, const double rho, int t = 0);
     Eigen::VectorXd getGoal(const std::string& task_name, int t = 0);
@@ -61,8 +61,10 @@ public:
     void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
     virtual void preupdate();
 
-    double getScalarCost(int t);
-    Eigen::VectorXd getScalarJacobian(int t);
+    double getScalarTaskCost(int t);
+    Eigen::VectorXd getScalarTaskJacobian(int t);
+    double getScalarTransitionCost(int t);
+    Eigen::VectorXd getScalarTransitionJacobian(int t);
 
     int T;          //!< Number of time steps
     double tau;     //!< Time step duration
@@ -80,12 +82,16 @@ public:
     std::vector<Eigen::MatrixXd> J;
     std::vector<Eigen::MatrixXd> S;
 
+    std::vector<Eigen::VectorXd> x;  // current internal problem state
+    std::vector<Eigen::VectorXd> xdiff;  // equivalent to dx = x(t)-x(t-1)
+
     int PhiN;
     int JN;
     int NumTasks;
 
 private:
     std::vector<Eigen::VectorXd> InitialTrajectory;
+    double ct;      //!< Normalisation of scalar cost and Jacobian over trajectory length
 };
 
 typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -68,6 +68,7 @@ public:
 
     int T;          //!< Number of time steps
     double tau;     //!< Time step duration
+    double ct;      //!< Normalisation of scalar cost and Jacobian over trajectory length
     double Q_rate;  //!< System transition error covariance multipler (per unit time) (constant throughout the trajectory)
     double H_rate;  //!< Control error covariance multipler (per unit time) (constant throughout the trajectory)
     double W_rate;  //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)
@@ -82,7 +83,7 @@ public:
     std::vector<Eigen::MatrixXd> J;
     std::vector<Eigen::MatrixXd> S;
 
-    std::vector<Eigen::VectorXd> x;  // current internal problem state
+    std::vector<Eigen::VectorXd> x;      // current internal problem state
     std::vector<Eigen::VectorXd> xdiff;  // equivalent to dx = x(t)-x(t-1)
 
     int PhiN;
@@ -91,7 +92,6 @@ public:
 
 private:
     std::vector<Eigen::VectorXd> InitialTrajectory;
-    double ct;      //!< Normalisation of scalar cost and Jacobian over trajectory length
 };
 
 typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -179,4 +179,52 @@ Scene_ptr PlanningProblem::getScene()
 {
     return scene_;
 }
+
+std::vector<double> PlanningProblem::getCostEvolution()
+{
+    // Find first NAN and resize vector
+    size_t position = 0;
+    for (position = 0; position < costEvolution.size(); position++)
+        if (std::isnan(costEvolution[position])) break;
+    costEvolution.resize(position);
+    return costEvolution;
+}
+
+double PlanningProblem::getCostEvolution(int index)
+{
+    if (index > -1 && index < costEvolution.size())
+    {
+        return costEvolution[index];
+    }
+    else if (index == -1)
+    {
+        return costEvolution[costEvolution.size() - 1];
+    }
+    else
+    {
+        throw_pretty("Out of range");
+    }
+}
+
+void PlanningProblem::resetCostEvolution(unsigned int size)
+{
+    costEvolution.resize(size);
+    costEvolution.assign(size, std::numeric_limits<double>::quiet_NaN());
+}
+
+void PlanningProblem::setCostEvolution(int index, double value)
+{
+    if (index > -1 && index < costEvolution.size())
+    {
+        costEvolution[index] = value;
+    }
+    else if (index == -1)
+    {
+        costEvolution[costEvolution.size() - 1] = value;
+    }
+    else
+    {
+        throw_pretty("Out of range: " << index << " where length=" << costEvolution.size());
+    }
+}
 }

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -110,6 +110,8 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
             S(i + task->Start, i + task->Start) = Rho(task->Id);
         }
     }
+
+    applyStartState();
 }
 
 void SamplingProblem::setGoalState(Eigen::VectorXdRefConst qT)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -110,6 +110,8 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
             S(i + task->Start, i + task->Start) = Rho(task->Id);
         }
     }
+
+    applyStartState();
 }
 
 Eigen::VectorXd TimeIndexedSamplingProblem::getGoalState()

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -87,6 +87,8 @@ void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitial
 
     S = Eigen::MatrixXd::Identity(JN, JN);
     ydiff = Eigen::VectorXd::Zero(JN);
+
+    applyStartState();
 }
 
 void UnconstrainedEndPoseProblem::preupdate()

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -59,6 +59,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     Q_rate = init.Qrate;
     H_rate = init.Hrate;
     W_rate = init.Wrate;
+    ct = 1.0 / tau / T;
 
     NumTasks = Tasks.size();
     PhiN = 0;
@@ -114,6 +115,8 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     ydiff.assign(T, Eigen::VectorXd::Zero(JN));
     J.assign(T, Eigen::MatrixXd(JN, N));
     S.assign(T, Eigen::MatrixXd::Identity(JN, JN));
+    x.assign(T, Eigen::VectorXd::Zero(JN));
+    xdiff.assign(T, Eigen::VectorXd::Zero(JN));
 
     // Set initial trajectory
     InitialTrajectory.resize(T, getStartState());
@@ -158,7 +161,7 @@ double UnconstrainedTimeIndexedProblem::getDuration()
     return tau * (double)T;
 }
 
-void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x, int t)
+void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
 {
     if (t >= T || t < -1)
     {
@@ -169,20 +172,25 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x, int t)
         t = T - 1;
     }
 
-    scene_->Update(x, static_cast<double>(t) * tau);
+    x[t] = x_in;
+    scene_->Update(x_in, static_cast<double>(t) * tau);
     Phi[t].setZero(PhiN);
     J[t].setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         // Only update TaskMap if Rho is not 0
         if (Rho[t](i) != 0)
-            Tasks[i]->update(x, Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
+            Tasks[i]->update(x_in, Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
     }
     ydiff[t] = Phi[t] - y[t];
+
+    // NB: The transition cost for the 0-th time step is set to 0 in the initialiser.
+    if (t > 0) xdiff[t] = x[t] - x[t - 1];
+
     numberOfProblemUpdates++;
 }
 
-double UnconstrainedTimeIndexedProblem::getScalarCost(int t)
+double UnconstrainedTimeIndexedProblem::getScalarTaskCost(int t)
 {
     if (t >= T || t < -1)
     {
@@ -192,10 +200,10 @@ double UnconstrainedTimeIndexedProblem::getScalarCost(int t)
     {
         t = T - 1;
     }
-    return ydiff[t].transpose() * S[t] * ydiff[t];
+    return ct * ydiff[t].transpose() * S[t] * ydiff[t];
 }
 
-Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarJacobian(int t)
+Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarTaskJacobian(int t)
 {
     if (t >= T || t < -1)
     {
@@ -205,7 +213,33 @@ Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarJacobian(int t)
     {
         t = T - 1;
     }
-    return J[t].transpose() * S[t] * ydiff[t] * 2.0;
+    return J[t].transpose() * S[t] * ydiff[t] * 2.0 * ct;
+}
+
+double UnconstrainedTimeIndexedProblem::getScalarTransitionCost(int t)
+{
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
+    return ct * xdiff[t].transpose() * W * xdiff[t];
+}
+
+Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarTransitionJacobian(int t)
+{
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
+    return 2.0 * ct * W * xdiff[t];
 }
 
 void UnconstrainedTimeIndexedProblem::setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t)

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -119,7 +119,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     xdiff.assign(T, Eigen::VectorXd::Zero(JN));
 
     // Set initial trajectory
-    InitialTrajectory.resize(T, getStartState());
+    InitialTrajectory.resize(T, applyStartState());
 }
 
 void UnconstrainedTimeIndexedProblem::preupdate()

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -543,7 +543,7 @@ PYBIND11_MODULE(_pyexotica, module)
     planningProblem.def_property("startTime", &PlanningProblem::getStartTime, &PlanningProblem::setStartTime);
     planningProblem.def("getNumberOfProblemUpdates", &PlanningProblem::getNumberOfProblemUpdates);
     planningProblem.def("resetNumberOfProblemUpdates", &PlanningProblem::resetNumberOfProblemUpdates);
-    planningProblem.def("getCostEvolution", (std::vector<double> (PlanningProblem::*)()) &PlanningProblem::getCostEvolution);
+    planningProblem.def("getCostEvolution", (std::vector<double> (PlanningProblem::*)()) & PlanningProblem::getCostEvolution);
 
     // Problem types
     py::module prob = module.def_submodule("Problems", "Problem types");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -543,7 +543,7 @@ PYBIND11_MODULE(_pyexotica, module)
     planningProblem.def_property("startTime", &PlanningProblem::getStartTime, &PlanningProblem::setStartTime);
     planningProblem.def("getNumberOfProblemUpdates", &PlanningProblem::getNumberOfProblemUpdates);
     planningProblem.def("resetNumberOfProblemUpdates", &PlanningProblem::resetNumberOfProblemUpdates);
-    planningProblem.def("getCostEvolution", &PlanningProblem::getCostEvolution);
+    planningProblem.def("getCostEvolution", (std::vector<double> (PlanningProblem::*)()) &PlanningProblem::getCostEvolution);
 
     // Problem types
     py::module prob = module.def_submodule("Problems", "Problem types");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -575,8 +575,10 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def_readonly("Phi", &UnconstrainedTimeIndexedProblem::Phi);
     unconstrainedTimeIndexedProblem.def_readonly("ydiff", &UnconstrainedTimeIndexedProblem::ydiff);
     unconstrainedTimeIndexedProblem.def_readonly("J", &UnconstrainedTimeIndexedProblem::J);
-    unconstrainedTimeIndexedProblem.def("getScalarCost", &UnconstrainedTimeIndexedProblem::getScalarCost);
-    unconstrainedTimeIndexedProblem.def("getScalarJacobian", &UnconstrainedTimeIndexedProblem::getScalarJacobian);
+    unconstrainedTimeIndexedProblem.def("getScalarTaskCost", &UnconstrainedTimeIndexedProblem::getScalarTaskCost);
+    unconstrainedTimeIndexedProblem.def("getScalarTaskJacobian", &UnconstrainedTimeIndexedProblem::getScalarTaskJacobian);
+    unconstrainedTimeIndexedProblem.def("getScalarTransitionCost", &UnconstrainedTimeIndexedProblem::getScalarTransitionCost);
+    unconstrainedTimeIndexedProblem.def("getScalarTransitionJacobian", &UnconstrainedTimeIndexedProblem::getScalarTransitionJacobian);
     py::class_<UnconstrainedEndPoseProblem, std::shared_ptr<UnconstrainedEndPoseProblem>, PlanningProblem> unconstrainedEndPoseProblem(prob, "UnconstrainedEndPoseProblem");
     unconstrainedEndPoseProblem.def("update", &UnconstrainedEndPoseProblem::Update);
     unconstrainedEndPoseProblem.def("setGoal", &UnconstrainedEndPoseProblem::setGoal);


### PR DESCRIPTION
- Fixes bug in UnconstrainedTimeIndexedProblem when no warm-start is provided (start state was wrong), and also fixes non-set start state for all the other problems
- Moves cost computation into problem to use the same cost between solvers: ``getScalarTaskCost``, ``getScalarTransitionCost`` (aka control)
- Stores and updates transition diff/cost in problem and saves on computation by computing it as part of the update rather than separate
- Adds cost normalisation over trajectory to AICO such that costs are comparable across solvers
- Makes AICO less noisy when not in debug mode

Resolves #204 