### PR TITLE
Problems: Check goal dimension for setGoal

### DIFF
--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -182,6 +182,7 @@ void BoundedEndPoseProblem::setGoal(const std::string& task_name, Eigen::VectorX
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y.data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }

--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -232,6 +232,7 @@ void BoundedTimeIndexedProblem::setGoal(const std::string& task_name, Eigen::Vec
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y[t].data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -218,6 +218,7 @@ void EndPoseProblem::setGoal(const std::string& task_name, Eigen::VectorXdRefCon
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y.data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }
@@ -269,6 +270,7 @@ void EndPoseProblem::setGoalEQ(const std::string& task_name, Eigen::VectorXdRefC
     {
         if (Equality.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Equality.Indexing[i].Length) throw_pretty("Expected length of " << Equality.Indexing[i].Length << " and got " << goal.rows());
             Equality.y.data.segment(Equality.Indexing[i].Start, Equality.Indexing[i].Length) = goal;
             return;
         }
@@ -320,6 +322,7 @@ void EndPoseProblem::setGoalNEQ(const std::string& task_name, Eigen::VectorXdRef
     {
         if (Inequality.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Inequality.Indexing[i].Length) throw_pretty("Expected length of " << Inequality.Indexing[i].Length << " and got " << goal.rows());
             Inequality.y.data.segment(Inequality.Indexing[i].Start, Inequality.Indexing[i].Length) = goal;
             return;
         }

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -366,6 +366,7 @@ void TimeIndexedProblem::setGoal(const std::string& task_name, Eigen::VectorXdRe
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y[t].data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }
@@ -449,6 +450,7 @@ void TimeIndexedProblem::setGoalEQ(const std::string& task_name, Eigen::VectorXd
     {
         if (Equality.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Equality.Indexing[i].Length) throw_pretty("Expected length of " << Equality.Indexing[i].Length << " and got " << goal.rows());
             Equality.y[t].data.segment(Equality.Indexing[i].Start, Equality.Indexing[i].Length) = goal;
             return;
         }
@@ -532,6 +534,7 @@ void TimeIndexedProblem::setGoalNEQ(const std::string& task_name, Eigen::VectorX
     {
         if (Inequality.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Inequality.Indexing[i].Length) throw_pretty("Expected length of " << Inequality.Indexing[i].Length << " and got " << goal.rows());
             Inequality.y[t].data.segment(Inequality.Indexing[i].Start, Inequality.Indexing[i].Length) = goal;
             return;
         }

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -161,6 +161,7 @@ void UnconstrainedEndPoseProblem::setGoal(const std::string& task_name, Eigen::V
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y.data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -283,6 +283,7 @@ void UnconstrainedTimeIndexedProblem::setGoal(const std::string& task_name, Eige
     {
         if (Cost.Tasks[i]->getObjectName() == task_name)
         {
+            if (goal.rows() != Cost.Indexing[i].Length) throw_pretty("Expected length of " << Cost.Indexing[i].Length << " and got " << goal.rows());
             Cost.y[t].data.segment(Cost.Indexing[i].Start, Cost.Indexing[i].Length) = goal;
             return;
         }


### PR DESCRIPTION
So far, the dimension for ``goal`` was not been checked in any problem when being set, i.e. one could set a 7d vector for an internal 6d one effectively truncating the 7th value. This particularly effected when a quaternion was given as a goal for a RPY-type frame. As this so far was a silent bug, it was the source of most recent constrained optimisation failures.

This PR adds dimensionality checks for setting goal states in all problems. 