### PR TITLE
Point2Line task map

### DIFF
--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -15,6 +15,7 @@ AddInitializer(
   EffFrame
   JointLimit
   Distance
+  Point2Line
   Identity
   SphereCollision
   Sphere
@@ -41,6 +42,7 @@ set(SOURCES
     src/EffFrame.cpp
     src/JointLimit.cpp
     src/Distance.cpp
+    src/Point2Line.cpp
     src/Identity.cpp
     src/SphereCollision.cpp
     src/CollisionCheck.cpp)

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -5,6 +5,9 @@
   <class name="exotica/Distance" type="exotica::Distance" base_class_type="exotica::TaskMap">
     <description>Distance</description>
   </class>
+  <class name="exotica/Point2Line" type="exotica::Point2Line" base_class_type="exotica::TaskMap">
+    <description>Point to line distance</description>
+  </class>
   <class name="exotica/EffPosition" type="exotica::EffPosition" base_class_type="exotica::TaskMap">
     <description>End-effector position (3D)</description>
   </class>

--- a/exotations/task_maps/task_map/init/Point2Line.in
+++ b/exotations/task_maps/task_map/init/Point2Line.in
@@ -1,0 +1,9 @@
+extend <exotica/TaskMap>
+// inherited from TaskMap:
+// string Link           > name of frame in which point is defined
+// VectorXd LinkOffset   > coordinate of point in Link frame
+// string Base           > name of frame in which line is defined
+// VectorXd BaseOffset   > starting point of line in Base frame
+
+Required Eigen::Vector3d EndPoint;  // point in 'Base' frame that defines the end of the line segment
+Optional bool infinite = true;      // true: interpret 'EndPoint' as the direction of an infinite line

--- a/exotations/task_maps/task_map/src/Point2Line.cpp
+++ b/exotations/task_maps/task_map/src/Point2Line.cpp
@@ -1,0 +1,103 @@
+/*
+ *      Author: Christian Rauch
+ *
+ * Copyright (c) 2018, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "task_map/Point2Line.hpp"
+
+REGISTER_TASKMAP_TYPE("Point2Line", exotica::Point2Line);
+
+namespace exotica
+{
+Eigen::Vector3d Point2Line::distance(const Eigen::Vector3d &point, const Eigen::Vector3d &line, const bool infinite, const bool dbg)
+{
+    // http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
+    // let:
+    //      s: start of line
+    //      e: end of line
+    //      p: point
+    // then the point on vector v = e-s that is closest to p is vp = s + t*(e-s) with
+    // t = ((s-p)*(e-s)) / (|e-s|^2)    (* denotes the dot product)
+
+    // the line starts at the origin of BaseOffset, hence s=0, v='line', vp=t*'line'
+    double t = (-point).dot(line) / line.norm();
+    if (dbg) HIGHLIGHT_NAMED("P2L", "t " << t);
+    if (!infinite)
+    {
+        // clip to to range [0,1]
+        t = std::min(std::max(0.0, t), 1.0);
+        if (dbg) HIGHLIGHT_NAMED("P2L", "|t| " << t);
+    }
+
+    // vector from point 'p' to point 'vp' on line
+    const Eigen::Vector3d dv = (t * line) - point;
+    if (dbg) HIGHLIGHT_NAMED("P2L", "dv " << dv.transpose());
+    return dv;
+}
+
+Point2Line::Point2Line() {}
+void Point2Line::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
+
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    {
+        phi(i) = distance(Eigen::Map<const Eigen::Vector3d>(Kinematics.Phi(i).p.data), line, infinite, debug_).norm();
+    }
+}
+
+void Point2Line::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != Kinematics.Phi.rows()) throw_named("Wrong size of phi!");
+    if (J.rows() != Kinematics.J.rows() || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    {
+        // direction from point to line
+        const Eigen::Vector3d dv = distance(Eigen::Map<const Eigen::Vector3d>(Kinematics.Phi(i).p.data), line, infinite, debug_);
+        phi(i) = dv.norm();
+        for (int j = 0; j < J.cols(); j++)
+        {
+            J(i, j) = -dv.dot(Eigen::Map<const Eigen::Vector3d>(Kinematics.J[i].getColumn(j).vel.data)) / dv.norm();
+        }
+    }
+}
+
+void Point2Line::Instantiate(Point2LineInitializer &init)
+{
+    line = init.EndPoint.head<3>() - boost::any_cast<Eigen::VectorXd>(init.EndEffector[0].getProperty("BaseOffset")).head<3>();
+    infinite = init.infinite;
+}
+
+int Point2Line::taskSpaceDim()
+{
+    return Kinematics.Phi.rows();
+}
+}  // namespace exotica

--- a/exotica/cmake/GenerateInitializers.py
+++ b/exotica/cmake/GenerateInitializers.py
@@ -198,6 +198,10 @@ public:
     return ret
 
 def ParseLine(line, ln, fn):
+    # ignore lines with comments, otherwise comments including ';' will not be recognised
+    if line.startswith("//"):
+        return None
+
     last = line.find(";")
     if last>=0:
         line=line[0:last].strip()

--- a/exotica/cmake/GenerateInitializers.py
+++ b/exotica/cmake/GenerateInitializers.py
@@ -75,6 +75,8 @@ def Parser(Type):
         return "boost::any_cast<std::vector<exotica::Initializer>>(prop.get())"
     elif Type=='Eigen::VectorXd':
         parser= "parseVector"
+    elif Type=='Eigen::Vector3d':
+        parser= "parseVector3"
     elif Type=='bool':
         parser= "parseBool"
     elif Type=='double':

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -55,7 +55,7 @@ public:
     virtual std::string print(std::string prepend);
     void setNumberOfMaxIterations(int maxIter)
     {
-        HIGHLIGHT_NAMED("MotionSolver", "Setting maximum iterations to " << maxIter << " (was " << maxIterations_ << ")");
+        if(debug_) HIGHLIGHT_NAMED("MotionSolver", "Setting maximum iterations to " << maxIter << " (was " << maxIterations_ << ")");
         maxIterations_ = maxIter;
     }
     int getNumberOfMaxIterations() { return maxIterations_; }

--- a/exotica/include/exotica/Tools/Conversions.h
+++ b/exotica/include/exotica/Tools/Conversions.h
@@ -180,6 +180,25 @@ inline Eigen::VectorXd parseVector(const std::string value)
     return ret;
 }
 
+inline Eigen::Vector3d parseVector3(const std::string value)
+{
+    Eigen::Vector3d ret;
+    double temp_entry;
+    int i = 0;
+
+    std::istringstream text_parser(value);
+
+    text_parser >> temp_entry;
+    while (!(text_parser.fail() || text_parser.bad()))
+    {
+        ++i;
+        ret(i - 1) = temp_entry;
+        text_parser >> temp_entry;
+    }
+    if (i == 0) throw_pretty("Empty vector!");
+    return ret;
+}
+
 inline bool parseBool(const std::string value)
 {
     bool ret;


### PR DESCRIPTION
This PR:
- fixes an issue where comments in *.in files including a semicolon would be recognised as code
- inhibits `Setting maximum iterations to...` when the debug flag is not set
- adds a `Point2Line` task map

The `Point2Line` task map computes the vector from a point in the Link frame to its closest point on a line in the Base frame. The magnitude of this vector is used for the task space error phi, and its direction is used to update the Jacobian of the objective.