### PR TITLE
UnconstrainedTimeIndexedProblem updates

### DIFF
--- a/exotations/solvers/aico/init/AICOsolver.in
+++ b/exotations/solvers/aico/init/AICOsolver.in
@@ -1,5 +1,5 @@
 extend <exotica/MotionSolver>
-Required std::string SweepMode;
+Required std::string SweepMode; // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
 Required int MaxIterations;
 Required double Tolerance;
 Required double Damping;

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -241,6 +241,14 @@ Eigen::VectorXd UnconstrainedTimeIndexedProblem::getScalarTransitionJacobian(int
 
 void UnconstrainedTimeIndexedProblem::setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
@@ -254,6 +262,14 @@ void UnconstrainedTimeIndexedProblem::setGoal(const std::string& task_name, Eige
 
 void UnconstrainedTimeIndexedProblem::setRho(const std::string& task_name, const double rho, int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
@@ -267,6 +283,14 @@ void UnconstrainedTimeIndexedProblem::setRho(const std::string& task_name, const
 
 Eigen::VectorXd UnconstrainedTimeIndexedProblem::getGoal(const std::string& task_name, int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
@@ -279,6 +303,14 @@ Eigen::VectorXd UnconstrainedTimeIndexedProblem::getGoal(const std::string& task
 
 double UnconstrainedTimeIndexedProblem::getRho(const std::string& task_name, int t)
 {
+    if (t >= T || t < -1)
+    {
+        throw_pretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T);
+    }
+    else if (t == -1)
+    {
+        t = T - 1;
+    }
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -98,6 +98,8 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     x.assign(T, Eigen::VectorXd::Zero(N));
     xdiff.assign(T, Eigen::VectorXd::Zero(N));
 
+    preupdate();
+
     // Set initial trajectory with current state
     InitialTrajectory.resize(T, scene_->getControlledState());
 

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -98,13 +98,13 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     x.assign(T, Eigen::VectorXd::Zero(N));
     xdiff.assign(T, Eigen::VectorXd::Zero(N));
 
-    preupdate();
-
     // Set initial trajectory with current state
     InitialTrajectory.resize(T, scene_->getControlledState());
 
     TaskSpaceVector dummy;
     Cost.initialize(init_.Cost, shared_from_this(), dummy);
+
+    preupdate();
 }
 
 void UnconstrainedTimeIndexedProblem::setT(int T_in)

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -52,6 +52,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     init_ = init;
     setT(init_.T);
     applyStartState(false);
+    reinitializeVariables();
 }
 
 void UnconstrainedTimeIndexedProblem::reinitializeVariables()
@@ -94,10 +95,10 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     yref.setZero(PhiN);
     Phi.assign(T, yref);
     J.assign(T, Eigen::MatrixXd(JN, N));
-    x.assign(T, Eigen::VectorXd::Zero(JN));
-    xdiff.assign(T, Eigen::VectorXd::Zero(JN));
+    x.assign(T, Eigen::VectorXd::Zero(N));
+    xdiff.assign(T, Eigen::VectorXd::Zero(N));
 
-    // Set initial trajectory
+    // Set initial trajectory with current state
     InitialTrajectory.resize(T, scene_->getControlledState());
 
     TaskSpaceVector dummy;
@@ -215,6 +216,10 @@ double UnconstrainedTimeIndexedProblem::getScalarTransitionCost(int t)
     else if (t == -1)
     {
         t = T - 1;
+    }
+    else if (t == 0)
+    {
+        return 0;
     }
     return ct * xdiff[t].transpose() * W * xdiff[t];
 }


### PR DESCRIPTION
- Re-adds t-indexing checks and -1 indexing (first two points in #227)
- Adds comments to AICOsolver initialiser
- Adds preupdate calls to make sure S is set up for roll-outs without a solver
- NaN fix for transition cost in roll-outs when dimension was wrong (JN instead of N for x and xdiff)

More fixes to be added later as I go (untangling the big branch with the memory leak fix right now)