### PR TITLE
TimeIndexedProblem: Add isValid check for constraints with tolerances

### DIFF
--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -50,6 +50,7 @@ public:
     virtual void Instantiate(TimeIndexedProblemInitializer& init);
     double getDuration();
     void Update(Eigen::VectorXdRefConst x, int t);
+    bool isValid();
     std::vector<Eigen::VectorXd> getInitialTrajectory();
     void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
     virtual void preupdate();

--- a/exotica/init/TimeIndexedProblem.in
+++ b/exotica/init/TimeIndexedProblem.in
@@ -9,3 +9,5 @@ Optional std::vector<exotica::Initializer> Equality = std::vector<exotica::Initi
 Optional Eigen::VectorXd LowerBound = Eigen::VectorXd();
 Optional Eigen::VectorXd UpperBound = Eigen::VectorXd();
 Optional bool UseBounds = true;
+Optional double InequalityFeasibilityTolerance = 1e-12;
+Optional double EqualityFeasibilityTolerance = 1e-6;

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -600,4 +600,45 @@ double TimeIndexedProblem::getRhoNEQ(const std::string& task_name, int t)
     }
     throw_pretty("Cannot get Rho. Task map '" << task_name << "' does not exist.");
 }
+
+bool TimeIndexedProblem::isValid()
+{
+    bool succeeded = true;
+
+    // Check for every state
+    for (unsigned int t = 0; t < T; t++)
+    {
+        // Check joint limits
+        for (unsigned int i = 0; i < N; i++)
+        {
+            if (x[t](i) < bounds_(i, 0) || x[t](i) > bounds_(i, 1))
+            {
+                if (debug_) HIGHLIGHT_NAMED("TimeIndexedProblem::isValid", "State at timestep " << t << " is out of bounds");
+                succeeded = false;
+            }
+        }
+
+        // Check inequality constraints
+        if (getInequality(t).rows() > 0)
+        {
+            if (getInequality(t).maxCoeff() > init_.InequalityFeasibilityTolerance)
+            {
+                if (debug_) HIGHLIGHT_NAMED("TimeIndexedProblem::isValid", "Violated inequality constraints at timestep " << t << ": " << getInequality(t).transpose());
+                succeeded = false;
+            }
+        }
+
+        // Check equality constraints
+        if (getEquality(t).rows() > 0)
+        {
+            if (getEquality(t).norm() > init_.EqualityFeasibilityTolerance)
+            {
+                if (debug_) HIGHLIGHT_NAMED("TimeIndexedProblem::isValid", "Violated equality constraints at timestep " << t << ": " << getEquality(t).norm());
+                succeeded = false;
+            }
+        }
+    }
+
+    return succeeded;
+}
 }


### PR DESCRIPTION
So after updating the problem with a trajectory a single call to ``isValid`` returns whether all constraints are within the required limits. If in debug mode, information will be printed which type of constraints are violated at which timestep.

I implemented the same for the other types of problems in #296.