### PR TITLE
Fix and workaround for NaN contact points for touching primitive shapes - Addresses #277

### DIFF
--- a/examples/exotica_examples/tests/collision_scene_distances.py
+++ b/examples/exotica_examples/tests/collision_scene_distances.py
@@ -102,6 +102,31 @@ def testSphereVsBoxDistance(collisionScene):
     print('PrimitiveSphere_vs_PrimitiveBox_Distance: Distance, Contact Points, Normals: PASSED')
 
 
+def testSphereVsBoxTouching(collisionScene):
+    PrimitiveSphere_vs_PrimitiveBox_Touching = getProblemInitializer(collisionScene, '{exotica_examples}/tests/resources/PrimitiveSphere_vs_PrimitiveBox_Touching.urdf')
+    prob = exo.Setup.createProblem(PrimitiveSphere_vs_PrimitiveBox_Touching)
+    prob.update(np.zeros(prob.N,))
+    scene = prob.getScene()
+
+    assert(scene.isStateValid(True) == False)
+    print('PrimitiveSphere_vs_PrimitiveBox_Touching: isStateValid(True): PASSED')
+
+    p = scene.getCollisionDistance("A", "B")
+    print(p)
+    debugPublish(p, scene)
+    assert(len(p) == 1)
+    assert(np.isclose(p[0].Distance, 0.))
+    expectedContact1 = np.array([0.5, 0, 0])
+    expectedContact2 = np.array([-1, 0, 0])
+    expectedNormal1 = np.array([-1, 0, 0])
+    expectedNormal2 = np.array([1, 0, 0])
+    assert(np.isclose(p[0].Contact1, expectedContact1, atol=AFAR_DISTANCE_ATOL).all())
+    assert(np.isclose(p[0].Contact2, expectedContact2, atol=AFAR_DISTANCE_ATOL).all())
+    assert(np.isclose(p[0].Normal1, expectedNormal1, atol=AFAR_DISTANCE_ATOL).all())
+    assert(np.isclose(p[0].Normal2, expectedNormal2, atol=AFAR_DISTANCE_ATOL).all())
+    print('PrimitiveSphere_vs_PrimitiveBox_Touching: Distance, Contact Points, Normals: PASSED')
+
+
 def testSphereVsBoxPenetrating(collisionScene):
     PrimitiveSphere_vs_PrimitiveBox_Penetrating = getProblemInitializer(collisionScene, '{exotica_examples}/tests/resources/PrimitiveSphere_vs_PrimitiveBox_Penetrating.urdf')
     prob = exo.Setup.createProblem(PrimitiveSphere_vs_PrimitiveBox_Penetrating)
@@ -273,6 +298,31 @@ def testBoxVsBoxDistance(collisionScene):
     assert(np.isclose(p[0].Normal1, expectedNormal1, atol=AFAR_DISTANCE_ATOL).all())
     assert(np.isclose(p[0].Normal2, expectedNormal2, atol=AFAR_DISTANCE_ATOL).all())
     print('PrimitiveBox_vs_PrimitiveBox_Distance: Distance, Contact Points, Normals: PASSED')
+
+
+def testBoxVsBoxTouching(collisionScene):
+    PrimitiveBox_vs_PrimitiveBox_Touching = getProblemInitializer(collisionScene, '{exotica_examples}/tests/resources/PrimitiveBox_vs_PrimitiveBox_Touching.urdf')
+    prob = exo.Setup.createProblem(PrimitiveBox_vs_PrimitiveBox_Touching)
+    prob.update(np.zeros(prob.N,))
+    scene = prob.getScene()
+
+    assert(scene.isStateValid(True) == False)
+    print('PrimitiveBox_vs_PrimitiveBox_Touching: isStateValid(True): PASSED')
+
+    p = scene.getCollisionDistance("A", "B")
+    print(p)
+    debugPublish(p, scene)
+    assert(len(p) == 1)
+    assert(np.isclose(p[0].Distance, 0.))
+    expectedContact1 = np.array([0.5, 0, 0])
+    expectedContact2 = np.array([-0.5, 0, 0])
+    expectedNormal1 = np.array([-1, 0, 0])
+    expectedNormal2 = np.array([1, 0, 0])
+    assert(np.isclose(p[0].Contact1, expectedContact1).all())
+    assert(np.isclose(p[0].Contact2, expectedContact2).all())
+    assert(np.isclose(p[0].Normal1, expectedNormal1).all())
+    assert(np.isclose(p[0].Normal2, expectedNormal2).all())
+    print('PrimitiveBox_vs_PrimitiveBox_Touching: Distance, Contact Points, Normals: PASSED')
 
 
 def testBoxVsBoxPenetrating(collisionScene):
@@ -598,12 +648,14 @@ for collisionScene in ['CollisionSceneFCLLatest']:
     testSphereVsSphereDistance(collisionScene)
     testSphereVsSpherePenetrating(collisionScene)
     testSphereVsBoxDistance(collisionScene)
+    testSphereVsBoxTouching(collisionScene)
     testSphereVsBoxPenetrating(collisionScene)
     testSphereVsCylinderDistance(collisionScene)
     testSphereVsCylinderPenetrating(collisionScene)
     testSphereVsMeshDistance(collisionScene)  # includes mesh vs sphere
     #testSphereVsMeshPenetrating(collisionScene)   # BROKEN with libccd
     testBoxVsBoxDistance(collisionScene)
+    testBoxVsBoxTouching(collisionScene)
     testBoxVsBoxPenetrating(collisionScene)
     testBoxVsCylinderDistance(collisionScene)
     testBoxVsCylinderPenetrating(collisionScene)

--- a/examples/exotica_examples/tests/resources/PrimitiveBox_vs_PrimitiveBox_Touching.urdf
+++ b/examples/exotica_examples/tests/resources/PrimitiveBox_vs_PrimitiveBox_Touching.urdf
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<robot name="A_vs_B">
+  <material name="blue">
+    <color rgba="0 0 0.8 .5"/>
+  </material>
+  <material name="green">
+    <color rgba="0 0.8 0 .5"/>
+  </material>
+  <link name="A">
+    <visual>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <origin rpy="0.0 0 0" xyz="-0.5 0 0"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+  <link name="B">
+    <visual>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0.5 0 0"/>
+      <material name="green"/>
+    </visual>
+  </link>
+  <joint name="joint1" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1" lower="-1" upper="1" velocity="1"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="A"/>
+    <child link="B"/>
+  </joint>
+</robot>

--- a/examples/exotica_examples/tests/resources/PrimitiveSphere_vs_PrimitiveBox_Touching.urdf
+++ b/examples/exotica_examples/tests/resources/PrimitiveSphere_vs_PrimitiveBox_Touching.urdf
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<robot name="A_vs_B">
+  <material name="blue">
+    <color rgba="0 0 0.8 .5"/>
+  </material>
+  <material name="green">
+    <color rgba="0 0.8 0 .5"/>
+  </material>
+  <link name="A">
+    <visual>
+      <geometry>
+        <sphere radius="1"/>
+      </geometry>
+      <origin rpy="0.0 0 0" xyz="-1 0 0"/>
+      <material name="blue"/>
+    </visual>
+  </link>
+  <link name="B">
+    <visual>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0.5 0 0"/>
+      <material name="green"/>
+    </visual>
+  </link>
+  <joint name="joint1" type="revolute">
+    <axis xyz="0 0 1"/>
+    <limit effort="1" lower="-1" upper="1" velocity="1"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="A"/>
+    <child link="B"/>
+  </joint>
+</robot>


### PR DESCRIPTION
This is a partial fix and partial workaround for some of the frequent issues we have been seeing computing nearest/penetration points for primitive shapes using CollisionSceneFCLLatest. 

Relates to (but unclear whether it fully resolves it) #277 
Fixes #277 for now