### PR TITLE
Add validity check to planning problem, tolerance checks for inequality/equality constraints, ability to retrieve task id by name

### DIFF
--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -93,6 +93,7 @@ public:
     void resetCostEvolution(unsigned int size);
     void setCostEvolution(int index, double value);
     KinematicRequestFlags getFlags() { return Flags; }
+    virtual bool isValid() { throw_named("Not implemented"); };
 protected:
     void updateTaskKinematics(std::shared_ptr<KinematicResponse> response);
 

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -58,6 +58,8 @@ public:
     virtual void preupdate();
     Eigen::MatrixXd& getBounds();
 
+    bool isValid();
+
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();
 

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -62,6 +62,7 @@ public:
 
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();
+    double getScalarTaskCost(const std::string& task_name);
 
     EndPoseTask Cost;
 

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -69,6 +69,7 @@ public:
 
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();
+    double getScalarTaskCost(const std::string& task_name);
     Eigen::VectorXd getEquality();
     Eigen::MatrixXd getEqualityJacobian();
     Eigen::VectorXd getInequality();

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -50,6 +50,7 @@ public:
 
     virtual void Instantiate(EndPoseProblemInitializer& init);
     void Update(Eigen::VectorXdRefConst x);
+    bool isValid();
 
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
     void setRho(const std::string& task_name, const double rho);
@@ -90,6 +91,7 @@ public:
 protected:
     void initTaskTerms(const std::vector<exotica::Initializer>& inits);
     Eigen::MatrixXd bounds_;
+    EndPoseProblemInitializer init_;
 };
 typedef std::shared_ptr<exotica::EndPoseProblem> EndPoseProblem_ptr;
 }

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -74,6 +74,8 @@ public:
     int JN;
     int NumTasks;
 
+    int getTaskId(const std::string& task_name);
+
 protected:
     void initTaskTerms(const std::vector<exotica::Initializer>& inits);
 };

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -62,6 +62,8 @@ public:
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();
 
+    double getScalarTaskCost(const std::string& task_name);
+
     EndPoseTask Cost;
 
     Eigen::MatrixXd W;

--- a/exotica/init/EndPoseProblem.in
+++ b/exotica/init/EndPoseProblem.in
@@ -6,3 +6,5 @@ Optional Eigen::VectorXd W = Eigen::VectorXd();
 Optional Eigen::VectorXd LowerBound = Eigen::VectorXd();
 Optional Eigen::VectorXd UpperBound = Eigen::VectorXd();
 Optional bool UseBounds = true;
+Optional double InequalityFeasibilityTolerance = 1e-12;
+Optional double EqualityFeasibilityTolerance = 1e-6;

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -214,4 +214,14 @@ double BoundedEndPoseProblem::getRho(const std::string& task_name)
     }
     throw_pretty("Cannot get Rho. Task map '" << task_name << "' does not exist.");
 }
+
+bool BoundedEndPoseProblem::isValid()
+{
+    Eigen::VectorXd x = scene_->getSolver().getControlledState();
+    for (unsigned int i = 0; i < N; i++)
+    {
+        if (x(i) < bounds_(i, 0) || x(i) > bounds_(i, 1)) return false;
+    }
+    return true;
+}
 }

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -124,6 +124,18 @@ Eigen::VectorXd BoundedEndPoseProblem::getScalarJacobian()
     return Cost.J.transpose() * Cost.S * Cost.ydiff * 2.0;
 }
 
+double BoundedEndPoseProblem::getScalarTaskCost(const std::string& task_name)
+{
+    for (int i = 0; i < Cost.Indexing.size(); i++)
+    {
+        if (Cost.Tasks[i]->getObjectName() == task_name)
+        {
+            return Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length).transpose() * Cost.Rho(Cost.Indexing[i].Id) * Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length);
+        }
+    }
+    throw_pretty("Cannot get scalar task cost. Task map '" << task_name << "' does not exist.");
+}
+
 void BoundedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x, tStart);

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -134,6 +134,18 @@ Eigen::VectorXd EndPoseProblem::getScalarJacobian()
     return Cost.J.transpose() * Cost.S * Cost.ydiff * 2.0;
 }
 
+double EndPoseProblem::getScalarTaskCost(const std::string& task_name)
+{
+    for (int i = 0; i < Cost.Indexing.size(); i++)
+    {
+        if (Cost.Tasks[i]->getObjectName() == task_name)
+        {
+            return Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length).transpose() * Cost.Rho(Cost.Indexing[i].Id) * Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length);
+        }
+    }
+    throw_pretty("Cannot get scalar task cost. Task map '" << task_name << "' does not exist.");
+}
+
 Eigen::VectorXd EndPoseProblem::getEquality()
 {
     return Equality.S * Equality.ydiff;

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -103,6 +103,18 @@ Eigen::VectorXd UnconstrainedEndPoseProblem::getScalarJacobian()
     return Cost.J.transpose() * Cost.S * Cost.ydiff * 2.0;
 }
 
+double UnconstrainedEndPoseProblem::getScalarTaskCost(const std::string& task_name)
+{
+    for (int i = 0; i < Cost.Indexing.size(); i++)
+    {
+        if (Cost.Tasks[i]->getObjectName() == task_name)
+        {
+            return Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length).transpose() * Cost.Rho(Cost.Indexing[i].Id) * Cost.ydiff.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length);
+        }
+    }
+    throw_pretty("Cannot get scalar task cost. Task map '" << task_name << "' does not exist.");
+}
+
 void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
 {
     scene_->Update(x, tStart);

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -207,4 +207,16 @@ void UnconstrainedEndPoseProblem::setNominalPose(Eigen::VectorXdRefConst qNomina
         throw_pretty("Cannot set qNominal - wrong number of rows (expected "
                      << N << ", received " << qNominal_in.rows() << ").");
 }
+
+int UnconstrainedEndPoseProblem::getTaskId(const std::string& task_name)
+{
+    for (int i = 0; i < Cost.Indexing.size(); i++)
+    {
+        if (Cost.Tasks[i]->getObjectName() == task_name)
+        {
+            return i;
+        }
+    }
+    throw_pretty("Cannot get task. Task map '" << task_name << "' does not exist.");
+}
 }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -633,6 +633,7 @@ PYBIND11_MODULE(_pyexotica, module)
     planningProblem.def("getNumberOfProblemUpdates", &PlanningProblem::getNumberOfProblemUpdates);
     planningProblem.def("resetNumberOfProblemUpdates", &PlanningProblem::resetNumberOfProblemUpdates);
     planningProblem.def("getCostEvolution", (std::pair<std::vector<double>, std::vector<double>> (PlanningProblem::*)()) & PlanningProblem::getCostEvolution);
+    planningProblem.def("isValid", &PlanningProblem::isValid);
 
     // Problem types
     py::module prob = module.def_submodule("Problems", "Problem types");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -759,6 +759,7 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedEndPoseProblem.def_property("qNominal", &UnconstrainedEndPoseProblem::getNominalPose, &UnconstrainedEndPoseProblem::setNominalPose);
     unconstrainedEndPoseProblem.def("getScalarCost", &UnconstrainedEndPoseProblem::getScalarCost);
     unconstrainedEndPoseProblem.def("getScalarJacobian", &UnconstrainedEndPoseProblem::getScalarJacobian);
+    unconstrainedEndPoseProblem.def("getScalarTaskCost", &UnconstrainedEndPoseProblem::getScalarTaskCost);
     unconstrainedEndPoseProblem.def_readonly("Cost", &UnconstrainedEndPoseProblem::Cost);
 
     py::class_<EndPoseProblem, std::shared_ptr<EndPoseProblem>, PlanningProblem> endPoseProblem(prob, "EndPoseProblem");
@@ -784,6 +785,7 @@ PYBIND11_MODULE(_pyexotica, module)
     endPoseProblem.def_readonly("J", &EndPoseProblem::J);
     endPoseProblem.def("getScalarCost", &EndPoseProblem::getScalarCost);
     endPoseProblem.def("getScalarJacobian", &EndPoseProblem::getScalarJacobian);
+    endPoseProblem.def("getScalarTaskCost", &EndPoseProblem::getScalarTaskCost);
     endPoseProblem.def("getBounds", &EndPoseProblem::getBounds);
     endPoseProblem.def_readonly("Cost", &EndPoseProblem::Cost);
     endPoseProblem.def_readonly("Inequality", &EndPoseProblem::Inequality);
@@ -804,6 +806,7 @@ PYBIND11_MODULE(_pyexotica, module)
     boundedEndPoseProblem.def_readonly("J", &BoundedEndPoseProblem::J);
     boundedEndPoseProblem.def("getScalarCost", &BoundedEndPoseProblem::getScalarCost);
     boundedEndPoseProblem.def("getScalarJacobian", &BoundedEndPoseProblem::getScalarJacobian);
+    boundedEndPoseProblem.def("getScalarTaskCost", &BoundedEndPoseProblem::getScalarTaskCost);
     boundedEndPoseProblem.def("getBounds", &BoundedEndPoseProblem::getBounds);
     boundedEndPoseProblem.def_readonly("Cost", &BoundedEndPoseProblem::Cost);
 


### PR DESCRIPTION
- Adds validity check to constrained problems: i.e. are the Inequality and Equality constraints within given tolerances (to be defined in initializer)
- Adds ability to get the id of a task by name