### PR TITLE
Expose Tasks

### DIFF
--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -555,6 +555,44 @@ PYBIND11_MODULE(_pyexotica, module)
     taskMap.def("taskSpaceJacobianDim", &TaskMap::taskSpaceJacobianDim);
     taskMap.def("debug", &TaskMap::debug);
 
+    py::class_<TimeIndexedTask, std::shared_ptr<TimeIndexedTask>> timeIndexedTask(module, "TimeIndexedTask");
+    timeIndexedTask.def_readonly("PhiN", &TimeIndexedTask::PhiN);
+    timeIndexedTask.def_readonly("JN", &TimeIndexedTask::JN);
+    timeIndexedTask.def_readonly("NumTasks", &TimeIndexedTask::NumTasks);
+    timeIndexedTask.def_readonly("y", &TimeIndexedTask::y);
+    timeIndexedTask.def_readonly("ydiff", &TimeIndexedTask::ydiff);
+    timeIndexedTask.def_readonly("Phi", &TimeIndexedTask::Phi);
+    // timeIndexedTask.def_readonly("H", &TimeIndexedTask::H);
+    timeIndexedTask.def_readonly("J", &TimeIndexedTask::J);
+    timeIndexedTask.def_readonly("S", &TimeIndexedTask::S);
+    timeIndexedTask.def_readonly("T", &TimeIndexedTask::T);
+    timeIndexedTask.def_readonly("Tasks", &TimeIndexedTask::Tasks);
+    timeIndexedTask.def_readonly("TaskMaps", &TimeIndexedTask::TaskMaps);
+
+    py::class_<EndPoseTask, std::shared_ptr<EndPoseTask>> endPoseTask(module, "EndPoseTask");
+    endPoseTask.def_readonly("PhiN", &EndPoseTask::PhiN);
+    endPoseTask.def_readonly("JN", &EndPoseTask::JN);
+    endPoseTask.def_readonly("NumTasks", &EndPoseTask::NumTasks);
+    endPoseTask.def_readonly("y", &EndPoseTask::y);
+    endPoseTask.def_readonly("ydiff", &EndPoseTask::ydiff);
+    endPoseTask.def_readonly("Phi", &EndPoseTask::Phi);
+    // endPoseTask.def_readonly("H", &EndPoseTask::H);
+    endPoseTask.def_readonly("J", &EndPoseTask::J);
+    endPoseTask.def_readonly("S", &EndPoseTask::S);
+    endPoseTask.def_readonly("Tasks", &EndPoseTask::Tasks);
+    endPoseTask.def_readonly("TaskMaps", &EndPoseTask::TaskMaps);
+
+    py::class_<SamplingTask, std::shared_ptr<SamplingTask>> samplingTask(module, "SamplingTask");
+    samplingTask.def_readonly("PhiN", &SamplingTask::PhiN);
+    samplingTask.def_readonly("JN", &SamplingTask::JN);
+    samplingTask.def_readonly("NumTasks", &SamplingTask::NumTasks);
+    samplingTask.def_readonly("y", &SamplingTask::y);
+    samplingTask.def_readonly("ydiff", &SamplingTask::ydiff);
+    samplingTask.def_readonly("Phi", &SamplingTask::Phi);
+    samplingTask.def_readonly("S", &SamplingTask::S);
+    samplingTask.def_readonly("Tasks", &SamplingTask::Tasks);
+    samplingTask.def_readonly("TaskMaps", &SamplingTask::TaskMaps);
+
     py::class_<TaskSpaceVector, std::shared_ptr<TaskSpaceVector>> taskSpaceVector(module, "TaskSpaceVector");
     taskSpaceVector.def("setZero", &TaskSpaceVector::setZero);
     taskSpaceVector.def_readwrite("data", &TaskSpaceVector::data);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -620,6 +620,7 @@ PYBIND11_MODULE(_pyexotica, module)
 
     // Problem types
     py::module prob = module.def_submodule("Problems", "Problem types");
+
     py::class_<UnconstrainedTimeIndexedProblem, std::shared_ptr<UnconstrainedTimeIndexedProblem>, PlanningProblem> unconstrainedTimeIndexedProblem(prob, "UnconstrainedTimeIndexedProblem");
     unconstrainedTimeIndexedProblem.def("getDuration", &UnconstrainedTimeIndexedProblem::getDuration);
     unconstrainedTimeIndexedProblem.def("update", &UnconstrainedTimeIndexedProblem::Update);
@@ -649,6 +650,8 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def("getScalarTaskJacobian", &UnconstrainedTimeIndexedProblem::getScalarTaskJacobian);
     unconstrainedTimeIndexedProblem.def("getScalarTransitionCost", &UnconstrainedTimeIndexedProblem::getScalarTransitionCost);
     unconstrainedTimeIndexedProblem.def("getScalarTransitionJacobian", &UnconstrainedTimeIndexedProblem::getScalarTransitionJacobian);
+    unconstrainedTimeIndexedProblem.def_readonly("Cost", &UnconstrainedTimeIndexedProblem::Cost);
+
     py::class_<TimeIndexedProblem, std::shared_ptr<TimeIndexedProblem>, PlanningProblem> timeIndexedProblem(prob, "TimeIndexedProblem");
     timeIndexedProblem.def("getDuration", &TimeIndexedProblem::getDuration);
     timeIndexedProblem.def("update", &TimeIndexedProblem::Update);
@@ -687,6 +690,10 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedProblem.def("getScalarTransitionCost", &TimeIndexedProblem::getScalarTransitionCost);
     timeIndexedProblem.def("getScalarTransitionJacobian", &TimeIndexedProblem::getScalarTransitionJacobian);
     timeIndexedProblem.def("getBounds", &TimeIndexedProblem::getBounds);
+    timeIndexedProblem.def_readonly("Cost", &TimeIndexedProblem::Cost);
+    timeIndexedProblem.def_readonly("Inequality", &TimeIndexedProblem::Inequality);
+    timeIndexedProblem.def_readonly("Equality", &TimeIndexedProblem::Equality);
+
     py::class_<BoundedTimeIndexedProblem, std::shared_ptr<BoundedTimeIndexedProblem>, PlanningProblem> boundedTimeIndexedProblem(prob, "BoundedTimeIndexedProblem");
     boundedTimeIndexedProblem.def("getDuration", &BoundedTimeIndexedProblem::getDuration);
     boundedTimeIndexedProblem.def("update", &BoundedTimeIndexedProblem::Update);
@@ -717,6 +724,8 @@ PYBIND11_MODULE(_pyexotica, module)
     boundedTimeIndexedProblem.def("getScalarTransitionCost", &BoundedTimeIndexedProblem::getScalarTransitionCost);
     boundedTimeIndexedProblem.def("getScalarTransitionJacobian", &BoundedTimeIndexedProblem::getScalarTransitionJacobian);
     boundedTimeIndexedProblem.def("getBounds", &BoundedTimeIndexedProblem::getBounds);
+    boundedTimeIndexedProblem.def_readonly("Cost", &BoundedTimeIndexedProblem::Cost);
+
     py::class_<UnconstrainedEndPoseProblem, std::shared_ptr<UnconstrainedEndPoseProblem>, PlanningProblem> unconstrainedEndPoseProblem(prob, "UnconstrainedEndPoseProblem");
     unconstrainedEndPoseProblem.def("update", &UnconstrainedEndPoseProblem::Update);
     unconstrainedEndPoseProblem.def("setGoal", &UnconstrainedEndPoseProblem::setGoal);
@@ -733,6 +742,8 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedEndPoseProblem.def_property("qNominal", &UnconstrainedEndPoseProblem::getNominalPose, &UnconstrainedEndPoseProblem::setNominalPose);
     unconstrainedEndPoseProblem.def("getScalarCost", &UnconstrainedEndPoseProblem::getScalarCost);
     unconstrainedEndPoseProblem.def("getScalarJacobian", &UnconstrainedEndPoseProblem::getScalarJacobian);
+    unconstrainedEndPoseProblem.def_readonly("Cost", &UnconstrainedEndPoseProblem::Cost);
+
     py::class_<EndPoseProblem, std::shared_ptr<EndPoseProblem>, PlanningProblem> endPoseProblem(prob, "EndPoseProblem");
     endPoseProblem.def("update", &EndPoseProblem::Update);
     endPoseProblem.def("setGoal", &EndPoseProblem::setGoal);
@@ -757,6 +768,10 @@ PYBIND11_MODULE(_pyexotica, module)
     endPoseProblem.def("getScalarCost", &EndPoseProblem::getScalarCost);
     endPoseProblem.def("getScalarJacobian", &EndPoseProblem::getScalarJacobian);
     endPoseProblem.def("getBounds", &EndPoseProblem::getBounds);
+    endPoseProblem.def_readonly("Cost", &EndPoseProblem::Cost);
+    endPoseProblem.def_readonly("Inequality", &EndPoseProblem::Inequality);
+    endPoseProblem.def_readonly("Equality", &EndPoseProblem::Equality);
+
     py::class_<BoundedEndPoseProblem, std::shared_ptr<BoundedEndPoseProblem>, PlanningProblem> boundedEndPoseProblem(prob, "BoundedEndPoseProblem");
     boundedEndPoseProblem.def("update", &BoundedEndPoseProblem::Update);
     boundedEndPoseProblem.def("setGoal", &BoundedEndPoseProblem::setGoal);
@@ -773,6 +788,8 @@ PYBIND11_MODULE(_pyexotica, module)
     boundedEndPoseProblem.def("getScalarCost", &BoundedEndPoseProblem::getScalarCost);
     boundedEndPoseProblem.def("getScalarJacobian", &BoundedEndPoseProblem::getScalarJacobian);
     boundedEndPoseProblem.def("getBounds", &BoundedEndPoseProblem::getBounds);
+    boundedEndPoseProblem.def_readonly("Cost", &BoundedEndPoseProblem::Cost);
+
     py::class_<SamplingProblem, std::shared_ptr<SamplingProblem>, PlanningProblem> samplingProblem(prob, "SamplingProblem");
     samplingProblem.def("update", &SamplingProblem::Update);
     samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);
@@ -781,6 +798,8 @@ PYBIND11_MODULE(_pyexotica, module)
     samplingProblem.def_readonly("N", &SamplingProblem::N);
     samplingProblem.def_readonly("NumTasks", &SamplingProblem::NumTasks);
     samplingProblem.def_readonly("Phi", &SamplingProblem::Phi);
+    samplingProblem.def_readonly("Constraint", &SamplingProblem::Constraint);
+
     py::class_<TimeIndexedSamplingProblem, std::shared_ptr<TimeIndexedSamplingProblem>, PlanningProblem> timeIndexedSamplingProblem(prob, "TimeIndexedSamplingProblem");
     timeIndexedSamplingProblem.def("update", &TimeIndexedSamplingProblem::Update);
     timeIndexedSamplingProblem.def("getSpaceDim", &TimeIndexedSamplingProblem::getSpaceDim);
@@ -790,6 +809,7 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedSamplingProblem.def_readonly("N", &TimeIndexedSamplingProblem::N);
     timeIndexedSamplingProblem.def_readonly("NumTasks", &TimeIndexedSamplingProblem::NumTasks);
     timeIndexedSamplingProblem.def_readonly("Phi", &TimeIndexedSamplingProblem::Phi);
+    timeIndexedSamplingProblem.def_readonly("Constraint", &TimeIndexedSamplingProblem::Constraint);
 
     py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> proxy(module, "Proxy");
     proxy.def(py::init());


### PR DESCRIPTION
This PR exposes the tasks associated with each problem (Cost, Equality, Inequality, Constraint) and the underlying data to Python. This allows e.g. to retrieve the ``Phi``, ``y``, ``ydiff`` values to interpret results without the squaring to cost terms (e.g. physical meaning of distance for positions).

cc: @christian-rauch I believe this is what you are looking for/requiring (in your case e.g. ``problem.Cost.ydiff``).