### PR TITLE
Scene: Update KinematicElement pointers in setModelState(Map) (Fixes #260)

### DIFF
--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -381,6 +381,11 @@ std::map<std::string, double> Scene::getModelStateMap()
 
 void Scene::setModelState(Eigen::VectorXdRefConst x, double t, bool updateTraj)
 {
+    if (requestNeedsUpdating && kinematicRequestCallback)
+    {
+        updateInternalFrames();
+    }
+
     if (updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);
@@ -391,6 +396,11 @@ void Scene::setModelState(Eigen::VectorXdRefConst x, double t, bool updateTraj)
 
 void Scene::setModelState(std::map<std::string, double> x, double t, bool updateTraj)
 {
+    if (requestNeedsUpdating && kinematicRequestCallback)
+    {
+        updateInternalFrames();
+    }
+
     if (updateTraj) updateTrajectoryGenerators(t);
     // Update Kinematica internal state
     kinematica_.setModelState(x);


### PR DESCRIPTION
The new kinematic request structure (from #253) did only update expired frames for ``Update`` (i.e. actuated joints) but not when calling ``setModelState`` (unactuated joints). This lead to runtime crashes when loading a scene and then setting unactuated joints. This fixes it.

Fixes #260 