### PR TITLE
Add BayesianIK

### DIFF
--- a/examples/exotica_examples/launch/PythonPlanBayesianIK.launch
+++ b/examples/exotica_examples/launch/PythonPlanBayesianIK.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_bayesianik.py" name="IKPlannerPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/examples/exotica_examples/resources/configs/example_bayesianik.xml
+++ b/examples/exotica_examples/resources/configs/example_bayesianik.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+  <BayesianIK Name="MySolver" />
+
+  <UnconstrainedEndPoseProblem Name="MyProblem">
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+    
+    <Maps>
+      <EffFrame Name="Position">
+        <EndEffector>
+            <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+        </EndEffector>
+      </EffFrame>
+    </Maps>
+
+    <Cost>
+      <Task Task="Position"/>
+    </Cost>
+
+    <StartState>0 0 0 0 0 0 0</StartState>
+    <W> 7 6 5 4 3 2 1 </W>
+  </UnconstrainedEndPoseProblem>
+</IKSolverDemoConfig>

--- a/examples/exotica_examples/scripts/example_bayesianik.py
+++ b/examples/exotica_examples/scripts/example_bayesianik.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from pyexotica.publish_trajectory import *
+from time import sleep
+
+
+def figureEight(t):
+    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2, 0, 0, 0])
+
+
+exo.Setup.initRos()
+solver = exo.Setup.loadSolver(
+    '{exotica_examples}/resources/configs/example_bayesianik.xml')
+problem = solver.getProblem()
+
+dt = 0.002
+t = 0.0
+q = array([0.0]*7)
+print('Publishing IK')
+signal.signal(signal.SIGINT, sigIntHandler)
+while True:
+    try:
+        problem.setGoal('Position', figureEight(t))
+        problem.startState = q
+        q = solver.solve()[0]
+        publishPose(q, problem)
+        sleep(dt)
+        t = t+dt
+    except KeyboardInterrupt:
+        del solver, problem
+        break

--- a/examples/exotica_examples/scripts/runexamples.py
+++ b/examples/exotica_examples/scripts/runexamples.py
@@ -20,6 +20,7 @@ roslaunch = ['CppCore',
              'PythonPlanAICO',
              'PythonPlanAICOTrajectory',
              'PythonPlanIK',
+             'PythonPlanBayesianIK',
              'PythonPlanOMPL',
             ]
 

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(aico)
 
 ## Find catkin macros and libraries
@@ -9,7 +9,10 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(LAPACK REQUIRED)
 
-AddInitializer(AICOsolver)
+AddInitializer(
+  AICOsolver
+  BayesianIK
+)
 GenInitializers()
 
 catkin_package(
@@ -28,6 +31,7 @@ include_directories(
 add_library(aico
   src/MathOperations.cpp
   src/AICOsolver.cpp
+  src/BayesianIK.cpp
 )
 
 ## Specify libraries to link a library or executable target against

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(
 
 ## Declare a cpp library
 add_library(aico
+  src/MathOperations.cpp
   src/AICOsolver.cpp
 )
 

--- a/exotations/solvers/aico/exotica_plugins.xml
+++ b/exotations/solvers/aico/exotica_plugins.xml
@@ -2,4 +2,7 @@
   <class name="exotica/AICOsolver" type="exotica::AICOsolver" base_class_type="exotica::MotionSolver">
     <description>AICO solver</description>
   </class>
+  <class name="exotica/BayesianIK" type="exotica::BayesianIK" base_class_type="exotica::MotionSolver">
+    <description>Bayesian Unconstrained Endpose Solver</description>
+  </class>
 </library>

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -105,9 +105,6 @@ public:
 
     void getStats(std::vector<SinglePassMeanCoviariance>& q_stat_);
 
-    std::map<std::string, std::pair<int, int> > taskIndex;
-    Eigen::VectorXi dim;  //!< Task dimension
-
 protected:
     /** \brief Initializes message data.
        *  @param q0 Start configuration
@@ -138,20 +135,19 @@ private:
 
     std::vector<SinglePassMeanCoviariance> q_stat;  //!< Cost weighted normal distribution of configurations across sweeps.
 
-    std::vector<Eigen::VectorXd> s;      //!< Forward message mean
-    std::vector<Eigen::MatrixXd> Sinv;   //!< Forward message covariance inverse
-    std::vector<Eigen::VectorXd> v;      //!< Backward message mean
-    std::vector<Eigen::MatrixXd> Vinv;   //!< Backward message covariance inverse
-    std::vector<Eigen::VectorXd> r;      //!< Task message mean
-    std::vector<Eigen::MatrixXd> R;      //!< Task message covariance
-    Eigen::VectorXd rhat;                //!< Task message point of linearisation
-    std::vector<Eigen::VectorXd> b;      //!< Belief mean
-    std::vector<Eigen::MatrixXd> Binv;   //!< Belief covariance inverse
-    std::vector<Eigen::VectorXd> q;      //!< Configuration space trajectory
-    std::vector<Eigen::VectorXd> qhat;   //!< Point of linearisation
-    Eigen::VectorXd costControl;         //!< Control cost for each time step
-    Eigen::VectorXd costTask;            //!< Task cost for each task for each time step
-    std::vector<std::string> taskNames;  //!< Task names (only used for printing debug info)
+    std::vector<Eigen::VectorXd> s;     //!< Forward message mean
+    std::vector<Eigen::MatrixXd> Sinv;  //!< Forward message covariance inverse
+    std::vector<Eigen::VectorXd> v;     //!< Backward message mean
+    std::vector<Eigen::MatrixXd> Vinv;  //!< Backward message covariance inverse
+    std::vector<Eigen::VectorXd> r;     //!< Task message mean
+    std::vector<Eigen::MatrixXd> R;     //!< Task message covariance
+    Eigen::VectorXd rhat;               //!< Task message point of linearisation
+    std::vector<Eigen::VectorXd> b;     //!< Belief mean
+    std::vector<Eigen::MatrixXd> Binv;  //!< Belief covariance inverse
+    std::vector<Eigen::VectorXd> q;     //!< Configuration space trajectory
+    std::vector<Eigen::VectorXd> qhat;  //!< Point of linearisation
+    Eigen::VectorXd costControl;        //!< Control cost for each time step
+    Eigen::VectorXd costTask;           //!< Task cost for each task for each time step
 
     std::vector<Eigen::VectorXd> s_old;     //!< Forward message mean (last most optimal value)
     std::vector<Eigen::MatrixXd> Sinv_old;  //!< Forward message covariance inverse (last most optimal value)
@@ -279,15 +275,6 @@ private:
        * \brief Reverts back to previous state if the cost of the current state is higher.
        */
     void perhapsUndoStep();
-
-    /**
-       * \brief Returns process transition matrices
-       * @param A_ System transition matrix.
-       * @param a_ System transition drift vector.
-       * @param B_ System control matrix.
-       */
-    void getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
-                    Eigen::Ref<Eigen::VectorXd> a_, Eigen::Ref<Eigen::MatrixXd> B_);
 
     /**
        * \brief Updates the task cost terms \f$ R, r, \hat{r} \f$ for time step \f$t\f$. UnconstrainedTimeIndexedProblem::update() has to be called before calling this function.

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -66,21 +66,12 @@
 #define AICOSOLVER_H_
 
 #include <aico/AICOsolverInitializer.h>
+#include <aico/MathOperations.h>
 #include <aico/incremental_gaussian.h>
 #include <exotica/Exotica.h>
 #include <exotica/Problems/UnconstrainedTimeIndexedProblem.h>
 #include <fstream>
 #include <iostream>
-
-#include "f2c.h"
-#include "lapack/cblas.h"
-#undef small
-#undef large
-#include <lapack/clapack.h>
-#undef double
-#undef max
-#undef min
-#undef abs
 
 namespace exotica
 {
@@ -111,21 +102,6 @@ public:
        * \brief Stores costs into a file
        */
     void saveCosts(std::string file_name);
-
-    /**
-       * \brief Computes an inverse of symmetric positive definite matrix using LAPACK (very fast)
-       * @param Ainv Resulting inverted matrix.
-       * @param A A symmetric positive definite matrix to be inverted.
-       */
-    void inverseSymPosDef(Eigen::Ref<Eigen::MatrixXd> Ainv_,
-                          const Eigen::Ref<const Eigen::MatrixXd>& A_);
-
-    /**
-       * \brief Computes the solution to the linear problem \f$x=Ab\f$ for symmetric positive definite matrix A
-       */
-    void AinvBSymPosDef(Eigen::Ref<Eigen::VectorXd> x_,
-                        const Eigen::Ref<const Eigen::MatrixXd>& A_,
-                        const Eigen::Ref<const Eigen::VectorXd>& b_);
 
     void getStats(std::vector<SinglePassMeanCoviariance>& q_stat_);
 

--- a/exotations/solvers/aico/include/aico/BayesianIK.h
+++ b/exotations/solvers/aico/include/aico/BayesianIK.h
@@ -1,0 +1,248 @@
+/*
+ *  Created on: 13 Mar 2018
+ *      Author: Wolfgang Merkt, Vladimir Ivan
+ *
+ *  This code is based on algorithm developed by Marc Toussaint
+ *  M. Toussaint: Robot Trajectory Optimization using Approximate Inference. In Proc. of the Int. Conf. on Machine Learning (ICML 2009), 1049-1056, ACM, 2009.
+ *  http://ipvs.informatik.uni-stuttgart.de/mlr/papers/09-toussaint-ICML.pdf
+ *  Original code available at http://ipvs.informatik.uni-stuttgart.de/mlr/marc/source-code/index.html
+ *
+ * 
+ * Copyright (c) 2018, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#ifndef BAYESIAN_IK_H_
+#define BAYESIAN_IK_H_
+
+#include <aico/BayesianIKInitializer.h>
+#include <aico/MathOperations.h>
+#include <aico/incremental_gaussian.h>
+#include <exotica/Exotica.h>
+#include <exotica/Problems/UnconstrainedEndPoseProblem.h>
+#include <iostream>
+
+namespace exotica
+{
+/**
+   * \brief Solves motion planning problem using Approximate Inference Control method.
+   * \ingroup AICO
+   */
+class BayesianIK : public MotionSolver, public Instantiable<BayesianIKInitializer>
+{
+public:
+    BayesianIK();
+    virtual void Instantiate(BayesianIKInitializer& init);
+    virtual ~BayesianIK();
+    /**
+       * \brief Solves the problem
+       * @param solution Returned end pose solution.
+       */
+    void Solve(Eigen::MatrixXd& solution);
+
+    /**
+       * \brief Binds the solver to a specific problem which must be pre-initalised
+       * @param pointer Shared pointer to the motion planning problem
+       * @return        Successful if the problem is a valid UnconstrainedEndPoseProblem
+       */
+    virtual void specifyProblem(PlanningProblem_ptr pointer);
+
+protected:
+    /** \brief Initializes message data.
+       *  @param q0 Start configuration
+       *  @return  Indicates success
+       */
+    void initMessages();
+
+    /**
+       * \brief Initialise AICO messages from an initial trajectory
+       * @param q_init Initial trajectory
+       * @return  Indicates success
+       */
+    void initTrajectory(const Eigen::VectorXd& q_init);
+
+private:
+    UnconstrainedEndPoseProblem_ptr prob_;  //!< Shared pointer to the planning problem.
+    double damping;                         //!< Damping
+    double damping_init;                    //!< Damping
+    double minimum_step_tolerance;          //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
+    double step_tolerance;                  //!< Relative step tolerance (termination criterion)
+    double function_tolerance;              //!< Relative function tolerance/first-order optimality criterion
+    int max_backtrack_iterations;           //!< Max. number of sweeps without improvement before terminating (= line-search)
+    bool useBwdMsg;                         //!< Flag for using backward message initialisation
+    Eigen::VectorXd bwdMsg_v;               //!< Backward message initialisation mean
+    Eigen::MatrixXd bwdMsg_Vinv;            //!< Backward message initialisation covariance
+    bool sweepImprovedCost;                 //!< Whether the last sweep improved the cost (for backtrack iterations count)
+    int iterationCount;                     //!< Iteration counter
+
+    Eigen::VectorXd s;     //!< Forward message mean
+    Eigen::MatrixXd Sinv;  //!< Forward message covariance inverse
+    Eigen::VectorXd v;     //!< Backward message mean
+    Eigen::MatrixXd Vinv;  //!< Backward message covariance inverse
+    Eigen::VectorXd r;     //!< Task message mean
+    Eigen::MatrixXd R;     //!< Task message covariance
+    double rhat;           //!< Task message point of linearisation
+    Eigen::VectorXd b;     //!< Belief mean
+    Eigen::MatrixXd Binv;  //!< Belief covariance inverse
+    Eigen::VectorXd q;     //!< Configuration space trajectory
+    Eigen::VectorXd qhat;  //!< Point of linearisation
+
+    Eigen::VectorXd s_old;     //!< Forward message mean (last most optimal value)
+    Eigen::MatrixXd Sinv_old;  //!< Forward message covariance inverse (last most optimal value)
+    Eigen::VectorXd v_old;     //!< Backward message mean (last most optimal value)
+    Eigen::MatrixXd Vinv_old;  //!< Backward message covariance inverse (last most optimal value)
+    Eigen::VectorXd r_old;     //!< Task message mean (last most optimal value)
+    Eigen::MatrixXd R_old;     //!< Task message covariance (last most optimal value)
+    double rhat_old;           //!< Task message point of linearisation (last most optimal value)
+    Eigen::VectorXd b_old;     //!< Belief mean (last most optimal value)
+    Eigen::MatrixXd Binv_old;  //!< Belief covariance inverse (last most optimal value)
+    Eigen::VectorXd q_old;     //!< Configuration space trajectory (last most optimal value)
+    Eigen::VectorXd qhat_old;  //!< Point of linearisation (last most optimal value)
+
+    Eigen::VectorXd dampingReference;  //!< Damping reference point
+    double cost;                       //!< cost of MAP trajectory
+    double cost_old;                   //!< cost of MAP trajectory (last most optimal value)
+    double cost_prev;                  //!< previous iteration cost
+    double b_step;                     //!< Squared configuration space step
+    double b_step_old;
+
+    Eigen::MatrixXd W;     //!< Configuration space weight matrix inverse
+    Eigen::MatrixXd Winv;  //!< Configuration space weight matrix inverse
+
+    int sweep;  //!< Sweeps so far
+    int bestSweep = 0;
+    int bestSweep_old = 0;
+    enum SweepMode
+    {
+        smForwardly = 0,
+        smSymmetric,
+        smLocalGaussNewton,
+        smLocalGaussNewtonDamped
+    };
+    int sweepMode;  //!< Sweep mode
+    int updateCount;
+
+    Eigen::MatrixXd linSolverTmp;
+
+    /**
+       * \brief Updates the forward message
+       *
+       * Updates the mean and covariance of the forward message using:
+       * \f$ \mu_{x_{t-1}\rightarrow x_t}(x)=\mathcal{N}(x_t|s_t,S_t) \f$
+       * , where
+       * \f$ s_t=a_{t-1}\!+\!A_{t-1}(S_{t-1}^{-1}\!+\!R_{t-1})^{-1}(S_{t-1}^{-1}s_{t-1}\!+\!r_{t-1}) \f$
+       * and
+       * \f$ S_t=Q+B_tH^{-1}B_t^{\!\top\!} + A_{t-1}(S_{t-1}^{-1}+R_{t-1})^{-1}A_{t-1}^{\!\top\!} \f$.
+       */
+    void updateFwdMessage();
+    /**
+       * \brief Updates the backward message
+       *
+       * Updates the mean and covariance of the backward message using:
+       * \f$ \mu_{x_{t+1}\rightarrow x_t}(x)=\mathcal{N}(x_t|v_t,V_t) \f$
+       * , where
+       * \f$ v_t=-A_{t}^{-1}a_{t}\!\!+\!\!A_{t}^{-1}(V_{t+1}^{-1}\!\!+\!\!R_{t+1})^{-1}(V_{t+1}^{-1}v_{t+1}\!\!+\!\!r_{t+1}) \f$
+       * and
+       * \f$ V_t=A_{t}^{-1}[Q+B_tH^{-1}B_t^{\!\top\!} + (V_{t+1}^{-1}+R_{t+1})^{-1}]A_{t}^{-{\!\top\!}} \f$.
+       */
+    void updateBwdMessage();
+    /**
+       * \brief Updates the task message
+       * @param qhat_t Point of linearisation at time step $t$
+       * @param tolerance_ Lazy update tolerance (only update the task message if the state changed more than this value)
+       * @param maxStepSize If step size >0, cap the motion at this step to the step size.
+       *
+       * Updates the mean and covariance of the task message using:
+       * \f$ \mu_{z_t\rightarrow x_t}(x)=\mathcal{N}[x_t|r_t,R_t] \f$
+       */
+    void updateTaskMessage(const Eigen::Ref<const Eigen::VectorXd>& qhat_t, double tolerance_,
+                           double maxStepSize = -1.);
+    /**
+       * \brief Update messages for given time step
+       * @param t Time step.
+       * @param updateFwd Update the forward message.
+       * @param updateBwd Update the backward message.
+       * @param maxRelocationIterations Maximum number of relocation while searching for a good linearisation point
+       * @param tolerance_ Tolerance for for stopping the search.
+       * @param forceRelocation Set to true to force relocation even when the result is within tolerance.
+       * @param maxStepSize Step size for updateTaskMessage.
+       */
+    void updateTimeStep(bool updateFwd, bool updateBwd,
+                        int maxRelocationIterations, double tolerance_, bool forceRelocation,
+                        double maxStepSize = -1.);
+    /**
+       * \brief Update messages for given time step using the Gauss Newton method
+       * @param t Time step.
+       * @param updateFwd Update the forward message.
+       * @param updateBwd Update the backward message.
+       * @param maxRelocationIterations Maximum number of relocation while searching for a good linearisation point
+       * @param tolerance Tolerance for for stopping the search.
+       * @param maxStepSize Step size for updateTaskMessage.
+       *
+       * First, the messages \f$ \mu_{x_{t-1}\rightarrow x_t}(x)=\mathcal{N}(x_t|s_t,S_t) \f$,
+       * \f$ \mu_{x_{t+1}\rightarrow x_t}(x)=\mathcal{N}(x_t|v_t,V_t) \f$ and
+       * \f$ \mu_{z_t\rightarrow x_t}(x)=\mathcal{N}[x_t|r_t,R_t] \f$
+       * are computed. Then, the belief is updated:
+       * \f$ b_t(X_t)=\mu_{x_{t-1}\rightarrow x_t}(x) \mu_{x_{t+1}\rightarrow x_t}(x) \mu_{z_t\rightarrow x_t}(x) \f$
+       * where the mean and covariance are updated as follows:
+       * \f$ b_t(X_t)=\mathcal{N}\left(x_t|(S_t^{-1}+V_t^{-1}+R_t)^{-1}(S_t^{-1}s_t+V_t^{-1}v_t+r_t),S_t^{-1}+V_t^{-1}+R_t \right) \f$.
+       */
+    void updateTimeStepGaussNewton(bool updateFwd, bool updateBwd,
+                                   int maxRelocationIterations, double tolerance, double maxStepSize =
+                                                                                      -1.);
+    /**
+       * \brief Computes the cost of the trajectory
+       * @param x Trajecotry.
+       * @return Cost of the trajectory.
+       */
+    double evaluateTrajectory(const Eigen::VectorXd& x, bool skipUpdate = false);
+    /**
+       * \brief Stores the previous state.
+       */
+    void rememberOldState();
+    /**
+       * \brief Reverts back to previous state if the cost of the current state is higher.
+       */
+    void perhapsUndoStep();
+
+    /**
+       * \brief Updates the task cost terms \f$ R, r, \hat{r} \f$. UnconstrainedEndPoseProblem::update() has to be called before calling this function.
+       */
+    double getTaskCosts();
+
+    /**
+       * \brief Compute one step of the AICO algorithm.
+       * @return Change in cost of the trajectory.
+       */
+    double step();
+};
+
+typedef std::shared_ptr<exotica::BayesianIK> BayesianIK_ptr;
+} /* namespace exotica */
+
+#endif /* BAYESIAN_IK_H_ */

--- a/exotations/solvers/aico/include/aico/MathOperations.h
+++ b/exotations/solvers/aico/include/aico/MathOperations.h
@@ -1,0 +1,74 @@
+/*
+ *  Created on: 13 Mar 2018
+ *      Author: Wolfgang Merkt, Vladimir Ivan
+ *
+ *  This code is based on algorithm developed by Marc Toussaint
+ *  M. Toussaint: Robot Trajectory Optimization using Approximate Inference. In Proc. of the Int. Conf. on Machine Learning (ICML 2009), 1049-1056, ACM, 2009.
+ *  http://ipvs.informatik.uni-stuttgart.de/mlr/papers/09-toussaint-ICML.pdf
+ *  Original code available at http://ipvs.informatik.uni-stuttgart.de/mlr/marc/source-code/index.html
+ *
+ * 
+ * Copyright (c) 2018, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#ifndef MATH_OPERATIONS_H_
+#define MATH_OPERATIONS_H_
+
+#include <exotica/Exotica.h>
+#include "f2c.h"
+#include "lapack/cblas.h"
+#undef small
+#undef large
+#include <lapack/clapack.h>
+#undef double
+#undef max
+#undef min
+#undef abs
+
+namespace exotica
+{
+/**
+ * \brief Computes an inverse of symmetric positive definite matrix using LAPACK (very fast)
+ * @param Ainv Resulting inverted matrix.
+ * @param A A symmetric positive definite matrix to be inverted.
+ */
+void inverseSymPosDef(Eigen::Ref<Eigen::MatrixXd> Ainv_,
+                      const Eigen::Ref<const Eigen::MatrixXd>& A_);
+
+/**
+ * \brief Computes the solution to the linear problem \f$x=Ab\f$ for symmetric positive definite matrix A
+ */
+void AinvBSymPosDef(Eigen::Ref<Eigen::VectorXd> x_,
+                    const Eigen::Ref<const Eigen::MatrixXd>& A_,
+                    const Eigen::Ref<const Eigen::VectorXd>& b_,
+                    Eigen::MatrixXd& linSolverTmp,
+                    int n_in);
+}
+
+#endif  // MATH_OPERATIONS_H_

--- a/exotations/solvers/aico/init/BayesianIK.in
+++ b/exotations/solvers/aico/init/BayesianIK.in
@@ -1,0 +1,9 @@
+extend <exotica/MotionSolver>
+Optional std::string SweepMode = "Symmetric";  // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
+Optional int MaxIterations = 100;
+Optional int MaxBacktrackIterations = 10;  // Patience on how many sweeps without improvement before terminating
+Optional double StepTolerance = 1e-5;  // Relative step tolerance
+Optional double FunctionTolerance = 1e-5;  // Relative function tolerance (first-order optimality)
+Optional double MinStep = 1e-5;  // Do not update task messages if the maximum coefficient changes less than the update tolerance
+Optional double Damping = 0.01;
+Optional bool UseBackwardMessage = false;

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -338,14 +338,6 @@ void AICOsolver::initMessages()
     lastT = prob_->getT();
 }
 
-void AICOsolver::getProcess(Eigen::Ref<Eigen::MatrixXd> A_,
-                            Eigen::Ref<Eigen::VectorXd> a_, Eigen::Ref<Eigen::MatrixXd> B_)
-{
-    A_ = Eigen::MatrixXd::Identity(prob_->N, prob_->N);
-    B_ = Eigen::MatrixXd::Identity(prob_->N, prob_->N);
-    a_ = Eigen::VectorXd::Zero(prob_->N);
-}
-
 void AICOsolver::initTrajectory(const std::vector<Eigen::VectorXd>& q_init)
 {
     if (q_init.size() != prob_->getT())
@@ -687,5 +679,4 @@ void AICOsolver::perhapsUndoStep()
         damping /= 5.;
     }
 }
-
 } /* namespace exotica */

--- a/exotations/solvers/aico/src/BayesianIK.cpp
+++ b/exotations/solvers/aico/src/BayesianIK.cpp
@@ -1,0 +1,562 @@
+/*
+ *  Created on: 13 Mar 2018
+ *      Author: Wolfgang Merkt, Vladimir Ivan
+ *
+ *  This code is based on algorithm developed by Marc Toussaint
+ *  M. Toussaint: Robot Trajectory Optimization using Approximate Inference. In Proc. of the Int. Conf. on Machine Learning (ICML 2009), 1049-1056, ACM, 2009.
+ *  http://ipvs.informatik.uni-stuttgart.de/mlr/papers/09-toussaint-ICML.pdf
+ *  Original code available at http://ipvs.informatik.uni-stuttgart.de/mlr/marc/source-code/index.html
+ * 
+ * Copyright (c) 2018, University of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#include "aico/BayesianIK.h"
+
+REGISTER_MOTIONSOLVER_TYPE("BayesianIK", exotica::BayesianIK)
+
+namespace exotica
+{
+void BayesianIK::Instantiate(BayesianIKInitializer& init)
+{
+    std::string mode = init.SweepMode;
+    if (mode == "Forwardly")
+        sweepMode = smForwardly;
+    else if (mode == "Symmetric")
+        sweepMode = smSymmetric;
+    else if (mode == "LocalGaussNewton")
+        sweepMode = smLocalGaussNewton;
+    else if (mode == "LocalGaussNewtonDamped")
+        sweepMode = smLocalGaussNewtonDamped;
+    else
+    {
+        throw_named("Unknown sweep mode '" << init.SweepMode << "'");
+    }
+    setNumberOfMaxIterations(init.MaxIterations);
+    max_backtrack_iterations = init.MaxBacktrackIterations;
+    minimum_step_tolerance = init.MinStep;
+    step_tolerance = init.StepTolerance;
+    function_tolerance = init.FunctionTolerance;
+    damping_init = init.Damping;
+    useBwdMsg = init.UseBackwardMessage;
+}
+
+BayesianIK::BayesianIK()
+    : damping(0.01),
+      minimum_step_tolerance(1e-5),
+      step_tolerance(1e-5),
+      function_tolerance(1e-5),
+      max_backtrack_iterations(10),
+      useBwdMsg(false),
+      bwdMsg_v(),
+      bwdMsg_Vinv(),
+      s(),
+      Sinv(),
+      v(),
+      Vinv(),
+      r(),
+      R(),
+      rhat(),
+      b(),
+      Binv(),
+      q(),
+      qhat(),
+      s_old(),
+      Sinv_old(),
+      v_old(),
+      Vinv_old(),
+      r_old(),
+      R_old(),
+      rhat_old(),
+      b_old(),
+      Binv_old(),
+      q_old(),
+      qhat_old(),
+      dampingReference(),
+      cost(0.0),
+      cost_old(0.0),
+      cost_prev(std::numeric_limits<double>::max()),
+      b_step(0.0),
+      Winv(),
+      sweep(0),
+      sweepMode(0),
+      W(),
+      updateCount(0),
+      damping_init(0.0)
+// q_stat()
+{
+}
+
+BayesianIK::~BayesianIK() {}
+void BayesianIK::specifyProblem(PlanningProblem_ptr problem)
+{
+    if (problem->type() != "exotica::UnconstrainedEndPoseProblem")
+    {
+        throw_named("This solver can't use problem of type '" << problem->type() << "'!");
+    }
+    MotionSolver::specifyProblem(problem);
+    prob_ = std::static_pointer_cast<UnconstrainedEndPoseProblem>(problem);
+
+    initMessages();
+}
+
+void BayesianIK::Solve(Eigen::MatrixXd& solution)
+{
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
+    prob_->terminationCriterion = TerminationCriterion::NotStarted;
+    planning_time_ = -1;
+
+    Eigen::VectorXd q0 = prob_->applyStartState();
+
+    Timer timer;
+    if (debug_) ROS_WARN_STREAM("BayesianIK: Setting up the solver");
+    updateCount = 0;
+    damping = damping_init;
+    double d;
+    iterationCount = -1;
+    initTrajectory(q0);
+    if (debug_) ROS_WARN_STREAM("BayesianIK: Solving");
+
+    // Reset sweep and iteration count
+    sweep = 0;
+    iterationCount = 0;
+    while (iterationCount < getNumberOfMaxIterations())
+    {
+        // Check whether user interrupted (Ctrl+C)
+        if (Server::isRos() && !ros::ok())
+        {
+            if (debug_) HIGHLIGHT("Solving cancelled by user");
+            prob_->terminationCriterion = TerminationCriterion::UserDefined;
+            break;
+        }
+
+        d = step();
+        if (d < 0)
+        {
+            throw_named("Negative step size!");
+        }
+
+        // Check stopping criteria
+        if (iterationCount > 1)
+        {
+            // 0. Check maximum backtrack iterations
+            if (damping && sweep >= max_backtrack_iterations)
+            {
+                if (debug_) HIGHLIGHT("Maximum backtrack iterations reached, exiting.");
+                prob_->terminationCriterion = TerminationCriterion::BacktrackIterationLimit;
+                break;
+            }
+
+            // Check convergence if
+            //    a) damping is on and the iteration has concluded (the sweep improved the cost)
+            //    b) damping is off [each sweep equals one iteration]
+            if (damping && sweepImprovedCost || !damping)
+            {
+                // 1. Check step tolerance
+                // || x_t-x_t-1 || <= stepTolerance * max(1, || x_t ||)
+                // TODO(#257): TODO(#256): move to Eigen::MatrixXd to make this easier to compute, in the meantime use old check
+                //
+                // TODO(#256): OLD TOLERANCE CHECK - TODO REMOVE
+                if (d < minimum_step_tolerance)
+                {
+                    if (debug_) HIGHLIGHT("Satisfied tolerance\titer=" << iterationCount << "\td=" << d << "\tminimum_step_tolerance=" << minimum_step_tolerance);
+                    prob_->terminationCriterion = TerminationCriterion::StepTolerance;
+                    break;
+                }
+
+                // 2. Check function tolerance
+                // (f_t-1 - f_t) <= functionTolerance * max(1, abs(f_t))
+                if ((cost_prev - cost) <= function_tolerance * std::max(1.0, std::abs(cost)))
+                {
+                    if (debug_) HIGHLIGHT("Function tolerance achieved: " << (cost_prev - cost) << " <= " << function_tolerance * std::max(1.0, std::abs(cost)));
+                    prob_->terminationCriterion = TerminationCriterion::FunctionTolerance;
+                    break;
+                }
+                cost_prev = cost;
+            }
+        }
+    }
+
+    // Check whether maximum iteration count was reached
+    if (iterationCount == getNumberOfMaxIterations())
+    {
+        HIGHLIGHT("Maximum iterations reached");
+        prob_->terminationCriterion = TerminationCriterion::IterationLimit;
+    }
+
+    solution.resize(1, prob_->N);
+    solution.row(0) = q;
+    planning_time_ = timer.getDuration();
+}
+
+void BayesianIK::initMessages()
+{
+    if (prob_ == nullptr) throw_named("Problem definition is a NULL pointer!");
+
+    if (prob_->N < 1)
+    {
+        throw_named("State dimension is too small: n=" << prob_->N);
+    }
+
+    s = Eigen::VectorXd::Zero(prob_->N);
+    Sinv = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
+    v = Eigen::VectorXd::Zero(prob_->N);
+    Vinv = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
+    // if (useBwdMsg)
+    // {
+    //     if (bwdMsg_v.rows() == prob_->N && bwdMsg_Vinv.rows() == prob_->N && bwdMsg_Vinv.cols() == prob_->N)
+    //     {
+    //         v[prob_->getT() - 1] = bwdMsg_v;
+    //         Vinv[prob_->getT() - 1] = bwdMsg_Vinv;
+    //     }
+    //     else
+    //     {
+    //         useBwdMsg = false;
+    //         WARNING("Backward message initialisation skipped, matrices have incorrect dimensions.");
+    //     }
+    // }
+    b = Eigen::VectorXd::Zero(prob_->N);
+    dampingReference = Eigen::VectorXd::Zero(prob_->N);
+    Binv = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
+    // Binv[0].setIdentity();
+    // Binv[0] = Binv[0] * 1e10;
+    r = Eigen::VectorXd::Zero(prob_->N);
+    R = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
+    rhat = 0;
+    qhat = Eigen::VectorXd::Zero(prob_->N);
+    linSolverTmp.resize(prob_->N, prob_->N);
+    {
+        q = b;
+        if (prob_->W.rows() != prob_->N)
+        {
+            throw_named(prob_->W.rows() << "!=" << prob_->N);
+        }
+    }
+    {
+        // Set constant W,Win,H,Hinv
+        W = prob_->W;
+        Winv = W.inverse();
+    }
+}
+
+void BayesianIK::initTrajectory(const Eigen::VectorXd& q_init)
+{
+    qhat = q_init;
+    q = q_init;
+    dampingReference = q_init;
+    b = q_init;
+    s = q_init;
+    v = q_init;
+    Sinv.setZero();
+    Sinv.diagonal().setConstant(damping);
+    Vinv.setZero();
+    Vinv.diagonal().setConstant(damping);
+
+    // Compute task message reference
+    updateTaskMessage(b, 0.0);
+
+    cost = evaluateTrajectory(b, true);  // The problem will be updated via updateTaskMessage, i.e. do not update on this roll-out
+    cost_prev = cost;
+    prob_->setCostEvolution(0, cost);
+    if (cost < 0) throw_named("Invalid cost! " << cost);
+    if (debug_) HIGHLIGHT("Initial cost, updates: " << updateCount << ", cost: " << cost);
+    rememberOldState();
+}
+
+void BayesianIK::updateFwdMessage()
+{
+    Eigen::MatrixXd barS(prob_->N, prob_->N), St;
+    inverseSymPosDef(barS, Sinv + R);
+    s = barS * (Sinv * s + r);
+    St = Winv + barS;
+    inverseSymPosDef(Sinv, St);
+}
+
+void BayesianIK::updateBwdMessage()
+{
+    Eigen::MatrixXd barV(prob_->N, prob_->N), Vt;
+    // if (t < prob_->getT() - 1)
+    // {
+    //     inverseSymPosDef(barV, Vinv[t + 1] + R[t + 1]);
+    //     v[t] = barV * (Vinv[t + 1] * v[t + 1] + r[t + 1]);
+    //     Vt = Winv + barV;
+    //     inverseSymPosDef(Vinv[t], Vt);
+    // }
+    if (true)
+    {
+        if (!useBwdMsg)
+        {
+            v = b;
+            Vinv.diagonal().setConstant(1);
+        }
+        else
+        {
+            v = bwdMsg_v;
+            Vinv = bwdMsg_Vinv;
+        }
+    }
+}
+
+void BayesianIK::updateTaskMessage(const Eigen::Ref<const Eigen::VectorXd>& qhat_t, double minimum_step_tolerance,
+                                   double maxStepSize)
+{
+    Eigen::VectorXd diff = qhat_t - qhat;
+    if ((diff.array().abs().maxCoeff() < minimum_step_tolerance)) return;
+    double nrm = diff.norm();
+    if (maxStepSize > 0. && nrm > maxStepSize)
+    {
+        qhat += diff * (maxStepSize / nrm);
+    }
+    else
+    {
+        qhat = qhat_t;
+    }
+
+    prob_->Update(qhat);
+    updateCount++;
+    double c = getTaskCosts();
+    // q_stat.addw(c > 0 ? 1.0 / (1.0 + c) : 1.0, qhat_t);
+}
+
+double BayesianIK::getTaskCosts()
+{
+    double C = 0;
+    Eigen::MatrixXd Jt;
+    double prec;
+    rhat = 0;
+    R.setZero();
+    r.setZero();
+    for (int i = 0; i < prob_->getTasks().size(); i++)
+    {
+        prec = prob_->Cost.Rho(i);
+        if (prec > 0)
+        {
+            int start = prob_->Cost.Indexing[i].StartJ;
+            int len = prob_->Cost.Indexing[i].LengthJ;
+            Jt = prob_->Cost.J.middleRows(start, len).transpose();
+            C += prec * (prob_->Cost.ydiff.segment(start, len)).squaredNorm();
+            R += prec * Jt * prob_->Cost.J.middleRows(start, len);
+            r += prec * Jt * (-prob_->Cost.ydiff.segment(start, len) + prob_->Cost.J.middleRows(start, len) * qhat);
+            rhat += prec * (-prob_->Cost.ydiff.segment(start, len) + prob_->Cost.J.middleRows(start, len) * qhat).squaredNorm();
+        }
+    }
+    return C;
+}
+
+void BayesianIK::updateTimeStep(bool updateFwd, bool updateBwd,
+                                int maxRelocationIterations, double minimum_step_tolerance, bool forceRelocation,
+                                double maxStepSize)
+{
+    if (updateFwd) updateFwdMessage();
+    if (updateBwd) updateBwdMessage();
+
+    if (damping)
+    {
+        Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
+        AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * dampingReference, linSolverTmp, prob_->N);
+    }
+    else
+    {
+        Binv = Sinv + Vinv + R;
+        AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r, linSolverTmp, prob_->N);
+    }
+
+    for (int k = 0; k < maxRelocationIterations && !(Server::isRos() && !ros::ok()); k++)
+    {
+        if (!((!k && forceRelocation) || (b - qhat).array().abs().maxCoeff() > minimum_step_tolerance)) break;
+
+        updateTaskMessage(b, 0., maxStepSize);
+
+        //optional reUpdate fwd or bwd message (if the Dynamics might have changed...)
+        if (updateFwd) updateFwdMessage();
+        if (updateBwd) updateBwdMessage();
+
+        if (damping)
+        {
+            Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
+            AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * dampingReference, linSolverTmp, prob_->N);
+        }
+        else
+        {
+            Binv = Sinv + Vinv + R;
+            AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r, linSolverTmp, prob_->N);
+        }
+    }
+}
+
+void BayesianIK::updateTimeStepGaussNewton(bool updateFwd,
+                                           bool updateBwd, int maxRelocationIterations, double minimum_step_tolerance,
+                                           double maxStepSize)
+{
+    // TODO: implement updateTimeStepGaussNewton
+    throw_named("Not implemented yet!");
+}
+
+double BayesianIK::evaluateTrajectory(const Eigen::VectorXd& x, bool skipUpdate)
+{
+    if (debug_) ROS_WARN_STREAM("Evaluating, iteration " << iterationCount << ", sweep " << sweep);
+    q = x;
+
+    // Perform update / roll-out
+    if (!skipUpdate)
+    {
+        updateCount++;
+        prob_->Update(q);
+    }
+
+    // Task cost
+    return prob_->getScalarCost();
+}
+
+double BayesianIK::step()
+{
+    rememberOldState();
+    switch (sweepMode)
+    {
+        //NOTE: the dependence on (Sweep?..:..) could perhaps be replaced by (DampingReference.N?..:..)
+        case smForwardly:
+            // for (t = 1; t < prob_->getT(); t++)
+            // {
+            updateTimeStep(true, false, 1, minimum_step_tolerance, !iterationCount, 1.);  //relocate once on fwd Sweep
+            // }
+            // for (t = prob_->getT() - 2; t > 0; t--)
+            // {
+            updateTimeStep(false, true, 0, minimum_step_tolerance, false, 1.);  //...not on bwd Sweep
+            // }
+            break;
+        case smSymmetric:
+            // ROS_WARN_STREAM("Updating forward, iterationCount "<<iterationCount);
+            // for (t = 1; t < prob_->getT(); t++)
+            // {
+            updateTimeStep(true, false, 1, minimum_step_tolerance, !iterationCount, 1.);  //relocate once on fwd & bwd Sweep
+            // }
+            // ROS_WARN_STREAM("Updating backward, iterationCount "<<iterationCount);
+            // for (t = prob_->getT() - 2; t > 0; t--)
+            // {
+            updateTimeStep(false, true, (iterationCount ? 1 : 0), minimum_step_tolerance, false, 1.);
+            // }
+            break;
+        case smLocalGaussNewton:
+            // for (t = 1; t < prob_->getT(); t++)
+            // {
+            //     updateTimeStep(t, true, false, (iterationCount ? 5 : 1), minimum_step_tolerance, !iterationCount, 1.);  //relocate iteratively on
+            // }
+            // for (t = prob_->getT() - 2; t > 0; t--)
+            // {
+            //     updateTimeStep(t, false, true, (iterationCount ? 5 : 0), minimum_step_tolerance, false, 1.);  //...fwd & bwd Sweep
+            // }
+            break;
+        case smLocalGaussNewtonDamped:
+            // for (t = 1; t < prob_->getT(); t++)
+            // {
+            //     updateTimeStepGaussNewton(t, true, false, (iterationCount ? 5 : 1),
+            //                               minimum_step_tolerance, 1.);  //GaussNewton in fwd & bwd Sweep
+            // }
+            // for (t = prob_->getT() - 2; t > 0; t--)
+            // {
+            //     updateTimeStep(t, false, true, (iterationCount ? 5 : 0), minimum_step_tolerance, false, 1.);
+            // }
+            break;
+        default:
+            throw_named("non-existing Sweep mode");
+    }
+    b_step = std::max((b_old - b).array().abs().maxCoeff(), 0.0);
+    dampingReference = b;
+    // q is set inside of evaluateTrajectory() function
+    cost = evaluateTrajectory(b);
+    if (debug_) HIGHLIGHT("Iteration: " << iterationCount << ", Sweep: " << sweep << ", updates: " << updateCount << ", cost: " << cost << " (dq=" << b_step << ", damping=" << damping << ")");
+    if (cost < 0) return -1.0;
+    bestSweep = sweep;
+
+    // If damping (similar to line-search) is being used, consider reverting this step
+    if (damping) perhapsUndoStep();
+
+    sweep++;
+    if (sweepImprovedCost)
+    {
+        // HIGHLIGHT("Sweep improved cost, increasing iteration count and resetting sweep count");
+        iterationCount++;
+        sweep = 0;
+        prob_->setCostEvolution(iterationCount, cost);
+    }
+
+    return b_step;
+}
+
+void BayesianIK::rememberOldState()
+{
+    s_old = s;
+    Sinv_old = Sinv;
+    v_old = v;
+    Vinv_old = Vinv;
+    r_old = r;
+    R_old = R;
+    Binv_old = Binv;
+    rhat_old = rhat;
+    b_old = b;
+    r_old = r;
+    q_old = q;
+    qhat_old = qhat;
+    cost_old = cost;
+
+
+    bestSweep_old = bestSweep;
+    b_step_old = b_step;
+}
+
+void BayesianIK::perhapsUndoStep()
+{
+    if (cost > cost_old)
+    {
+        sweepImprovedCost = false;
+        damping *= 10.;
+        s = s_old;
+        Sinv = Sinv_old;
+        v = v_old;
+        Vinv = Vinv_old;
+        r = r_old;
+        R = R_old;
+        Binv = Binv_old;
+        rhat = rhat_old;
+        b = b_old;
+        r = r_old;
+        q = q_old;
+        qhat = qhat_old;
+        cost = cost_old;
+        dampingReference = b_old;
+        bestSweep = bestSweep_old;
+        b_step = b_step_old;
+        if (debug_) HIGHLIGHT("Reverting to previous line-search step (" << bestSweep << ")");
+    }
+    else
+    {
+        sweepImprovedCost = true;
+        damping /= 5.;
+    }
+}
+} /* namespace exotica */

--- a/exotations/solvers/aico/src/MathOperations.cpp
+++ b/exotations/solvers/aico/src/MathOperations.cpp
@@ -1,0 +1,89 @@
+/*
+ *  Created on: 13 Mar 2018
+ *      Author: Wolfgang Merkt, Vladimir Ivan
+ *
+ *  This code is based on algorithm developed by Marc Toussaint
+ *  M. Toussaint: Robot Trajectory Optimization using Approximate Inference. In Proc. of the Int. Conf. on Machine Learning (ICML 2009), 1049-1056, ACM, 2009.
+ *  http://ipvs.informatik.uni-stuttgart.de/mlr/papers/09-toussaint-ICML.pdf
+ *  Original code available at http://ipvs.informatik.uni-stuttgart.de/mlr/marc/source-code/index.html
+ *
+ * 
+ * Copyright (c) 2018, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#include "aico/MathOperations.h"
+
+namespace exotica
+{
+void inverseSymPosDef(Eigen::Ref<Eigen::MatrixXd> Ainv_,
+                      const Eigen::Ref<const Eigen::MatrixXd>& A_)
+{
+    Ainv_ = A_;
+    double* AA = Ainv_.data();
+    integer info;
+    integer nn = A_.rows();
+    // Compute Cholesky
+    dpotrf_((char*)"L", &nn, AA, &nn, &info);
+    if (info != 0)
+    {
+        throw_pretty("Cholesky decomposition error: " << info << "\n"
+                                                      << A_);
+    }
+    // Invert
+    dpotri_((char*)"L", &nn, AA, &nn, &info);
+    if (info != 0)
+    {
+        throw_pretty("Matrix inversion error: " << info);
+    }
+    Ainv_.triangularView<Eigen::Upper>() = Ainv_.transpose();
+}
+
+/**
+ * \brief Computes the solution to the linear problem \f$x=Ab\f$ for symmetric positive definite matrix A
+ */
+void AinvBSymPosDef(Eigen::Ref<Eigen::VectorXd> x_,
+                    const Eigen::Ref<const Eigen::MatrixXd>& A_,
+                    const Eigen::Ref<const Eigen::VectorXd>& b_,
+                    Eigen::MatrixXd& linSolverTmp,
+                    int n_in)
+{
+    integer n_ = n_in, m_ = 1;
+    integer info;
+    linSolverTmp = A_;
+    x_ = b_;
+    double* AA = linSolverTmp.data();
+    double* xx = x_.data();
+    dposv_((char*)"L", &n_, &m_, AA, &n_, xx, &n_, &info);
+    if (info != 0)
+    {
+        throw_pretty("Linear solver error: " << info << "\nA:\n"
+                                             << A_ << "\nb: " << b_.transpose() << "\nx: " << x_.transpose());
+    }
+}
+}

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -566,6 +566,7 @@ void KinematicTree::publishFrames()
                     mrk.ns = "CollisionObjects";
                     mrk.color = getColor(Tree[i].lock()->Color);
                     mrk.header.frame_id = "exotica/" + Tree[i].lock()->Segment.getName();
+                    mrk.pose.orientation.w = 1.0;
                     msg.markers.push_back(mrk);
                 }
             }


### PR DESCRIPTION
This PR adds a **BayesianIK** aka an end-pose/1-step version of AICO for solving UnconstrainedEndPoseProblem via message passing. It uses the same name as the previous (presumably very similar/identical version) in libSOC/libAICO. Test/example included.

Additionally, shared AICO math operations are moved into its own file and some remnant/stale variables and methods cleaned up.