### PR TITLE
Scene: Apply padding and scaling to PlanningScene message, deprecate …

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -41,6 +41,10 @@
 #include <iostream>
 #include <string>
 
+#include <geometric_shapes/mesh_operations.h>
+#include <geometric_shapes/shape_operations.h>
+#include <geometric_shapes/shapes.h>
+
 #include <exotica/SceneInitializer.h>
 
 #include "exotica/CollisionScene.h"
@@ -77,7 +81,7 @@ public:
     std::string getRootFrameName();
     std::string getRootJointName();
     std::string getModelRootLinkName();
-    planning_scene::PlanningScenePtr getPlanningScene();
+    moveit_msgs::PlanningScene getPlanningSceneMsg();
     exotica::KinematicTree& getSolver();
     robot_model::RobotModelPtr getRobotModel();
     void getJointNames(std::vector<std::string>& joints);


### PR DESCRIPTION
…direct access to planning scene

- As we are only using the planning scene to load, we should not allow users to interact with it later.
- Only current interaction is in HDRM, where we are getting a message - this currently caused a bug for paddings and scalings not to be propagated (as they are owned by they CollisionScene implementations and not the MoveIt Planning Scene)
- Update the planning scene message with corresponding information before returning it

**NOTE** The padding and scaling of environment objects appears to not fully work yet (from visualisation; robot links do). It's the right step forward though and other improvements are included below that are required for HDRM integration.