### PR TITLE
Fix OMPL motion simplification and expose OMPL properties to Python

### DIFF
--- a/exotations/solvers/ompl_solver/include/ompl_solver/ompl_native_solvers.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/ompl_native_solvers.h
@@ -50,6 +50,8 @@ class RRTConnect : public OMPLsolver<SamplingProblem>, Instantiable<RRTConnectIn
 public:
     RRTConnect();
     virtual void Instantiate(RRTConnectInitializer& init);
+    void setRange(double range);
+    double getRange();
 };
 
 class EST : public OMPLsolver<SamplingProblem>, Instantiable<ESTInitializer>

--- a/exotations/solvers/ompl_solver/include/ompl_solver/ompl_solver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/ompl_solver.h
@@ -72,6 +72,12 @@ public:
 
     int getRandomSeed();
 
+    // StateSpace related methods exposed via solver
+    double getMaximumExtent() { return state_space_->getMaximumExtent(); }
+    double getLongestValidSegmentLength() { return state_space_->getLongestValidSegmentLength(); }
+    void setLongestValidSegmentFraction(double segmentFraction) { state_space_->setLongestValidSegmentFraction(segmentFraction); }
+    void setValidSegmentCountFactor(unsigned int factor) { state_space_->setValidSegmentCountFactor(factor); }
+    unsigned int getValidSegmentCountFactor() const { return state_space_->getValidSegmentCountFactor(); }
 protected:
     template <typename T>
     static ompl::base::PlannerPtr allocatePlanner(const ompl::base::SpaceInformationPtr &si, const std::string &new_name)

--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -1,5 +1,7 @@
 extend <exotica/MotionSolver>
 Optional bool Smooth = true;
+Optional bool ReduceVertices = true;
+Optional bool ShortcutPath = true;
 Optional int SimplifyTryCnt = 10; // [reduceVertices/shortcutPath] Number of attempts to reduce vertices and shortcut path. Both will be attempted the given number of tasks, and the latter only if it is a metric state space.
 Optional int SimplifyInterpolationLength = 20; // [reduceVertices/shortcutPath] Interpolation after the first attempt.
 Optional double RangeRatio = 0.33; // [reduceVertices/shortcutPath] Between 0.0-1.0, how far to attempt to connect vertices. Set to 1.0 for maximum simplification.
@@ -7,6 +9,7 @@ Optional double SnapToVertex = 0.005; // [shortcutPath] Set to 1.0 will do maxim
 Optional double SmoothnessFactor = 1.0;
 Optional double Timeout = 60.0;
 Optional std::string Range = "1";
+Optional double LongestValidSegmentFraction = 0.01; // Fraction of the maximum extent of the state space for which a segment is considered valid in discrete motion validation. Be careful when changing!
 Optional bool UseGoalBias = false;
 Optional std::string GoalBias = "0.05";
 Optional int RandomSeed = -1;  // Only set if not -1

--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -1,9 +1,9 @@
 extend <exotica/MotionSolver>
 Optional bool Smooth = true;
-Optional int SimplifyTryCnt = 10;
-Optional int SimplifyInterpolationLength = 20;
-Optional double RangeRatio = 0.33; // Set to 1.0 will do maximum simplification
-Optional double SnapToVertex = 0.005; // Set to 1.0 will do maximum simplification
+Optional int SimplifyTryCnt = 10; // [reduceVertices/shortcutPath] Number of attempts to reduce vertices and shortcut path. Both will be attempted the given number of tasks, and the latter only if it is a metric state space.
+Optional int SimplifyInterpolationLength = 20; // [reduceVertices/shortcutPath] Interpolation after the first attempt.
+Optional double RangeRatio = 0.33; // [reduceVertices/shortcutPath] Between 0.0-1.0, how far to attempt to connect vertices. Set to 1.0 for maximum simplification.
+Optional double SnapToVertex = 0.005; // [shortcutPath] Set to 1.0 will do maximum simplification.
 Optional double SmoothnessFactor = 1.0;
 Optional double Timeout = 60.0;
 Optional std::string Range = "1";

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_exo.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_exo.cpp
@@ -75,6 +75,7 @@ OMPLRNStateSpace::OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLsolverInitiali
         bounds.setLow(i, prob->getBounds()[i]);
     }
     getSubspace(0)->as<ompl::base::RealVectorStateSpace>()->setBounds(bounds);
+    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
     lock();
 }
 
@@ -144,6 +145,7 @@ OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLsolverIn
         ERROR("State space bounds were not specified!\n"
               << prob->getBounds().size() << " " << n);
     }
+    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
     lock();
 }
 
@@ -212,6 +214,7 @@ OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLsolverIn
         ERROR("State space bounds were not specified!\n"
               << prob->getBounds().size() << " " << n);
     }
+    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
     lock();
 }
 

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_native_solvers.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_native_solvers.cpp
@@ -104,6 +104,18 @@ void RRTConnect::Instantiate(RRTConnectInitializer& init)
         &allocatePlanner<ompl::geometric::RRTConnect>, _1, _2);
 }
 
+void RRTConnect::setRange(double range)
+{
+    ompl_ptr<ompl::geometric::RRTConnect> rrtcon = ompl_cast<ompl::geometric::RRTConnect>(ompl_simple_setup_->getPlanner());
+    rrtcon->setRange(range);
+}
+
+double RRTConnect::getRange()
+{
+    ompl_ptr<ompl::geometric::RRTConnect> rrtcon = ompl_cast<ompl::geometric::RRTConnect>(ompl_simple_setup_->getPlanner());
+    return rrtcon->getRange();
+}
+
 EST::EST()
 {
 }

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_py.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_py.cpp
@@ -15,12 +15,24 @@ PYBIND11_MODULE(ompl_solver_py, module)
 
     py::module::import("pyexotica");
 
-    py::class_<RRT, std::shared_ptr<RRT>, MotionSolver> rrt(module, "RRT");
-    py::class_<RRTConnect, std::shared_ptr<RRTConnect>, MotionSolver> rrtcon(module, "RRTConnect");
-    py::class_<EST, std::shared_ptr<EST>, MotionSolver> est(module, "EST");
-    py::class_<KPIECE, std::shared_ptr<KPIECE>, MotionSolver> kpiece(module, "KPIECE");
-    py::class_<BKPIECE, std::shared_ptr<BKPIECE>, MotionSolver> bkpiece(module, "BKPIECE");
-    py::class_<PRM, std::shared_ptr<PRM>, MotionSolver> prm(module, "PRM");
+    py::class_<OMPLsolver<SamplingProblem>, std::shared_ptr<OMPLsolver<SamplingProblem>>, MotionSolver> omplSolver(module, "OMPLMotionSolver");
+    omplSolver.def("getRandomSeed", &OMPLsolver<SamplingProblem>::getRandomSeed);
+
+    // State-space properties exposed via OMPLsolver
+    omplSolver.def("getMaximumExtent", &OMPLsolver<SamplingProblem>::getMaximumExtent);
+    omplSolver.def("getLongestValidSegmentLength", &OMPLsolver<SamplingProblem>::getLongestValidSegmentLength);
+    omplSolver.def("setLongestValidSegmentFraction", &OMPLsolver<SamplingProblem>::setLongestValidSegmentFraction);
+    omplSolver.def("setValidSegmentCountFactor", &OMPLsolver<SamplingProblem>::setValidSegmentCountFactor);
+    omplSolver.def("getValidSegmentCountFactor", &OMPLsolver<SamplingProblem>::getValidSegmentCountFactor);
+
+    py::class_<RRT, std::shared_ptr<RRT>, OMPLsolver<SamplingProblem>> rrt(module, "RRT");
+    py::class_<RRTConnect, std::shared_ptr<RRTConnect>, OMPLsolver<SamplingProblem>> rrtcon(module, "RRTConnect");
+    rrtcon.def("getRange", &RRTConnect::getRange);
+    rrtcon.def("setRange", &RRTConnect::setRange);
+    py::class_<EST, std::shared_ptr<EST>, OMPLsolver<SamplingProblem>> est(module, "EST");
+    py::class_<KPIECE, std::shared_ptr<KPIECE>, OMPLsolver<SamplingProblem>> kpiece(module, "KPIECE");
+    py::class_<BKPIECE, std::shared_ptr<BKPIECE>, OMPLsolver<SamplingProblem>> bkpiece(module, "BKPIECE");
+    py::class_<PRM, std::shared_ptr<PRM>, OMPLsolver<SamplingProblem>> prm(module, "PRM");
     prm.def("growRoadmap", &PRM::growRoadmap);
     prm.def("expandRoadmap", &PRM::expandRoadmap);
     prm.def("clear", &PRM::clear);
@@ -30,7 +42,7 @@ PYBIND11_MODULE(ompl_solver_py, module)
     prm.def("milestoneCount", &PRM::milestoneCount);
     prm.def_property("multiQuery", &PRM::isMultiQuery, &PRM::setMultiQuery);
 
-    py::class_<LazyPRM, std::shared_ptr<LazyPRM>, MotionSolver> lprm(module, "LazyPRM");
+    py::class_<LazyPRM, std::shared_ptr<LazyPRM>, OMPLsolver<SamplingProblem>> lprm(module, "LazyPRM");
     lprm.def("clear", &LazyPRM::clear);
     lprm.def("clearQuery", &LazyPRM::clearQuery);
     lprm.def("setup", &LazyPRM::setup);

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -172,14 +172,7 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
         }
         if (init_.ShortcutPath && si->getStateSpace()->isMetricSpace())
         {
-            if (ptc == false)
-            {
-                if (times > 0)
-                    pg.interpolate(init_.SimplifyInterpolationLength);
-                tryMore = psf_->shortcutPath(pg, 0, 0, init_.RangeRatio, init_.SnapToVertex);
-            }
-            else
-                tryMore = false;
+            times = 0;
             while (times < init_.SimplifyTryCnt && tryMore && ptc == false)
             {
                 pg.interpolate(init_.SimplifyInterpolationLength);

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -166,8 +166,7 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
         int times = 0;
         while (init_.ReduceVertices && times < init_.SimplifyTryCnt && tryMore && ptc == false)
         {
-            if (times > 0)
-                pg.interpolate(init_.SimplifyInterpolationLength);
+            pg.interpolate(init_.SimplifyInterpolationLength);
             tryMore = psf_->reduceVertices(pg, 0, 0, init_.RangeRatio);
             times++;
         }
@@ -183,8 +182,7 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
                 tryMore = false;
             while (times < init_.SimplifyTryCnt && tryMore && ptc == false)
             {
-                if (times > 0)
-                    pg.interpolate(init_.SimplifyInterpolationLength);
+                pg.interpolate(init_.SimplifyInterpolationLength);
                 tryMore = psf_->shortcutPath(pg, 0, 0, init_.RangeRatio, init_.SnapToVertex);
                 times++;
             }

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -62,7 +62,7 @@ void OMPLsolver<ProblemType>::specifyProblem(PlanningProblem_ptr pointer)
         throw_named("Unsupported base type " << prob_->getScene()->getBaseType());
     ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(state_space_));
     ompl_simple_setup_->setStateValidityChecker(ompl::base::StateValidityCheckerPtr(new OMPLStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_)));
-    ompl_simple_setup_->setPlannerAllocator(boost::bind(planner_allocator_, _1, "Exotica_" + algorithm_));
+    ompl_simple_setup_->setPlannerAllocator(boost::bind(planner_allocator_, _1, algorithm_));
 
     if (init_.Projection.rows() > 0)
     {

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -164,14 +164,14 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
     {
         bool tryMore = true;
         int times = 0;
-        while (times < init_.SimplifyTryCnt && tryMore && ptc == false)
+        while (init_.ReduceVertices && times < init_.SimplifyTryCnt && tryMore && ptc == false)
         {
             if (times > 0)
                 pg.interpolate(init_.SimplifyInterpolationLength);
             tryMore = psf_->reduceVertices(pg, 0, 0, init_.RangeRatio);
             times++;
         }
-        if (si->getStateSpace()->isMetricSpace())
+        if (init_.ShortcutPath && si->getStateSpace()->isMetricSpace())
         {
             if (ptc == false)
             {


### PR DESCRIPTION
E.g. state-space properties for collision checking

Relates to #307 