### PR TITLE
Adds option not to update trajectory on initialisation

### DIFF
--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -65,7 +65,7 @@ public:
     void setStartTime(double t);
     Eigen::VectorXd getStartState();
     double getStartTime();
-    Eigen::VectorXd applyStartState();
+    Eigen::VectorXd applyStartState(bool updateTraj = true);
     int N;
     double tStart;
     virtual void preupdate();

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -89,8 +89,8 @@ public:
     Eigen::VectorXd getControlledState();
     Eigen::VectorXd getModelState();
     std::map<std::string, double> getModelStateMap();
-    void setModelState(Eigen::VectorXdRefConst x, double t = 0);
-    void setModelState(std::map<std::string, double> x, double t = 0);
+    void setModelState(Eigen::VectorXdRefConst x, double t = 0, bool updateTraj = true);
+    void setModelState(std::map<std::string, double> x, double t = 0, bool updateTraj = true);
     std::string getGroupName();
 
     void addTrajectoryFromFile(const std::string& link, const std::string& traj);

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -49,9 +49,9 @@ std::string PlanningProblem::print(std::string prepend)
     return ret;
 }
 
-Eigen::VectorXd PlanningProblem::applyStartState()
+Eigen::VectorXd PlanningProblem::applyStartState(bool updateTraj)
 {
-    scene_->setModelState(startState, tStart);
+    scene_->setModelState(startState, tStart, updateTraj);
     return scene_->getControlledState();
 }
 

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -111,7 +111,7 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
         }
     }
 
-    applyStartState();
+    applyStartState(false);
 }
 
 void SamplingProblem::setGoalState(Eigen::VectorXdRefConst qT)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -111,7 +111,7 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
         }
     }
 
-    applyStartState();
+    applyStartState(false);
 }
 
 Eigen::VectorXd TimeIndexedSamplingProblem::getGoalState()

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -88,7 +88,7 @@ void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitial
     S = Eigen::MatrixXd::Identity(JN, JN);
     ydiff = Eigen::VectorXd::Zero(JN);
 
-    applyStartState();
+    applyStartState(false);
 }
 
 void UnconstrainedEndPoseProblem::preupdate()

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -122,7 +122,7 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     xdiff.assign(T, Eigen::VectorXd::Zero(JN));
 
     // Set initial trajectory
-    InitialTrajectory.resize(T, applyStartState());
+    InitialTrajectory.resize(T, applyStartState(false));
 }
 
 void UnconstrainedTimeIndexedProblem::setT(int T_in)

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -358,7 +358,7 @@ std::map<std::string, double> Scene::getModelStateMap()
 
 void Scene::setModelState(Eigen::VectorXdRefConst x, double t, bool updateTraj)
 {
-    if(updateTraj) updateTrajectoryGenerators(t);
+    if (updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
@@ -368,7 +368,7 @@ void Scene::setModelState(Eigen::VectorXdRefConst x, double t, bool updateTraj)
 
 void Scene::setModelState(std::map<std::string, double> x, double t, bool updateTraj)
 {
-    if(updateTraj) updateTrajectoryGenerators(t);
+    if (updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -356,9 +356,9 @@ std::map<std::string, double> Scene::getModelStateMap()
     return kinematica_.getModelStateMap();
 }
 
-void Scene::setModelState(Eigen::VectorXdRefConst x, double t)
+void Scene::setModelState(Eigen::VectorXdRefConst x, double t, bool updateTraj)
 {
-    updateTrajectoryGenerators(t);
+    if(updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
@@ -366,9 +366,9 @@ void Scene::setModelState(Eigen::VectorXdRefConst x, double t)
     if (debug_) publishScene();
 }
 
-void Scene::setModelState(std::map<std::string, double> x, double t)
+void Scene::setModelState(std::map<std::string, double> x, double t, bool updateTraj)
 {
-    updateTrajectoryGenerators(t);
+    if(updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -648,8 +648,8 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getModelJointNames", &Scene::getModelJointNames);
     scene.def("getModelState", &Scene::getModelState);
     scene.def("getModelStateMap", &Scene::getModelStateMap);
-    scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst, double)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0);
-    scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>, double)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0);
+    scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst, double, bool)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0, py::arg("updateTrajectory") = false);
+    scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>, double, bool)) & Scene::setModelState, py::arg("x"), py::arg("t") = 0.0, py::arg("updateTrajectory") = false);
     scene.def("getControlledState", &Scene::getControlledState);
     scene.def("publishScene", &Scene::publishScene);
     scene.def("publishProxies", &Scene::publishProxies);


### PR DESCRIPTION
#205 added a call to ```applyStartState``` into each problem's init method. This updates the trajectory generators to time 0 on init. That is a problem if you want to attach objects to each other as they were defined in the scene.

This PR:
- ```Scene::setModelState``` now takes an optional argument that allows it to bypass updating the trajectory generators.
- ```PlanningProblem::applyStartState``` also has this argument and passes it to ```Scene::setModelState```.
- All problems update the start state within init without updating the trajectory generators by default (```applyStartState(false)```).