### PR TITLE
Fix BoundedEndPoseProblem bounds

### DIFF
--- a/examples/exotica_examples/scripts/example_ik_noros.py
+++ b/examples/exotica_examples/scripts/example_ik_noros.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 print('Start')
+import signal
 import pyexotica as exo
+from pyexotica.publish_trajectory import sigIntHandler
 from numpy import array
 from numpy import matrix
 import math

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -56,7 +56,7 @@ public:
     Eigen::VectorXd getGoal(const std::string& task_name);
     double getRho(const std::string& task_name);
     virtual void preupdate();
-    std::vector<double>& getBounds();
+    Eigen::MatrixXd& getBounds();
 
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();
@@ -73,7 +73,7 @@ public:
 
 protected:
     void initTaskTerms(const std::vector<exotica::Initializer>& inits);
-    std::vector<double> bounds_;
+    Eigen::MatrixXd bounds_;
 };
 typedef std::shared_ptr<exotica::BoundedEndPoseProblem> BoundedEndPoseProblem_ptr;
 }

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -51,7 +51,7 @@ void BoundedEndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer
 {
 }
 
-std::vector<double>& BoundedEndPoseProblem::getBounds()
+Eigen::MatrixXd& BoundedEndPoseProblem::getBounds()
 {
     return bounds_;
 }
@@ -82,20 +82,10 @@ void BoundedEndPoseProblem::Instantiate(BoundedEndPoseProblemInitializer& init)
     }
     J = Eigen::MatrixXd(JN, N);
 
-    std::vector<std::string> jnts;
-    scene_->getJointNames(jnts);
-
-    bounds_.resize(jnts.size() * 2);
-    std::map<std::string, std::vector<double>> joint_limits = scene_->getSolver().getUsedJointLimits();
-    for (int i = 0; i < jnts.size(); i++)
-    {
-        bounds_[i] = joint_limits.at(jnts[i])[0];
-        bounds_[i + jnts.size()] = joint_limits.at(jnts[i])[1];
-    }
-
+    bounds_ = scene_->getSolver().getJointLimits();
     if (init.LowerBound.rows() == N)
     {
-        for (int i = 0; i < jnts.size(); i++) bounds_[i] = init.LowerBound(i);
+        bounds_.col(0) = init.LowerBound;
     }
     else if (init.LowerBound.rows() != 0)
     {
@@ -103,7 +93,7 @@ void BoundedEndPoseProblem::Instantiate(BoundedEndPoseProblemInitializer& init)
     }
     if (init.UpperBound.rows() == N)
     {
-        for (int i = 0; i < jnts.size(); i++) bounds_[i + N] = init.UpperBound(i);
+        bounds_.col(1) = init.UpperBound;
     }
     else if (init.UpperBound.rows() != 0)
     {


### PR DESCRIPTION
Changes the bounds to ``Eigen::MatrixXd`` and uses the correct/other function in ``KinematicTree`` to retrieve them. I finished implementing a Bounded-IK-Solver and it works like a charm using these changes.

I'll propagate similar changes to the time indexed version as I get there.