### PR TITLE
Setup creation, document, getRandomControlledState

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -40,6 +40,7 @@
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
 #include <map>
+#include <random>
 #include <set>
 #include <string>
 #include <vector>
@@ -203,6 +204,12 @@ public:
     bool Debug;
 
     std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();
+
+    // Random state generation
+    std::random_device rd;
+    std::mt19937 generator_;
+    std::vector<std::uniform_real_distribution<double>> random_state_distributions_;
+    Eigen::VectorXd getRandomControlledState();
 
 private:
     void BuildTree(const KDL::Tree& RobotKinematics);

--- a/exotica/include/exotica/Loaders/XMLLoader.h
+++ b/exotica/include/exotica/Loaders/XMLLoader.h
@@ -43,6 +43,20 @@ public:
         return any_solver;
     }
 
+    static std::shared_ptr<exotica::MotionSolver> loadSolverStandalone(const std::string& file_name)
+    {
+        Initializer solver = XMLLoader::load(file_name);
+        MotionSolver_ptr any_solver = Setup::createSolver(solver);
+        return any_solver;
+    }
+
+    static std::shared_ptr<exotica::PlanningProblem> loadProblem(const std::string& file_name)
+    {
+        Initializer problem = XMLLoader::load(file_name);
+        PlanningProblem_ptr any_problem = Setup::createProblem(problem);
+        return any_problem;
+    }
+
 private:
     XMLLoader();
     static std::shared_ptr<XMLLoader> instance_;

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -484,6 +484,8 @@ PYBIND11_MODULE(_pyexotica, module)
                      },
                      py::arg("name") = "exotica", py::arg("anonymous") = false);
     setup.def_static("loadSolver", &XMLLoader::loadSolver);
+    setup.def_static("loadSolverStandalone", &XMLLoader::loadSolverStandalone);
+    setup.def_static("loadProblem", &XMLLoader::loadProblem);
 
     py::module tools = module.def_submodule("Tools");
     tools.def("parsePath", &parsePath);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -459,16 +459,16 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<Setup, std::unique_ptr<Setup, py::nodelete>> setup(module, "Setup");
     setup.def("__init__", [](Setup* instance) { instance = Setup::Instance().get(); });
-    setup.def_static("getSolvers", &Setup::getSolvers);
-    setup.def_static("getProblems", &Setup::getProblems);
-    setup.def_static("getMaps", &Setup::getMaps);
-    setup.def_static("getCollisionScenes", &Setup::getCollisionScenes);
-    setup.def_static("createSolver", &createSolver, py::return_value_policy::take_ownership);
-    setup.def_static("createMap", &createMap, py::return_value_policy::take_ownership);
-    setup.def_static("createProblem", &createProblem, py::return_value_policy::take_ownership);
-    setup.def_static("printSupportedClasses", &Setup::printSupportedClasses);
-    setup.def_static("getInitializers", &Setup::getInitializers, py::return_value_policy::copy);
-    setup.def_static("getPackagePath", &ros::package::getPath);
+    setup.def_static("getSolvers", &Setup::getSolvers, "Returns a list of available solvers.");
+    setup.def_static("getProblems", &Setup::getProblems, "Returns a list of available problems.");
+    setup.def_static("getMaps", &Setup::getMaps, "Returns a list of available task maps.");
+    setup.def_static("getCollisionScenes", &Setup::getCollisionScenes, "Returns a list of available collision scene plug-ins.");
+    setup.def_static("createSolver", &createSolver, py::return_value_policy::take_ownership);    // "Creates an instance of the solver identified by name parameter.", py::arg("solverType"), py::arg("prependExoticaNamespace"));
+    setup.def_static("createProblem", &createProblem, py::return_value_policy::take_ownership);  // "Creates an instance of the problem identified by name parameter.", py::arg("problemType"), py::arg("prependExoticaNamespace"));
+    setup.def_static("createMap", &createMap, py::return_value_policy::take_ownership);          // "Creates an instance of the task map identified by name parameter.", py::arg("taskmapType"), py::arg("prependExoticaNamespace"));
+    setup.def_static("printSupportedClasses", &Setup::printSupportedClasses, "Print a list of available plug-ins sorted by class.");
+    setup.def_static("getInitializers", &Setup::getInitializers, py::return_value_policy::copy, "Returns a list of available initializers with all available parameters/arguments.");
+    setup.def_static("getPackagePath", &ros::package::getPath, "ROS package path resolution.");
     setup.def_static("initRos",
                      [](const std::string& name, const bool& anonymous) {
                          int argc = 0;
@@ -482,10 +482,11 @@ PYBIND11_MODULE(_pyexotica, module)
                          }
                          Server::InitRos(std::make_shared<ros::NodeHandle>("~"));
                      },
+                     "Initializes an internal ROS node for publishing debug information from Exotica (i.e., activates ROS features). Options are setting the name and whether to spawn an anonymous node.",
                      py::arg("name") = "exotica", py::arg("anonymous") = false);
-    setup.def_static("loadSolver", &XMLLoader::loadSolver);
-    setup.def_static("loadSolverStandalone", &XMLLoader::loadSolverStandalone);
-    setup.def_static("loadProblem", &XMLLoader::loadProblem);
+    setup.def_static("loadSolver", &XMLLoader::loadSolver, "Instantiate solver and problem from an XML file containing both a solver and problem initializer.", py::arg("filepath"));
+    setup.def_static("loadSolverStandalone", &XMLLoader::loadSolverStandalone, "Instantiate only a solver from an XML file containing solely a solver initializer.", py::arg("filepath"));
+    setup.def_static("loadProblem", &XMLLoader::loadProblem, "Instantiate only a problem from an XML file containing solely a problem initializer.", py::arg("filepath"));
 
     py::module tools = module.def_submodule("Tools");
     tools.def("parsePath", &parsePath);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -943,6 +943,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getControlledBaseType", &KinematicTree::getControlledBaseType);
     kinematicTree.def("getControlledLinkMass", &KinematicTree::getControlledLinkMass);
     kinematicTree.def("getCollisionObjectTypes", &KinematicTree::getCollisionObjectTypes);
+    kinematicTree.def("getRandomControlledState", &KinematicTree::getRandomControlledState);
 
     py::enum_<shapes::ShapeType>(module, "ShapeType")
         .value("UnknownShape", shapes::ShapeType::UNKNOWN_SHAPE)


### PR DESCRIPTION
- Create problems and solvers separately without being tied together (for benchmarking)
- Document
- Add ``getRandomControlledState`` (within joint bounds, no notion of collision-free-ness)