### PR TITLE
Exception: assemble error message in constructor

### DIFF
--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -75,15 +75,13 @@ Eigen::MatrixXd inverseSymPosDef(const Eigen::Ref<const Eigen::MatrixXd>& A_)
     dpotrf_((char*)"L", &nn, AA, &nn, &info);
     if (info != 0)
     {
-        throw_pretty("Can't invert matrix. Cholesky decomposition failsed: " << info << "\n"
-                                                                             << A_);
+        throw_pretty("Can't invert matrix. Cholesky decomposition failed: " << info << std::endl << A_);
     }
     // Invert
     dpotri_((char*)"L", &nn, AA, &nn, &info);
     if (info != 0)
     {
-        throw_pretty("Can't invert matrix: " << info << "\n"
-                                             << A_);
+        throw_pretty("Can't invert matrix: " << info << std::endl << A_);
     }
     Ainv_.triangularView<Eigen::Upper>() = Ainv_.transpose();
     return Ainv_;

--- a/exotica/include/exotica/Tools/Exception.h
+++ b/exotica/include/exotica/Tools/Exception.h
@@ -37,16 +37,10 @@ public:
         ObjectName = 16
     };
 
-    Exception();
-    explicit Exception(const std::string &msg, const char *file, const char *func, int line);
-    explicit Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object);
-    virtual const char *what() const noexcept override;
+    explicit Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object = std::string());
+    virtual const char *what() const noexcept;
 
     std::string msg_;
-    std::string file_;
-    std::string func_;
-    std::string line_;
-    std::string object_;
 
 private:
     static ReportingType reporting_;

--- a/exotica/src/Tools/Exception.cpp
+++ b/exotica/src/Tools/Exception.cpp
@@ -4,26 +4,19 @@ namespace exotica
 {
 Exception::ReportingType Exception::reporting_ = Exception::Message | Exception::FileName | Exception::FunctionName | Exception::LineNumber | Exception::ObjectName;
 
-Exception::Exception()
+Exception::Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object)
 {
-}
-
-Exception::Exception(const std::string &msg, const char *file, const char *func, int line) : msg_(msg), file_(file), func_(func), line_(std::to_string(line))
-{
-}
-
-Exception::Exception(const std::string &msg, const char *file, const char *func, int line, const std::string &object) : msg_(msg), file_(file), func_(func), line_(std::to_string(line)), object_(object)
-{
+    std::string tmp;
+    if (Exception::reporting_ | FileName) tmp += "In " + std::string(file) + "\n";
+    if (Exception::reporting_ | FunctionName) tmp += std::string(func) + " ";
+    if (Exception::reporting_ | LineNumber) tmp += std::to_string(line) + "\n";
+    if ((Exception::reporting_ | ObjectName) && !object.empty()) tmp += "Object: " + object + ": ";
+    if (Exception::reporting_ | Message) tmp += msg;
+    msg_ = tmp;
 }
 
 const char *Exception::what() const noexcept
 {
-    std::string tmp;
-    if (Exception::reporting_ | FileName) tmp += "In " + file_ + "\n";
-    if (Exception::reporting_ | FunctionName) tmp += func_ + " ";
-    if (Exception::reporting_ | LineNumber) tmp += line_ + "\n";
-    if (Exception::reporting_ | ObjectName) tmp += "Object: " + object_ + ": ";
-    if (Exception::reporting_ | Message) tmp += msg_;
-    return tmp.c_str();
+    return msg_.c_str();
 }
 }


### PR DESCRIPTION
This was a hard nut to crack :-)

The root cause of truncated error message (https://github.com/ipab-slmc/exotica/issues/299, https://github.com/ipab-slmc/exotica/issues/287) is that the error message was constructed in `what()` in a local variable `tmp`. But this variable goes out of scope when `what()` returns and hence the returned pointer points to some deallocated memory when the message is printed on screen.
The solution to this is simply to construct the error message in the constructor and return the pointer to this in `what()`.