### PR TITLE
Fixes AICO's incorrect indexing into the Jacobian submatrices

### DIFF
--- a/examples/exotica_examples/resources/configs/aico_trajectory.xml
+++ b/examples/exotica_examples/resources/configs/aico_trajectory.xml
@@ -8,6 +8,7 @@
     <Damping>0.01</Damping>
     <UseBackwardMessage>0</UseBackwardMessage>
     <Dynamic>0</Dynamic>
+    <Debug>1</Debug>
   </AICOsolver>
 
   <UnconstrainedTimeIndexedProblem Name="MyProblem">

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -216,6 +216,8 @@ private:
     int lastT;  //!< T the last time initMessages was called.
 
     int sweep;  //!< Sweeps so far
+    int bestSweep;
+    int bestSweep_old;
     enum SweepMode
     {
         smForwardly = 0,

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -133,6 +133,9 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
         HIGHLIGHT("AICO::Solve called with initial trajectory guess");
     }
 
+    prob_->setStartState(q_init[0]);
+    prob_->applyStartState();
+
     Timer timer;
     if (debug_) ROS_WARN_STREAM("AICO: Setting up the solver");
     updateCount = 0;

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -503,9 +503,9 @@ double AICOsolver::getTaskCosts(int t)
             {
                 int start = prob_->Cost.Indexing[i].StartJ;
                 int len = prob_->Cost.Indexing[i].LengthJ;
-                Jt = prob_->J[t].middleRows(start, len).transpose();
+                Jt = prob_->Cost.J[t].middleRows(start, len).transpose();
                 C += prec * (prob_->Cost.ydiff[t].segment(start, len)).squaredNorm();
-                R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
+                R[t] += prec * Jt * prob_->Cost.J[t].middleRows(start, len);
                 r[t] += prec * Jt * (-prob_->Cost.ydiff[t].segment(start, len) + prob_->Cost.J[t].middleRows(start, len) * qhat[t]);
                 rhat[t] += prec * (-prob_->Cost.ydiff[t].segment(start, len) + prob_->Cost.J[t].middleRows(start, len) * qhat[t]).squaredNorm();
             }

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -344,7 +344,7 @@ void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
 
     cost = evaluateTrajectory(b, true);
     if (cost < 0) throw_named("Invalid cost! " << cost);
-    if(debug_) HIGHLIGHT("Initial cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << ", updates: " << updateCount);
+    if (debug_) HIGHLIGHT("Initial cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << ", updates: " << updateCount);
     rememberOldState();
 }
 
@@ -784,7 +784,7 @@ void AICOsolver::perhapsUndoStep()
                 prob_->Update(q[t], t);
             }
         }
-        if (debug_) HIGHLIGHT("Reverting to previous step ("<<bestSweep<<")");
+        if (debug_) HIGHLIGHT("Reverting to previous step (" << bestSweep << ")");
     }
     else
     {

--- a/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
@@ -73,6 +73,8 @@ public:
     double ct;  //!< Normalisation of scalar cost and Jacobian over trajectory length
     TimeIndexedTask Cost;
 
+    TaskSpaceVector CostPhi;
+
     double W_rate;  //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)
     Eigen::MatrixXd W;
 

--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -83,6 +83,10 @@ public:
     TimeIndexedTask Inequality;
     TimeIndexedTask Equality;
 
+    TaskSpaceVector CostPhi;
+    TaskSpaceVector InequalityPhi;
+    TaskSpaceVector EqualityPhi;
+
     double W_rate;  //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)
     Eigen::MatrixXd W;
 

--- a/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
@@ -76,6 +76,8 @@ public:
     TaskSpaceVector Phi;
     SamplingTask Constraint;
 
+    TaskSpaceVector ConstraintPhi;
+
     int PhiN;
     int JN;
     int NumTasks;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -87,7 +87,8 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
-    TaskSpaceVector TaskPhi;  // passed to the TimeIndexedTask, needs to be kept for reinitialisation
+
+    TaskSpaceVector CostPhi;  // passed to the TimeIndexedTask, needs to be kept for reinitialisation
 
 private:
     int T;       //!< Number of time steps

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -76,6 +76,7 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
+
 protected:
     std::vector<TaskInitializer> TaskInitializers;
 };

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -87,7 +87,7 @@ public:
     virtual void initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& phi);
     void updateS();
     void update(const TaskSpaceVector& Phi, Eigen::MatrixXdRefConst J, int t);
-    void reinitializeVariables(int T, std::shared_ptr<PlanningProblem> prob);
+    void reinitializeVariables(int T, std::shared_ptr<PlanningProblem> prob, const TaskSpaceVector& phi);
 
     std::vector<Eigen::VectorXd> Rho;
     std::vector<TaskSpaceVector> y;

--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -301,8 +301,8 @@ void BoundedTimeIndexedProblem::reinitializeVariables()
     // Set initial trajectory
     InitialTrajectory.resize(T, scene_->getControlledState());
 
-    TaskSpaceVector dummy;
-    Cost.initialize(init_.Cost, shared_from_this(), dummy);
+    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
+    Cost.reinitializeVariables(T, shared_from_this(), CostPhi);
     applyStartState(false);
 }
 }

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -115,10 +115,12 @@ void TimeIndexedProblem::reinitializeVariables()
     // Set initial trajectory
     InitialTrajectory.resize(T, scene_->getControlledState());
 
-    TaskSpaceVector dummy;
-    Cost.initialize(init_.Cost, shared_from_this(), dummy);
-    Inequality.initialize(init_.Inequality, shared_from_this(), dummy);
-    Equality.initialize(init_.Equality, shared_from_this(), dummy);
+    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
+    Inequality.initialize(init_.Inequality, shared_from_this(), InequalityPhi);
+    Equality.initialize(init_.Equality, shared_from_this(), EqualityPhi);
+    Cost.reinitializeVariables(T, shared_from_this(), CostPhi);
+    Inequality.reinitializeVariables(T, shared_from_this(), InequalityPhi);
+    Equality.reinitializeVariables(T, shared_from_this(), EqualityPhi);
 }
 
 void TimeIndexedProblem::setT(int T_in)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -92,8 +92,7 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
     }
     Phi.setZero(PhiN);
 
-    TaskSpaceVector dummy;
-    Constraint.initialize(init.Constraint, shared_from_this(), dummy);
+    Constraint.initialize(init.Constraint, shared_from_this(), ConstraintPhi);
 
     applyStartState(false);
 }

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -83,7 +83,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     H = Eigen::MatrixXd::Identity(N, N) * Q_rate;
     Q = Eigen::MatrixXd::Identity(N, N) * H_rate;
 
-    Cost.initialize(init_.Cost, shared_from_this(), TaskPhi);
+    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
 
     T = init_.T;
     applyStartState(false);
@@ -104,7 +104,7 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     // Set initial trajectory with current state
     InitialTrajectory.resize(T, scene_->getControlledState());
 
-    Cost.reinitializeVariables(T, shared_from_this());
+    Cost.reinitializeVariables(T, shared_from_this(), CostPhi);
     preupdate();
 }
 


### PR DESCRIPTION
- Fixes AICO Jacobian indexing.
- Removes dependency of the `Task` classes on the `UnconstrainedTimeIndexedProblem`.
   - `TimeIndexedTask` now implements `reinitializeVariables(T, problem, phi)` method that sets up the time T.
   - The `phi` argument must be the same `TaskSpaceVector` as the one used to (and returned from the) initialize the task. Keep these as a member variable of the problem for problems with time indexing. E.g. `TimeIndexedProblem::CostPhi`. Problems that don't use the `TimeIndexedTask` can keep using a dummy local `TaskSpaceVector` (e.g. `EndPoseProblem::Cost`).
- AICO now prints out more details when in debug mode.