### PR TITLE
Minor changes to OMPL solvers and exposed KDL frame constructor

### DIFF
--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -1,5 +1,6 @@
 extend <exotica/MotionSolver>
 Optional bool Smooth = true;
+Optional double SmoothnessFactor = 1.0;
 Optional double Timeout = 60.0;
 Optional std::string Range = "1";
 Optional bool UseGoalBias = false;

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -183,7 +183,7 @@ void OMPLsolver::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTerminationCo
     const int n1 = states.size() - 1;
     for (int i = 0; i < n1; ++i)
         length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
-    pg.interpolate(length);
+    pg.interpolate(int(length*init_.SmoothnessFactor));
 
     traj.resize(pg.getStateCount(), prob_->getSpaceDim());
     Eigen::VectorXd tmp(prob_->getSpaceDim());

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -183,7 +183,7 @@ void OMPLsolver::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTerminationCo
     const int n1 = states.size() - 1;
     for (int i = 0; i < n1; ++i)
         length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
-    pg.interpolate(int(length*init_.SmoothnessFactor));
+    pg.interpolate(int(length * init_.SmoothnessFactor));
 
     traj.resize(pg.getStateCount(), prob_->getSpaceDim());
     Eigen::VectorXd tmp(prob_->getSpaceDim());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -508,6 +508,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kdlFrame.def(py::init());
     kdlFrame.def("__init__", [](KDL::Frame& me, Eigen::MatrixXd other) { me = getFrameFromMatrix(other); });
     kdlFrame.def("__init__", [](KDL::Frame& me, Eigen::VectorXd other) { me = getFrame(other); });
+    kdlFrame.def("__init__", [](KDL::Frame& me, const KDL::Frame& other) { me = other; });
     kdlFrame.def("__repr__", [](KDL::Frame* me) { return "KDL::Frame " + toString(*me); });
     kdlFrame.def("getRPY", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::RPY); });
     kdlFrame.def("getZYZ", [](KDL::Frame* me) { return getFrameAsVector(*me, RotationType::ZYZ); });
@@ -811,6 +812,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getTrajectory", [](Scene* instance, const std::string& link) { return instance->getTrajectory(link)->toString(); });
     scene.def("removeTrajectory", &Scene::removeTrajectory);
     scene.def("updateSceneFrames", &Scene::updateSceneFrames);
+    scene.def("updateInternalFrames", &Scene::updateInternalFrames, py::arg("updateRequest") = true);
 
     py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
     // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation


### PR DESCRIPTION
Collection of a couple of minor changes
- Added smoothness factor to OMPL solvers to scale the number of points at which to subsample the trajectory. 1=default, values above 1 will make the trajectory denser/smoother.
- Added ```KDLFrame``` copy constructor into the Python wrapper.
- Exposed ```Scene::updateInternalFrames``` in python. This should be called after loading one or more scene files to manually update the internal structures. This will get called lazily during update but now the internal frames can be updated without updating the robot state. This is useful for extracting the frames from the scene (eg. using FK) before trajectories or other operations move them. 