### PR TITLE
Fixes memory leaks in KinematicElement and Initializer python bindings

### DIFF
--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -101,7 +101,7 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
     shapes::ShapeConstPtr shape = element->Shape;
 
     // Apply scaling and padding
-    if (element->isRobotLink || element->ClosestRobotLink)
+    if (element->isRobotLink || element->ClosestRobotLink.lock())
     {
         if (robotLinkScale_ != 1.0 || robotLinkPadding_ > 0.0)
         {
@@ -198,21 +198,21 @@ bool CollisionSceneFCLLatest::isAllowedToCollide(fcl::CollisionObjectd* o1, fcl:
     std::shared_ptr<KinematicElement> e1 = scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())];
     std::shared_ptr<KinematicElement> e2 = scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())];
 
-    bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink;
-    bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink;
+    bool isRobot1 = e1->isRobotLink || e1->ClosestRobotLink.lock();
+    bool isRobot2 = e2->isRobotLink || e2->ClosestRobotLink.lock();
     // Don't check collisions between world objects
     if (!isRobot1 && !isRobot2) return false;
     // Skip self collisions if requested
     if (isRobot1 && isRobot2 && !self) return false;
     // Skip collisions between shapes within the same objects
-    if (e1->Parent == e2->Parent) return false;
+    if (e1->Parent.lock() == e2->Parent.lock()) return false;
     // Skip collisions between bodies attached to the same object
-    if (e1->ClosestRobotLink && e2->ClosestRobotLink && e1->ClosestRobotLink == e2->ClosestRobotLink) return false;
+    if (e1->ClosestRobotLink.lock() && e2->ClosestRobotLink.lock() && e1->ClosestRobotLink.lock() == e2->ClosestRobotLink.lock()) return false;
 
     if (isRobot1 && isRobot2)
     {
-        const std::string& name1 = e1->ClosestRobotLink ? e1->ClosestRobotLink->Segment.getName() : e1->Parent->Segment.getName();
-        const std::string& name2 = e2->ClosestRobotLink ? e2->ClosestRobotLink->Segment.getName() : e2->Parent->Segment.getName();
+        const std::string& name1 = e1->ClosestRobotLink.lock() ? e1->ClosestRobotLink.lock()->Segment.getName() : e1->Parent.lock()->Segment.getName();
+        const std::string& name2 = e2->ClosestRobotLink.lock() ? e2->ClosestRobotLink.lock()->Segment.getName() : e2->Parent.lock()->Segment.getName();
         return scene->acm_.getAllowedCollision(name1, name2);
     }
     return true;
@@ -454,8 +454,8 @@ bool CollisionSceneFCLLatest::isCollisionFree(const std::string& o1, const std::
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
-        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
-        if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
+        if (e->Segment.getName() == o1 || e->Parent.lock()->Segment.getName() == o1) shapes1.push_back(o);
+        if (e->Segment.getName() == o2 || e->Parent.lock()->Segment.getName() == o2) shapes2.push_back(o);
     }
     if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
     if (shapes2.size() == 0) throw_pretty("Can't find object '" << o2 << "'!");
@@ -493,8 +493,8 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(const 
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
-        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1) shapes1.push_back(o);
-        if (e->Segment.getName() == o2 || e->Parent->Segment.getName() == o2) shapes2.push_back(o);
+        if (e->Segment.getName() == o1 || e->Parent.lock()->Segment.getName() == o1) shapes1.push_back(o);
+        if (e->Segment.getName() == o2 || e->Parent.lock()->Segment.getName() == o2) shapes2.push_back(o);
     }
     if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
     if (shapes2.size() == 0) throw_pretty("Can't find object '" << o2 << "'!");
@@ -529,7 +529,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
-        if (e->Segment.getName() == o1 || e->Parent->Segment.getName() == o1)
+        if (e->Segment.getName() == o1 || e->Parent.lock()->Segment.getName() == o1)
             shapes1.push_back(o);
     }
 
@@ -539,7 +539,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())];
         // Collision Object does not belong to o1
-        if (e->Segment.getName() != o1 || e->Parent->Segment.getName() != o1)
+        if (e->Segment.getName() != o1 || e->Parent.lock()->Segment.getName() != o1)
         {
             bool allowedToCollide = false;
             for (fcl::CollisionObjectd* o1_shape : shapes1)
@@ -596,7 +596,7 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionWorldLinks()
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
-        if (!element->ClosestRobotLink)
+        if (!element->ClosestRobotLink.lock())
         {
             tmp.push_back(element->Segment.getName());
         }
@@ -615,7 +615,7 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionRobotLinks()
     for (fcl::CollisionObjectd* object : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())];
-        if (element->ClosestRobotLink)
+        if (element->ClosestRobotLink.lock())
         {
             tmp.push_back(element->Segment.getName());
         }

--- a/exotica/include/exotica/KinematicElement.h
+++ b/exotica/include/exotica/KinematicElement.h
@@ -10,13 +10,13 @@
 class KinematicElement
 {
 public:
-    KinematicElement(int id, std::shared_ptr<KinematicElement> parent, KDL::Segment segment) : Parent(parent), Segment(segment), Id(id), IsControlled(false), ControlId(-1), Shape(nullptr), isRobotLink(false), ClosestRobotLink(nullptr), IsTrajectoryGenerated(false)
+    KinematicElement(int id, std::shared_ptr<KinematicElement> parent, KDL::Segment segment) : Parent(parent), Segment(segment), Id(id), IsControlled(false), ControlId(-1), Shape(nullptr), isRobotLink(false), ClosestRobotLink(std::shared_ptr<KinematicElement>(nullptr)), IsTrajectoryGenerated(false)
     {
     }
     inline void updateClosestRobotLink()
     {
-        std::shared_ptr<KinematicElement> element = Parent;
-        ClosestRobotLink = nullptr;
+        std::shared_ptr<KinematicElement> element = Parent.lock();
+        ClosestRobotLink = std::shared_ptr<KinematicElement>(nullptr);
         while (element && element->Id > 0)
         {
             if (element->isRobotLink)
@@ -24,7 +24,7 @@ public:
                 ClosestRobotLink = element;
                 break;
             }
-            element = element->Parent;
+            element = element->Parent.lock();
         }
         setChildrenClosestRobotLink();
     }
@@ -44,9 +44,9 @@ public:
     int Id;
     int ControlId;
     bool IsControlled;
-    std::shared_ptr<KinematicElement> Parent;
+    std::weak_ptr<KinematicElement> Parent;
     std::vector<std::shared_ptr<KinematicElement>> Children;
-    std::shared_ptr<KinematicElement> ClosestRobotLink;
+    std::weak_ptr<KinematicElement> ClosestRobotLink;
     KDL::Segment Segment;
     KDL::Frame Frame;
     KDL::Frame GeneratedOffset;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -486,7 +486,7 @@ void Scene::updateSceneFrames()
         Eigen::Affine3d pose;
         tf::transformKDLToEigen(it->Segment.getFrameToTip(), pose);
         const auto& temp = it;
-        it = kinematica_.AddElement(it->Segment.getName(), pose, it->Parent->Segment.getName(), it->Shape, it->Segment.getInertia());
+        it = kinematica_.AddElement(it->Segment.getName(), pose, it->Parent.lock()->Segment.getName(), it->Shape, it->Segment.getInertia());
         it->IsControlled = temp->IsControlled;
     }
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -371,7 +371,11 @@ public:
         {
             addPropertyToDict(dict, prop.first, prop.second);
         }
-        return PyTuple_Pack(2, stringAsPy(src.getName()), dict);
+        PyObject* name = stringAsPy(src.getName());
+        PyObject* tup = PyTuple_Pack(2, name, dict);
+        Py_DECREF(dict);
+        Py_DECREF(name);
+        return tup;
     }
 
     static void addPropertyToDict(PyObject* dict, const std::string& name, const Property& prop)
@@ -402,16 +406,21 @@ public:
         }
         else if (prop.getType() == "exotica::Initializer")
         {
-            PyDict_SetItemString(dict, name.c_str(), InitializerToTuple(boost::any_cast<Initializer>(prop.get())));
+            PyObject* init = InitializerToTuple(boost::any_cast<Initializer>(prop.get()));
+            PyDict_SetItemString(dict, name.c_str(), init);
+            Py_DECREF(init);
         }
         else if (prop.isInitializerVectorType())
         {
             PyObject* vec = PyList_New(0);
             for (Initializer& i : boost::any_cast<std::vector<Initializer>>(prop.get()))
             {
-                PyList_Append(vec, InitializerToTuple(i));
+                PyObject* init = InitializerToTuple(i);
+                PyList_Append(vec, init);
+                Py_DECREF(init);
             }
             PyDict_SetItemString(dict, name.c_str(), vec);
+            Py_DECREF(vec);
         }
         else
         {


### PR DESCRIPTION
- ```KinematicElement``` never gets deleted once its added to the tree because shared pointers to parents/children keep it alive. Changed `Parent` and `ClosestRobotLink` to a ```std::weak_ptr``` to fix this.
- Now, every time the `Parent` and `ClosestRobotLink` are used, they have to be converted to a shared pointer using ```Parent.lock()```.
- The ```Initializer``` class python wrapper constructs a tuple and a dictionary. Each entry into the tuple/dictionary was created anew but never freed (keeping these containers alive). The temporary python objects are now being freed (```Py_DECREF```) after being added to the container.