### PR TITLE
Add termination criterion, fix AICO first-order optimality, use shared planning time/max iterations

### DIFF
--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -151,13 +151,18 @@ private:
     UnconstrainedTimeIndexedProblem_ptr prob_;  //!< Shared pointer to the planning problem.
     double damping;                             //!< Damping
     double damping_init;                        //!< Damping
-    double tolerance;                           //!< Termination error threshold
+    double update_tolerance;                    //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
+    double step_tolerance;                      //!< Relative step tolerance (termination criterion)
+    double function_tolerance;                  //!< Relative function tolerance/first-order optimality criterion
     int max_iterations;                         //!< Max. number of AICO iterations
+    int max_backtrack_iterations;               //!< Max. number of sweeps without improvement before terminating (= line-search)
     bool useBwdMsg;                             //!< Flag for using backward message initialisation
     Eigen::VectorXd bwdMsg_v;                   //!< Backward message initialisation mean
     Eigen::MatrixXd bwdMsg_Vinv;                //!< Backward message initialisation covariance
+    bool sweepImprovedCost;                     //!< Whether the last sweep improved the cost (for backtrack iterations count)
+    int iterationCount;                         //!< Iteration counter
 
-    std::vector<SinglePassMeanCoviariance> q_stat;  //!< Cost weigthed normal distribution of configurations across sweeps.
+    std::vector<SinglePassMeanCoviariance> q_stat;  //!< Cost weighted normal distribution of configurations across sweeps.
 
     std::vector<Eigen::VectorXd> s;      //!< Forward message mean
     std::vector<Eigen::MatrixXd> Sinv;   //!< Forward message covariance inverse
@@ -191,6 +196,7 @@ private:
     std::vector<Eigen::VectorXd> dampingReference;  //!< Damping reference point
     double cost;                                    //!< cost of MAP trajectory
     double cost_old;                                //!< cost of MAP trajectory (last most optimal value)
+    double cost_prev;                               //!< previous iteration cost
     double b_step;                                  //!< Squared configuration space step
     double b_step_old;
 

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -151,7 +151,7 @@ private:
     UnconstrainedTimeIndexedProblem_ptr prob_;  //!< Shared pointer to the planning problem.
     double damping;                             //!< Damping
     double damping_init;                        //!< Damping
-    double update_tolerance;                    //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
+    double minimum_step_tolerance;              //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
     double step_tolerance;                      //!< Relative step tolerance (termination criterion)
     double function_tolerance;                  //!< Relative function tolerance/first-order optimality criterion
     int max_iterations;                         //!< Max. number of AICO iterations

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -131,7 +131,6 @@ public:
 
     std::map<std::string, std::pair<int, int> > taskIndex;
     Eigen::VectorXi dim;  //!< Task dimension
-    double planning_time_;
 
 protected:
     /** \brief Initializes message data.
@@ -154,7 +153,6 @@ private:
     double minimum_step_tolerance;              //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
     double step_tolerance;                      //!< Relative step tolerance (termination criterion)
     double function_tolerance;                  //!< Relative function tolerance/first-order optimality criterion
-    int max_iterations;                         //!< Max. number of AICO iterations
     int max_backtrack_iterations;               //!< Max. number of sweeps without improvement before terminating (= line-search)
     bool useBwdMsg;                             //!< Flag for using backward message initialisation
     Eigen::VectorXd bwdMsg_v;                   //!< Backward message initialisation mean

--- a/exotations/solvers/aico/init/AICOsolver.in
+++ b/exotations/solvers/aico/init/AICOsolver.in
@@ -4,6 +4,6 @@ Optional int MaxIterations = 100;
 Optional int MaxBacktrackIterations = 10;  // Patience on how many sweeps without improvement before terminating
 Optional double StepTolerance = 1e-5;  // Relative step tolerance
 Optional double FunctionTolerance = 1e-5;  // Relative function tolerance (first-order optimality)
-Optional double UpdateTolerance = 1e-5;  // Do not update task messages if the maximum coefficient changes less than the update tolerance
+Optional double MinStep = 1e-5;  // Do not update task messages if the maximum coefficient changes less than the update tolerance
 Optional double Damping = 0.01;
 Optional bool UseBackwardMessage = false;

--- a/exotations/solvers/aico/init/AICOsolver.in
+++ b/exotations/solvers/aico/init/AICOsolver.in
@@ -1,6 +1,9 @@
 extend <exotica/MotionSolver>
-Optional std::string SweepMode = "Symmetric"; // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
+Optional std::string SweepMode = "Symmetric";  // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
 Optional int MaxIterations = 100;
-Optional double Tolerance = 1e-5; // This relates to the minimal change in configuration values between two sweeps
+Optional int MaxBacktrackIterations = 10;  // Patience on how many sweeps without improvement before terminating
+Optional double StepTolerance = 1e-5;  // Relative step tolerance
+Optional double FunctionTolerance = 1e-5;  // Relative function tolerance (first-order optimality)
+Optional double UpdateTolerance = 1e-5;  // Do not update task messages if the maximum coefficient changes less than the update tolerance
 Optional double Damping = 0.01;
 Optional bool UseBackwardMessage = false;

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -220,6 +220,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
             {
                 if (debug_) HIGHLIGHT("Maximum backtrack iterations reached, exiting.");
                 prob_->terminationCriterion = TerminationCriterion::BacktrackIterationLimit;
+                break;
             }
 
             // Check convergence if

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -60,7 +60,7 @@ void AICOsolver::Instantiate(AICOsolverInitializer& init)
     {
         throw_named("Unknown sweep mode '" << init.SweepMode << "'");
     }
-    max_iterations = init.MaxIterations;
+    setNumberOfMaxIterations(init.MaxIterations);
     max_backtrack_iterations = init.MaxBacktrackIterations;
     minimum_step_tolerance = init.MinStep;
     step_tolerance = init.StepTolerance;
@@ -88,7 +88,6 @@ AICOsolver::AICOsolver()
       minimum_step_tolerance(1e-5),
       step_tolerance(1e-5),
       function_tolerance(1e-5),
-      max_iterations(100),
       max_backtrack_iterations(10),
       useBwdMsg(false),
       bwdMsg_v(),
@@ -155,8 +154,9 @@ void AICOsolver::specifyProblem(PlanningProblem_ptr problem)
 
 void AICOsolver::Solve(Eigen::MatrixXd& solution)
 {
-    prob_->resetCostEvolution(max_iterations + 1);
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
     prob_->terminationCriterion = TerminationCriterion::NotStarted;
+    planning_time_ = -1;
 
     Eigen::VectorXd q0 = prob_->applyStartState();
     std::vector<Eigen::VectorXd> q_init = prob_->getInitialTrajectory();
@@ -196,7 +196,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     // Reset sweep and iteration count
     sweep = 0;
     iterationCount = 0;
-    while (iterationCount < max_iterations)
+    while (iterationCount < getNumberOfMaxIterations())
     {
         // Check whether user interrupted (Ctrl+C)
         if (Server::isRos() && !ros::ok())
@@ -254,7 +254,7 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     }
 
     // Check whether maximum iteration count was reached
-    if (iterationCount == max_iterations)
+    if (iterationCount == getNumberOfMaxIterations())
     {
         HIGHLIGHT("Maximum iterations reached");
         prob_->terminationCriterion = TerminationCriterion::IterationLimit;

--- a/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
+++ b/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
@@ -59,12 +59,6 @@ public:
 
     UnconstrainedEndPoseProblem_ptr& getProblem();
 
-    Eigen::MatrixXd PseudoInverse(Eigen::MatrixXdRefConst J);
-
-    double error;
-    double planning_time_;
-
-    int getMaxIteration();
     int getLastIteration();
 
 private:
@@ -72,6 +66,7 @@ private:
 
     inline void vel_solve(double& err, int t, Eigen::VectorXdRefConst q);
 
+    Eigen::MatrixXd PseudoInverse(Eigen::MatrixXdRefConst J);
     void ScaleToStepSize(Eigen::VectorXdRef xd);
 
     UnconstrainedEndPoseProblem_ptr prob_;  // Shared pointer to the planning problem.
@@ -81,6 +76,7 @@ private:
     Eigen::MatrixXd W;
     Eigen::MatrixXd Winv;
     int iterations_;
+    double error;
 };
 typedef std::shared_ptr<exotica::IKsolver> IKsolver_ptr;
 }

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -92,6 +92,7 @@ Eigen::MatrixXd inverseSymPosDef(const Eigen::Ref<const Eigen::MatrixXd>& A_)
 void IKsolver::Instantiate(IKsolverInitializer& init)
 {
     parameters_ = init;
+    setNumberOfMaxIterations(init.MaxIt);
 }
 
 void IKsolver::specifyProblem(PlanningProblem_ptr pointer)
@@ -118,11 +119,6 @@ UnconstrainedEndPoseProblem_ptr& IKsolver::getProblem()
     return prob_;
 }
 
-int IKsolver::getMaxIteration()
-{
-    return parameters_.MaxIt;
-}
-
 int IKsolver::getLastIteration()
 {
     return iterations_;
@@ -144,7 +140,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
     Eigen::VectorXd q = q0;
     error = INFINITY;
     int i;
-    for (i = 0; i < parameters_.MaxIt; i++)
+    for (i = 0; i < getNumberOfMaxIterations(); i++)
     {
         prob_->Update(q);
         Eigen::VectorXd yd = prob_->Cost.S * prob_->Cost.ydiff;

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -53,9 +53,17 @@ public:
     virtual void Solve(Eigen::MatrixXd& solution) = 0;
     PlanningProblem_ptr getProblem() { return problem_; }
     virtual std::string print(std::string prepend);
-
+    void setNumberOfMaxIterations(int maxIter)
+    {
+        HIGHLIGHT_NAMED("MotionSolver", "Setting maximum iterations to " << maxIter << " (was " << maxIterations_ << ")");
+        maxIterations_ = maxIter;
+    }
+    int getNumberOfMaxIterations() { return maxIterations_; }
+    double getPlanningTime() { return planning_time_; }
 protected:
     PlanningProblem_ptr problem_;
+    double planning_time_ = -1;
+    int maxIterations_ = 100;
 };
 
 typedef exotica::Factory<exotica::MotionSolver> MotionSolver_fac;

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -58,6 +58,20 @@
 
 namespace exotica
 {
+enum class TerminationCriterion
+{
+    NotStarted = -1,
+    // Continue = 0,
+    IterationLimit,
+    BacktrackIterationLimit,
+    StepTolerance,
+    FunctionTolerance,
+    GradientTolerance,
+    Divergence,
+    UserDefined
+    // Condition,
+};
+
 class PlanningProblem : public Object, Uncopyable, public virtual InstantiableBase, public std::enable_shared_from_this<PlanningProblem>
 {
 public:
@@ -75,6 +89,7 @@ public:
     Eigen::VectorXd applyStartState(bool updateTraj = true);
     int N;
     double tStart;
+    TerminationCriterion terminationCriterion;
     virtual void preupdate();
     unsigned int getNumberOfProblemUpdates() { return numberOfProblemUpdates; }
     void resetNumberOfProblemUpdates() { numberOfProblemUpdates = 0; }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -550,6 +550,8 @@ PYBIND11_MODULE(_pyexotica, module)
     taskSpaceVector.def("__repr__", [](TaskSpaceVector* instance) { return ((std::ostringstream&)(std::ostringstream("") << "TaskSpaceVector (" << instance->data.transpose() << ")")).str(); });
 
     py::class_<MotionSolver, std::shared_ptr<MotionSolver>, Object> motionSolver(module, "MotionSolver");
+    motionSolver.def_property("maxIterations", &MotionSolver::getNumberOfMaxIterations, &MotionSolver::setNumberOfMaxIterations);
+    motionSolver.def("getPlanningTime", &MotionSolver::getPlanningTime);
     motionSolver.def("specifyProblem", &MotionSolver::specifyProblem, "Assign problem to the solver", py::arg("planningProblem"));
     motionSolver.def(
         "solve", [](std::shared_ptr<MotionSolver> sol) { return Solve(sol); },

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -489,6 +489,17 @@ PYBIND11_MODULE(_pyexotica, module)
     object.def_readwrite("namespace", &Object::ns_);
     object.def_readwrite("debugMode", &Object::debug_);
 
+    py::enum_<TerminationCriterion>(module, "TerminationCriterion")
+        .value("NotStarted", TerminationCriterion::NotStarted)
+        .value("IterationLimit", TerminationCriterion::IterationLimit)
+        .value("BacktrackIterationLimit", TerminationCriterion::BacktrackIterationLimit)
+        .value("StepTolerance", TerminationCriterion::StepTolerance)
+        .value("FunctionTolerance", TerminationCriterion::FunctionTolerance)
+        .value("GradientTolerance", TerminationCriterion::GradientTolerance)
+        .value("Divergence", TerminationCriterion::Divergence)
+        .value("UserDefined", TerminationCriterion::UserDefined)
+        .export_values();
+
     py::enum_<RotationType>(module, "RotationType")
         .value("Quaternion", RotationType::QUATERNION)
         .value("RPY", RotationType::RPY)


### PR DESCRIPTION
Bringing in a few updates from the past few weeks: common termination criteria across solvers, tolerances and other first-order optimality criteria for AICO, moving planning time and max iterations to the solver so we can compare and query different solvers. It also fixes AICO's treatise of sweeps vs iterations and introduces the notion of iterations which was previously missing.