### PR TITLE
Move MaxIterations to MotionSolver

### DIFF
--- a/exotations/solvers/aico/init/AICOsolver.in
+++ b/exotations/solvers/aico/init/AICOsolver.in
@@ -1,6 +1,5 @@
 extend <exotica/MotionSolver>
 Optional std::string SweepMode = "Symmetric";  // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
-Optional int MaxIterations = 100;
 Optional int MaxBacktrackIterations = 10;  // Patience on how many sweeps without improvement before terminating
 Optional double StepTolerance = 1e-5;  // Relative step tolerance
 Optional double FunctionTolerance = 1e-5;  // Relative function tolerance (first-order optimality)

--- a/exotations/solvers/aico/init/BayesianIK.in
+++ b/exotations/solvers/aico/init/BayesianIK.in
@@ -1,6 +1,5 @@
 extend <exotica/MotionSolver>
 Optional std::string SweepMode = "Symmetric";  // Forwardly, Symmetric, LocalGaussNewton, LocalGaussNewtonDamped
-Optional int MaxIterations = 100;
 Optional int MaxBacktrackIterations = 10;  // Patience on how many sweeps without improvement before terminating
 Optional double StepTolerance = 1e-5;  // Relative step tolerance
 Optional double FunctionTolerance = 1e-5;  // Relative function tolerance (first-order optimality)

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -60,7 +60,6 @@ void AICOsolver::Instantiate(AICOsolverInitializer& init)
     {
         throw_named("Unknown sweep mode '" << init.SweepMode << "'");
     }
-    setNumberOfMaxIterations(init.MaxIterations);
     max_backtrack_iterations = init.MaxBacktrackIterations;
     minimum_step_tolerance = init.MinStep;
     step_tolerance = init.StepTolerance;

--- a/exotations/solvers/aico/src/BayesianIK.cpp
+++ b/exotations/solvers/aico/src/BayesianIK.cpp
@@ -57,7 +57,6 @@ void BayesianIK::Instantiate(BayesianIKInitializer& init)
     {
         throw_named("Unknown sweep mode '" << init.SweepMode << "'");
     }
-    setNumberOfMaxIterations(init.MaxIterations);
     max_backtrack_iterations = init.MaxBacktrackIterations;
     minimum_step_tolerance = init.MinStep;
     step_tolerance = init.StepTolerance;

--- a/exotations/solvers/ik_solver/init/IKsolver.in
+++ b/exotations/solvers/ik_solver/init/IKsolver.in
@@ -1,7 +1,6 @@
 extend <exotica/MotionSolver>
 Optional double Tolerance = 1e-5;
 Optional double Convergence = 0.0;
-Optional int MaxIterations = 50;
 Optional double MaxStep = 0.02;
 Optional double C = 0.0;
 Optional double Alpha = 1.0;

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -90,7 +90,6 @@ Eigen::MatrixXd inverseSymPosDef(const Eigen::Ref<const Eigen::MatrixXd>& A_)
 void IKsolver::Instantiate(IKsolverInitializer& init)
 {
     parameters_ = init;
-    setNumberOfMaxIterations(init.MaxIterations);
 }
 
 void IKsolver::specifyProblem(PlanningProblem_ptr pointer)

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -55,6 +55,7 @@ public:
     virtual std::string print(std::string prepend);
     void setNumberOfMaxIterations(int maxIter)
     {
+        if (maxIter < 1) throw_pretty("Number of maximum iterations needs to be greater than 0.");
         if (debug_) HIGHLIGHT_NAMED("MotionSolver", "Setting maximum iterations to " << maxIter << " (was " << maxIterations_ << ")");
         maxIterations_ = maxIter;
     }

--- a/exotica/init/MotionSolver.in
+++ b/exotica/init/MotionSolver.in
@@ -1,1 +1,2 @@
 extend <exotica/Object>
+Optional int MaxIterations = 100;

--- a/exotica/src/MotionSolver.cpp
+++ b/exotica/src/MotionSolver.cpp
@@ -31,12 +31,14 @@
  */
 
 #include "exotica/MotionSolver.h"
+#include "exotica/MotionSolverInitializer.h"
 
 namespace exotica
 {
 void MotionSolver::InstantiateBase(const Initializer& init)
 {
     Object::InstatiateObject(init);
+    setNumberOfMaxIterations(MotionSolverInitializer(init).MaxIterations);
 }
 
 MotionSolver::MotionSolver()


### PR DESCRIPTION
This takes #291 one step further and actually moves the MaxIterations property into MotionSolver - and thus reduces the need for repeated setting of the maximum iterations variable in every solver. It also thereby reduces the risk of missing to implement this functionality in some solvers while it's present in others.