### PR TITLE
Use 'MaxIterations' in all solvers

### DIFF
--- a/examples/exotica_examples/resources/configs/example.xml
+++ b/examples/exotica_examples/resources/configs/example.xml
@@ -2,7 +2,7 @@
 <ExampleConfig>
 
 <IKsolver Name="MySolver">
-  <MaxIt>100</MaxIt>
+  <MaxIterations>100</MaxIterations>
   <MaxStep>0.1</MaxStep>
   <Tolerance>1e-5</Tolerance>
   <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/example_manipulate_ik.xml
+++ b/examples/exotica_examples/resources/configs/example_manipulate_ik.xml
@@ -2,7 +2,7 @@
 <ExampleConfig>
 
 <IKsolver Name="MySolver">
-  <MaxIt>100</MaxIt>
+  <MaxIterations>100</MaxIterations>
   <MaxStep>0.1</MaxStep>
   <Tolerance>1e-5</Tolerance>
   <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/ik_solver_demo.xml
+++ b/examples/exotica_examples/resources/configs/ik_solver_demo.xml
@@ -2,7 +2,7 @@
 <IKSolverDemoConfig>
 
   <IKsolver Name="MySolver">
-    <MaxIt>1</MaxIt>
+    <MaxIterations>1</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/ik_solver_demo_freebase.xml
+++ b/examples/exotica_examples/resources/configs/ik_solver_demo_freebase.xml
@@ -2,7 +2,7 @@
 <IKSolverDemoConfig>
 
   <IKsolver Name="MySolver">
-    <MaxIt>1</MaxIt>
+    <MaxIterations>1</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/test_com_valkyrie.xml
+++ b/examples/exotica_examples/resources/configs/test_com_valkyrie.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
   <IKsolver Name="DummySolver">
-    <MaxIt>100</MaxIt>
+    <MaxIterations>100</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/test_valkyrie_collisionscene_fcl.xml
+++ b/examples/exotica_examples/resources/configs/test_valkyrie_collisionscene_fcl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
   <IKsolver Name="DummySolver">
-    <MaxIt>100</MaxIt>
+    <MaxIterations>100</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/resources/configs/test_valkyrie_collisionscene_fcl_latest.xml
+++ b/examples/exotica_examples/resources/configs/test_valkyrie_collisionscene_fcl_latest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
   <IKsolver Name="DummySolver">
-    <MaxIt>100</MaxIt>
+    <MaxIterations>100</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -67,7 +67,7 @@ void run()
 
     Initializer solver("exotica/IKsolver", {
                                                {"Name", std::string("MySolver")},
-                                               {"MaxIt", 1},
+                                               {"MaxIterations", 1},
                                                {"MaxStep", 0.1},
                                                {"C", 1e-3},
                                            });

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -59,7 +59,7 @@ void run()
     UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, startState, 0.0, -1, {cost}, W, nominalState);
     IKsolverInitializer solver("MySolver");
     solver.C = 1e-3;
-    solver.MaxIt = 1;
+    solver.MaxIterations = 1;
     solver.MaxStep = 0.1;
 
     HIGHLIGHT_NAMED("ManualLoader", "Loaded from a hardcoded specialized initializer.");

--- a/examples/exotica_examples/tests/test_initializers.cpp
+++ b/examples/exotica_examples/tests/test_initializers.cpp
@@ -73,7 +73,7 @@ bool testGenericInit()
                                                                });
     Initializer solver("exotica/IKsolver", {
                                                {"Name", std::string("MySolver")},
-                                               {"MaxIt", 1},
+                                               {"MaxIterations", 1},
                                                {"MaxStep", 0.1},
                                                {"C", 1e-3},
                                            });
@@ -85,7 +85,7 @@ bool testGenericInit()
 
 bool testXMLInit()
 {
-    std::string XMLstring = "<IKSolverDemoConfig><IKsolver Name=\"MySolver\"><MaxIt>1</MaxIt><MaxStep>0.1</MaxStep><C>1e-3</C></IKsolver><UnconstrainedEndPoseProblem Name=\"MyProblem\"><PlanningScene><Scene Name=\"MyScene\"><JointGroup>arm</JointGroup></Scene></PlanningScene><Maps><EffPosition Name=\"Position\"><Scene>MyScene</Scene><EndEffector><Frame Link=\"endeff\" /></EndEffector></EffPosition></Maps><W> 3 2 1 </W></UnconstrainedEndPoseProblem></IKSolverDemoConfig>";
+    std::string XMLstring = "<IKSolverDemoConfig><IKsolver Name=\"MySolver\"><MaxIterations>1</MaxIterations><MaxStep>0.1</MaxStep><C>1e-3</C></IKsolver><UnconstrainedEndPoseProblem Name=\"MyProblem\"><PlanningScene><Scene Name=\"MyScene\"><JointGroup>arm</JointGroup></Scene></PlanningScene><Maps><EffPosition Name=\"Position\"><Scene>MyScene</Scene><EndEffector><Frame Link=\"endeff\" /></EndEffector></EffPosition></Maps><W> 3 2 1 </W></UnconstrainedEndPoseProblem></IKSolverDemoConfig>";
     Initializer solver, problem;
     XMLLoader::load(XMLstring, solver, problem, "", "", true);
     PlanningProblem_ptr any_problem = Setup::createProblem(problem);

--- a/exotations/solvers/ik_solver/init/IKsolver.in
+++ b/exotations/solvers/ik_solver/init/IKsolver.in
@@ -1,7 +1,7 @@
 extend <exotica/MotionSolver>
 Optional double Tolerance = 1e-5;
 Optional double Convergence = 0.0;
-Optional int MaxIt = 50;
+Optional int MaxIterations = 50;
 Optional double MaxStep = 0.02;
 Optional double C = 0.0;
 Optional double Alpha = 1.0;

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -92,7 +92,7 @@ Eigen::MatrixXd inverseSymPosDef(const Eigen::Ref<const Eigen::MatrixXd>& A_)
 void IKsolver::Instantiate(IKsolverInitializer& init)
 {
     parameters_ = init;
-    setNumberOfMaxIterations(init.MaxIt);
+    setNumberOfMaxIterations(init.MaxIterations);
 }
 
 void IKsolver::specifyProblem(PlanningProblem_ptr pointer)

--- a/exotica/doc/Manual-Initialization.rst
+++ b/exotica/doc/Manual-Initialization.rst
@@ -35,7 +35,7 @@ the UnconstrainedEndPoseProblem found in the `exotica_examples <https://github.c
         UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, W);
         IKsolverInitializer solver("MySolver");
         solver.C = 1e-3;
-        solver.MaxIt = 1;
+        solver.MaxIterations = 1;
         solver.MaxStep = 0.1;
     ...
 
@@ -171,7 +171,7 @@ will set up:
 
         IKsolverInitializer solver("MySolver");
         solver.C = 1e-3;
-        solver.MaxIt = 1;
+        solver.MaxIterations = 1;
         solver.MaxStep = 0.1;
 
 Again, we have an initialiser for the solver (``IKsolverInitializer``)
@@ -192,7 +192,7 @@ are seen below:
         extend <exotica/MotionSolver>
         Optional double Tolerance = 1e-5;
         Optional double Convergence = 0.0;
-        Optional int MaxIt = 50;
+        Optional int MaxIterations = 50;
         Optional double MaxStep = 0.02;
         Optional double C = 0.0;
         Optional double Alpha = 1.0;
@@ -204,7 +204,7 @@ this solver:
 .. code-block:: c++
 
         solver.C = 1e-3;
-        solver.MaxIt = 1;
+        solver.MaxIterations = 1;
         solver.MaxStep = 0.1;
 
 This method is extensible to all the options in all the solvers. Before

--- a/exotica/doc/Quickstart-cpp.rst
+++ b/exotica/doc/Quickstart-cpp.rst
@@ -91,7 +91,7 @@ in the ``exotica_examples`` folder. We can see a copy of it below:
     <ExampleConfig>
 
     <IKsolver Name="MySolver">
-    <MaxIt>100</MaxIt>
+    <MaxIterations>100</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
     <Alpha>1.0</Alpha>

--- a/exotica/doc/Setting-up-problems-and-solvers.rst
+++ b/exotica/doc/Setting-up-problems-and-solvers.rst
@@ -40,7 +40,7 @@ example file as a guide. The code is displayed below.
         UnconstrainedEndPoseProblemInitializer problem("MyProblem", scene, false, {map}, W);
         IKsolverInitializer solver("MySolver");
         solver.C = 1e-3;
-        solver.MaxIt = 1;
+        solver.MaxIterations = 1;
         solver.MaxStep = 0.1;
 
         HIGHLIGHT_NAMED("ManualLoader", "Loaded from a hardcoded specialized initializer.");
@@ -207,7 +207,7 @@ create an initializer, give the solver itself a name ("MySolver") then set the p
 
     IKsolverInitializer solver("MySolver");
     solver.C = 1e-3;
-    solver.MaxIt = 1;
+    solver.MaxIterations = 1;
     solver.MaxStep = 0.1;
 
 or parameters can be set in arguments to the initializer. See 

--- a/exotica/doc/Using-EXOTica.rst
+++ b/exotica/doc/Using-EXOTica.rst
@@ -142,14 +142,14 @@ Now we have a solution to our problem. But what does it look like?
 
     [ INFO] [1501240815.111167097]: Finished solving in 3.085e-05s. Solution [  -0.109557   -0.653855  -0.0687444     1.28515 1.06079e-17           0           0]
 
-When using the IK_solver as in this tutorial and we set the ``MaxIt`` to a
+When using the IK_solver as in this tutorial and we set the ``MaxIterations`` to a
 low number, we get single step solution to the IK problem, as shown above -
 this is what you would expect to see if you run this code;
 it shows a vector of angles, one column  for each joint in our
 robot. Each entry a joint configuration in radians, which will result in
 the end effector reaching the desired target. The rows of the output
 represent the positional steps each joint must pass through to reach 
-the end effector goal. When using a higher ``MaxIt`` setting, the number 
+the end effector goal. When using a higher ``MaxIterations`` setting, the number 
 of rows in your motion plan would likely increase. 
 
 When using other problems or a different configuration of the

--- a/exotica/doc/XML.rst
+++ b/exotica/doc/XML.rst
@@ -14,7 +14,7 @@ file and is shown below:
   <IKSolverDemoConfig>
 
     <IKsolver Name="MySolver">
-      <MaxIt>1</MaxIt>
+      <MaxIterations>1</MaxIterations>
       <MaxStep>0.1</MaxStep>
       <Tolerance>1e-5</Tolerance>
       <Alpha>1.0</Alpha>
@@ -49,7 +49,7 @@ file and is shown below:
 .. rubric:: CODE EXPLAINED
 
 In the code we see:
-* the initialization of the ``IKSolver`` and its parameters (e.g. ``MaxIt``,\ ``MaxStep``) set
+* the initialization of the ``IKSolver`` and its parameters (e.g. ``MaxIterations``,\ ``MaxStep``) set
 * a problem (``UnconstrainedEndPoseProblem``) is specified and  necessary parameters input. 
 - Within the problem, a ``PlanningScene`` and ``Maps`` are initialized in addition to the problem parameters. 
 
@@ -65,7 +65,7 @@ Solver options are then specified:
 
 .. code-block:: xml
 
-      <MaxIt>1</MaxIt>
+      <MaxIterations>1</MaxIterations>
       <MaxStep>0.1</MaxStep>
       <Tolerance>1e-5</Tolerance>
       <Alpha>1.0</Alpha>


### PR DESCRIPTION
Different solvers use different variable names for the same properties like the maximum iterations or the cost tolerance. It would be nice, if the shared properties have the same parameter name.
I replaced `MaxIt` by `MaxIterations` in the code and documentation of `IKsolver`.

This will break the API, but I think it is important to have shared parameter names to make it easier to compare methods.
