### PR TITLE
Make UnconstrainedTimeIndexedProblem resizable during runtime

### DIFF
--- a/examples/exotica_examples/src/planner.cpp
+++ b/examples/exotica_examples/src/planner.cpp
@@ -65,7 +65,7 @@ void run()
     if (any_problem->type() == "exotica::UnconstrainedTimeIndexedProblem")
     {
         UnconstrainedTimeIndexedProblem_ptr problem = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(any_problem);
-        for (int t = 0; t < problem->T - 1; t++)
+        for (int t = 0; t < problem->getT() - 1; t++)
         {
             // This sets the precision of all time steps BUT the last one to zero
             // This means we only aim to minimize the task cost in the last time step

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -213,6 +213,8 @@ private:
     std::vector<Eigen::MatrixXd> Hinv;   //!< Integrated state transition covariance inverse
     std::vector<Eigen::MatrixXd> Q;      //!< State transition covariance
 
+    int lastT;  //!< T the last time initMessages was called.
+
     int sweep;  //!< Sweeps so far
     enum SweepMode
     {

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -222,7 +222,6 @@ private:
         smLocalGaussNewtonDamped
     };
     int sweepMode;  //!< Sweep mode
-    int T;          //!< Number of time steps
     int n;          //!< Configuration space size
     int updateCount;
 

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -111,6 +111,9 @@ void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
 
 void AICOsolver::Solve(Eigen::MatrixXd& solution)
 {
+    // Check if the trajectory length has changed, if so update the messages.
+    if (prob_->getT() != lastT) initMessages();
+
     prob_->resetCostEvolution(max_iterations);
 
     Eigen::VectorXd q0 = prob_->applyStartState();
@@ -274,6 +277,9 @@ void AICOsolver::initMessages()
     {
         q_stat[t].resize(n);
     }
+
+    // Set lastT to the problem T
+    lastT = prob_->getT();
 }
 
 void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -72,7 +72,7 @@ void AICOsolver::saveCosts(std::string file_name)
     std::ofstream myfile;
     myfile.open(file_name.c_str());
     myfile << "Control Task";
-    for (int t = 0; t < T; t++)
+    for (int t = 0; t < prob_->getT(); t++)
     {
         myfile << "\n"
                << costControl(t);
@@ -82,7 +82,7 @@ void AICOsolver::saveCosts(std::string file_name)
 }
 
 AICOsolver::AICOsolver()
-    : damping(0.01), tolerance(1e-2), max_iterations(100), useBwdMsg(false), bwdMsg_v(), bwdMsg_Vinv(), s(), Sinv(), v(), Vinv(), r(), R(), rhat(), b(), Binv(), q(), qhat(), s_old(), Sinv_old(), v_old(), Vinv_old(), r_old(), R_old(), rhat_old(), b_old(), Binv_old(), q_old(), qhat_old(), dampingReference(), cost(0.0), cost_old(0.0), b_step(0.0), A(), tA(), Ainv(), invtA(), a(), B(), tB(), Winv(), Hinv(), Q(), sweep(0), sweepMode(0), W(), H(), T(0), dynamic(false), n(0), updateCount(0), damping_init(0.0), preupdateTrajectory_(false), q_stat()
+    : damping(0.01), tolerance(1e-2), max_iterations(100), useBwdMsg(false), bwdMsg_v(), bwdMsg_Vinv(), s(), Sinv(), v(), Vinv(), r(), R(), rhat(), b(), Binv(), q(), qhat(), s_old(), Sinv_old(), v_old(), Vinv_old(), r_old(), R_old(), rhat_old(), b_old(), Binv_old(), q_old(), qhat_old(), dampingReference(), cost(0.0), cost_old(0.0), b_step(0.0), A(), tA(), Ainv(), invtA(), a(), B(), tB(), Winv(), Hinv(), Q(), sweep(0), sweepMode(0), W(), H(), dynamic(false), n(0), updateCount(0), damping_init(0.0), preupdateTrajectory_(false), q_stat()
 {
 }
 
@@ -106,7 +106,6 @@ void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
     MotionSolver::specifyProblem(problem);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(problem);
 
-    T = prob_->T;
     initMessages();
 }
 
@@ -122,7 +121,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     // with the start state
     if (!(q0 - q_init[0]).isMuchSmallerThan(1e-6))
     {
-        q_init.resize(T, Eigen::VectorXd::Zero(q0.rows()));
+        q_init.resize(prob_->getT(), Eigen::VectorXd::Zero(q0.rows()));
         for (int i = 0; i < q_init.size(); i++) q_init[i] = q0;
     }
     else
@@ -140,7 +139,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     sweep = -1;
     damping = damping_init;
     double d;
-    if (!(T > 0))
+    if (!(prob_->getT() > 0))
     {
         throw_named("Problem has not been initialized properly: T=0!");
     }
@@ -156,8 +155,8 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
         }
         if (k && d < tolerance) break;
     }
-    Eigen::MatrixXd sol(T, n);
-    for (int tt = 0; tt < T; tt++)
+    Eigen::MatrixXd sol(prob_->getT(), n);
+    for (int tt = 0; tt < prob_->getT(); tt++)
     {
         sol.row(tt) = q[tt];
     }
@@ -185,22 +184,22 @@ void AICOsolver::initMessages()
             throw_named("State dimension is too small: n=" << n);
         }
     }
-    if (T < 2)
+    if (prob_->getT() < 2)
     {
-        throw_named("Number of time steps is too small: T=" << T);
+        throw_named("Number of time steps is too small: T=" << prob_->getT());
     }
 
-    s.assign(T, Eigen::VectorXd::Zero(n));
-    Sinv.assign(T, Eigen::MatrixXd::Zero(n, n));
+    s.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
+    Sinv.assign(prob_->getT(), Eigen::MatrixXd::Zero(n, n));
     Sinv[0].diagonal().setConstant(1e10);
-    v.assign(T, Eigen::VectorXd::Zero(n));
-    Vinv.assign(T, Eigen::MatrixXd::Zero(n, n));
+    v.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
+    Vinv.assign(prob_->getT(), Eigen::MatrixXd::Zero(n, n));
     if (useBwdMsg)
     {
         if (bwdMsg_v.rows() == n && bwdMsg_Vinv.rows() == n && bwdMsg_Vinv.cols() == n)
         {
-            v[T] = bwdMsg_v;
-            Vinv[T] = bwdMsg_Vinv;
+            v[prob_->getT()] = bwdMsg_v;
+            Vinv[prob_->getT()] = bwdMsg_Vinv;
         }
         else
         {
@@ -208,20 +207,20 @@ void AICOsolver::initMessages()
             WARNING("Backward message initialisation skipped, matrices have incorrect dimensions.");
         }
     }
-    b.assign(T, Eigen::VectorXd::Zero(n));
-    dampingReference.assign(T, Eigen::VectorXd::Zero(n));
-    Binv.assign(T, Eigen::MatrixXd::Zero(n, n));
+    b.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
+    dampingReference.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
+    Binv.assign(prob_->getT(), Eigen::MatrixXd::Zero(n, n));
     Binv[0].setIdentity();
     Binv[0] = Binv[0] * 1e10;
-    r.assign(T, Eigen::VectorXd::Zero(n));
-    R.assign(T, Eigen::MatrixXd::Zero(n, n));
-    rhat = Eigen::VectorXd::Zero(T);
-    qhat.assign(T, Eigen::VectorXd::Zero(n));
+    r.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
+    R.assign(prob_->getT(), Eigen::MatrixXd::Zero(n, n));
+    rhat = Eigen::VectorXd::Zero(prob_->getT());
+    qhat.assign(prob_->getT(), Eigen::VectorXd::Zero(n));
     linSolverTmp.resize(n, n);
     {
         if (dynamic)
         {
-            q.resize(T);
+            q.resize(prob_->getT());
             for (int i = 0; i < q.size(); i++)
                 q.at(i) = b.at(i).head(n2);
             if (prob_->W.rows() != n2)
@@ -248,30 +247,30 @@ void AICOsolver::initMessages()
         tA_ = A_.transpose();
         Ainv_ = A_.inverse();
         invtA_ = Ainv_.transpose();
-        B.assign(T, B_);
-        tB.assign(T, tB_);
-        A.assign(T, A_);
-        tA.assign(T, tA_);
-        Ainv.assign(T, Ainv_);
-        invtA.assign(T, invtA_);
-        a.assign(T, a_);
+        B.assign(prob_->getT(), B_);
+        tB.assign(prob_->getT(), tB_);
+        A.assign(prob_->getT(), A_);
+        tA.assign(prob_->getT(), tA_);
+        Ainv.assign(prob_->getT(), Ainv_);
+        invtA.assign(prob_->getT(), invtA_);
+        a.assign(prob_->getT(), a_);
     }
     {
         // Set constant W,Win,H,Hinv
-        W.assign(T, prob_->W);
-        Winv.assign(T, prob_->W.inverse());
-        H.assign(T, prob_->H);
-        Hinv.assign(T, prob_->H.inverse());
-        Q.assign(T, prob_->Q);
+        W.assign(prob_->getT(), prob_->W);
+        Winv.assign(prob_->getT(), prob_->W.inverse());
+        H.assign(prob_->getT(), prob_->H);
+        Hinv.assign(prob_->getT(), prob_->H.inverse());
+        Q.assign(prob_->getT(), prob_->Q);
     }
 
-    costControl.resize(T);
+    costControl.resize(prob_->getT());
     costControl.setZero();
-    costTask.resize(T);
+    costTask.resize(prob_->getT());
     costTask.setZero();
 
-    q_stat.resize(T);
-    for (int t = 0; t < T; t++)
+    q_stat.resize(prob_->getT());
+    for (int t = 0; t < prob_->getT(); t++)
     {
         q_stat[t].resize(n);
     }
@@ -308,7 +307,7 @@ void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
 
 void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
 {
-    if (q_init.size() != T)
+    if (q_init.size() != prob_->getT())
     {
         throw_named("Incorrect number of timesteps provided!");
     }
@@ -322,19 +321,19 @@ void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
     for (int i = 0; i < q.size(); i++)
         q.at(i) = b.at(i).head(n2);
     s = b;
-    for (int t = 1; t < T; t++)
+    for (int t = 1; t < prob_->getT(); t++)
     {
         Sinv.at(t).setZero();
         Sinv.at(t).diagonal().setConstant(damping);
     }
     v = b;
-    for (int t = 0; t < T; t++)
+    for (int t = 0; t < prob_->getT(); t++)
     {
         Vinv.at(t).setZero();
         Vinv.at(t).diagonal().setConstant(damping);
     }
     dampingReference = b;
-    for (int t = 0; t < T; t++)
+    for (int t = 0; t < prob_->getT(); t++)
     {
         // Compute task message reference
         updateTaskMessage(t, b.at(t), 0.0);
@@ -411,14 +410,14 @@ void AICOsolver::updateBwdMessage(int t)
     Eigen::MatrixXd barV(n, n), Vt;
     if (dynamic)
     {
-        if (t < T - 1)
+        if (t < prob_->getT() - 1)
         {
             inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
             Vt = Ainv[t] * (Q[t] + B[t] * Hinv[t] * tB[t] + barV) * invtA[t];
             v[t] = Ainv[t] * (-a[t] + barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]));
             inverseSymPosDef(Vinv[t], Vt);
         }
-        if (t == T - 1)
+        if (t == prob_->getT() - 1)
         {
             if (!useBwdMsg)
             {
@@ -427,21 +426,21 @@ void AICOsolver::updateBwdMessage(int t)
             }
             else
             {
-                v[T - 1] = bwdMsg_v;
-                Vinv[T - 1] = bwdMsg_Vinv;
+                v[prob_->getT() - 1] = bwdMsg_v;
+                Vinv[prob_->getT() - 1] = bwdMsg_Vinv;
             }
         }
     }
     else
     {
-        if (t < T - 1)
+        if (t < prob_->getT() - 1)
         {
             inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
             v[t] = barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]);
             Vt = Winv[t] + barV;
             inverseSymPosDef(Vinv[t], Vt);
         }
-        if (t == T - 1)
+        if (t == prob_->getT() - 1)
         {
             if (!useBwdMsg)
             {
@@ -450,8 +449,8 @@ void AICOsolver::updateBwdMessage(int t)
             }
             else
             {
-                v[T - 1] = bwdMsg_v;
-                Vinv[T - 1] = bwdMsg_Vinv;
+                v[prob_->getT() - 1] = bwdMsg_v;
+                Vinv[prob_->getT() - 1] = bwdMsg_Vinv;
             }
         }
     }
@@ -605,7 +604,7 @@ double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
     if (preupdateTrajectory_)
     {
         if (debug_) ROS_WARN_STREAM("Pre-update, sweep " << sweep);
-        for (int t = 0; t < T; t++)
+        for (int t = 0; t < prob_->getT(); t++)
         {
             if (Server::isRos() && !ros::ok()) return -1.0;
             updateCount++;
@@ -614,7 +613,7 @@ double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
     }
     dPre = timer.getDuration();
 
-    for (int t = 0; t < T; t++)
+    for (int t = 0; t < prob_->getT(); t++)
     {
         timer.reset();
         if (Server::isRos() && !ros::ok()) return -1.0;
@@ -634,7 +633,7 @@ double AICOsolver::evaluateTrajectory(const std::vector<Eigen::VectorXd>& x,
         else
         {
             throw_pretty("Not supported at the moment");
-            // if (t < T - 1 && t > 0)
+            // if (t < prob_->getT() - 1 && t > 0)
             // {
             //     // For fully dynamic system use: v=tau_2*M*(q[t+1]+q[t-1]-2.0*q[t])-F;
             //     vv = tau_2 * (q[t + 1] + q[t - 1] - 2.0 * q[t]);
@@ -668,44 +667,44 @@ double AICOsolver::step()
     {
         //NOTE: the dependence on (Sweep?..:..) could perhaps be replaced by (DampingReference.N?..:..)
         case smForwardly:
-            for (t = 1; t < T; t++)
+            for (t = 1; t < prob_->getT(); t++)
             {
                 updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd Sweep
             }
-            for (t = T - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t >= 0; t--)
             {
                 updateTimeStep(t, false, true, 0, tolerance, false, 1.);  //...not on bwd Sweep
             }
             break;
         case smSymmetric:
             //ROS_WARN_STREAM("Updating forward, sweep "<<sweep);
-            for (t = 1; t < T; t++)
+            for (t = 1; t < prob_->getT(); t++)
             {
                 updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd & bwd Sweep
             }
             //ROS_WARN_STREAM("Updating backward, sweep "<<sweep);
-            for (t = T - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t >= 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 1 : 0), tolerance, false, 1.);
             }
             break;
         case smLocalGaussNewton:
-            for (t = 1; t < T; t++)
+            for (t = 1; t < prob_->getT(); t++)
             {
                 updateTimeStep(t, true, false, (sweep ? 5 : 1), tolerance, !sweep, 1.);  //relocate iteratively on
             }
-            for (t = T - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t >= 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);  //...fwd & bwd Sweep
             }
             break;
         case smLocalGaussNewtonDamped:
-            for (t = 1; t < T; t++)
+            for (t = 1; t < prob_->getT(); t++)
             {
                 updateTimeStepGaussNewton(t, true, false, (sweep ? 5 : 1),
                                           tolerance, 1.);  //GaussNewton in fwd & bwd Sweep
             }
-            for (t = T - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t >= 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);
             }
@@ -774,7 +773,7 @@ void AICOsolver::perhapsUndoStep()
         dim = dim_old;
         if (preupdateTrajectory_)
         {
-            for (int t = 0; t < T; t++)
+            for (int t = 0; t < prob_->getT(); t++)
             {
                 updateCount++;
                 prob_->Update(q[t], t);

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -287,7 +287,7 @@ void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
     }
     else
     {
-        double tau = prob_->tau;
+        double tau = prob_->getTau();
         int n2 = n / 2;
         A_ = Eigen::MatrixXd::Identity(n, n);
         B_ = Eigen::MatrixXd::Zero(n, n2);

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -93,7 +93,7 @@ public:
     int NumTasks;
 
 private:
-    int T;          //!< Number of time steps
+    int T;  //!< Number of time steps
 
     std::vector<Eigen::VectorXd> InitialTrajectory;
     UnconstrainedTimeIndexedProblemInitializer init_;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -61,12 +61,14 @@ public:
     void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
     virtual void preupdate();
 
+    int getT() const { return T; }
+    void setT(int T_in);
+
     double getScalarTaskCost(int t);
     Eigen::VectorXd getScalarTaskJacobian(int t);
     double getScalarTransitionCost(int t);
     Eigen::VectorXd getScalarTransitionJacobian(int t);
 
-    int T;          //!< Number of time steps
     double tau;     //!< Time step duration
     double ct;      //!< Normalisation of scalar cost and Jacobian over trajectory length
     double Q_rate;  //!< System transition error covariance multipler (per unit time) (constant throughout the trajectory)
@@ -91,7 +93,11 @@ public:
     int NumTasks;
 
 private:
+    int T;          //!< Number of time steps
+
     std::vector<Eigen::VectorXd> InitialTrajectory;
+    UnconstrainedTimeIndexedProblemInitializer init_;
+    void reinitializeVariables();
 };
 
 typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblem_ptr;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -64,12 +64,14 @@ public:
     int getT() const { return T; }
     void setT(int T_in);
 
+    double getTau() const { return tau; }
+    void setTau(double tau_in);
+
     double getScalarTaskCost(int t);
     Eigen::VectorXd getScalarTaskJacobian(int t);
     double getScalarTransitionCost(int t);
     Eigen::VectorXd getScalarTransitionJacobian(int t);
 
-    double tau;     //!< Time step duration
     double ct;      //!< Normalisation of scalar cost and Jacobian over trajectory length
     double Q_rate;  //!< System transition error covariance multipler (per unit time) (constant throughout the trajectory)
     double H_rate;  //!< Control error covariance multipler (per unit time) (constant throughout the trajectory)
@@ -93,7 +95,8 @@ public:
     int NumTasks;
 
 private:
-    int T;  //!< Number of time steps
+    int T;       //!< Number of time steps
+    double tau;  //!< Time step duration
 
     std::vector<Eigen::VectorXd> InitialTrajectory;
     UnconstrainedTimeIndexedProblemInitializer init_;

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -59,11 +59,10 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
 {
     if (debug_) HIGHLIGHT_NAMED("UnconstrainedTimeIndexedProblem", "Initialize problem with T=" << T);
 
-    tau = init_.Tau;
+    setTau(init_.Tau);
     Q_rate = init_.Qrate;
     H_rate = init_.Hrate;
     W_rate = init_.Wrate;
-    ct = 1.0 / tau / T;
 
     NumTasks = Tasks.size();
     PhiN = 0;
@@ -134,6 +133,13 @@ void UnconstrainedTimeIndexedProblem::setT(int T_in)
     }
     T = T_in;
     reinitializeVariables();
+}
+
+void UnconstrainedTimeIndexedProblem::setTau(double tau_in)
+{
+    if (tau_in <= 0.) throw_pretty("tau is expected to be greater than 0. (tau=" << tau_in << ")");
+    tau = tau_in;
+    ct = 1.0 / tau / T;
 }
 
 void UnconstrainedTimeIndexedProblem::preupdate()

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -50,15 +50,19 @@ UnconstrainedTimeIndexedProblem::~UnconstrainedTimeIndexedProblem()
 
 void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProblemInitializer& init)
 {
-    T = init.T;
-    if (T <= 2)
-    {
-        throw_named("Invalid number of timesteps: " << T);
-    }
-    tau = init.Tau;
-    Q_rate = init.Qrate;
-    H_rate = init.Hrate;
-    W_rate = init.Wrate;
+    init_ = init;
+    setT(init_.T);
+    reinitializeVariables();
+}
+
+void UnconstrainedTimeIndexedProblem::reinitializeVariables()
+{
+    HIGHLIGHT_NAMED("UnconstrainedTimeIndexedProblem", "Reinitialize variables with T=" << T);
+
+    tau = init_.Tau;
+    Q_rate = init_.Qrate;
+    H_rate = init_.Hrate;
+    W_rate = init_.Wrate;
     ct = 1.0 / tau / T;
 
     NumTasks = Tasks.size();
@@ -75,39 +79,39 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     N = scene_->getSolver().getNumControlledJoints();
 
     W = Eigen::MatrixXd::Identity(N, N) * W_rate;
-    if (init.W.rows() > 0)
+    if (init_.W.rows() > 0)
     {
-        if (init.W.rows() == N)
+        if (init_.W.rows() == N)
         {
-            W.diagonal() = init.W * W_rate;
+            W.diagonal() = init_.W * W_rate;
         }
         else
         {
-            throw_named("W dimension mismatch! Expected " << N << ", got " << init.W.rows());
+            throw_named("W dimension mismatch! Expected " << N << ", got " << init_.W.rows());
         }
     }
     H = Eigen::MatrixXd::Identity(N, N) * Q_rate;
     Q = Eigen::MatrixXd::Identity(N, N) * H_rate;
 
-    if (init.Rho.rows() == 0)
+    if (init_.Rho.rows() == 0)
     {
         Rho.assign(T, Eigen::VectorXd::Ones(NumTasks));
     }
-    else if (init.Rho.rows() == NumTasks)
+    else if (init_.Rho.rows() == NumTasks)
     {
-        Rho.assign(T, init.Rho);
+        Rho.assign(T, init_.Rho);
     }
-    else if (init.Rho.rows() == NumTasks * T)
+    else if (init_.Rho.rows() == NumTasks * T)
     {
         Rho.resize(T);
         for (int i = 0; i < T; i++)
         {
-            Rho[i] = init.Rho.segment(i * NumTasks, NumTasks);
+            Rho[i] = init_.Rho.segment(i * NumTasks, NumTasks);
         }
     }
     else
     {
-        throw_named("Invalid task weights rho! " << init.Rho.rows());
+        throw_named("Invalid task weights rho! " << init_.Rho.rows());
     }
     yref.setZero(PhiN);
     y.assign(T, yref);
@@ -120,6 +124,16 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
 
     // Set initial trajectory
     InitialTrajectory.resize(T, applyStartState());
+}
+
+void UnconstrainedTimeIndexedProblem::setT(int T_in)
+{
+    if (T_in <= 2)
+    {
+        throw_named("Invalid number of timesteps: " << T_in);
+    }
+    T = T_in;
+    reinitializeVariables();
 }
 
 void UnconstrainedTimeIndexedProblem::preupdate()

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -57,7 +57,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
 
 void UnconstrainedTimeIndexedProblem::reinitializeVariables()
 {
-    HIGHLIGHT_NAMED("UnconstrainedTimeIndexedProblem", "Reinitialize variables with T=" << T);
+    if (debug_) HIGHLIGHT_NAMED("UnconstrainedTimeIndexedProblem", "Initialize problem with T=" << T);
 
     tau = init_.Tau;
     Q_rate = init_.Qrate;

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -554,7 +554,9 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def("setRho", &UnconstrainedTimeIndexedProblem::setRho);
     unconstrainedTimeIndexedProblem.def("getGoal", &UnconstrainedTimeIndexedProblem::getGoal);
     unconstrainedTimeIndexedProblem.def("getRho", &UnconstrainedTimeIndexedProblem::getRho);
-    unconstrainedTimeIndexedProblem.def_readwrite("tau", &UnconstrainedTimeIndexedProblem::tau);
+    unconstrainedTimeIndexedProblem.def_property("tau",
+                                                 &UnconstrainedTimeIndexedProblem::getTau,
+                                                 &UnconstrainedTimeIndexedProblem::setTau);
     unconstrainedTimeIndexedProblem.def_readwrite("Q_rate", &UnconstrainedTimeIndexedProblem::Q_rate);
     unconstrainedTimeIndexedProblem.def_readwrite("H_rate", &UnconstrainedTimeIndexedProblem::H_rate);
     unconstrainedTimeIndexedProblem.def_readwrite("W_rate", &UnconstrainedTimeIndexedProblem::W_rate);
@@ -565,7 +567,9 @@ PYBIND11_MODULE(_pyexotica, module)
         "InitialTrajectory",
         &UnconstrainedTimeIndexedProblem::getInitialTrajectory,
         &UnconstrainedTimeIndexedProblem::setInitialTrajectory);
-    unconstrainedTimeIndexedProblem.def_property("T", &UnconstrainedTimeIndexedProblem::getT, &UnconstrainedTimeIndexedProblem::setT);
+    unconstrainedTimeIndexedProblem.def_property("T",
+                                                 &UnconstrainedTimeIndexedProblem::getT,
+                                                 &UnconstrainedTimeIndexedProblem::setT);
     unconstrainedTimeIndexedProblem.def_readonly("PhiN", &UnconstrainedTimeIndexedProblem::PhiN);
     unconstrainedTimeIndexedProblem.def_readonly("JN", &UnconstrainedTimeIndexedProblem::JN);
     unconstrainedTimeIndexedProblem.def_readonly("N", &UnconstrainedTimeIndexedProblem::N);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -565,7 +565,7 @@ PYBIND11_MODULE(_pyexotica, module)
         "InitialTrajectory",
         &UnconstrainedTimeIndexedProblem::getInitialTrajectory,
         &UnconstrainedTimeIndexedProblem::setInitialTrajectory);
-    unconstrainedTimeIndexedProblem.def_readonly("T", &UnconstrainedTimeIndexedProblem::T);
+    unconstrainedTimeIndexedProblem.def_property("T", &UnconstrainedTimeIndexedProblem::getT, &UnconstrainedTimeIndexedProblem::setT);
     unconstrainedTimeIndexedProblem.def_readonly("PhiN", &UnconstrainedTimeIndexedProblem::PhiN);
     unconstrainedTimeIndexedProblem.def_readonly("JN", &UnconstrainedTimeIndexedProblem::JN);
     unconstrainedTimeIndexedProblem.def_readonly("N", &UnconstrainedTimeIndexedProblem::N);


### PR DESCRIPTION
This PR will allow runtime resizing of the trajectory length without having to unnecessarily re-initialise the entire problem, e.g. when optimising over different time horizons.

- Makes ``T`` private and adds getters and setters
- Moves all users of ``T`` to the getter
- Make ``UnconstrainedTimeIndexedProblem`` resizable by re-initialising all required variables upon changes to the time horizon

