### PR TITLE
Expose validity checker resolution

### DIFF
--- a/exotations/solvers/time_indexed_rrt_connect/init/TimeIndexedRRTConnect.in
+++ b/exotations/solvers/time_indexed_rrt_connect/init/TimeIndexedRRTConnect.in
@@ -3,3 +3,4 @@ Optional bool Smooth = true;
 Optional double Timeout = 60.0;
 Optional std::string Range = "1";
 Optional bool AddTimeIntoSolution = false;
+Optional double ValidityCheckResolution = 0.01;

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -133,6 +133,7 @@ void TimeIndexedRRTConnect::specifyProblem(PlanningProblem_ptr pointer)
     ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(state_space_));
     ompl_simple_setup_->setStateValidityChecker(ompl::base::StateValidityCheckerPtr(new OMPLTimeIndexedStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_)));
     ompl_simple_setup_->setPlannerAllocator(boost::bind(planner_allocator_, _1, "Exotica_" + algorithm_));
+    ompl_simple_setup_->getSpaceInformation()->setStateValidityCheckingResolution(init_.ValidityCheckResolution);
 
     ompl_simple_setup_->getSpaceInformation()->setup();
     ompl_simple_setup_->setup();


### PR DESCRIPTION
- Exposes time indexed rrt-connect validity check resolution via the initializer.
- Default value is ```<ValidityCheckResolution>0.01</ValidityCheckResolution>```

This should be propagated back to all OMPL solvers as well.

Merge #211 before merging this.
