### PR TITLE
exotica_python: Remove setModel

### DIFF
--- a/exotica_python/src/pyexotica/__init__.py
+++ b/exotica_python/src/pyexotica/__init__.py
@@ -1,5 +1,1 @@
 from _pyexotica import *
-
-def setModel(prob, urdf, srdf):
-    prob[1]['PlanningScene'][0][1]['URDF'] = urdf
-    prob[1]['PlanningScene'][0][1]['SRDF'] = srdf


### PR DESCRIPTION
We are not using this method anymore which modifies an initializer. I don't think we want to manually butcher like this in an initializer.