### PR TITLE
Change debug messages in IKsolver and MotionSolver

### DIFF
--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -128,11 +128,11 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
     Timer timer;
 
     if (!prob_) throw_named("Solver has not been initialized!");
-    Eigen::VectorXd q0 = prob_->applyStartState();
+    const Eigen::VectorXd q0 = prob_->applyStartState();
 
     if (prob_->N != q0.rows()) throw_named("Wrong size q0 size=" << q0.rows() << ", required size=" << prob_->N);
 
-    bool UseNullspace = prob_->qNominal.rows() == prob_->N;
+    const bool UseNullspace = prob_->qNominal.rows() == prob_->N;
 
     solution.resize(1, prob_->N);
 
@@ -150,6 +150,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
         if (error < parameters_.Tolerance)
         {
+            if (debug_) HIGHLIGHT_NAMED("IKsolver", "Reached tolerance (" << error << " < " << parameters_.Tolerance << ")");
             break;
         }
 
@@ -163,6 +164,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
         if (qd.norm() < parameters_.Convergence)
         {
+            if (debug_) HIGHLIGHT_NAMED("IKsolver", "Reached convergence (" << qd.norm() << " < " << parameters_.Convergence << ")");
             break;
         }
     }

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -56,7 +56,6 @@ public:
     void setNumberOfMaxIterations(int maxIter)
     {
         if (maxIter < 1) throw_pretty("Number of maximum iterations needs to be greater than 0.");
-        if (debug_) HIGHLIGHT_NAMED("MotionSolver", "Setting maximum iterations to " << maxIter << " (was " << maxIterations_ << ")");
         maxIterations_ = maxIter;
     }
     int getNumberOfMaxIterations() { return maxIterations_; }


### PR DESCRIPTION
- add debug message for IKsolver
- remove debug message for MotionSolver

I remove the message for MotionSolver, since its a configurable parameter that is changed by the user. The message is therefore not informative.