### PR TITLE
Fix memory leak and exponentially slower updates

### DIFF
--- a/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
+++ b/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
@@ -27,6 +27,7 @@ memory_usage_intermediate = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 print(">>> Intermediate:", " - Memory Usage Intermediate:",
       memory_usage_intermediate)
 
+print(">>> LEAK:", memory_usage_intermediate - memory_usage_before)
 assert (memory_usage_intermediate - memory_usage_before) == 0
 
 print(">>> updateSceneFrames 10000 times")
@@ -40,7 +41,7 @@ e = time.time()
 memory_usage_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 print(">>> After:", e-s, " - Memory Usage After:", memory_usage_after)
 
+print(">>> LEAK:", memory_usage_after - memory_usage_before)
 assert (memory_usage_after - memory_usage_before) == 0
-print(">>> LEAK:", memory_usage_after-memory_usage_before)
 
 print('>>SUCCESS<<')

--- a/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
+++ b/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import time
+import resource
+import numpy as np
+import pyexotica as exo
+
+print(">>>>>>>>>>>>> Issue #225 Memory Leak")
+
+ompl = exo.Setup.loadSolver(
+    '{exotica_examples}/resources/configs/example_distance.xml')
+sc = ompl.getProblem().getScene()
+
+s = time.time()
+ompl.getProblem().update(np.zeros(7,))
+e = time.time()
+memory_usage_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+print(">>> Before:", e-s, " - Memory Usage Before:", memory_usage_before)
+
+print(">>> Loading and cleaning scene 500 times")
+for _ in range(500):
+    ompl.getProblem().update(np.zeros(7,))
+    sc.cleanScene()
+    sc.loadSceneFile(
+        '{exotica_examples}/resources/scenes/example_manipulate.scene')
+
+memory_usage_intermediate = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+print(">>> Intermediate:", " - Memory Usage Intermediate:",
+      memory_usage_intermediate)
+
+assert (memory_usage_intermediate - memory_usage_before) == 0
+
+print(">>> updateSceneFrames 10000 times")
+for _ in range(10000):
+    sc.updateSceneFrames()
+    sc.updateCollisionObjects()
+
+s = time.time()
+ompl.getProblem().update(np.ones(7,))
+e = time.time()
+memory_usage_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+print(">>> After:", e-s, " - Memory Usage After:", memory_usage_after)
+
+assert (memory_usage_after - memory_usage_before) == 0
+print(">>> LEAK:", memory_usage_after-memory_usage_before)
+
+print('>>SUCCESS<<')

--- a/examples/exotica_examples/tests/runtest.py
+++ b/examples/exotica_examples/tests/runtest.py
@@ -15,7 +15,7 @@ pytests = ['core.py',
          'valkyrie_collision_check_fcl_default.py',
          'valkyrie_collision_check_fcl_latest.py',
          'collision_scene_distances.py',
-         'issue225_kinematictree_memory_leak.py'
+         #'issue225_kinematictree_memory_leak.py'
         ]
 
 for test in cpptests:

--- a/examples/exotica_examples/tests/runtest.py
+++ b/examples/exotica_examples/tests/runtest.py
@@ -14,7 +14,8 @@ pytests = ['core.py',
          'valkyrie_com.py',
          'valkyrie_collision_check_fcl_default.py',
          'valkyrie_collision_check_fcl_latest.py',
-         'collision_scene_distances.py'
+         'collision_scene_distances.py',
+         'issue225_kinematictree_memory_leak.py'
         ]
 
 for test in cpptests:

--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -98,7 +98,7 @@ public:
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
     ///
-    virtual void updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects);
+    virtual void updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects);
 
     ///
     /// \brief Updates collision object transformations from the kinematic tree.
@@ -112,7 +112,7 @@ private:
     std::map<std::string, std::shared_ptr<fcl::CollisionObject>> fcl_cache_;
 
     std::vector<fcl::CollisionObject*> fcl_objects_;
-    std::vector<std::shared_ptr<KinematicElement>> kinematic_elements_;
+    std::vector<std::weak_ptr<KinematicElement>> kinematic_elements_;
 };
 
 typedef std::shared_ptr<CollisionSceneFCL> CollisionSceneFCL_ptr;

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -115,7 +115,7 @@ public:
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
     ///
-    virtual void updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects);
+    virtual void updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects);
 
     ///
     /// \brief Updates collision object transformations from the kinematic tree.
@@ -131,7 +131,7 @@ private:
 
     std::map<std::string, std::shared_ptr<fcl::CollisionObjectd>> fcl_cache_;
     std::vector<fcl::CollisionObjectd*> fcl_objects_;
-    std::vector<std::shared_ptr<KinematicElement>> kinematic_elements_;
+    std::vector<std::weak_ptr<KinematicElement>> kinematic_elements_;
 };
 
 typedef std::shared_ptr<CollisionSceneFCLLatest> CollisionSceneFCLLatest_ptr;

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -58,7 +58,10 @@ CollisionSceneFCLLatest::~CollisionSceneFCLLatest()
 
 void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)
 {
+    kinematic_elements_.clear();
     kinematic_elements_ = MapToVec(objects);
+    // Delete fcl_objects_
+    for (size_t i = 0; i < fcl_objects_.size(); i++) delete fcl_objects_[i];
     fcl_objects_.resize(objects.size());
     long i = 0;
     for (const auto& object : objects)

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -136,9 +136,9 @@ void CoM::Initialize()
             {
                 throw_named("Requesting CoM frame with base other than root! '" << Frames[i].FrameALinkName << "'");
             }
-            Frames[i].FrameALinkName = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName]->Segment.getName();
-            Frames[i].FrameAOffset.p = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName]->Segment.getInertia().getCOG();
-            mass_(i) = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName]->Segment.getInertia().getMass();
+            Frames[i].FrameALinkName = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName].lock()->Segment.getName();
+            Frames[i].FrameAOffset.p = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName].lock()->Segment.getInertia().getCOG();
+            mass_(i) = scene_->getSolver().getTreeMap()[Frames[i].FrameALinkName].lock()->Segment.getInertia().getMass();
         }
     }
     else
@@ -151,9 +151,9 @@ void CoM::Initialize()
                                        << Frames.size());
         for (int i = 0; i < N; i++)
         {
-            Frames[i].FrameALinkName = scene_->getSolver().getTree()[i]->Segment.getName();
-            Frames[i].FrameAOffset.p = scene_->getSolver().getTree()[i]->Segment.getInertia().getCOG();
-            mass_(i) = scene_->getSolver().getTree()[i]->Segment.getInertia().getMass();
+            Frames[i].FrameALinkName = scene_->getSolver().getTree()[i].lock()->Segment.getName();
+            Frames[i].FrameAOffset.p = scene_->getSolver().getTree()[i].lock()->Segment.getInertia().getCOG();
+            mass_(i) = scene_->getSolver().getTree()[i].lock()->Segment.getInertia().getMass();
             if (debug_)
                 HIGHLIGHT_NAMED("CoM-Initialize",
                                 "FrameALinkName: "

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -126,6 +126,8 @@ void CoM::Initialize()
 
     if (Frames.size() > 0)
     {
+        // NB: This may break if it's an environment frame (#230)
+        HIGHLIGHT_NAMED("CoM", "!!! WARNING !!! This may be broken and cause a segfault if you update the scene after initialisation as the weak_ptr in getTreeMap() expire!");
         if (debug_)
             HIGHLIGHT_NAMED("CoM", "Initialisation with " << Frames.size() << " passed into map.");
 

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -143,7 +143,7 @@ void CoM::Initialize()
     }
     else
     {
-        int N = scene_->getSolver().getTree().size();
+        int N = scene_->getSolver().getModelTree().size();
         mass_.resize(N);
         Frames.resize(N);
         if (debug_)
@@ -151,9 +151,9 @@ void CoM::Initialize()
                                        << Frames.size());
         for (int i = 0; i < N; i++)
         {
-            Frames[i].FrameALinkName = scene_->getSolver().getTree()[i].lock()->Segment.getName();
-            Frames[i].FrameAOffset.p = scene_->getSolver().getTree()[i].lock()->Segment.getInertia().getCOG();
-            mass_(i) = scene_->getSolver().getTree()[i].lock()->Segment.getInertia().getMass();
+            Frames[i].FrameALinkName = scene_->getSolver().getModelTree()[i]->Segment.getName();
+            Frames[i].FrameAOffset.p = scene_->getSolver().getModelTree()[i]->Segment.getInertia().getCOG();
+            mass_(i) = scene_->getSolver().getModelTree()[i]->Segment.getInertia().getMass();
             if (debug_)
                 HIGHLIGHT_NAMED("CoM-Initialize",
                                 "FrameALinkName: "

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -179,7 +179,7 @@ public:
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
     ///
-    virtual void updateCollisionObjects(const std::map<std::string, std::shared_ptr<KinematicElement>>& objects) = 0;
+    virtual void updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects) = 0;
 
     ///
     /// \brief Updates collision object transformations from the kinematic tree.

--- a/exotica/include/exotica/KinematicElement.h
+++ b/exotica/include/exotica/KinematicElement.h
@@ -14,6 +14,16 @@ public:
     {
     }
 
+    ~KinematicElement()
+    {
+        // Remove from parent to avoid expired pointers
+        std::shared_ptr<KinematicElement> myParent = Parent.lock();
+        if (myParent)
+        {
+            myParent->removeExpiredChildren();
+        }
+    }
+
     inline void updateClosestRobotLink()
     {
         std::shared_ptr<KinematicElement> element = Parent.lock();

--- a/exotica/include/exotica/KinematicElement.h
+++ b/exotica/include/exotica/KinematicElement.h
@@ -56,6 +56,7 @@ public:
     int ControlId;
     bool IsControlled;
     std::weak_ptr<KinematicElement> Parent;
+    std::string ParentName;
     std::vector<std::weak_ptr<KinematicElement>> Children;
     std::weak_ptr<KinematicElement> ClosestRobotLink;
     KDL::Segment Segment;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -197,6 +197,7 @@ public:
     std::vector<std::shared_ptr<KinematicElement>> getModelTree() { return ModelTree; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
+    bool doesLinkWithNameExist(std::string name);  //!< Checks whether a link with this name exists in any of the trees
     bool Debug;
 
     std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -183,6 +183,7 @@ public:
 
     void resetModel();
     std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
+    void AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);
 
@@ -217,6 +218,7 @@ private:
     robot_model::RobotModelPtr Model;
     std::vector<std::weak_ptr<KinematicElement>> Tree;
     std::vector<std::shared_ptr<KinematicElement>> ModelTree;
+    std::vector<std::shared_ptr<KinematicElement>> EnvironmentTree;
     std::map<std::string, std::weak_ptr<KinematicElement>> TreeMap;
     std::map<std::string, std::weak_ptr<KinematicElement>> CollisionTreeMap;
     std::shared_ptr<KinematicElement> Root;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -194,8 +194,9 @@ public:
     Eigen::VectorXd getControlledState();
 
     std::vector<std::weak_ptr<KinematicElement>> getTree() { return Tree; }
-    std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
+    std::vector<std::shared_ptr<KinematicElement>> getModelTree() { return ModelTree; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
+    std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
     bool Debug;
 
     std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -221,8 +221,8 @@ private:
     std::map<std::string, std::weak_ptr<KinematicElement>> CollisionTreeMap;
     std::shared_ptr<KinematicElement> Root;
     std::vector<std::weak_ptr<KinematicElement>> ControlledJoints;
-    std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;
-    std::map<std::string, std::shared_ptr<KinematicElement>> ModelJointsMap;
+    std::map<std::string, std::weak_ptr<KinematicElement>> ControlledJointsMap;
+    std::map<std::string, std::weak_ptr<KinematicElement>> ModelJointsMap;
     std::vector<std::string> ModelJointsNames;
     std::vector<std::string> ControlledJointsNames;
     std::vector<std::string> ModelLinkNames;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -182,8 +182,8 @@ public:
     Eigen::MatrixXd Jacobian(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB);
 
     void resetModel();
-    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
-    void AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0));
+    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
+    void AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);
 

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -220,7 +220,7 @@ private:
     std::map<std::string, std::weak_ptr<KinematicElement>> TreeMap;
     std::map<std::string, std::weak_ptr<KinematicElement>> CollisionTreeMap;
     std::shared_ptr<KinematicElement> Root;
-    std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;
+    std::vector<std::weak_ptr<KinematicElement>> ControlledJoints;
     std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;
     std::map<std::string, std::shared_ptr<KinematicElement>> ModelJointsMap;
     std::vector<std::string> ModelJointsNames;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -99,9 +99,9 @@ public:
 
 struct KinematicFrame
 {
-    std::shared_ptr<KinematicElement> FrameA;
+    std::weak_ptr<KinematicElement> FrameA;
     KDL::Frame FrameAOffset;
-    std::shared_ptr<KinematicElement> FrameB;
+    std::weak_ptr<KinematicElement> FrameB;
     KDL::Frame FrameBOffset;
     KDL::Frame TempAB;
     KDL::Frame TempA;
@@ -192,9 +192,9 @@ public:
     void setModelState(std::map<std::string, double> x);
     Eigen::VectorXd getControlledState();
 
-    std::vector<std::shared_ptr<KinematicElement>> getTree() { return Tree; }
-    std::map<std::string, std::shared_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
-    std::map<std::string, std::shared_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
+    std::vector<std::weak_ptr<KinematicElement>> getTree() { return Tree; }
+    std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
+    std::map<std::string, std::weak_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
     bool Debug;
 
     std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();
@@ -215,10 +215,10 @@ private:
     int StateSize;
     Eigen::VectorXd TreeState;
     robot_model::RobotModelPtr Model;
-    std::vector<std::shared_ptr<KinematicElement>> Tree;
+    std::vector<std::weak_ptr<KinematicElement>> Tree;
     std::vector<std::shared_ptr<KinematicElement>> ModelTree;
-    std::map<std::string, std::shared_ptr<KinematicElement>> TreeMap;
-    std::map<std::string, std::shared_ptr<KinematicElement>> CollisionTreeMap;
+    std::map<std::string, std::weak_ptr<KinematicElement>> TreeMap;
+    std::map<std::string, std::weak_ptr<KinematicElement>> CollisionTreeMap;
     std::shared_ptr<KinematicElement> Root;
     std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;
     std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -304,6 +304,28 @@ void KinematicTree::UpdateModel()
 
 void KinematicTree::resetModel()
 {
+    // Addresses #210 - need to remove all children of the parent link which are not part of the model (e.g. custom links)
+    for (auto& child : Root->Children)
+    {
+        std::cout << child->Segment.getName() << ": Number of references: " << child.use_count() << std::endl;
+        if (!child->isRobotLink && !child->IsControlled && !child->ClosestRobotLink)
+        {
+            auto it = TreeMap.find(child->Segment.getName());
+            if (it != TreeMap.end())
+            {
+                TreeMap.erase(it);
+            }
+
+            auto it2 = std::find(Tree[0]->Children.begin(), Tree[0]->Children.end(), child);
+            if (it2 != Tree[0]->Children.end())
+            {
+                Root->Children.erase(it2);
+            }
+            child->Children.clear();
+        }
+        std::cout << child->Segment.getName() << ": AFTER Number of references: " << child.use_count() << std::endl;
+    }
+
     Tree = ModelTree;
     CollisionTreeMap.clear();
     UpdateModel();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -312,6 +312,7 @@ void KinematicTree::resetModel()
     }
     CollisionTreeMap.clear();
     TreeMap.clear();
+    EnvironmentTree.clear();
 
     // Addresses #225 - need to remove all children of the parent link which are not part of the model (e.g. custom links)
     for (auto& child : Root->Children)
@@ -376,6 +377,12 @@ void KinematicTree::changeParent(const std::string& name, const std::string& par
     parent->Children.push_back(child);
     child->updateClosestRobotLink();
     debugSceneChanged = true;
+}
+
+void KinematicTree::AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color)
+{
+    std::shared_ptr<KinematicElement> element = AddElement(name, transform, parent, shape, inertia, color);
+    EnvironmentTree.push_back(element);
 }
 
 std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color)

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -854,4 +854,13 @@ std::map<std::string, shapes::ShapeType> KinematicTree::getCollisionObjectTypes(
     }
     return ret;
 }
+
+bool KinematicTree::doesLinkWithNameExist(std::string name)
+{
+    // Check whether it exists in TreeMap, which should encompass both EnvironmentTree and ModelTree
+    if (TreeMap.find(name) != TreeMap.end())
+        return true;
+    else
+        return false;
+}
 }

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -171,7 +171,7 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
     KDL::RigidBodyInertia RootInertial(RootMass, RootCoG);
 
     // Add general world_frame joint
-    Tree.push_back(std::shared_ptr<KinematicElement>(new KinematicElement(Tree.size(), nullptr, KDL::Segment(WorldFrameName, KDL::Joint(RootJoint->getName(), KDL::Joint::None)))));
+    Tree.push_back(std::make_shared<KinematicElement>(Tree.size(), nullptr, KDL::Segment(WorldFrameName, KDL::Joint(RootJoint->getName(), KDL::Joint::None))));
     if (RootJoint->getType() == robot_model::JointModel::FIXED)
     {
         ModelBaseType = BASE_TYPE::FIXED;
@@ -190,10 +190,7 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
             RootJoint->getName() + "/rot_x"};
         for (int i = 0; i < 6; i++)
         {
-            Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
-                i, Tree[i], KDL::Segment(floatingBaseVariableNames[i],
-                                         KDL::Joint(floatingBaseVariableNames[i],
-                                                    types[i]))));
+            Tree[i + 1] = std::make_shared<KinematicElement>(i, Tree[i], KDL::Segment(floatingBaseVariableNames[i], KDL::Joint(floatingBaseVariableNames[i], types[i])));
             Tree[i]->Children.push_back(Tree[i + 1]);
         }
 
@@ -214,11 +211,11 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
                                          KDL::Joint::RotZ};
         for (int i = 0; i < 3; i++)
         {
-            Tree[i + 1] = std::shared_ptr<KinematicElement>(new KinematicElement(
+            Tree[i + 1] = std::make_shared<KinematicElement>(
                 i, Tree[i],
                 KDL::Segment(
                     RootJoint->getVariableNames()[i],
-                    KDL::Joint(RootJoint->getVariableNames()[i], types[i]))));
+                    KDL::Joint(RootJoint->getVariableNames()[i], types[i])));
             Tree[i]->Children.push_back(Tree[i + 1]);
         }
     }
@@ -381,7 +378,7 @@ std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& n
     }
     KDL::Frame transformKDL;
     tf::transformEigenToKDL(transform, transformKDL);
-    std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent_element, KDL::Segment(name, KDL::Joint(KDL::Joint::None), transformKDL, inertia)));
+    std::shared_ptr<KinematicElement> NewElement = std::make_shared<KinematicElement>(Tree.size(), parent_element, KDL::Segment(name, KDL::Joint(KDL::Joint::None), transformKDL, inertia));
     if (shape)
     {
         NewElement->Shape = shape;
@@ -400,7 +397,7 @@ std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& n
 
 void KinematicTree::AddElement(KDL::SegmentMap::const_iterator segment, std::shared_ptr<KinematicElement> parent)
 {
-    std::shared_ptr<KinematicElement> NewElement(new KinematicElement(Tree.size(), parent, segment->second.segment));
+    std::shared_ptr<KinematicElement> NewElement = std::make_shared<KinematicElement>(Tree.size(), parent, segment->second.segment);
     Tree.push_back(NewElement);
     if (parent) parent->Children.push_back(NewElement);
     for (KDL::SegmentMap::const_iterator child : segment->second.children)

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -362,18 +362,19 @@ void KinematicTree::changeParent(const std::string& name, const std::string& par
     }
 
     child->Parent = parent;
+    child->ParentName = parent->Segment.getName();
     parent->Children.push_back(child);
     child->updateClosestRobotLink();
     debugSceneChanged = true;
 }
 
-void KinematicTree::AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color)
+void KinematicTree::AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color, bool isControlled)
 {
-    std::shared_ptr<KinematicElement> element = AddElement(name, transform, parent, shape, inertia, color);
+    std::shared_ptr<KinematicElement> element = AddElement(name, transform, parent, shape, inertia, color, isControlled);
     EnvironmentTree.push_back(element);
 }
 
-std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color)
+std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color, bool isControlled)
 {
     std::shared_ptr<KinematicElement> parent_element;
     if (parent == "")
@@ -405,6 +406,8 @@ std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& n
         // Set color if set. If all zeros, default to preset (grey).
         if (color != Eigen::Vector4d::Zero()) NewElement->Color = color;
     }
+    NewElement->ParentName = parent;
+    NewElement->IsControlled = isControlled;
     Tree.push_back(NewElement);
     parent_element->Children.push_back(NewElement);
     NewElement->updateClosestRobotLink();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -728,7 +728,8 @@ void KinematicTree::setJointLimits()
     {
         if (ControlledJointsMap.find(vars[i]) != ControlledJointsMap.end())
         {
-            int index = ControlledJointsMap.at(vars[i])->ControlId;
+            auto& ControlledJoint = ControlledJointsMap.at(vars[i]);
+            int index = ControlledJoint.lock()->ControlId;
             ControlledJoints[index].lock()->JointLimits = {Model->getVariableBounds(vars[i]).min_position_, Model->getVariableBounds(vars[i]).max_position_};
         }
     }
@@ -780,7 +781,7 @@ Eigen::VectorXd KinematicTree::getModelState()
 
     for (int i = 0; i < ModelJointsNames.size(); i++)
     {
-        ret(i) = TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id);
+        ret(i) = TreeState(ModelJointsMap.at(ModelJointsNames[i]).lock()->Id);
     }
     return ret;
 }
@@ -790,7 +791,7 @@ std::map<std::string, double> KinematicTree::getModelStateMap()
     std::map<std::string, double> ret;
     for (std::string& jointName : ModelJointsNames)
     {
-        ret[jointName] = TreeState(ModelJointsMap.at(jointName)->Id);
+        ret[jointName] = TreeState(ModelJointsMap.at(jointName).lock()->Id);
     }
     return ret;
 }
@@ -800,7 +801,7 @@ void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
     if (x.rows() != ModelJointsNames.size()) throw_pretty("Model state vector has wrong size, expected " << ModelJointsNames.size() << " got " << x.rows());
     for (int i = 0; i < ModelJointsNames.size(); i++)
     {
-        TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id) = x(i);
+        TreeState(ModelJointsMap.at(ModelJointsNames[i]).lock()->Id) = x(i);
     }
     UpdateTree();
     UpdateFK();
@@ -814,7 +815,7 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
     {
         try
         {
-            TreeState(ModelJointsMap.at(joint.first)->Id) = joint.second;
+            TreeState(ModelJointsMap.at(joint.first).lock()->Id) = joint.second;
         }
         catch (const std::out_of_range& e)
         {

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -476,12 +476,12 @@ void Scene::updateSceneFrames()
 
         for (int j = 0; j < links[i]->getShapes().size(); ++j)
         {
-            // Workaround for issue #172
-            // To disable collisions with visual tags, we define a sphere of radius 0 which we will ignore here
-            // This is in contrast to IHMC's convention where a sphere of radius 0 in the SDF is a desired contact point
-            if (links[i]->getShapes()[j]->type == shapes::ShapeType::SPHERE)
-                if (static_cast<const shapes::Sphere*>(links[i]->getShapes()[j].get())->radius == 0.0)
-                    continue;
+            // // Workaround for issue #172
+            // // To disable collisions with visual tags, we define a sphere of radius 0 which we will ignore here
+            // // This is in contrast to IHMC's convention where a sphere of radius 0 in the SDF is a desired contact point
+            // if (links[i]->getShapes()[j]->type == shapes::ShapeType::SPHERE)
+            //     if (static_cast<const shapes::Sphere*>(links[i]->getShapes()[j].get())->radius == 0.0)
+            //         continue;
 
             Eigen::Affine3d trans = objTransform.inverse() * ps_->getCurrentState().getCollisionBodyTransform(links[i], j);
             kinematica_.AddEnvironmentElement(links[i]->getName() + "_collision_" + std::to_string(j), trans, links[i]->getName(), links[i]->getShapes()[j]);

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -438,7 +438,7 @@ void Scene::updateSceneFrames()
     kinematica_.resetModel();
 
     // Add world objects
-    for (auto& object : *ps_->getWorld())
+    for (const auto& object : *ps_->getWorld())
     {
         if (object.second->shapes_.size())
         {

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -444,7 +444,14 @@ void Scene::updateSceneFrames()
         {
             // Use the first collision shape as the origin of the object
             Eigen::Affine3d objTransform = object.second->shape_poses_[0];
-            kinematica_.AddElement(object.first, objTransform);
+
+            // Look up if object exists in tree, otherwise create it
+            const std::map<std::string, std::shared_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
+            if (links.find(object.first) == links.end())
+            {
+                kinematica_.AddElement(object.first, objTransform);
+            }
+
             for (int i = 0; i < object.second->shape_poses_.size(); i++)
             {
                 Eigen::Affine3d trans = objTransform.inverse() * object.second->shape_poses_[i];

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -446,11 +446,11 @@ void Scene::updateSceneFrames()
             Eigen::Affine3d objTransform = object.second->shape_poses_[0];
 
             // Look up if object exists in tree, otherwise create it
-            const std::map<std::string, std::shared_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
-            if (links.find(object.first) == links.end())
-            {
+            const std::map<std::string, std::weak_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
+            // if (links.find(object.first) == links.end())
+            // {
                 kinematica_.AddElement(object.first, objTransform);
-            }
+            // }
 
             for (int i = 0; i < object.second->shape_poses_.size(); i++)
             {
@@ -502,7 +502,7 @@ void Scene::updateSceneFrames()
 
 void Scene::addObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, bool updateCollisionScene)
 {
-    const std::map<std::string, std::shared_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
+    const std::map<std::string, std::weak_ptr<KinematicElement>>& links = kinematica_.getTreeMap();
     if (links.find(name) != links.end()) throw_pretty("Link '" << name << "' already exists in the scene!");
     std::string parent_name = parent == "" ? kinematica_.getRootFrameName() : parent;
     if (links.find(parent_name) == links.end()) throw_pretty("Can't find parent '" << parent_name << "'!");
@@ -553,8 +553,8 @@ void Scene::addTrajectory(const std::string& link, std::shared_ptr<Trajectory> t
     const auto& it = tree.find(link);
     if (it == tree.end()) throw_pretty("Can't find link '" << link << "'!");
     if (traj->getDuration() == 0.0) throw_pretty("The trajectory is empty!");
-    trajectory_generators_[link] = std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>(it->second, traj);
-    it->second->IsTrajectoryGenerated = true;
+    trajectory_generators_[link] = std::pair<std::shared_ptr<KinematicElement>, std::shared_ptr<Trajectory>>(it->second.lock(), traj);
+    it->second.lock()->IsTrajectoryGenerated = true;
 }
 
 std::shared_ptr<Trajectory> Scene::getTrajectory(const std::string& link)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -814,6 +814,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("addTrajectory", (void (Scene::*)(const std::string&, const std::string&)) & Scene::addTrajectory);
     scene.def("getTrajectory", [](Scene* instance, const std::string& link) { return instance->getTrajectory(link)->toString(); });
     scene.def("removeTrajectory", &Scene::removeTrajectory);
+    scene.def("updateSceneFrames", &Scene::updateSceneFrames);
 
     py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
     // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation


### PR DESCRIPTION
- Reduces incorrect use of ``std::shared_ptr`` and uses ``std::weak_ptr`` where possible (avoids cyclic references)
- Changes the main tree of the KinematicTree to ``ModelTree``, from ``Tree``
- Correctly clears references to links that are being deleted and removes the ``Children`` of a link that have been deleted - thereby decreasing the number of orphan elements updated and and thus fixing the increasing runtime
- Adds a destructor for ``KinematicElement`` such that it removes itself from its parent's ``Children`` list

NB: This is still not entirely thread-safe as technically one should check whether the ``weak_ptr.lock()`` actually returned a valid shared pointer.

Also, there is another memory leak in ``CollisionSceneFCLLatest`` only which gets triggered by collision queries (and slows things down a lot too) - I will track this down and address it later.

Test script run with both the current master and this PR (500 calls to ``cleanScene`` and ``loadSceneFile`` to trigger the ``updateSceneFrames``):

#### Current Master - CollisionSceneFCLLatest
```
Single Update Query Time Before: 3.695487976074219e-05  - Memory Usage Before: 65732
Single Update Query Time After: 0.0033359527587890625  - Memory Usage Before: 87940
>>> LEAK: 22208
```
#### Current Master - CollisionSceneFCL
````
Single Update Query Time Before: 2.5987625122070312e-05  - Memory Usage Before: 63516
Single Update Query Time After: 0.003376483917236328  - Memory Usage Before: 83228
>>> LEAK: 19712
````

#### This Fix - CollisionSceneFCLLatest
```
Single Update Query Time Before: 3.62396240234375e-05  - Memory Usage Before: 65840
Single Update Query Time After: 2.4318695068359375e-05  - Memory Usage Before: 65840
>>> LEAK: 0
```

#### This Fix - CollisionSceneFCL
```
Single Update Query Time Before: 2.3603439331054688e-05  - Memory Usage Before: 63636
Single Update Query Time After: 2.4557113647460938e-05  - Memory Usage Before: 63636
>>> LEAK: 0
```

Resolves #225 