### PR TITLE
Fix constrained trajectory problems (finally working!)

### DIFF
--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -55,7 +55,6 @@ std::vector<double>& BoundedTimeIndexedProblem::getBounds()
 void BoundedTimeIndexedProblem::Instantiate(BoundedTimeIndexedProblemInitializer& init)
 {
     init_ = init;
-    setT(init_.T);
 
     std::vector<std::string> jnts;
     scene_->getJointNames(jnts);
@@ -84,6 +83,12 @@ void BoundedTimeIndexedProblem::Instantiate(BoundedTimeIndexedProblemInitializer
     {
         throw_named("Lower bound size incorrect! Expected " << N << " got " << init.UpperBound.rows());
     }
+
+    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
+
+    T = init_.T;
+    applyStartState(false);
+    reinitializeVariables();
 }
 
 void BoundedTimeIndexedProblem::preupdate()
@@ -337,7 +342,6 @@ void BoundedTimeIndexedProblem::reinitializeVariables()
     // Set initial trajectory
     InitialTrajectory.resize(T, scene_->getControlledState());
 
-    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
     Cost.reinitializeVariables(T, shared_from_this(), CostPhi);
     applyStartState(false);
     preupdate();

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -55,8 +55,6 @@ Eigen::MatrixXd& TimeIndexedProblem::getBounds()
 void TimeIndexedProblem::Instantiate(TimeIndexedProblemInitializer& init)
 {
     init_ = init;
-    applyStartState(false);
-    setT(init_.T);
 
     N = scene_->getSolver().getNumControlledJoints();
 
@@ -94,6 +92,12 @@ void TimeIndexedProblem::Instantiate(TimeIndexedProblemInitializer& init)
 
     useBounds = init.UseBounds;
 
+    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
+    Inequality.initialize(init_.Inequality, shared_from_this(), InequalityPhi);
+    Equality.initialize(init_.Equality, shared_from_this(), EqualityPhi);
+
+    T = init_.T;
+    applyStartState(false);
     reinitializeVariables();
 }
 
@@ -130,9 +134,6 @@ void TimeIndexedProblem::reinitializeVariables()
     // Set initial trajectory
     InitialTrajectory.resize(T, scene_->getControlledState());
 
-    Cost.initialize(init_.Cost, shared_from_this(), CostPhi);
-    Inequality.initialize(init_.Inequality, shared_from_this(), InequalityPhi);
-    Equality.initialize(init_.Equality, shared_from_this(), EqualityPhi);
     Cost.reinitializeVariables(T, shared_from_this(), CostPhi);
     Inequality.reinitializeVariables(T, shared_from_this(), InequalityPhi);
     Equality.reinitializeVariables(T, shared_from_this(), EqualityPhi);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -709,6 +709,8 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedProblem.def("getScalarTaskJacobian", &TimeIndexedProblem::getScalarTaskJacobian);
     timeIndexedProblem.def("getScalarTransitionCost", &TimeIndexedProblem::getScalarTransitionCost);
     timeIndexedProblem.def("getScalarTransitionJacobian", &TimeIndexedProblem::getScalarTransitionJacobian);
+    timeIndexedProblem.def("getEquality", &TimeIndexedProblem::getEquality);
+    timeIndexedProblem.def("getInequality", &TimeIndexedProblem::getInequality);
     timeIndexedProblem.def("getBounds", &TimeIndexedProblem::getBounds);
     timeIndexedProblem.def_readonly("Cost", &TimeIndexedProblem::Cost);
     timeIndexedProblem.def_readonly("Inequality", &TimeIndexedProblem::Inequality);


### PR DESCRIPTION
``TimeIndexedProblem`` and ``BoundedTimeIndexedProblem`` are currently infeasible to be solved by a constrained NLP solver. The reason is that during instantiation they reference each task twice (i.e. a taskmap with one-dimensional ``Phi`` would create _two_ inequality constraints, and only the first would receive updates to ``Rho`` or ``y`` causing numerical inconsistency). The underlying cause is that the ``T`` parameter was set incorrectly using the ``setT`` method forcing a reinitialization before the Tasks had been initialised, along with a initialization-_and_-reinitialization on every reinitialisation.

This pull request fixes this by:

- First initialising Cost, Inequality, and Equality tasks
- Then manually setting the number of timesteps and applying the start state, rather than by using the ``setT`` method (which internally reinitialises).

With these fixes we can now finally solve constrained trajectories :-).