### PR TITLE
Fix AICO computation, do not change initial timestep (=> fix AICO warm-starts)

### DIFF
--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -210,7 +210,6 @@ private:
         smLocalGaussNewtonDamped
     };
     int sweepMode;  //!< Sweep mode
-    int n;          //!< Configuration space size
     int updateCount;
 
     Eigen::MatrixXd linSolverTmp;

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -545,7 +545,7 @@ double AICOsolver::step()
             {
                 updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd Sweep
             }
-            for (t = prob_->getT() - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t > 0; t--)
             {
                 updateTimeStep(t, false, true, 0, tolerance, false, 1.);  //...not on bwd Sweep
             }
@@ -557,7 +557,7 @@ double AICOsolver::step()
                 updateTimeStep(t, true, false, 1, tolerance, !sweep, 1.);  //relocate once on fwd & bwd Sweep
             }
             // ROS_WARN_STREAM("Updating backward, sweep "<<sweep);
-            for (t = prob_->getT() - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t > 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 1 : 0), tolerance, false, 1.);
             }
@@ -567,7 +567,7 @@ double AICOsolver::step()
             {
                 updateTimeStep(t, true, false, (sweep ? 5 : 1), tolerance, !sweep, 1.);  //relocate iteratively on
             }
-            for (t = prob_->getT() - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t > 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);  //...fwd & bwd Sweep
             }
@@ -578,7 +578,7 @@ double AICOsolver::step()
                 updateTimeStepGaussNewton(t, true, false, (sweep ? 5 : 1),
                                           tolerance, 1.);  //GaussNewton in fwd & bwd Sweep
             }
-            for (t = prob_->getT() - 2; t >= 0; t--)
+            for (t = prob_->getT() - 2; t > 0; t--)
             {
                 updateTimeStep(t, false, true, (sweep ? 5 : 0), tolerance, false, 1.);
             }

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -159,8 +159,8 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     // with the start state
     if (!(q0 - q_init[0]).isMuchSmallerThan(1e-6))
     {
-        q_init.resize(prob_->getT(), Eigen::VectorXd::Zero(q0.rows()));
-        for (int i = 0; i < q_init.size(); i++) q_init[i] = q0;
+        HIGHLIGHT("AICO::Solve cold-started");
+        q_init.assign(prob_->getT(), q0);
     }
     else
     {
@@ -316,7 +316,7 @@ void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
     cost = evaluateTrajectory(b, true);  // The problem will be updated via updateTaskMessage, i.e. do not update on this roll-out
     prob_->setCostEvolution(0, cost);
     if (cost < 0) throw_named("Invalid cost! " << cost);
-    if (debug_) HIGHLIGHT("Initial cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost << ", updates: " << updateCount);
+    if (debug_) HIGHLIGHT("Initial cost, updates: " << updateCount << ", cost(ctrl/task/total): " << costControl.sum() << "/" << costTask.sum() << "/" << cost);
     rememberOldState();
 }
 


### PR DESCRIPTION
The underlying reason for the failure to initialise AICO from an AICO trajectory was that it used to change the initial timestep _slightly_ (1e-9) and thus switched to cold-start when in fact a trajectory was provided:
```
[EXOTica]: AICO::Solve cold-started
[EXOTica]: q0:        0        0        0 0.300197     1.25        0 0.785398    1.571        0        0
[EXOTica]: q_init[0]:   9.3878e-09 -4.78724e-09  3.80724e-09     0.300197         1.25 -3.94972e-09     0.785398        1.571 -2.18962e-09  8.01216e-11
```

The reason for this was that the backward messages for the 0th timestep were updated thereby slightly changing the value. The 1e10 covariance value wasn't high enough to prevent this from happening. 

Resolves #246 