### PR TITLE
CollisionSceneFCLLatest: Update CMakeLists to support binary fcl_catkin on Kinetic

### DIFF
--- a/exotations/collision_scene_fcl_latest/CMakeLists.txt
+++ b/exotations/collision_scene_fcl_latest/CMakeLists.txt
@@ -3,17 +3,14 @@ project(collision_scene_fcl_latest)
 
 add_compile_options(-std=c++11)
 
+# Find fcl_catkin
+find_package(catkin REQUIRED COMPONENTS fcl_catkin)
+set(fcl_catkin_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
+set(fcl_catkin_LIBRARIES ${catkin_LIBRARIES})
 
-find_package(catkin REQUIRED COMPONENTS
-  exotica
-)
-
+# Find other catkin packages
+find_package(catkin REQUIRED COMPONENTS exotica geometric_shapes)
 set(exotica_INCLUDES ${catkin_INCLUDE_DIRS})
-
-find_package(catkin REQUIRED COMPONENTS
-  fcl_catkin
-  geometric_shapes
-)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -23,8 +20,9 @@ catkin_package(
 
 include_directories(
   include
+  ${fcl_catkin_INCLUDE_DIRS}
+  ${fcl_catkin_INCLUDE_DIRS}/fcl_catkin
   ${catkin_INCLUDE_DIRS}
-  ${exotica_INCLUDES}
 )
 
 add_library(${PROJECT_NAME}
@@ -33,6 +31,7 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  ${fcl_catkin_LIBRARIES}
 )
 
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
- Builds from source on Indigo (cf. travis)
- Allows use of ``ros-kinetic-fcl-catkin`` from binaries on Kinetic