### PR TITLE
Adds Hessians to problems and Jdot to the kinematic tree

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -54,6 +54,10 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(test_initializers ${catkin_LIBRARIES})
     install(TARGETS test_initializers RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+    add_executable(test_problems tests/test_problems.cpp)
+    target_link_libraries(test_problems ${catkin_LIBRARIES})
+    install(TARGETS test_problems RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
     FILE(GLOB python_tests "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.py")
     catkin_install_python(PROGRAMS ${python_tests} DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 

--- a/examples/exotica_examples/resources/configs/test_problems.xml
+++ b/examples/exotica_examples/resources/configs/test_problems.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" ?>
+<TestConfig>
+
+<IKsolver Name="Dummy" />
+
+<UnconstrainedEndPoseProblem Name="UnconstrainedEndPoseProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+
+    <W> 7 6 5 4 3 2 1 </W>
+</UnconstrainedEndPoseProblem>
+
+<UnconstrainedTimeIndexedProblem Name="UnconstrainedTimeIndexedProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+
+    <T>5</T>
+    <Tau>0.05</Tau>
+    <W> 7 6 5 4 3 2 1 </W>
+</UnconstrainedTimeIndexedProblem>
+
+<SamplingProblem Name="SamplingProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+
+    <Maps>
+        <Distance Name="Distance">
+        <EndEffector>
+                <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0.1 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.35 -0.2 0.9 0 0 0 1"/>
+            </EndEffector>
+        </Distance>
+    </Maps>
+
+    <Constraint>
+        <Task Task="Distance" Rho="-1" Goal="0.42"/>
+    </Constraint>
+
+    <Goal>2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
+</SamplingProblem>
+
+<TimeIndexedSamplingProblem Name="TimeIndexedSamplingProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+            <LoadScene>{exotica_examples}/resources/scenes/example_moving_obstacle.scene</LoadScene>
+            <Trajectories>
+                <Trajectory Link="Obstacle" File="{exotica_examples}/resources/scenes/example_moving_obstacle.traj" />
+            </Trajectories>
+        </Scene>
+    </PlanningScene>
+
+    <Maps>
+        <CollisionCheck Name="Collision" SelfCollision="1" />
+    </Maps>
+
+    <Constraint>
+        <Task Task="Collision"/>
+    </Constraint>
+
+    <T>3</T>
+    <GoalTime>3</GoalTime>
+    <JointVelocityLimits>2 2 2 2 2 2 2</JointVelocityLimits>
+    <Goal>2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
+</TimeIndexedSamplingProblem>
+
+<BoundedEndPoseProblem Name="BoundedEndPoseProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+
+    <W> 7 6 5 4 3 2 1 </W>
+</BoundedEndPoseProblem>
+
+<BoundedTimeIndexedProblem Name="BoundedTimeIndexedProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+
+    <T>5</T>
+    <Tau>0.05</Tau>
+    <W> 7 6 5 4 3 2 1 </W>
+</BoundedTimeIndexedProblem>
+
+<EndPoseProblem Name="EndPoseProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+    <Equality>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Equality>
+    <Inequality>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Inequality>
+
+    <W> 7 6 5 4 3 2 1 </W>
+</EndPoseProblem>
+
+<TimeIndexedProblem Name="TimeIndexedProblem">
+    <PlanningScene>
+        <Scene>
+            <JointGroup>arm</JointGroup>
+            <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+            <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        </Scene>
+    </PlanningScene>
+    <Maps>
+        <EffPosition Name="Position">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+            </EndEffector>
+        </EffPosition>
+        <EffOrientation Name="Orientation">
+            <EndEffector>
+                <Frame Link="lwr_arm_7_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+            </EndEffector>
+        </EffOrientation>
+    </Maps>
+
+    <Cost>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Cost>
+    <Equality>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Equality>
+    <Inequality>
+        <Task Task="Position"/>
+        <Task Task="Orientation"/>
+    </Inequality>
+
+    <T>5</T>
+    <Tau>0.05</Tau>
+    <W> 7 6 5 4 3 2 1 </W>
+</TimeIndexedProblem>
+
+</TestConfig>

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -56,7 +56,7 @@ void run()
     Eigen::VectorXd startState = Eigen::VectorXd::Zero(7);
     Eigen::VectorXd nominalState = Eigen::VectorXd::Zero(7);
 
-    UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, startState, 0.0, {cost}, W, nominalState);
+    UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, startState, 0.0, -1, {cost}, W, nominalState);
     IKsolverInitializer solver("MySolver");
     solver.C = 1e-3;
     solver.MaxIt = 1;

--- a/examples/exotica_examples/tests/runtest.py
+++ b/examples/exotica_examples/tests/runtest.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 cpptests = ['test_initializers',
-         'test_maps'
+         'test_maps', 'test_problems'
         ]
 
 pytests = ['core.py',

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -130,7 +130,7 @@ UnconstrainedEndPoseProblem_ptr setupProblem(Initializer& map)
 {
     Initializer scene("Scene", {{"Name", std::string("MyScene")}, {"JointGroup", std::string("arm")}});
     Initializer cost("exotica/Task", {{"Task", std::string("MyTask")}});
-    Eigen::VectorXd W = Eigen::Vector3d(3,2,1);
+    Eigen::VectorXd W = Eigen::Vector3d(3, 2, 1);
     Initializer problem("exotica/UnconstrainedEndPoseProblem", {
                                                                    {"Name", std::string("MyProblem")},
                                                                    {"PlanningScene", scene},

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -130,8 +130,7 @@ UnconstrainedEndPoseProblem_ptr setupProblem(Initializer& map)
 {
     Initializer scene("Scene", {{"Name", std::string("MyScene")}, {"JointGroup", std::string("arm")}});
     Initializer cost("exotica/Task", {{"Task", std::string("MyTask")}});
-    Eigen::VectorXd W(3);
-    W << 3, 2, 1;
+    Eigen::VectorXd W = Eigen::Vector3d(3,2,1);
     Initializer problem("exotica/UnconstrainedEndPoseProblem", {
                                                                    {"Name", std::string("MyProblem")},
                                                                    {"PlanningScene", scene},

--- a/examples/exotica_examples/tests/test_problems.cpp
+++ b/examples/exotica_examples/tests/test_problems.cpp
@@ -68,7 +68,7 @@ void testHessianEndPose(std::shared_ptr<T> problem, EndPoseTask& task, double ep
         Hessian H1 = H0;
         for (int k = 0; k < task.JN; k++)
         {
-            H1(k) = J0.row(k).transpose()*J0.row(k);
+            H1(k) = J0.row(k).transpose() * J0.row(k);
         }
         for (int i = 0; i < H.rows(); i++) H(i).setZero();
         for (int i = 0; i < problem->N; i++)
@@ -79,22 +79,25 @@ void testHessianEndPose(std::shared_ptr<T> problem, EndPoseTask& task, double ep
             Eigen::MatrixXd Ji = task.J;
             for (int k = 0; k < task.JN; k++)
             {
-                H(k).row(i) = (Ji.row(k) - J0.row(k))/eps;
+                H(k).row(i) = (Ji.row(k) - J0.row(k)) / eps;
             }
         }
-        Hessian dH=H-H0;
-        Hessian dH1=H1-H0;
+        Hessian dH = H - H0;
+        Hessian dH1 = H1 - H0;
         double errH = 0.0;
-        for(int i=0;i<dH.rows();i++)
-            errH=std::min(std::max(errH,dH(i).array().cwiseAbs().maxCoeff()),
-                          std::max(errH,dH1(i).array().cwiseAbs().maxCoeff()));
+        for (int i = 0; i < dH.rows(); i++)
+            errH = std::min(std::max(errH, dH(i).array().cwiseAbs().maxCoeff()),
+                            std::max(errH, dH1(i).array().cwiseAbs().maxCoeff()));
         if (errH > eps)
         {
-            for(int i=0;i<dH.rows();i++)
+            for (int i = 0; i < dH.rows(); i++)
             {
-                HIGHLIGHT("Computed:\n"<<H0(i));
-                HIGHLIGHT("FD:\n"<<H(i));
-                HIGHLIGHT("Diff:\n"<<dH(i));
+                HIGHLIGHT("Computed:\n"
+                          << H0(i));
+                HIGHLIGHT("FD:\n"
+                          << H(i));
+                HIGHLIGHT("Diff:\n"
+                          << dH(i));
             }
             throw_pretty("Hessian error out of bounds: " << errH);
         }
@@ -110,7 +113,7 @@ void testJacobianTimeIndexed(std::shared_ptr<T> problem, TimeIndexedTask& task, 
     {
         Eigen::VectorXd x0(problem->N);
         x0.setRandom();
-        problem->Update(x0,t);
+        problem->Update(x0, t);
         TaskSpaceVector y0 = task.Phi[t];
         Eigen::MatrixXd J0 = task.J[t];
         Eigen::MatrixXd J = Eigen::MatrixXd::Zero(J0.rows(), J0.cols());
@@ -118,7 +121,7 @@ void testJacobianTimeIndexed(std::shared_ptr<T> problem, TimeIndexedTask& task, 
         {
             Eigen::VectorXd x = x0;
             x(i) += eps;
-            problem->Update(x,t);
+            problem->Update(x, t);
             J.col(i) = (task.Phi[t] - y0) / eps;
         }
         double errJ = (J - J0).norm();
@@ -143,40 +146,43 @@ void testHessianTimeIndexed(std::shared_ptr<T> problem, TimeIndexedTask& task, i
     {
         Eigen::VectorXd x0(problem->N);
         x0.setRandom();
-        problem->Update(x0,t);
+        problem->Update(x0, t);
         Eigen::MatrixXd J0 = task.J[t];
         Hessian H0 = task.H[t];
         Hessian H = H0;
         Hessian H1 = H0;
         for (int k = 0; k < task.JN; k++)
         {
-            H1(k) = J0.row(k).transpose()*J0.row(k);
+            H1(k) = J0.row(k).transpose() * J0.row(k);
         }
         for (int i = 0; i < H.rows(); i++) H(i).setZero();
         for (int i = 0; i < problem->N; i++)
         {
             Eigen::VectorXd x = x0;
             x(i) += eps;
-            problem->Update(x,t);
+            problem->Update(x, t);
             Eigen::MatrixXd Ji = task.J[t];
             for (int k = 0; k < task.JN; k++)
             {
-                H(k).row(i) = (Ji.row(k) - J0.row(k))/eps;
+                H(k).row(i) = (Ji.row(k) - J0.row(k)) / eps;
             }
         }
-        Hessian dH=H-H0;
-        Hessian dH1=H1-H0;
+        Hessian dH = H - H0;
+        Hessian dH1 = H1 - H0;
         double errH = 0.0;
-        for(int i=0;i<dH.rows();i++)
-            errH=std::min(std::max(errH,dH(i).array().cwiseAbs().maxCoeff()),
-                          std::max(errH,dH1(i).array().cwiseAbs().maxCoeff()));
+        for (int i = 0; i < dH.rows(); i++)
+            errH = std::min(std::max(errH, dH(i).array().cwiseAbs().maxCoeff()),
+                            std::max(errH, dH1(i).array().cwiseAbs().maxCoeff()));
         if (errH > eps)
         {
-            for(int i=0;i<dH.rows();i++)
+            for (int i = 0; i < dH.rows(); i++)
             {
-                HIGHLIGHT("Computed:\n"<<H0(i));
-                HIGHLIGHT("FD:\n"<<H(i));
-                HIGHLIGHT("Diff:\n"<<dH(i));
+                HIGHLIGHT("Computed:\n"
+                          << H0(i));
+                HIGHLIGHT("FD:\n"
+                          << H(i));
+                HIGHLIGHT("Diff:\n"
+                          << dH(i));
             }
             throw_pretty("Hessian error out of bounds: " << errH);
         }
@@ -202,7 +208,7 @@ int main(int argc, char** argv)
             {
                 J[d] = problem->Cost.J;
                 testJacobianEndPose(problem, problem->Cost);
-                if(d>1)
+                if (d > 1)
                 {
                     testHessianEndPose(problem, problem->Cost);
                 }
@@ -229,7 +235,7 @@ int main(int argc, char** argv)
             {
                 J[d] = problem->Cost.J;
                 testJacobianEndPose(problem, problem->Cost);
-                if(d>1)
+                if (d > 1)
                 {
                     testHessianEndPose(problem, problem->Cost);
                 }
@@ -257,7 +263,7 @@ int main(int argc, char** argv)
                 {
                     J[d - 1] = problem->Cost.J;
                     testJacobianEndPose(problem, problem->Cost);
-                    if(d>1)
+                    if (d > 1)
                     {
                         testHessianEndPose(problem, problem->Cost);
                     }
@@ -266,12 +272,12 @@ int main(int argc, char** argv)
             problem->Update(x);
             {
                 INFO_PLAIN("Testing equality");
-                X[d+3] = problem->Equality.ydiff;
+                X[d + 3] = problem->Equality.ydiff;
                 if (d > 0)
                 {
-                    J[d+3] = problem->Equality.J;
+                    J[d + 3] = problem->Equality.J;
                     testJacobianEndPose(problem, problem->Equality);
-                    if(d>1)
+                    if (d > 1)
                     {
                         testHessianEndPose(problem, problem->Equality);
                     }
@@ -280,12 +286,12 @@ int main(int argc, char** argv)
             problem->Update(x);
             {
                 INFO_PLAIN("Testing inequality");
-                X[d+6] = problem->Inequality.ydiff;
+                X[d + 6] = problem->Inequality.ydiff;
                 if (d > 0)
                 {
-                    J[d+6] = problem->Inequality.J;
+                    J[d + 6] = problem->Inequality.J;
                     testJacobianEndPose(problem, problem->Inequality);
-                    if(d>1)
+                    if (d > 1)
                     {
                         testHessianEndPose(problem, problem->Inequality);
                     }
@@ -306,18 +312,13 @@ int main(int argc, char** argv)
             throw_pretty("Inequality Jacobians are inconsistent!");
     }
 
-
-
-
-
-
     {
         int T;
         {
             CREATE_PROBLEM(UnconstrainedTimeIndexedProblem, 0);
-            T=problem->getT();
+            T = problem->getT();
         }
-        for(int t=0;t<T;t++)
+        for (int t = 0; t < T; t++)
         {
             std::vector<Eigen::VectorXd> X(3);
             std::vector<Eigen::MatrixXd> J(3);
@@ -326,7 +327,7 @@ int main(int argc, char** argv)
                 CREATE_PROBLEM(UnconstrainedTimeIndexedProblem, d);
                 Eigen::VectorXd x = problem->getStartState();
                 INFO_PLAIN("Testing problem update");
-                problem->Update(x,t);
+                problem->Update(x, t);
                 INFO_PLAIN("Test passed");
                 X[d] = problem->Cost.ydiff[t];
                 INFO_PLAIN("Testing cost");
@@ -334,7 +335,7 @@ int main(int argc, char** argv)
                 {
                     J[d] = problem->Cost.J[t];
                     testJacobianTimeIndexed(problem, problem->Cost, t);
-                    if(d>1)
+                    if (d > 1)
                     {
                         testHessianTimeIndexed(problem, problem->Cost, t);
                     }
@@ -351,9 +352,9 @@ int main(int argc, char** argv)
         int T;
         {
             CREATE_PROBLEM(BoundedTimeIndexedProblem, 0);
-            T=problem->getT();
+            T = problem->getT();
         }
-        for(int t=0;t<T;t++)
+        for (int t = 0; t < T; t++)
         {
             std::vector<Eigen::VectorXd> X(3);
             std::vector<Eigen::MatrixXd> J(3);
@@ -362,7 +363,7 @@ int main(int argc, char** argv)
                 CREATE_PROBLEM(BoundedTimeIndexedProblem, d);
                 Eigen::VectorXd x = problem->getStartState();
                 INFO_PLAIN("Testing problem update");
-                problem->Update(x,t);
+                problem->Update(x, t);
                 INFO_PLAIN("Test passed");
                 X[d] = problem->Cost.ydiff[t];
                 INFO_PLAIN("Testing cost");
@@ -370,7 +371,7 @@ int main(int argc, char** argv)
                 {
                     J[d] = problem->Cost.J[t];
                     testJacobianTimeIndexed(problem, problem->Cost, t);
-                    if(d>1)
+                    if (d > 1)
                     {
                         testHessianTimeIndexed(problem, problem->Cost, t);
                     }
@@ -387,9 +388,9 @@ int main(int argc, char** argv)
         int T;
         {
             CREATE_PROBLEM(TimeIndexedProblem, 0);
-            T=problem->getT();
+            T = problem->getT();
         }
-        for(int t=0;t<T;t++)
+        for (int t = 0; t < T; t++)
         {
             std::vector<Eigen::VectorXd> X(9);
             std::vector<Eigen::MatrixXd> J(9);
@@ -398,7 +399,7 @@ int main(int argc, char** argv)
                 CREATE_PROBLEM(TimeIndexedProblem, d);
                 Eigen::VectorXd x = problem->getStartState();
                 INFO_PLAIN("Testing problem update");
-                problem->Update(x,t);
+                problem->Update(x, t);
                 INFO_PLAIN("Test passed");
                 {
                     INFO_PLAIN("Testing cost");
@@ -407,35 +408,35 @@ int main(int argc, char** argv)
                     {
                         J[d] = problem->Cost.J[t];
                         testJacobianTimeIndexed(problem, problem->Cost, t);
-                        if(d>1)
+                        if (d > 1)
                         {
                             testHessianTimeIndexed(problem, problem->Cost, t);
                         }
                     }
                 }
-                problem->Update(x,t);
+                problem->Update(x, t);
                 {
                     INFO_PLAIN("Testing equality");
-                    X[d+3] = problem->Equality.ydiff[t];
+                    X[d + 3] = problem->Equality.ydiff[t];
                     if (d > 0)
                     {
-                        J[d+3] = problem->Equality.J[t];
+                        J[d + 3] = problem->Equality.J[t];
                         testJacobianTimeIndexed(problem, problem->Equality, t);
-                        if(d>1)
+                        if (d > 1)
                         {
                             testHessianTimeIndexed(problem, problem->Equality, t);
                         }
                     }
                 }
-                problem->Update(x,t);
+                problem->Update(x, t);
                 {
                     INFO_PLAIN("Testing inequality");
-                    X[d+6] = problem->Inequality.ydiff[t];
+                    X[d + 6] = problem->Inequality.ydiff[t];
                     if (d > 0)
                     {
-                        J[d+6] = problem->Inequality.J[t];
+                        J[d + 6] = problem->Inequality.J[t];
                         testJacobianTimeIndexed(problem, problem->Inequality, t);
-                        if(d>1)
+                        if (d > 1)
                         {
                             testHessianTimeIndexed(problem, problem->Inequality, t);
                         }
@@ -458,24 +459,24 @@ int main(int argc, char** argv)
     }
 
     {
-            CREATE_PROBLEM(SamplingProblem, 0);
-            Eigen::VectorXd x = problem->getStartState();
-            INFO_PLAIN("Testing problem update");
-            problem->Update(x);
-            INFO_PLAIN("Test passed");
-            INFO_PLAIN("Testing valid state");
-            if(!problem->isValid(x)) throw_pretty("Start state is invalid!");
-            INFO_PLAIN("Test passed");
+        CREATE_PROBLEM(SamplingProblem, 0);
+        Eigen::VectorXd x = problem->getStartState();
+        INFO_PLAIN("Testing problem update");
+        problem->Update(x);
+        INFO_PLAIN("Test passed");
+        INFO_PLAIN("Testing valid state");
+        if (!problem->isValid(x)) throw_pretty("Start state is invalid!");
+        INFO_PLAIN("Test passed");
     }
     {
-            CREATE_PROBLEM(TimeIndexedSamplingProblem, 0);
-            Eigen::VectorXd x = problem->getStartState();
-            INFO_PLAIN("Testing problem update");
-            problem->Update(x, 0.0);
-            INFO_PLAIN("Test passed");
-            INFO_PLAIN("Testing valid state");
-            if(!problem->isValid(x, 0.0)) throw_pretty("Start state is invalid!");
-            INFO_PLAIN("Test passed");
+        CREATE_PROBLEM(TimeIndexedSamplingProblem, 0);
+        Eigen::VectorXd x = problem->getStartState();
+        INFO_PLAIN("Testing problem update");
+        problem->Update(x, 0.0);
+        INFO_PLAIN("Test passed");
+        INFO_PLAIN("Testing valid state");
+        if (!problem->isValid(x, 0.0)) throw_pretty("Start state is invalid!");
+        INFO_PLAIN("Test passed");
     }
     Setup::Destroy();
 }

--- a/examples/exotica_examples/tests/test_problems.cpp
+++ b/examples/exotica_examples/tests/test_problems.cpp
@@ -1,0 +1,481 @@
+#include <exotica/Exotica.h>
+
+using namespace exotica;
+#include <string>
+#include <vector>
+
+#define CREATE_PROBLEM(X, I) std::shared_ptr<X> problem = createProblem<X>(#X, I);
+#define NUM_TRIALS 100
+
+template <class T>
+std::shared_ptr<T> createProblem(const std::string& name, int derivative)
+{
+    HIGHLIGHT("Creating " << name << " with derivatives " << derivative);
+    Initializer dummy;
+    Initializer init;
+    XMLLoader::load("{exotica_examples}/resources/configs/test_problems.xml", dummy, init, "Dummy", name);
+    init.addProperty(Property("DerivativeOrder", false, derivative));
+    std::shared_ptr<T> ret = std::static_pointer_cast<T>(Setup::createProblem(init));
+    INFO_PLAIN("Problem loaded");
+    return ret;
+}
+
+template <class T>
+void testJacobianEndPose(std::shared_ptr<T> problem, EndPoseTask& task, double eps = 1e-5)
+{
+    INFO_PLAIN("Testing Jacobian:");
+    for (int tr = 0; tr < NUM_TRIALS; tr++)
+    {
+        Eigen::VectorXd x0(problem->N);
+        x0.setRandom();
+        problem->Update(x0);
+        TaskSpaceVector y0 = task.Phi;
+        Eigen::MatrixXd J0 = task.J;
+        Eigen::MatrixXd J = Eigen::MatrixXd::Zero(J0.rows(), J0.cols());
+        for (int i = 0; i < problem->N; i++)
+        {
+            Eigen::VectorXd x = x0;
+            x(i) += eps;
+            problem->Update(x);
+            J.col(i) = (task.Phi - y0) / eps;
+        }
+        double errJ = (J - J0).norm();
+        if (errJ > eps)
+        {
+            HIGHLIGHT("x: " << x0.transpose());
+            HIGHLIGHT("J*:\n"
+                      << J);
+            HIGHLIGHT("J:\n"
+                      << J0);
+            throw_pretty("Jacobian error out of bounds: " << errJ);
+        }
+    }
+    INFO_PLAIN("Test passed");
+}
+
+template <class T>
+void testHessianEndPose(std::shared_ptr<T> problem, EndPoseTask& task, double eps = 1e-5)
+{
+    INFO_PLAIN("Testing Hessian:");
+    for (int tr = 0; tr < NUM_TRIALS; tr++)
+    {
+        Eigen::VectorXd x0(problem->N);
+        x0.setRandom();
+        problem->Update(x0);
+        Eigen::MatrixXd J0 = task.J;
+        Hessian H0 = task.H;
+        Hessian H = H0;
+        Hessian H1 = H0;
+        for (int k = 0; k < task.JN; k++)
+        {
+            H1(k) = J0.row(k).transpose()*J0.row(k);
+        }
+        for (int i = 0; i < H.rows(); i++) H(i).setZero();
+        for (int i = 0; i < problem->N; i++)
+        {
+            Eigen::VectorXd x = x0;
+            x(i) += eps;
+            problem->Update(x);
+            Eigen::MatrixXd Ji = task.J;
+            for (int k = 0; k < task.JN; k++)
+            {
+                H(k).row(i) = (Ji.row(k) - J0.row(k))/eps;
+            }
+        }
+        Hessian dH=H-H0;
+        Hessian dH1=H1-H0;
+        double errH = 0.0;
+        for(int i=0;i<dH.rows();i++)
+            errH=std::min(std::max(errH,dH(i).array().cwiseAbs().maxCoeff()),
+                          std::max(errH,dH1(i).array().cwiseAbs().maxCoeff()));
+        if (errH > eps)
+        {
+            for(int i=0;i<dH.rows();i++)
+            {
+                HIGHLIGHT("Computed:\n"<<H0(i));
+                HIGHLIGHT("FD:\n"<<H(i));
+                HIGHLIGHT("Diff:\n"<<dH(i));
+            }
+            throw_pretty("Hessian error out of bounds: " << errH);
+        }
+    }
+    INFO_PLAIN("Test passed");
+}
+
+template <class T>
+void testJacobianTimeIndexed(std::shared_ptr<T> problem, TimeIndexedTask& task, int t, double eps = 1e-5)
+{
+    INFO_PLAIN("Testing Jacobian:");
+    for (int tr = 0; tr < NUM_TRIALS; tr++)
+    {
+        Eigen::VectorXd x0(problem->N);
+        x0.setRandom();
+        problem->Update(x0,t);
+        TaskSpaceVector y0 = task.Phi[t];
+        Eigen::MatrixXd J0 = task.J[t];
+        Eigen::MatrixXd J = Eigen::MatrixXd::Zero(J0.rows(), J0.cols());
+        for (int i = 0; i < problem->N; i++)
+        {
+            Eigen::VectorXd x = x0;
+            x(i) += eps;
+            problem->Update(x,t);
+            J.col(i) = (task.Phi[t] - y0) / eps;
+        }
+        double errJ = (J - J0).norm();
+        if (errJ > eps)
+        {
+            HIGHLIGHT("x: " << x0.transpose());
+            HIGHLIGHT("J*:\n"
+                      << J);
+            HIGHLIGHT("J:\n"
+                      << J0);
+            throw_pretty("Jacobian error out of bounds: " << errJ);
+        }
+    }
+    INFO_PLAIN("Test passed");
+}
+
+template <class T>
+void testHessianTimeIndexed(std::shared_ptr<T> problem, TimeIndexedTask& task, int t, double eps = 1e-5)
+{
+    INFO_PLAIN("Testing Hessian:");
+    for (int tr = 0; tr < NUM_TRIALS; tr++)
+    {
+        Eigen::VectorXd x0(problem->N);
+        x0.setRandom();
+        problem->Update(x0,t);
+        Eigen::MatrixXd J0 = task.J[t];
+        Hessian H0 = task.H[t];
+        Hessian H = H0;
+        Hessian H1 = H0;
+        for (int k = 0; k < task.JN; k++)
+        {
+            H1(k) = J0.row(k).transpose()*J0.row(k);
+        }
+        for (int i = 0; i < H.rows(); i++) H(i).setZero();
+        for (int i = 0; i < problem->N; i++)
+        {
+            Eigen::VectorXd x = x0;
+            x(i) += eps;
+            problem->Update(x,t);
+            Eigen::MatrixXd Ji = task.J[t];
+            for (int k = 0; k < task.JN; k++)
+            {
+                H(k).row(i) = (Ji.row(k) - J0.row(k))/eps;
+            }
+        }
+        Hessian dH=H-H0;
+        Hessian dH1=H1-H0;
+        double errH = 0.0;
+        for(int i=0;i<dH.rows();i++)
+            errH=std::min(std::max(errH,dH(i).array().cwiseAbs().maxCoeff()),
+                          std::max(errH,dH1(i).array().cwiseAbs().maxCoeff()));
+        if (errH > eps)
+        {
+            for(int i=0;i<dH.rows();i++)
+            {
+                HIGHLIGHT("Computed:\n"<<H0(i));
+                HIGHLIGHT("FD:\n"<<H(i));
+                HIGHLIGHT("Diff:\n"<<dH(i));
+            }
+            throw_pretty("Hessian error out of bounds: " << errH);
+        }
+    }
+    INFO_PLAIN("Test passed");
+}
+
+int main(int argc, char** argv)
+{
+    {
+        std::vector<Eigen::VectorXd> X(3);
+        std::vector<Eigen::MatrixXd> J(3);
+        for (int d = 0; d < 3; d++)
+        {
+            CREATE_PROBLEM(UnconstrainedEndPoseProblem, d);
+            Eigen::VectorXd x = problem->getStartState();
+            INFO_PLAIN("Testing problem update");
+            problem->Update(x);
+            INFO_PLAIN("Test passed");
+            X[d] = problem->Cost.ydiff;
+            INFO_PLAIN("Testing cost");
+            if (d > 0)
+            {
+                J[d] = problem->Cost.J;
+                testJacobianEndPose(problem, problem->Cost);
+                if(d>1)
+                {
+                    testHessianEndPose(problem, problem->Cost);
+                }
+            }
+        }
+        if (!(X[0] == X[1] && X[1] == X[2]))
+            throw_pretty("Cost FK is inconsistent!");
+        if (!(J[1] == J[2]))
+            throw_pretty("Cost Jacobians are inconsistent!");
+    }
+    {
+        std::vector<Eigen::VectorXd> X(3);
+        std::vector<Eigen::MatrixXd> J(3);
+        for (int d = 0; d < 3; d++)
+        {
+            CREATE_PROBLEM(BoundedEndPoseProblem, d);
+            Eigen::VectorXd x = problem->getStartState();
+            INFO_PLAIN("Testing problem update");
+            problem->Update(x);
+            INFO_PLAIN("Test passed");
+            X[d] = problem->Cost.ydiff;
+            INFO_PLAIN("Testing cost");
+            if (d > 0)
+            {
+                J[d] = problem->Cost.J;
+                testJacobianEndPose(problem, problem->Cost);
+                if(d>1)
+                {
+                    testHessianEndPose(problem, problem->Cost);
+                }
+            }
+        }
+        if (!(X[0] == X[1] && X[1] == X[2]))
+            throw_pretty("Cost FK is inconsistent!");
+        if (!(J[1] == J[2]))
+            throw_pretty("Cost Jacobians are inconsistent!");
+    }
+    {
+        std::vector<Eigen::VectorXd> X(9);
+        std::vector<Eigen::MatrixXd> J(9);
+        for (int d = 0; d < 3; d++)
+        {
+            CREATE_PROBLEM(EndPoseProblem, d);
+            Eigen::VectorXd x = problem->getStartState();
+            INFO_PLAIN("Testing problem update");
+            problem->Update(x);
+            INFO_PLAIN("Test passed");
+            {
+                INFO_PLAIN("Testing cost");
+                X[d] = problem->Cost.ydiff;
+                if (d > 0)
+                {
+                    J[d - 1] = problem->Cost.J;
+                    testJacobianEndPose(problem, problem->Cost);
+                    if(d>1)
+                    {
+                        testHessianEndPose(problem, problem->Cost);
+                    }
+                }
+            }
+            problem->Update(x);
+            {
+                INFO_PLAIN("Testing equality");
+                X[d+3] = problem->Equality.ydiff;
+                if (d > 0)
+                {
+                    J[d+3] = problem->Equality.J;
+                    testJacobianEndPose(problem, problem->Equality);
+                    if(d>1)
+                    {
+                        testHessianEndPose(problem, problem->Equality);
+                    }
+                }
+            }
+            problem->Update(x);
+            {
+                INFO_PLAIN("Testing inequality");
+                X[d+6] = problem->Inequality.ydiff;
+                if (d > 0)
+                {
+                    J[d+6] = problem->Inequality.J;
+                    testJacobianEndPose(problem, problem->Inequality);
+                    if(d>1)
+                    {
+                        testHessianEndPose(problem, problem->Inequality);
+                    }
+                }
+            }
+        }
+        if (!(X[0] == X[1] && X[1] == X[2]))
+            throw_pretty("Cost FK is inconsistent!");
+        if (!(J[1] == J[2]))
+            throw_pretty("Cost Jacobians are inconsistent!");
+        if (!(X[3] == X[4] && X[4] == X[5]))
+            throw_pretty("Equality FK is inconsistent!");
+        if (!(J[4] == J[5]))
+            throw_pretty("Equality Jacobians are inconsistent!");
+        if (!(X[6] == X[7] && X[7] == X[8]))
+            throw_pretty("Inequality FK is inconsistent!");
+        if (!(J[7] == J[8]))
+            throw_pretty("Inequality Jacobians are inconsistent!");
+    }
+
+
+
+
+
+
+    {
+        int T;
+        {
+            CREATE_PROBLEM(UnconstrainedTimeIndexedProblem, 0);
+            T=problem->getT();
+        }
+        for(int t=0;t<T;t++)
+        {
+            std::vector<Eigen::VectorXd> X(3);
+            std::vector<Eigen::MatrixXd> J(3);
+            for (int d = 0; d < 3; d++)
+            {
+                CREATE_PROBLEM(UnconstrainedTimeIndexedProblem, d);
+                Eigen::VectorXd x = problem->getStartState();
+                INFO_PLAIN("Testing problem update");
+                problem->Update(x,t);
+                INFO_PLAIN("Test passed");
+                X[d] = problem->Cost.ydiff[t];
+                INFO_PLAIN("Testing cost");
+                if (d > 0)
+                {
+                    J[d] = problem->Cost.J[t];
+                    testJacobianTimeIndexed(problem, problem->Cost, t);
+                    if(d>1)
+                    {
+                        testHessianTimeIndexed(problem, problem->Cost, t);
+                    }
+                }
+            }
+            if (!(X[0] == X[1] && X[1] == X[2]))
+                throw_pretty("Cost FK is inconsistent!");
+            if (!(J[1] == J[2]))
+                throw_pretty("Cost Jacobians are inconsistent!");
+        }
+    }
+
+    {
+        int T;
+        {
+            CREATE_PROBLEM(BoundedTimeIndexedProblem, 0);
+            T=problem->getT();
+        }
+        for(int t=0;t<T;t++)
+        {
+            std::vector<Eigen::VectorXd> X(3);
+            std::vector<Eigen::MatrixXd> J(3);
+            for (int d = 0; d < 3; d++)
+            {
+                CREATE_PROBLEM(BoundedTimeIndexedProblem, d);
+                Eigen::VectorXd x = problem->getStartState();
+                INFO_PLAIN("Testing problem update");
+                problem->Update(x,t);
+                INFO_PLAIN("Test passed");
+                X[d] = problem->Cost.ydiff[t];
+                INFO_PLAIN("Testing cost");
+                if (d > 0)
+                {
+                    J[d] = problem->Cost.J[t];
+                    testJacobianTimeIndexed(problem, problem->Cost, t);
+                    if(d>1)
+                    {
+                        testHessianTimeIndexed(problem, problem->Cost, t);
+                    }
+                }
+            }
+            if (!(X[0] == X[1] && X[1] == X[2]))
+                throw_pretty("Cost FK is inconsistent!");
+            if (!(J[1] == J[2]))
+                throw_pretty("Cost Jacobians are inconsistent!");
+        }
+    }
+
+    {
+        int T;
+        {
+            CREATE_PROBLEM(TimeIndexedProblem, 0);
+            T=problem->getT();
+        }
+        for(int t=0;t<T;t++)
+        {
+            std::vector<Eigen::VectorXd> X(9);
+            std::vector<Eigen::MatrixXd> J(9);
+            for (int d = 0; d < 3; d++)
+            {
+                CREATE_PROBLEM(TimeIndexedProblem, d);
+                Eigen::VectorXd x = problem->getStartState();
+                INFO_PLAIN("Testing problem update");
+                problem->Update(x,t);
+                INFO_PLAIN("Test passed");
+                {
+                    INFO_PLAIN("Testing cost");
+                    X[d] = problem->Cost.ydiff[t];
+                    if (d > 0)
+                    {
+                        J[d] = problem->Cost.J[t];
+                        testJacobianTimeIndexed(problem, problem->Cost, t);
+                        if(d>1)
+                        {
+                            testHessianTimeIndexed(problem, problem->Cost, t);
+                        }
+                    }
+                }
+                problem->Update(x,t);
+                {
+                    INFO_PLAIN("Testing equality");
+                    X[d+3] = problem->Equality.ydiff[t];
+                    if (d > 0)
+                    {
+                        J[d+3] = problem->Equality.J[t];
+                        testJacobianTimeIndexed(problem, problem->Equality, t);
+                        if(d>1)
+                        {
+                            testHessianTimeIndexed(problem, problem->Equality, t);
+                        }
+                    }
+                }
+                problem->Update(x,t);
+                {
+                    INFO_PLAIN("Testing inequality");
+                    X[d+6] = problem->Inequality.ydiff[t];
+                    if (d > 0)
+                    {
+                        J[d+6] = problem->Inequality.J[t];
+                        testJacobianTimeIndexed(problem, problem->Inequality, t);
+                        if(d>1)
+                        {
+                            testHessianTimeIndexed(problem, problem->Inequality, t);
+                        }
+                    }
+                }
+            }
+            if (!(X[0] == X[1] && X[1] == X[2]))
+                throw_pretty("Cost FK is inconsistent!");
+            if (!(J[1] == J[2]))
+                throw_pretty("Cost Jacobians are inconsistent!");
+            if (!(X[3] == X[4] && X[4] == X[5]))
+                throw_pretty("Equality FK is inconsistent!");
+            if (!(J[4] == J[5]))
+                throw_pretty("Equality Jacobians are inconsistent!");
+            if (!(X[6] == X[7] && X[7] == X[8]))
+                throw_pretty("Inequality FK is inconsistent!");
+            if (!(J[7] == J[8]))
+                throw_pretty("Inequality Jacobians are inconsistent!");
+        }
+    }
+
+    {
+            CREATE_PROBLEM(SamplingProblem, 0);
+            Eigen::VectorXd x = problem->getStartState();
+            INFO_PLAIN("Testing problem update");
+            problem->Update(x);
+            INFO_PLAIN("Test passed");
+            INFO_PLAIN("Testing valid state");
+            if(!problem->isValid(x)) throw_pretty("Start state is invalid!");
+            INFO_PLAIN("Test passed");
+    }
+    {
+            CREATE_PROBLEM(TimeIndexedSamplingProblem, 0);
+            Eigen::VectorXd x = problem->getStartState();
+            INFO_PLAIN("Testing problem update");
+            problem->Update(x, 0.0);
+            INFO_PLAIN("Test passed");
+            INFO_PLAIN("Testing valid state");
+            if(!problem->isValid(x, 0.0)) throw_pretty("Start state is invalid!");
+            INFO_PLAIN("Test passed");
+    }
+    Setup::Destroy();
+}

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -148,7 +148,6 @@ void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
 
 void AICOsolver::Solve(Eigen::MatrixXd& solution)
 {
-    prob_->preupdate();
     prob_->resetCostEvolution(max_iterations + 1);
 
     Eigen::VectorXd q0 = prob_->applyStartState();

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -132,8 +132,6 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 {
     Timer timer;
 
-    prob_->preupdate();
-
     if (!prob_) throw_named("Solver has not been initialized!");
     Eigen::VectorXd q0 = prob_->applyStartState();
 

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -181,7 +181,6 @@ void OMPLsolver::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTerminationCo
 
 void OMPLsolver::Solve(Eigen::MatrixXd &solution)
 {
-    prob_->preupdate();
     Eigen::VectorXd q0 = prob_->applyStartState();
     setGoalState(prob_->goal_);
 

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -239,7 +239,6 @@ void TimeIndexedRRTConnect::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTe
 
 void TimeIndexedRRTConnect::Solve(Eigen::MatrixXd &solution)
 {
-    prob_->preupdate();
     Eigen::VectorXd q0 = prob_->applyStartState();
     setGoalState(prob_->goal_, prob_->tGoal);
 

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -83,7 +83,6 @@ public:
     void resetCostEvolution(unsigned int size);
     void setCostEvolution(int index, double value);
     KinematicRequestFlags getFlags() { return Flags; }
-
 protected:
     Scene_ptr scene_;
     TaskMap_map TaskMaps;

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -82,6 +82,7 @@ public:
     double getCostEvolution(int index);
     void resetCostEvolution(unsigned int size);
     void setCostEvolution(int index, double value);
+    KinematicRequestFlags getFlags() { return Flags; }
 
 protected:
     Scene_ptr scene_;

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -65,6 +65,7 @@ public:
 
     Eigen::MatrixXd W;
     TaskSpaceVector Phi;
+    Hessian H;
     Eigen::MatrixXd J;
 
     int PhiN;

--- a/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
@@ -80,6 +80,7 @@ public:
 
     std::vector<TaskSpaceVector> Phi;
     std::vector<Eigen::MatrixXd> J;
+    std::vector<Hessian> H;
 
     std::vector<Eigen::VectorXd> x;      // current internal problem state
     std::vector<Eigen::VectorXd> xdiff;  // equivalent to dx = x(t)-x(t-1)

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -76,6 +76,7 @@ public:
     Eigen::MatrixXd W;
     TaskSpaceVector Phi;
     Eigen::MatrixXd J;
+    Hessian H;
 
     int PhiN;
     int JN;

--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -92,6 +92,7 @@ public:
 
     std::vector<TaskSpaceVector> Phi;
     std::vector<Eigen::MatrixXd> J;
+    std::vector<Hessian> H;
 
     std::vector<Eigen::VectorXd> x;      // current internal problem state
     std::vector<Eigen::VectorXd> xdiff;  // equivalent to dx = x(t)-x(t-1)

--- a/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
@@ -50,6 +50,7 @@ public:
 
     void Update(Eigen::VectorXdRefConst x, double t);
     bool isValid(Eigen::VectorXdRefConst x, double t);
+    virtual void preupdate();
 
     int getSpaceDim();
 

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -67,6 +67,7 @@ public:
     Eigen::MatrixXd W;
     TaskSpaceVector Phi;
     Eigen::MatrixXd J;
+    Hessian H;
     Eigen::VectorXd qNominal;
 
     int PhiN;

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -76,6 +76,7 @@ public:
 
     std::vector<TaskSpaceVector> Phi;
     std::vector<Eigen::MatrixXd> J;
+    std::vector<Hessian> H;
 
     std::vector<Eigen::VectorXd> x;      // current internal problem state
     std::vector<Eigen::VectorXd> xdiff;  // equivalent to dx = x(t)-x(t-1)

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -64,9 +64,8 @@ public:
 
     virtual void assignScene(Scene_ptr scene) {}
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) = 0;
-
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J) { throw_named("Not implemented"); }
-    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::VectorXdRef phidot, Eigen::MatrixXdRef J, Eigen::MatrixXdRef Jdot) { throw_named("Not implemented"); }
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, HessianRef H);
     virtual int taskSpaceDim() = 0;
 
     virtual int taskSpaceJacobianDim() { return taskSpaceDim(); }

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -76,6 +76,7 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
+
 protected:
     std::vector<TaskInitializer> TaskInitializers;
 };

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -76,7 +76,6 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
-
 protected:
     std::vector<TaskInitializer> TaskInitializers;
 };
@@ -87,13 +86,16 @@ public:
     TimeIndexedTask();
     virtual void initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& phi);
     void updateS();
+    void update(const TaskSpaceVector& Phi, Eigen::MatrixXdRefConst J, HessianRefConst H, int t);
     void update(const TaskSpaceVector& Phi, Eigen::MatrixXdRefConst J, int t);
+    void update(const TaskSpaceVector& Phi, int t);
     void reinitializeVariables(int T, std::shared_ptr<PlanningProblem> prob, const TaskSpaceVector& phi);
 
     std::vector<Eigen::VectorXd> Rho;
     std::vector<TaskSpaceVector> y;
     std::vector<Eigen::VectorXd> ydiff;
     std::vector<TaskSpaceVector> Phi;
+    std::vector<Hessian> H;
     std::vector<Eigen::MatrixXd> J;
     std::vector<Eigen::MatrixXd> S;
     int T;
@@ -105,13 +107,16 @@ public:
     EndPoseTask();
     virtual void initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& phi);
     void updateS();
+    void update(const TaskSpaceVector& Phi, Eigen::MatrixXdRefConst J, HessianRefConst H);
     void update(const TaskSpaceVector& Phi, Eigen::MatrixXdRefConst J);
+    void update(const TaskSpaceVector& Phi);
 
     Eigen::VectorXd Rho;
     TaskSpaceVector y;
     Eigen::VectorXd ydiff;
     TaskSpaceVector Phi;
     Eigen::MatrixXd J;
+    Hessian H;
     Eigen::MatrixXd S;
 };
 

--- a/exotica/include/exotica/Tools/Conversions.h
+++ b/exotica/include/exotica/Tools/Conversions.h
@@ -102,12 +102,18 @@ Eigen::VectorXd getFrameAsVector(const KDL::Frame& val, RotationType type = Rota
 typedef Eigen::Array<KDL::Frame, Eigen::Dynamic, 1> ArrayFrame;
 typedef Eigen::Array<KDL::Twist, Eigen::Dynamic, 1> ArrayTwist;
 typedef Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1> ArrayJacobian;
+typedef Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1> Hessian;
+typedef Eigen::Array<Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1>, Eigen::Dynamic, 1> ArrayHessian;
 typedef Eigen::Ref<Eigen::Array<KDL::Frame, Eigen::Dynamic, 1>> ArrayFrameRef;
 typedef Eigen::Ref<Eigen::Array<KDL::Twist, Eigen::Dynamic, 1>> ArrayTwistRef;
 typedef Eigen::Ref<Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1>> ArrayJacobianRef;
+typedef Eigen::Ref<Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1>> HessianRef;
+typedef Eigen::Ref<Eigen::Array<Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1>, Eigen::Dynamic, 1>> ArrayHessianRef;
 typedef const Eigen::Ref<Eigen::Array<KDL::Frame, Eigen::Dynamic, 1>>& ArrayFrameRefConst;
 typedef const Eigen::Ref<Eigen::Array<KDL::Twist, Eigen::Dynamic, 1>>& ArrayTwistRefConst;
 typedef const Eigen::Ref<Eigen::Array<KDL::Jacobian, Eigen::Dynamic, 1>>& ArrayJacobianRefConst;
+typedef const Eigen::Ref<Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1>> HessianRefConst;
+typedef const Eigen::Ref<Eigen::Array<Eigen::Array<Eigen::MatrixXd, Eigen::Dynamic, 1>, Eigen::Dynamic, 1>> ArrayHessianRefConst;
 
 inline bool IsContainerType(std::string type)
 {

--- a/exotica/init/PlanningProblem.in
+++ b/exotica/init/PlanningProblem.in
@@ -4,3 +4,4 @@ Required exotica::Initializer PlanningScene; # SceneInitializer
 Optional std::vector<exotica::Initializer> Maps = std::vector<exotica::Initializer>();
 Optional Eigen::VectorXd StartState = Eigen::VectorXd();
 Optional double StartTime = 0;
+Optional int DerivativeOrder = -1;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -638,7 +638,7 @@ Eigen::MatrixXd KinematicTree::Jacobian(const std::string& elementA, const KDL::
 
 void KinematicTree::ComputeJdot(KDL::Jacobian& J, KDL::Jacobian& JDot)
 {
-    JDot.data.setZero(J.rows(),J.columns());
+    JDot.data.setZero(J.rows(), J.columns());
     for (int i = 0; i < J.columns(); i++)
     {
         KDL::Twist tmp;

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -121,6 +121,19 @@ void PlanningProblem::InstantiateBase(const Initializer& init_)
     if (init.StartTime < 0)
         throw_named("Invalid start time " << init.StartTime) else tStart = init.StartTime;
 
+    switch(init.DerivativeOrder)
+    {
+    case 0:
+        Flags = KIN_FK;
+        break;
+    case 1:
+        Flags = KIN_FK | KIN_J;
+        break;
+    case 2:
+        Flags = KIN_FK | KIN_J | KIN_J_DOT;
+        break;
+    }
+
     KinematicsRequest Request;
     Request.Flags = Flags;
 

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -121,17 +121,17 @@ void PlanningProblem::InstantiateBase(const Initializer& init_)
     if (init.StartTime < 0)
         throw_named("Invalid start time " << init.StartTime) else tStart = init.StartTime;
 
-    switch(init.DerivativeOrder)
+    switch (init.DerivativeOrder)
     {
-    case 0:
-        Flags = KIN_FK;
-        break;
-    case 1:
-        Flags = KIN_FK | KIN_J;
-        break;
-    case 2:
-        Flags = KIN_FK | KIN_J | KIN_J_DOT;
-        break;
+        case 0:
+            Flags = KIN_FK;
+            break;
+        case 1:
+            Flags = KIN_FK | KIN_J;
+            break;
+        case 2:
+            Flags = KIN_FK | KIN_J | KIN_J_DOT;
+            break;
     }
 
     KinematicsRequest Request;

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -80,8 +80,8 @@ void BoundedEndPoseProblem::Instantiate(BoundedEndPoseProblemInitializer& init)
             throw_named("W dimension mismatch! Expected " << N << ", got " << init.W.rows());
         }
     }
-    if(Flags&KIN_J) J = Eigen::MatrixXd(JN, N);
-    if(Flags&KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+    if (Flags & KIN_J) J = Eigen::MatrixXd(JN, N);
+    if (Flags & KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
 
     bounds_ = scene_->getSolver().getJointLimits();
     if (init.LowerBound.rows() == N)
@@ -128,17 +128,18 @@ void BoundedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x);
     Phi.setZero(PhiN);
-    if(Flags&KIN_J) J.setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H(i).setZero();
+    if (Flags & KIN_J) J.setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H(i).setZero();
     for (int i = 0; i < Tasks.size(); i++)
     {
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H.segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -148,11 +149,11 @@ void BoundedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi, J, H);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi, J);
     }

--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -131,18 +131,19 @@ void BoundedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
     x[t] = x_in;
     scene_->Update(x_in, static_cast<double>(t) * tau);
     Phi[t].setZero(PhiN);
-    if(Flags&KIN_J) J[t].setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H[t](i).setZero();
+    if (Flags & KIN_J) J[t].setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H[t](i).setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         // Only update TaskMap if Rho is not 0
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H[t].segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -152,11 +153,11 @@ void BoundedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi[t], J[t], H[t], t);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi[t], J[t], t);
     }
@@ -323,13 +324,13 @@ void BoundedTimeIndexedProblem::reinitializeVariables()
 
     yref.setZero(PhiN);
     Phi.assign(T, yref);
-    if(Flags&KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
+    if (Flags & KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
     x.assign(T, Eigen::VectorXd::Zero(JN));
     xdiff.assign(T, Eigen::VectorXd::Zero(JN));
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Hessian Htmp;
-        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
         H.assign(T, Htmp);
     }
 

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -80,8 +80,8 @@ void EndPoseProblem::Instantiate(EndPoseProblemInitializer& init)
             throw_named("W dimension mismatch! Expected " << N << ", got " << init.W.rows());
         }
     }
-    if(Flags&KIN_J) J = Eigen::MatrixXd(JN, N);
-    if(Flags&KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+    if (Flags & KIN_J) J = Eigen::MatrixXd(JN, N);
+    if (Flags & KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
 
     std::vector<std::string> jnts;
     scene_->getJointNames(jnts);
@@ -144,17 +144,18 @@ void EndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x);
     Phi.setZero(PhiN);
-    if(Flags&KIN_J) J.setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H(i).setZero();
+    if (Flags & KIN_J) J.setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H(i).setZero();
     for (int i = 0; i < Tasks.size(); i++)
     {
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H.segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -164,13 +165,13 @@ void EndPoseProblem::Update(Eigen::VectorXdRefConst x)
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi, J, H);
         Inequality.update(Phi, J, H);
         Equality.update(Phi, J, H);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi, J);
         Inequality.update(Phi, J);

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -91,6 +91,7 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
     TaskSpaceVector dummy;
     Constraint.initialize(init.Constraint, shared_from_this(), dummy);
     applyStartState(false);
+    preupdate();
 }
 
 void SamplingProblem::preupdate()

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -110,13 +110,13 @@ void TimeIndexedProblem::reinitializeVariables()
 
     yref.setZero(PhiN);
     Phi.assign(T, yref);
-    if(Flags&KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
+    if (Flags & KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
     x.assign(T, Eigen::VectorXd::Zero(N));
     xdiff.assign(T, Eigen::VectorXd::Zero(N));
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Hessian Htmp;
-        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
         H.assign(T, Htmp);
     }
 
@@ -196,18 +196,19 @@ void TimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
     x[t] = x_in;
     scene_->Update(x_in, static_cast<double>(t) * tau);
     Phi[t].setZero(PhiN);
-    if(Flags&KIN_J) J[t].setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H[t](i).setZero();
+    if (Flags & KIN_J) J[t].setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H[t](i).setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         // Only update TaskMap if Rho is not 0
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H[t].segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -217,13 +218,13 @@ void TimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi[t], J[t], H[t], t);
         Inequality.update(Phi[t], J[t], H[t], t);
         Equality.update(Phi[t], J[t], H[t], t);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi[t], J[t], t);
         Inequality.update(Phi[t], J[t], t);

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -95,6 +95,7 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
     Constraint.initialize(init.Constraint, shared_from_this(), ConstraintPhi);
 
     applyStartState(false);
+    preupdate();
 }
 
 Eigen::VectorXd TimeIndexedSamplingProblem::getGoalState()
@@ -130,6 +131,13 @@ bool TimeIndexedSamplingProblem::isValid(Eigen::VectorXdRefConst x, double t)
     Constraint.update(Phi);
     numberOfProblemUpdates++;
     return ((Constraint.S * Constraint.ydiff).array() < 0.0).all();
+}
+
+void TimeIndexedSamplingProblem::preupdate()
+{
+    PlanningProblem::preupdate();
+    for (int i = 0; i < Tasks.size(); i++) Tasks[i]->isUsed = false;
+    Constraint.updateS();
 }
 
 void TimeIndexedSamplingProblem::Update(Eigen::VectorXdRefConst x, double t)

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -75,8 +75,8 @@ void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitial
             throw_named("W dimension mismatch! Expected " << N << ", got " << init.W.rows());
         }
     }
-    if(Flags&KIN_J) J = Eigen::MatrixXd(JN, N);
-    if(Flags&KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+    if (Flags & KIN_J) J = Eigen::MatrixXd(JN, N);
+    if (Flags & KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
 
     if (init.NominalState.rows() > 0 && init.NominalState.rows() != N) throw_named("Invalid size of NominalState (" << init.NominalState.rows() << "), expected: " << N);
     if (init.NominalState.rows() == N) qNominal = init.NominalState;
@@ -107,17 +107,18 @@ void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x);
     Phi.setZero(PhiN);
-    if(Flags&KIN_J) J.setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H(i).setZero();
+    if (Flags & KIN_J) J.setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H(i).setZero();
     for (int i = 0; i < Tasks.size(); i++)
     {
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H.segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -127,11 +128,11 @@ void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi, J, H);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi, J);
     }

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -93,13 +93,13 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     setTau(init_.Tau);
 
     Phi.assign(T, yref);
-    if(Flags&KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
+    if (Flags & KIN_J) J.assign(T, Eigen::MatrixXd(JN, N));
     x.assign(T, Eigen::VectorXd::Zero(N));
     xdiff.assign(T, Eigen::VectorXd::Zero(N));
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Hessian Htmp;
-        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N,N));
+        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(N, N));
         H.assign(T, Htmp);
     }
 
@@ -173,18 +173,19 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t
     scene_->Update(x_in, static_cast<double>(t) * tau);
 
     Phi[t].setZero(PhiN);
-    if(Flags&KIN_J) J[t].setZero();
-    if(Flags&KIN_J_DOT) for(int i=0;i<JN;i++) H[t](i).setZero();
+    if (Flags & KIN_J) J[t].setZero();
+    if (Flags & KIN_J_DOT)
+        for (int i = 0; i < JN; i++) H[t](i).setZero();
     for (int i = 0; i < NumTasks; i++)
     {
         // Only update TaskMap if Rho is not 0
         if (Tasks[i]->isUsed)
         {
-            if(Flags&KIN_J_DOT)
+            if (Flags & KIN_J_DOT)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ), H[t].segment(Tasks[i]->Start, Tasks[i]->Length));
             }
-            else if(Flags&KIN_J)
+            else if (Flags & KIN_J)
             {
                 Tasks[i]->update(x[t], Phi[t].data.segment(Tasks[i]->Start, Tasks[i]->Length), J[t].middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
             }
@@ -194,11 +195,11 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t
             }
         }
     }
-    if(Flags&KIN_J_DOT)
+    if (Flags & KIN_J_DOT)
     {
         Cost.update(Phi[t], J[t], H[t], t);
     }
-    else if(Flags&KIN_J)
+    else if (Flags & KIN_J)
     {
         Cost.update(Phi[t], J[t], t);
     }

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -71,4 +71,15 @@ void TaskMap::taskSpaceDim(int& task_dim)
 {
     task_dim = taskSpaceDim();
 }
+
+void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, HessianRef H)
+{
+    update(x, phi, J);
+    H.resize(taskSpaceDim());
+    for(int i=0;i<taskSpaceDim();i++)
+    {
+        H(i)=J.row(i).transpose()*J.row(i);
+    }
+}
+
 }

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -76,10 +76,9 @@ void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::M
 {
     update(x, phi, J);
     H.resize(taskSpaceDim());
-    for(int i=0;i<taskSpaceDim();i++)
+    for (int i = 0; i < taskSpaceDim(); i++)
     {
-        H(i)=J.row(i).transpose()*J.row(i);
+        H(i) = J.row(i).transpose() * J.row(i);
     }
 }
-
 }

--- a/exotica/src/Tasks.cpp
+++ b/exotica/src/Tasks.cpp
@@ -80,8 +80,8 @@ void EndPoseTask::initialize(const std::vector<exotica::Initializer>& inits, Pla
     y = Phi;
     y.setZero(PhiN);
     Rho = Eigen::VectorXd::Ones(NumTasks);
-    if(prob->getFlags() & KIN_J) J = Eigen::MatrixXd(JN, prob->N);
-    if(prob->getFlags() & KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(prob->N,prob->N));
+    if (prob->getFlags() & KIN_J) J = Eigen::MatrixXd(JN, prob->N);
+    if (prob->getFlags() & KIN_J_DOT) H.setConstant(JN, Eigen::MatrixXd::Zero(prob->N, prob->N));
     S = Eigen::MatrixXd::Identity(JN, JN);
     ydiff = Eigen::VectorXd::Zero(JN);
 
@@ -218,11 +218,11 @@ void TimeIndexedTask::reinitializeVariables(int T_in, PlanningProblem_ptr prob, 
     Phi.assign(T, phi);
     y = Phi;
     Rho.assign(T, Eigen::VectorXd::Ones(NumTasks));
-    if(prob->getFlags() & KIN_J)J.assign(T, Eigen::MatrixXd(JN, prob->N));
-    if(prob->getFlags() & KIN_J_DOT)
+    if (prob->getFlags() & KIN_J) J.assign(T, Eigen::MatrixXd(JN, prob->N));
+    if (prob->getFlags() & KIN_J_DOT)
     {
         Hessian Htmp;
-        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(prob->N,prob->N));
+        Htmp.setConstant(JN, Eigen::MatrixXd::Zero(prob->N, prob->N));
         H.assign(T, Htmp);
     }
     S.assign(T, Eigen::MatrixXd::Identity(JN, JN));


### PR DESCRIPTION
- Adds the ```Hessian``` class (```Eigen::Array<Eigen::MatrixXd>```). Each element of the array is a NxN hessian for the respective task vector element.
- Problems own a Hessian for the task maps. Each Task then indexes into this in similarly to how Jacobians do.
- ```TaskMap``` computes an approximate Hessian (J'J) if the derived class doesn't provide one.
- Kinematic flags of a problem can be now changed in the initializer (-1=default, 0=FK only, 1=FK+Jacobian, 2=FK+Jacobian+Hessian/Jdot).
- Added planning problem tests that also test Jacobians and update Hessians where applicable.
- Fixed untested features in new problems.
- ```preupdate()``` call is no longer required in the solver. The problems handle this at init and in Rho updates.
- ```updateS``` in the tasks was using wrong indexing. Fixed.
- Relates to #223

TODO: 
- Implement actual Hessians for each task map.