### PR TITLE
Tasks: Set tasks to used unless Rho is 0 - i.e. allow negative Rhos

### DIFF
--- a/exotica/src/Tasks.cpp
+++ b/exotica/src/Tasks.cpp
@@ -120,7 +120,7 @@ void EndPoseTask::updateS()
         for (int i = 0; i < task.Length; i++)
         {
             S(i + task.Start, i + task.Start) = Rho(task.Id);
-            if (Rho(task.Id) > 0.0) Tasks[task.Id]->isUsed = true;
+            if (Rho(task.Id) != 0.0) Tasks[task.Id]->isUsed = true;
         }
     }
 }
@@ -196,7 +196,7 @@ void TimeIndexedTask::updateS()
             for (int i = 0; i < task.Length; i++)
             {
                 S[t](i + task.Start, i + task.Start) = Rho[t](task.Id);
-                if (Rho[t](task.Id) > 0.0) Tasks[task.Id]->isUsed = true;
+                if (Rho[t](task.Id) != 0.0) Tasks[task.Id]->isUsed = true;
             }
         }
     }


### PR DESCRIPTION
For ``EndPoseTask`` and ``TimeIndexedTask`` as currently as part of #220, task maps will not get updated if their weighting is negative - this is incorrect as we may want to assign negative Rhos.