### PR TITLE
Added quasistatic task map

### DIFF
--- a/examples/exotica_examples/launch/PythonPlanIKValkyrie.launch
+++ b/examples/exotica_examples/launch/PythonPlanIKValkyrie.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/valkyrie_sim.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/valkyrie_sim.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_ik_valkyrie.py" name="IKPlannerPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/examples/exotica_examples/launch/PythonPlanIKValkyrie.launch
+++ b/examples/exotica_examples/launch/PythonPlanIKValkyrie.launch
@@ -1,5 +1,4 @@
 <launch>
-
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
@@ -9,5 +8,5 @@
 
   <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_ik_valkyrie.py" name="IKPlannerPythonExampleNode" output="screen" />
 
-  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false" args="-d $(find exotica_examples)/resources/rviz.rviz" />
 </launch>

--- a/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
+++ b/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<ExoticaWholeBodyIKConfig>
+  <!--<BayesianIK Name="IK" MaxIterations="20" MaxBacktrackIterations="5" MinStep="1e-5" FunctionTolerance="1e-5" StepTolerance="1e-5"/>-->
+  <IKsolver Name="MySolver">
+    <MaxIterations>100</MaxIterations>
+    <MaxStep>0.1</MaxStep>
+    <Tolerance>1e-8</Tolerance>
+    <Alpha>0.01</Alpha>
+    <C>1e-4</C>
+  </IKsolver>
+  
+  <UnconstrainedEndPoseProblem>
+    <PlanningScene>
+      <Scene Name="Scene">
+        <JointGroup>whole_body</JointGroup>
+        <Debug>0</Debug>
+        <URDF>{exotica_examples}/resources/robots/valkyrie_sim.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/valkyrie_sim.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+    <Maps>
+      <!--<CoM Name="CoM"/>-->
+      <EffPosition Name="CoM">
+          <EndEffector>
+              <Frame Link="pelvis"/>
+          </EndEffector>
+      </EffPosition>
+      <EffOrientation Name="StraightBack">
+          <EndEffector>
+              <Frame Link="pelvis"/>
+              <Frame Link="torso"/>
+          </EndEffector>
+      </EffOrientation>
+      <EffFrame Name="FootPosition">
+          <EndEffector>
+              <Frame Link="leftFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 0.1 0"/>
+              <Frame Link="rightFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 -0.1 0"/>
+          </EndEffector>
+      </EffFrame>
+      <QuasiStatic Name="Stability" PositiveOnly="1" Debug="1">
+          <EndEffector>
+              <Frame Link="leftFoot_collision_5"/>
+              <Frame Link="leftFoot_collision_6"/>
+              <Frame Link="leftFoot_collision_7"/>
+              <Frame Link="leftFoot_collision_8"/>
+              <Frame Link="rightFoot_collision_5"/>
+              <Frame Link="rightFoot_collision_6"/>
+              <Frame Link="rightFoot_collision_7"/>
+              <Frame Link="rightFoot_collision_8"/>
+          </EndEffector>
+      </QuasiStatic>
+      <Identity Name="Pose">
+          <JointRef>0.00062 -0.00027 -0.00872 0.3002 -1.25 0 -0.7854 1.571 0 0 0 0 0 0.3002 1.25 0 0.7854 1.571 0 0</JointRef>
+          <JointMap>18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37</JointMap>
+      </Identity>
+    </Maps>
+    <Cost>
+      <Task Task="CoM" Rho="1e-1"/>
+      <Task Task="Stability" Rho="1e0"/>
+      <Task Task="FootPosition" Rho="1e3"/>
+      <Task Task="StraightBack" Rho="1e0"/>
+      <Task Task="Pose" Rho="1e3"/>
+    </Cost>
+    <!--<NominalState>0.000031 -3e-06 0.9 0.009 0.00133 -0.000621 0.0067 -0.04594 -0.6825 1.62 -0.9363 0.0374 0.0026 0.0241 -0.66641 1.6231 -0.9524 -0.0344 0.00062 -0.00027 -0.00872 0.3002 -1.25 0 -0.7854 1.571 0 0 0 0 0 0.3002 1.25 0 0.7854 1.571 0 0</NominalState>-->
+    <StartState>0.000031 -3e-06 0.9 0.009 0.00133 -0.000621 0.0067 -0.04594 -0.6825 1.62 -0.9363 0.0374 0.0026 0.0241 -0.66641 1.6231 -0.9524 -0.0344 0.00062 -0.00027 -0.00872 0.3002 -1.25 0 -0.7854 1.571 0 0 0 0 0 0.3002 1.25 0 0.7854 1.571 0 0</StartState>
+  </UnconstrainedEndPoseProblem>
+</ExoticaWholeBodyIKConfig>

--- a/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
+++ b/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
@@ -8,7 +8,7 @@
     <Alpha>0.05</Alpha>
     <C>1e-3</C>
   </IKsolver>
-  
+
   <UnconstrainedEndPoseProblem>
     <PlanningScene>
       <Scene Name="Scene">
@@ -21,37 +21,37 @@
     <Maps>
       <!--<CoM Name="CoM"/>-->
       <EffPosition Name="CoM">
-          <EndEffector>
-              <Frame Link="pelvis"/>
-          </EndEffector>
+        <EndEffector>
+          <Frame Link="pelvis"/>
+        </EndEffector>
       </EffPosition>
       <EffOrientation Name="StraightBack">
-          <EndEffector>
-              <Frame Link="pelvis"/>
-              <Frame Link="torso"/>
-          </EndEffector>
+        <EndEffector>
+          <Frame Link="pelvis"/>
+          <Frame Link="torso"/>
+        </EndEffector>
       </EffOrientation>
       <EffFrame Name="FootPosition">
-          <EndEffector>
-              <Frame Link="leftFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 0.1 0"/>
-              <Frame Link="rightFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 -0.1 0"/>
-          </EndEffector>
+        <EndEffector>
+          <Frame Link="leftFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 0.1 0"/>
+          <Frame Link="rightFoot" LinkOffset="0.052 0.0 -0.09" BaseOffset="0 -0.1 0"/>
+        </EndEffector>
       </EffFrame>
       <QuasiStatic Name="Stability" PositiveOnly="1" Debug="1">
-          <EndEffector>
-              <Frame Link="leftFoot_collision_5"/>
-              <Frame Link="leftFoot_collision_6"/>
-              <Frame Link="leftFoot_collision_7"/>
-              <Frame Link="leftFoot_collision_8"/>
-              <Frame Link="rightFoot_collision_5"/>
-              <Frame Link="rightFoot_collision_6"/>
-              <Frame Link="rightFoot_collision_7"/>
-              <Frame Link="rightFoot_collision_8"/>
-          </EndEffector>
+        <EndEffector>
+          <Frame Link="leftFoot_collision_5"/>
+          <Frame Link="leftFoot_collision_6"/>
+          <Frame Link="leftFoot_collision_7"/>
+          <Frame Link="leftFoot_collision_8"/>
+          <Frame Link="rightFoot_collision_5"/>
+          <Frame Link="rightFoot_collision_6"/>
+          <Frame Link="rightFoot_collision_7"/>
+          <Frame Link="rightFoot_collision_8"/>
+        </EndEffector>
       </QuasiStatic>
       <Identity Name="Pose">
-          <JointRef>0.00062 -0.00027 -0.00872 0.3002 -1.25 0 -0.7854 1.571 0 0 0 0 0 0.3002 1.25 0 0.7854 1.571 0 0</JointRef>
-          <JointMap>18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37</JointMap>
+        <JointRef>0.00062 -0.00027 -0.00872 0.3002 -1.25 0 -0.7854 1.571 0 0 0 0 0 0.3002 1.25 0 0.7854 1.571 0 0</JointRef>
+        <JointMap>18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37</JointMap>
       </Identity>
     </Maps>
     <Cost>

--- a/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
+++ b/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
-  <!--<BayesianIK Name="IK" MaxIterations="20" MaxBacktrackIterations="5" MinStep="1e-5" FunctionTolerance="1e-5" StepTolerance="1e-5"/>-->
-  <IKsolver Name="MySolver">
+  <!--<BayesianIK Name="Bayesian" MaxIterations="20" MaxBacktrackIterations="10" />-->
+  <IKsolver Name="IK">
     <MaxIterations>100</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-8</Tolerance>
-    <Alpha>0.01</Alpha>
-    <C>1e-4</C>
+    <Alpha>0.05</Alpha>
+    <C>1e-3</C>
   </IKsolver>
   
   <UnconstrainedEndPoseProblem>
@@ -56,7 +56,7 @@
     </Maps>
     <Cost>
       <Task Task="CoM" Rho="1e-1"/>
-      <Task Task="Stability" Rho="1e0"/>
+      <Task Task="Stability" Rho="1e1"/>
       <Task Task="FootPosition" Rho="1e3"/>
       <Task Task="StraightBack" Rho="1e0"/>
       <Task Task="Pose" Rho="1e3"/>

--- a/examples/exotica_examples/scripts/example_ik_valkyrie.py
+++ b/examples/exotica_examples/scripts/example_ik_valkyrie.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from pyexotica.publish_trajectory import *
+from time import sleep
+
+def com(t):
+    return array([-0.1, math.sin(t * 0.5 * math.pi) * 0.3, 0.9])
+
+exo.Setup.initRos()
+(sol, prob)=exo.Initializers.loadXMLFull('{exotica_examples}/resources/configs/ik_quasistatic_valkyrie.xml')
+problem = exo.Setup.createProblem(prob)
+solver = exo.Setup.createSolver(sol)
+solver.specifyProblem(problem)
+
+tick = exo.Timer()
+t=0.0;
+q=problem.startState
+print('Publishing IK')
+signal.signal(signal.SIGINT, sigIntHandler)
+pose=[0]*20;
+while True:
+    try:
+        problem.setGoal('CoM',com(tick.getDuration()))
+        pose[3]=math.sin(tick.getDuration() * 0.25 * math.pi)*0.8;
+        pose[13]=-math.sin(tick.getDuration() * 0.25 * math.pi)*0.8;
+        problem.setGoal('Pose',pose)
+        problem.startState = q
+        q = solver.solve()[0]
+        publishPose(q, problem)
+    except KeyboardInterrupt:
+        break
+

--- a/examples/exotica_examples/scripts/example_ik_valkyrie.py
+++ b/examples/exotica_examples/scripts/example_ik_valkyrie.py
@@ -22,6 +22,13 @@ q=problem.startState
 print('Publishing IK')
 signal.signal(signal.SIGINT, sigIntHandler)
 pose=[0]*20;
+stability=None
+for task in problem.getTasks():
+    if task.getName()=='Stability':
+        stability=task
+        break
+if not stability:
+    quit(2)
 while True:
     try:
         problem.setGoal('CoM',com(tick.getDuration()))
@@ -29,7 +36,10 @@ while True:
         pose[13]=-math.sin(tick.getDuration() * 0.25 * math.pi)*0.8;
         problem.setGoal('Pose',pose)
         problem.startState = q
+        stability.debugMode=False
         q = solver.solve()[0]
+        stability.debugMode=True
+        problem.update(q)
         publishPose(q, problem)
     except KeyboardInterrupt:
         break

--- a/examples/exotica_examples/scripts/example_ik_valkyrie.py
+++ b/examples/exotica_examples/scripts/example_ik_valkyrie.py
@@ -1,46 +1,47 @@
 #!/usr/bin/env python
 
-import pyexotica as exo
-from numpy import array
-from numpy import matrix
 import math
-from pyexotica.publish_trajectory import *
 from time import sleep
+
+import pyexotica as exo
+from numpy import array, matrix
+from pyexotica.publish_trajectory import *
+
 
 def com(t):
     return array([-0.1, math.sin(t * 0.5 * math.pi) * 0.3, 0.9])
 
+
 exo.Setup.initRos()
-(sol, prob)=exo.Initializers.loadXMLFull('{exotica_examples}/resources/configs/ik_quasistatic_valkyrie.xml')
+(sol, prob) = exo.Initializers.loadXMLFull('{exotica_examples}/resources/configs/ik_quasistatic_valkyrie.xml')
 problem = exo.Setup.createProblem(prob)
 solver = exo.Setup.createSolver(sol)
 solver.specifyProblem(problem)
 
 tick = exo.Timer()
-t=0.0;
-q=problem.startState
+t = 0.0
+q = problem.startState
 print('Publishing IK')
 signal.signal(signal.SIGINT, sigIntHandler)
-pose=[0]*20;
-stability=None
+pose = [0] * 20
+stability = None
 for task in problem.getTasks():
-    if task.getName()=='Stability':
-        stability=task
+    if task.getName() == 'Stability':
+        stability = task
         break
 if not stability:
     quit(2)
 while True:
     try:
-        problem.setGoal('CoM',com(tick.getDuration()))
-        pose[3]=math.sin(tick.getDuration() * 0.25 * math.pi)*0.8;
-        pose[13]=-math.sin(tick.getDuration() * 0.25 * math.pi)*0.8;
-        problem.setGoal('Pose',pose)
+        problem.setGoal('CoM', com(tick.getDuration()))
+        pose[3] = math.sin(tick.getDuration() * 0.25 * math.pi) * 0.8
+        pose[13] = -math.sin(tick.getDuration() * 0.25 * math.pi) * 0.8
+        problem.setGoal('Pose', pose)
         problem.startState = q
-        stability.debugMode=False
+        stability.debugMode = False
         q = solver.solve()[0]
-        stability.debugMode=True
+        stability.debugMode = True
         problem.update(q)
         publishPose(q, problem)
     except KeyboardInterrupt:
         break
-

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -746,10 +746,11 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem);
+        testJacobian(problem, 1e-3, 1e-8);
     }
 
-    {
+    // TODO(VladimirIvan): Re-enable
+    /*{
         HIGHLIGHT("QuasiStatic test outside capped");
         Initializer map("exotica/QuasiStatic", {
                                                    {"Name", std::string("MyTask")},
@@ -761,8 +762,8 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem);
-    }
+        testJacobian(problem, 1e-2, 1e-8);
+    }*/
 
     {
         HIGHLIGHT("QuasiStatic test inside");
@@ -776,7 +777,7 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem);
+        testJacobian(problem, 1e-3, 1e-8);
     }
 
     {
@@ -791,7 +792,7 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem);
+        testJacobian(problem, 1e-2, 1e-8);
     }
 }
 

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -732,6 +732,73 @@ void testPoint2Plane()
     }
 }
 
+void testQuasiStatic()
+{
+    {
+        HIGHLIGHT("QuasiStatic test inside capped");
+        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
+                                                {"PositiveOnly", true},
+                                        {"EndEffector", std::vector<Initializer>({
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")} })
+                                         })},
+                                        });
+        UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+        testRandom(problem);
+        testJacobian(problem);
+    }
+
+    {
+        HIGHLIGHT("QuasiStatic test outside capped");
+        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
+                                                {"PositiveOnly", true},
+                                        {"EndEffector", std::vector<Initializer>({
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")} })
+                                         })},
+                                        });
+        UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+        testRandom(problem);
+        testJacobian(problem);
+    }
+
+    {
+        HIGHLIGHT("QuasiStatic test inside");
+        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
+                                                {"PositiveOnly", false},
+                                        {"EndEffector", std::vector<Initializer>({
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")} })
+                                         })},
+                                        });
+        UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+        testRandom(problem);
+        testJacobian(problem);
+    }
+
+    {
+        HIGHLIGHT("QuasiStatic test outside");
+        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
+                                                {"PositiveOnly", false},
+                                        {"EndEffector", std::vector<Initializer>({
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")} }),
+                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")} })
+                                         })},
+                                        });
+        UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+        testRandom(problem);
+        testJacobian(problem);
+    }
+}
+
 int main(int argc, char** argv)
 {
     ros::init(argc, argv, "EXOTica_test_maps");
@@ -747,6 +814,7 @@ int main(int argc, char** argv)
     testCoM();
     testIMesh();
     testPoint2Plane();
+    testQuasiStatic();
     Setup::Destroy();
     return 0;
 }

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -739,18 +739,17 @@ void testQuasiStatic()
         Initializer map("exotica/QuasiStatic", {
                                                    {"Name", std::string("MyTask")},
                                                    {"PositiveOnly", true},
-                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")}})})},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-3 3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-3 -3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("3 -3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("3 3 0")}})})},
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem, 1e-3, 1e-8);
+        testJacobian(problem, 1e-5, 1e-5);
     }
 
-    // TODO(VladimirIvan): Re-enable
-    /*{
+    {
         HIGHLIGHT("QuasiStatic test outside capped");
         Initializer map("exotica/QuasiStatic", {
                                                    {"Name", std::string("MyTask")},
@@ -762,22 +761,22 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem, 1e-2, 1e-8);
-    }*/
+        testJacobian(problem, 1e-5, 1e-5);
+    }
 
     {
         HIGHLIGHT("QuasiStatic test inside");
         Initializer map("exotica/QuasiStatic", {
                                                    {"Name", std::string("MyTask")},
                                                    {"PositiveOnly", false},
-                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")}}),
-                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")}})})},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-3 3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-3 -3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("3 -3 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("3 3 0")}})})},
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem, 1e-3, 1e-8);
+        testJacobian(problem, 1e-5, 1e-5);
     }
 
     {
@@ -792,7 +791,7 @@ void testQuasiStatic()
                                                });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
-        testJacobian(problem, 1e-2, 1e-8);
+        testJacobian(problem, 1e-5, 1e-5);
     }
 }
 

--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -736,15 +736,14 @@ void testQuasiStatic()
 {
     {
         HIGHLIGHT("QuasiStatic test inside capped");
-        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
-                                                {"PositiveOnly", true},
-                                        {"EndEffector", std::vector<Initializer>({
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")} })
-                                         })},
-                                        });
+        Initializer map("exotica/QuasiStatic", {
+                                                   {"Name", std::string("MyTask")},
+                                                   {"PositiveOnly", true},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")}})})},
+                                               });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
         testJacobian(problem);
@@ -752,15 +751,14 @@ void testQuasiStatic()
 
     {
         HIGHLIGHT("QuasiStatic test outside capped");
-        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
-                                                {"PositiveOnly", true},
-                                        {"EndEffector", std::vector<Initializer>({
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")} })
-                                         })},
-                                        });
+        Initializer map("exotica/QuasiStatic", {
+                                                   {"Name", std::string("MyTask")},
+                                                   {"PositiveOnly", true},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")}})})},
+                                               });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
         testJacobian(problem);
@@ -768,15 +766,14 @@ void testQuasiStatic()
 
     {
         HIGHLIGHT("QuasiStatic test inside");
-        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
-                                                {"PositiveOnly", false},
-                                        {"EndEffector", std::vector<Initializer>({
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")} })
-                                         })},
-                                        });
+        Initializer map("exotica/QuasiStatic", {
+                                                   {"Name", std::string("MyTask")},
+                                                   {"PositiveOnly", false},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-1 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("1 1 0")}})})},
+                                               });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
         testJacobian(problem);
@@ -784,15 +781,14 @@ void testQuasiStatic()
 
     {
         HIGHLIGHT("QuasiStatic test outside");
-        Initializer map("exotica/QuasiStatic", {{"Name", std::string("MyTask")},
-                                                {"PositiveOnly", false},
-                                        {"EndEffector", std::vector<Initializer>({
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")} }),
-                                         Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")} })
-                                         })},
-                                        });
+        Initializer map("exotica/QuasiStatic", {
+                                                   {"Name", std::string("MyTask")},
+                                                   {"PositiveOnly", false},
+                                                   {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-11 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 -1 0")}}),
+                                                                                             Initializer("Frame", {{"Link", std::string("")}, {"LinkOffset", std::string("-10 1 0")}})})},
+                                               });
         UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
         testRandom(problem);
         testJacobian(problem);

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -593,7 +593,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
         }
     }
 
-    if (shapes1.size() == 0) return data.Proxies; //throw_pretty("Can't find object '" << o1 << "'!");
+    if (shapes1.size() == 0) return data.Proxies;  //throw_pretty("Can't find object '" << o1 << "'!");
 
     // There are no objects o1 is allowed to collide with, return the empty proxies vector
     if (shapes2.size() == 0) return data.Proxies;

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -24,6 +24,7 @@ AddInitializer(
   Sphere
   CollisionCheck
   Point2Plane
+  QuasiStatic
 )
 GenInitializers()
 
@@ -52,10 +53,10 @@ set(SOURCES
     src/Point2Plane.cpp
     src/Identity.cpp
     src/SphereCollision.cpp
-    src/CollisionCheck.cpp)
+    src/CollisionCheck.cpp
+    src/QuasiStatic.cpp)
 
 add_library(${PROJECT_NAME} ${SOURCES})
-
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -41,4 +41,7 @@
   <class name="exotica/CollisionCheck" type="exotica::CollisionCheck" base_class_type="exotica::TaskMap">
     <description>Collision checking</description>
   </class>
+  <class name="exotica/QuasiStatic" type="exotica::QuasiStatic" base_class_type="exotica::TaskMap">
+    <description>Plannar quasi static cost/constraint</description>
+  </class>
 </library>

--- a/exotations/task_maps/task_map/include/task_map/ConvexHull.h
+++ b/exotations/task_maps/task_map/include/task_map/ConvexHull.h
@@ -1,0 +1,85 @@
+#ifndef CONVEXHULL_H
+#define CONVEXHULL_H
+
+#include "exotica/Tools.h"
+#include "Eigen/Dense"
+
+namespace exotica
+{
+
+double lineDist2D(Eigen::VectorXdRefConst p1, Eigen::VectorXdRefConst p2, Eigen::VectorXdRefConst p)
+{
+    return (p(1) - p1(1)) * (p2(0) - p1(0)) -
+           (p2(1) - p1(1)) * (p(0) - p1(0));
+}
+
+
+std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoints, int p1, int p2)
+{
+    int ind = -1;
+    double max_dist = 0;
+    std::list<int> newHalfPoints;
+    for (int i : halfPoints)
+    {
+        double d = lineDist2D(points.row(p1), points.row(p2), points.row(i));
+        if (d>0.0)
+        {
+            newHalfPoints.push_back(i);
+        }
+        if (d > max_dist)
+        {
+            ind = i;
+            max_dist = d;
+        }
+    }
+
+    std::list<int> hull;
+
+    if (ind == -1)
+    {
+        hull.push_back(p2);
+    }
+    else
+    {
+        hull.splice(hull.begin(), quickHull(points, newHalfPoints, p1, ind));
+        hull.splice(hull.end(), quickHull(points, newHalfPoints, ind, p2));
+    }
+    return hull;
+}
+
+std::list<int> convexHull2D(Eigen::MatrixXdRefConst points)
+{
+    if (points.cols()!=2) throw_pretty("Input must contain 2D points!");
+
+    int n = points.rows();
+
+    std::list<int> hull;
+    std::list<int> halfPoints;
+
+    if (n < 3)
+    {
+        for(int i=0; i<n; i++) hull.push_back(i);
+    }
+    else
+    {
+        int min_x = 0, max_x = 0;
+        halfPoints.push_back(0);
+        for (int i=1; i<n; i++)
+        {
+            if (points(i,0) < points(min_x,0))
+                min_x = i;
+            if (points(i,0) > points(max_x,0))
+                max_x = i;
+            halfPoints.push_back(i);
+        }
+        hull.splice(hull.begin(), quickHull(points, halfPoints, min_x, max_x));
+        hull.splice(hull.end(), quickHull(points, halfPoints, max_x, min_x));
+    }
+    return hull;
+}
+
+
+
+}
+
+#endif // CONVEXHULL_H

--- a/exotations/task_maps/task_map/include/task_map/ConvexHull.h
+++ b/exotations/task_maps/task_map/include/task_map/ConvexHull.h
@@ -20,7 +20,7 @@ std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoi
     for (int i : halfPoints)
     {
         double d = lineDist2D(points.row(p1), points.row(p2), points.row(i));
-        if (d > 0.0)
+        if (d >= 0.0)
         {
             newHalfPoints.push_back(i);
         }

--- a/exotations/task_maps/task_map/include/task_map/ConvexHull.h
+++ b/exotations/task_maps/task_map/include/task_map/ConvexHull.h
@@ -1,18 +1,16 @@
 #ifndef CONVEXHULL_H
 #define CONVEXHULL_H
 
-#include "exotica/Tools.h"
 #include "Eigen/Dense"
+#include "exotica/Tools.h"
 
 namespace exotica
 {
-
 double lineDist2D(Eigen::VectorXdRefConst p1, Eigen::VectorXdRefConst p2, Eigen::VectorXdRefConst p)
 {
     return (p(1) - p1(1)) * (p2(0) - p1(0)) -
            (p2(1) - p1(1)) * (p(0) - p1(0));
 }
-
 
 std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoints, int p1, int p2)
 {
@@ -22,7 +20,7 @@ std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoi
     for (int i : halfPoints)
     {
         double d = lineDist2D(points.row(p1), points.row(p2), points.row(i));
-        if (d>0.0)
+        if (d > 0.0)
         {
             newHalfPoints.push_back(i);
         }
@@ -49,7 +47,7 @@ std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoi
 
 std::list<int> convexHull2D(Eigen::MatrixXdRefConst points)
 {
-    if (points.cols()!=2) throw_pretty("Input must contain 2D points!");
+    if (points.cols() != 2) throw_pretty("Input must contain 2D points!");
 
     int n = points.rows();
 
@@ -58,17 +56,17 @@ std::list<int> convexHull2D(Eigen::MatrixXdRefConst points)
 
     if (n < 3)
     {
-        for(int i=0; i<n; i++) hull.push_back(i);
+        for (int i = 0; i < n; i++) hull.push_back(i);
     }
     else
     {
         int min_x = 0, max_x = 0;
         halfPoints.push_back(0);
-        for (int i=1; i<n; i++)
+        for (int i = 1; i < n; i++)
         {
-            if (points(i,0) < points(min_x,0))
+            if (points(i, 0) < points(min_x, 0))
                 min_x = i;
-            if (points(i,0) > points(max_x,0))
+            if (points(i, 0) > points(max_x, 0))
                 max_x = i;
             halfPoints.push_back(i);
         }
@@ -77,9 +75,6 @@ std::list<int> convexHull2D(Eigen::MatrixXdRefConst points)
     }
     return hull;
 }
-
-
-
 }
 
-#endif // CONVEXHULL_H
+#endif  // CONVEXHULL_H

--- a/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
+++ b/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
@@ -1,0 +1,71 @@
+/*
+ *      Author: Vladimir Ivan
+ *
+ * Copyright (c) 2017, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef QuasiStatic_H_
+#define QuasiStatic_H_
+
+#include <exotica/KinematicTree.h>
+#include <exotica/TaskMap.h>
+#include <task_map/QuasiStaticInitializer.h>
+#include <visualization_msgs/MarkerArray.h>
+
+namespace exotica
+{
+class QuasiStatic : public TaskMap, public Instantiable<QuasiStaticInitializer>
+{
+public:
+    QuasiStatic();
+    virtual ~QuasiStatic();
+
+    virtual void Instantiate(QuasiStaticInitializer& init);
+
+    virtual void assignScene(Scene_ptr scene);
+
+    void Initialize();
+
+    void InitDebug();
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+
+    virtual int taskSpaceDim();
+
+private:
+    QuasiStaticInitializer init_;
+    Scene_ptr scene_;
+    visualization_msgs::MarkerArray debug_msg;
+    ros::Publisher debug_pub;
+};
+}
+
+#endif /* QuasiStatic_H_ */

--- a/exotations/task_maps/task_map/init/QuasiStatic.in
+++ b/exotations/task_maps/task_map/init/QuasiStatic.in
@@ -1,0 +1,2 @@
+extend <exotica/TaskMap>
+Optional bool PositiveOnly = true;

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -1,0 +1,396 @@
+/*
+ *      Author: Vladimir Ivan
+ *
+ * Copyright (c) 2017, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "task_map/QuasiStatic.h"
+#include "task_map/ConvexHull.h"
+#include <math.h>
+
+REGISTER_TASKMAP_TYPE("QuasiStatic", exotica::QuasiStatic);
+
+namespace exotica
+{
+
+constexpr double eps = 1e-6;
+
+QuasiStatic::QuasiStatic()
+{
+}
+
+QuasiStatic::~QuasiStatic()
+{
+}
+
+///
+/// \brief cross 2D cross product (z coordinate of a 3D cross product of 2 vectors on a xy plane).
+/// \param a 2D Vector.
+/// \param b 2D Vector.
+/// \return 2D cross product.
+///
+double cross(Eigen::VectorXdRefConst a, Eigen::VectorXdRefConst b)
+{
+    return a(0)*b(1)-a(1)*b(0);
+}
+
+///
+/// \brief potential Calculates electrostatic potential at pont P induced by a uniformly charged line AB.
+/// \param phi Potential.
+/// \param A 1st point on the line.
+/// \param B 2nd point on the line.
+/// \param P Query point.
+///
+void potential(double& phi, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P)
+{
+    double C = A.dot(B) - A.dot(P) + B.dot(P) - B.dot(B);
+    double D = -A.dot(B) - A.dot(P) + B.dot(P) + A.dot(A);
+    double E = cross(A,B) - cross(A,P) + cross(B,P);
+    if (fabs(E)<=eps)
+    {
+        phi=0.0;
+    }
+    else
+    {
+        phi = (atan(C/E)-atan(D/E))/E;
+    }
+}
+
+///
+/// \brief potential Calculates electrostatic potential at pont P induced by a uniformly charged line AB.
+/// \param phi Potential.
+/// \param J Gradient of the potential.
+/// \param A 1st point on the line.
+/// \param B 2nd point on the line.
+/// \param P Query point.
+/// \param A_ Derivative of 1st point on the line.
+/// \param B_ Derivative of 2nd point on the line.
+/// \param P_ Derivative of query point.
+///
+void potential(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P, Eigen::MatrixXdRefConst A_, Eigen::MatrixXdRefConst B_, Eigen::MatrixXdRefConst P_)
+{
+    double C = A.dot(B) - A.dot(P) + B.dot(P) - B.dot(B);
+    double D = -A.dot(B) - A.dot(P) + B.dot(P) + A.dot(A);
+    double E = cross(A,B) - cross(A,P) + cross(B,P);
+    if (fabs(E)<=eps)
+    {
+        phi=0.0;
+        J.setZero();
+    }
+    else
+    {
+        phi = (atan(C/E)-atan(D/E))/E;
+        for(int i=0; i<J.rows(); i++)
+        {
+            double C_ = A_.col(i).dot(B)+A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) - 2*B_.col(i).dot(B);
+            double D_ = -A_.col(i).dot(B)-A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) + 2*A_.col(i).dot(A);
+            double E_ = cross(A_.col(i),B)+cross(A,B_.col(i)) - cross(A_.col(i),P)-cross(A,P_.col(i)) + cross(B_.col(i),P)+cross(B,P_.col(i));
+            J(i) = ((E_*C/E/E + C_/E)/(C*C/E/E+1)-(E_*D/E/E + D_/E)/(D*D/E/E+1))/E-E_/E*phi;
+        }
+    }
+}
+
+///
+/// \brief winding Calculates the winding number around pont P w.r.t. thw line AB.
+/// \param phi Winding number.
+/// \param A 1st point on the line.
+/// \param B 2nd point on the line.
+/// \param P Query point.
+///
+void winding(double& phi, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P)
+{
+    double C = cross(A-P,B-P);
+    double D = (A-P).dot(B-P);
+    phi = atan2(C,D)/2.0/M_PI;
+}
+
+///
+/// \brief winding Calculates the winding number around pont P w.r.t. thw line AB.
+/// \param phi Winding number.
+/// \param J Gradient of the Winding number.
+/// \param A 1st point on the line.
+/// \param B 2nd point on the line.
+/// \param P Query point.
+/// \param A_ Derivative of 1st point on the line.
+/// \param B_ Derivative of 2nd point on the line.
+/// \param P_ Derivative of query point.
+///
+void winding(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P, Eigen::MatrixXdRefConst A_, Eigen::MatrixXdRefConst B_, Eigen::MatrixXdRefConst P_)
+{
+    double C = cross(A-P,B-P);
+    double D = (A-P).dot(B-P);
+    phi = atan2(C,D)/2.0/M_PI;
+    for(int i=0; i<J.rows(); i++)
+    {
+        double C_ = cross(A_.col(i)-P_.col(i),B-P)+cross(A-P,B_.col(i)-P_.col(i));
+        double D_ = (A_.col(i)-P_.col(i)).dot(B-P) + (A-P).dot(B_.col(i)-P_.col(i));
+        J(i) = (C_*D-C*D_)/(C*C+D*D)/2.0/M_PI;
+    }
+}
+
+void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != 1) throw_named("Wrong size of phi!");
+    phi(0) = 0.0;
+    KDL::Vector KDLcom;
+    double M = 0.0;
+    for (std::weak_ptr<KinematicElement> welement : scene_->getSolver().getTree())
+    {
+        std::shared_ptr<KinematicElement> element = welement.lock();
+        if (element->isRobotLink || element->ClosestRobotLink.lock()) // Only for robot links and attached objects
+        {
+            double mass = element->Segment.getInertia().getMass();
+            if (mass>0)
+            {
+                KDL::Frame cog = KDL::Frame(element->Segment.getInertia().getCOG());
+                KDL::Frame com_local = scene_->getSolver().FK(element, cog, nullptr, KDL::Frame());
+                KDLcom += com_local.p * mass;
+                M += mass;
+            }
+        }
+    }
+    if (M == 0.0) return;
+    KDLcom = KDLcom / M;
+    Eigen::VectorXd com(2);
+    com(0) = KDLcom[0];
+    com(1) = KDLcom[1];
+
+
+
+    Eigen::MatrixXd supports(Kinematics.Phi.rows(),2);
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    {
+        supports(i,0) = Kinematics.Phi(i).p[0];
+        supports(i,1) = Kinematics.Phi(i).p[1];
+    }
+
+    std::list<int> hull = convexHull2D(supports);
+
+    double n = hull.size();
+    double wnd = 0.0;
+    double pot=0.0;
+    double tmp;
+    for (std::list<int>::iterator it=hull.begin(); it != hull.end(); )
+    {
+        int a = *it;
+        int b = ++it==hull.end()?*hull.begin():*(it);
+        potential(tmp, supports.row(a), supports.row(b), com);
+        pot+=tmp;
+        winding(tmp, supports.row(a), supports.row(b), com);
+        wnd+=tmp;
+    }
+    wnd=fabs(wnd);
+
+    if(pot<eps)
+    {
+        if(wnd<0.5)
+        {
+            phi(0)=-sqrt(-n/pot);
+        }
+        else
+        {
+            if(!init_.PositiveOnly)
+            {
+                phi(0)=sqrt(-n/pot);
+            }
+        }
+    }
+
+    if (debug_)
+    {
+        debug_msg.markers[0].pose.position.x = com(0);
+        debug_msg.markers[0].pose.position.y = com(1);
+        debug_msg.markers[0].pose.position.z = 0.0;
+
+        debug_msg.markers[1].points.resize(hull.size()+1);
+        int ii=0;
+        for(int i : hull)
+        {
+            debug_msg.markers[1].points[ii].x = supports(i,0);
+            debug_msg.markers[1].points[ii].y = supports(i,1);
+            debug_msg.markers[1].points[ii++].z = 0.0;
+        }
+        debug_msg.markers[1].points[hull.size()] = debug_msg.markers[1].points[0];
+
+        debug_pub.publish(debug_msg);
+    }
+}
+
+void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (phi.rows() != 1) throw_named("Wrong size of phi!");
+    if (J.rows() != 1 || J.cols() != x.rows()) throw_named("Wrong size of J! " << x.rows());
+    phi(0) = 0.0;
+    J.setZero();
+    Eigen::MatrixXd Jcom = Eigen::MatrixXd::Zero(2, J.cols());
+    KDL::Vector KDLcom;
+    double M = 0.0;
+    for (std::weak_ptr<KinematicElement> welement : scene_->getSolver().getTree())
+    {
+        std::shared_ptr<KinematicElement> element = welement.lock();
+        if (element->isRobotLink || element->ClosestRobotLink.lock()) // Only for robot links and attached objects
+        {
+            double mass = element->Segment.getInertia().getMass();
+            if (mass>0)
+            {
+                KDL::Frame cog = KDL::Frame(element->Segment.getInertia().getCOG());
+                KDL::Frame com_local = scene_->getSolver().FK(element, cog, nullptr, KDL::Frame());
+                Eigen::MatrixXd Jcom_local = scene_->getSolver().Jacobian(element, cog, nullptr, KDL::Frame());
+                KDLcom += com_local.p * mass;
+                Jcom += Jcom_local.topRows(2) * mass;
+                M += mass;
+            }
+        }
+    }
+    if (M == 0.0) return;
+    KDLcom = KDLcom / M;
+    Eigen::VectorXd com(2);
+    com(0) = KDLcom[0];
+    com(1) = KDLcom[1];
+    Jcom = Jcom / M;
+
+
+
+    Eigen::MatrixXd supports(Kinematics.Phi.rows(),2);
+    Eigen::MatrixXd supportsJ(Kinematics.Phi.rows()*2,x.rows());
+    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    {
+        supports(i,0) = Kinematics.Phi(i).p[0];
+        supports(i,1) = Kinematics.Phi(i).p[1];
+        supportsJ.middleRows(i*2, 2) = Kinematics.J(i).data.topRows(2);
+    }
+
+    std::list<int> hull = convexHull2D(supports);
+
+    double n = hull.size();
+    double wnd = 0.0;
+    double pot=0.0;
+    Eigen::VectorXd potJ=J.row(0);
+    double tmp;
+    Eigen::VectorXd tmpJ=J.row(0);
+    for (std::list<int>::iterator it=hull.begin(); it != hull.end(); )
+    {
+        int a = *it;
+        int b = ++it==hull.end()?*hull.begin():*(it);
+        potential(tmp, tmpJ, supports.row(a), supports.row(b), com, supportsJ.middleRows(a*2,2), supportsJ.middleRows(b*2,2), Jcom);
+        pot+=tmp;
+        potJ+=tmpJ;
+        winding(tmp, supports.row(a), supports.row(b), com);
+        wnd+=tmp;
+    }
+    wnd=fabs(wnd);
+
+    if(pot<eps)
+    {
+        if(wnd<0.5)
+        {
+            phi(0)=-sqrt(-n/pot);
+            J.row(0) = potJ*(n/(2*pot*pot*phi(0)));
+        }
+        else
+        {
+            if(!init_.PositiveOnly)
+            {
+                phi(0)=sqrt(-n/pot);
+                J.row(0) = -potJ*(n/(2*pot*pot*phi(0)));
+            }
+        }
+    }
+
+    if (debug_)
+    {
+        debug_msg.markers[0].pose.position.x = com(0);
+        debug_msg.markers[0].pose.position.y = com(1);
+        debug_msg.markers[0].pose.position.z = 0.0;
+
+        debug_msg.markers[1].points.resize(hull.size()+1);
+        int ii=0;
+        for(int i : hull)
+        {
+            debug_msg.markers[1].points[ii].x = supports(i,0);
+            debug_msg.markers[1].points[ii].y = supports(i,1);
+            debug_msg.markers[1].points[ii++].z = 0.0;
+        }
+        debug_msg.markers[1].points[hull.size()] = debug_msg.markers[1].points[0];
+
+        debug_pub.publish(debug_msg);
+    }
+}
+
+int QuasiStatic::taskSpaceDim()
+{
+    return 1;
+}
+
+void QuasiStatic::Initialize()
+{
+    {
+        visualization_msgs::Marker mrk;
+        mrk.action = visualization_msgs::Marker::ADD;
+        mrk.header.frame_id = "exotica/" + scene_->getRootFrameName();
+        mrk.id = 1;
+        mrk.type = visualization_msgs::Marker::SPHERE;
+        mrk.scale.x = mrk.scale.y = mrk.scale.z = 0.05;
+        mrk.color.r = 0;
+        mrk.color.g = 1;
+        mrk.color.b = 0;
+        mrk.color.a = 1;
+        debug_msg.markers.push_back(mrk);
+    }
+    {
+        visualization_msgs::Marker mrk;
+        mrk.action = visualization_msgs::Marker::ADD;
+        mrk.header.frame_id = "exotica/" + scene_->getRootFrameName();
+        mrk.id = 2;
+        mrk.type = visualization_msgs::Marker::LINE_STRIP;
+        mrk.color.r = 0;
+        mrk.color.g = 0;
+        mrk.color.b = 1;
+        mrk.color.a = 1;
+        mrk.scale.x = 0.02;
+        debug_msg.markers.push_back(mrk);
+    }
+    if (debug_)
+    {
+        debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ + "/exotica/QuasiStatic", 1, true);
+    }
+}
+
+void QuasiStatic::assignScene(Scene_ptr scene)
+{
+    scene_ = scene;
+    Initialize();
+}
+
+void QuasiStatic::Instantiate(QuasiStaticInitializer& init)
+{
+    init_ = init;
+}
+
+}

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -111,7 +111,7 @@ void potential(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eig
             double C_ = A_.col(i).dot(B)+A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) - 2*B_.col(i).dot(B);
             double D_ = -A_.col(i).dot(B)-A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) + 2*A_.col(i).dot(A);
             double E_ = cross(A_.col(i),B)+cross(A,B_.col(i)) - cross(A_.col(i),P)-cross(A,P_.col(i)) + cross(B_.col(i),P)+cross(B,P_.col(i));
-            J(i) = ((E_*C/E/E + C_/E)/(C*C/E/E+1)-(E_*D/E/E + D_/E)/(D*D/E/E+1))/E-E_/E*phi;
+            J(i) = ((C_/E - E_*C/E/E)/(C*C/E/E+1)-(D_/E - E_*D/E/E)/(D*D/E/E+1))/E- E_/E*phi;
         }
     }
 }
@@ -310,15 +310,15 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     {
         if(wnd<0.5)
         {
-            phi(0)=-sqrt(-n/pot);
+            phi(0)=sqrt(-n/pot);
             J.row(0) = potJ*(n/(2*pot*pot*phi(0)));
         }
         else
         {
             if(!init_.PositiveOnly)
             {
-                phi(0)=sqrt(-n/pot);
-                J.row(0) = -potJ*(n/(2*pot*pot*phi(0)));
+                phi(0)=-sqrt(-n/pot);
+                J.row(0) = potJ*(n/(2*pot*pot*phi(0)));
             }
         }
     }

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -289,10 +289,11 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     Eigen::VectorXd potJ = J.row(0);
     double tmp;
     Eigen::VectorXd tmpJ = J.row(0);
-    for (std::list<int>::iterator it = hull.begin(); it != hull.end();)
+    for (std::list<int>::iterator it = hull.begin(); it != hull.end(); it++)
     {
         int a = *it;
-        int b = ++it == hull.end() ? *hull.begin() : *(it);
+        int b = (it == hull.end()) ? *hull.begin() : *(std::next(it));
+        b = a;
         potential(tmp, tmpJ, supports.row(a), supports.row(b), com, supportsJ.middleRows(a * 2, 2), supportsJ.middleRows(b * 2, 2), Jcom);
         pot += tmp;
         potJ += tmpJ;

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -180,11 +180,11 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     com(0) = KDLcom[0];
     com(1) = KDLcom[1];
 
-    Eigen::MatrixXd supports(Kinematics.Phi.rows(), 2);
-    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    Eigen::MatrixXd supports(Kinematics[0].Phi.rows(), 2);
+    for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
     {
-        supports(i, 0) = Kinematics.Phi(i).p[0];
-        supports(i, 1) = Kinematics.Phi(i).p[1];
+        supports(i, 0) = Kinematics[0].Phi(i).p[0];
+        supports(i, 1) = Kinematics[0].Phi(i).p[1];
     }
 
     std::list<int> hull = convexHull2D(supports);
@@ -272,13 +272,13 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     com(1) = KDLcom[1];
     Jcom = Jcom / M;
 
-    Eigen::MatrixXd supports(Kinematics.Phi.rows(), 2);
-    Eigen::MatrixXd supportsJ(Kinematics.Phi.rows() * 2, x.rows());
-    for (int i = 0; i < Kinematics.Phi.rows(); i++)
+    Eigen::MatrixXd supports(Kinematics[0].Phi.rows(), 2);
+    Eigen::MatrixXd supportsJ(Kinematics[0].Phi.rows() * 2, x.rows());
+    for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
     {
-        supports(i, 0) = Kinematics.Phi(i).p[0];
-        supports(i, 1) = Kinematics.Phi(i).p[1];
-        supportsJ.middleRows(i * 2, 2) = Kinematics.J(i).data.topRows(2);
+        supports(i, 0) = Kinematics[0].Phi(i).p[0];
+        supports(i, 1) = Kinematics[0].Phi(i).p[1];
+        supportsJ.middleRows(i * 2, 2) = Kinematics[0].J(i).data.topRows(2);
     }
 
     std::list<int> hull = convexHull2D(supports);

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -31,14 +31,13 @@
  */
 
 #include "task_map/QuasiStatic.h"
-#include "task_map/ConvexHull.h"
 #include <math.h>
+#include "task_map/ConvexHull.h"
 
 REGISTER_TASKMAP_TYPE("QuasiStatic", exotica::QuasiStatic);
 
 namespace exotica
 {
-
 constexpr double eps = 1e-6;
 
 QuasiStatic::QuasiStatic()
@@ -57,7 +56,7 @@ QuasiStatic::~QuasiStatic()
 ///
 double cross(Eigen::VectorXdRefConst a, Eigen::VectorXdRefConst b)
 {
-    return a(0)*b(1)-a(1)*b(0);
+    return a(0) * b(1) - a(1) * b(0);
 }
 
 ///
@@ -71,14 +70,14 @@ void potential(double& phi, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B
 {
     double C = A.dot(B) - A.dot(P) + B.dot(P) - B.dot(B);
     double D = -A.dot(B) - A.dot(P) + B.dot(P) + A.dot(A);
-    double E = cross(A,B) - cross(A,P) + cross(B,P);
-    if (fabs(E)<=eps)
+    double E = cross(A, B) - cross(A, P) + cross(B, P);
+    if (fabs(E) <= eps)
     {
-        phi=0.0;
+        phi = 0.0;
     }
     else
     {
-        phi = (atan(C/E)-atan(D/E))/E;
+        phi = (atan(C / E) - atan(D / E)) / E;
     }
 }
 
@@ -97,21 +96,21 @@ void potential(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eig
 {
     double C = A.dot(B) - A.dot(P) + B.dot(P) - B.dot(B);
     double D = -A.dot(B) - A.dot(P) + B.dot(P) + A.dot(A);
-    double E = cross(A,B) - cross(A,P) + cross(B,P);
-    if (fabs(E)<=eps)
+    double E = cross(A, B) - cross(A, P) + cross(B, P);
+    if (fabs(E) <= eps)
     {
-        phi=0.0;
+        phi = 0.0;
         J.setZero();
     }
     else
     {
-        phi = (atan(C/E)-atan(D/E))/E;
-        for(int i=0; i<J.rows(); i++)
+        phi = (atan(C / E) - atan(D / E)) / E;
+        for (int i = 0; i < J.rows(); i++)
         {
-            double C_ = A_.col(i).dot(B)+A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) - 2*B_.col(i).dot(B);
-            double D_ = -A_.col(i).dot(B)-A.dot(B_.col(i)) - A_.col(i).dot(P)-A.dot(P_.col(i)) + B_.col(i).dot(P)+B.dot(P_.col(i)) + 2*A_.col(i).dot(A);
-            double E_ = cross(A_.col(i),B)+cross(A,B_.col(i)) - cross(A_.col(i),P)-cross(A,P_.col(i)) + cross(B_.col(i),P)+cross(B,P_.col(i));
-            J(i) = ((C_/E - E_*C/E/E)/(C*C/E/E+1)-(D_/E - E_*D/E/E)/(D*D/E/E+1))/E- E_/E*phi;
+            double C_ = A_.col(i).dot(B) + A.dot(B_.col(i)) - A_.col(i).dot(P) - A.dot(P_.col(i)) + B_.col(i).dot(P) + B.dot(P_.col(i)) - 2 * B_.col(i).dot(B);
+            double D_ = -A_.col(i).dot(B) - A.dot(B_.col(i)) - A_.col(i).dot(P) - A.dot(P_.col(i)) + B_.col(i).dot(P) + B.dot(P_.col(i)) + 2 * A_.col(i).dot(A);
+            double E_ = cross(A_.col(i), B) + cross(A, B_.col(i)) - cross(A_.col(i), P) - cross(A, P_.col(i)) + cross(B_.col(i), P) + cross(B, P_.col(i));
+            J(i) = ((C_ / E - E_ * C / E / E) / (C * C / E / E + 1) - (D_ / E - E_ * D / E / E) / (D * D / E / E + 1)) / E - E_ / E * phi;
         }
     }
 }
@@ -125,9 +124,9 @@ void potential(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eig
 ///
 void winding(double& phi, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P)
 {
-    double C = cross(A-P,B-P);
-    double D = (A-P).dot(B-P);
-    phi = atan2(C,D)/2.0/M_PI;
+    double C = cross(A - P, B - P);
+    double D = (A - P).dot(B - P);
+    phi = atan2(C, D) / 2.0 / M_PI;
 }
 
 ///
@@ -143,14 +142,14 @@ void winding(double& phi, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, 
 ///
 void winding(double& phi, Eigen::VectorXdRef J, Eigen::VectorXdRefConst A, Eigen::VectorXdRefConst B, Eigen::VectorXdRefConst P, Eigen::MatrixXdRefConst A_, Eigen::MatrixXdRefConst B_, Eigen::MatrixXdRefConst P_)
 {
-    double C = cross(A-P,B-P);
-    double D = (A-P).dot(B-P);
-    phi = atan2(C,D)/2.0/M_PI;
-    for(int i=0; i<J.rows(); i++)
+    double C = cross(A - P, B - P);
+    double D = (A - P).dot(B - P);
+    phi = atan2(C, D) / 2.0 / M_PI;
+    for (int i = 0; i < J.rows(); i++)
     {
-        double C_ = cross(A_.col(i)-P_.col(i),B-P)+cross(A-P,B_.col(i)-P_.col(i));
-        double D_ = (A_.col(i)-P_.col(i)).dot(B-P) + (A-P).dot(B_.col(i)-P_.col(i));
-        J(i) = (C_*D-C*D_)/(C*C+D*D)/2.0/M_PI;
+        double C_ = cross(A_.col(i) - P_.col(i), B - P) + cross(A - P, B_.col(i) - P_.col(i));
+        double D_ = (A_.col(i) - P_.col(i)).dot(B - P) + (A - P).dot(B_.col(i) - P_.col(i));
+        J(i) = (C_ * D - C * D_) / (C * C + D * D) / 2.0 / M_PI;
     }
 }
 
@@ -163,10 +162,10 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     for (std::weak_ptr<KinematicElement> welement : scene_->getSolver().getTree())
     {
         std::shared_ptr<KinematicElement> element = welement.lock();
-        if (element->isRobotLink || element->ClosestRobotLink.lock()) // Only for robot links and attached objects
+        if (element->isRobotLink || element->ClosestRobotLink.lock())  // Only for robot links and attached objects
         {
             double mass = element->Segment.getInertia().getMass();
-            if (mass>0)
+            if (mass > 0)
             {
                 KDL::Frame cog = KDL::Frame(element->Segment.getInertia().getCOG());
                 KDL::Frame com_local = scene_->getSolver().FK(element, cog, nullptr, KDL::Frame());
@@ -181,43 +180,41 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     com(0) = KDLcom[0];
     com(1) = KDLcom[1];
 
-
-
-    Eigen::MatrixXd supports(Kinematics.Phi.rows(),2);
+    Eigen::MatrixXd supports(Kinematics.Phi.rows(), 2);
     for (int i = 0; i < Kinematics.Phi.rows(); i++)
     {
-        supports(i,0) = Kinematics.Phi(i).p[0];
-        supports(i,1) = Kinematics.Phi(i).p[1];
+        supports(i, 0) = Kinematics.Phi(i).p[0];
+        supports(i, 1) = Kinematics.Phi(i).p[1];
     }
 
     std::list<int> hull = convexHull2D(supports);
 
     double n = hull.size();
     double wnd = 0.0;
-    double pot=0.0;
+    double pot = 0.0;
     double tmp;
-    for (std::list<int>::iterator it=hull.begin(); it != hull.end(); )
+    for (std::list<int>::iterator it = hull.begin(); it != hull.end();)
     {
         int a = *it;
-        int b = ++it==hull.end()?*hull.begin():*(it);
+        int b = ++it == hull.end() ? *hull.begin() : *(it);
         potential(tmp, supports.row(a), supports.row(b), com);
-        pot+=tmp;
+        pot += tmp;
         winding(tmp, supports.row(a), supports.row(b), com);
-        wnd+=tmp;
+        wnd += tmp;
     }
-    wnd=fabs(wnd);
+    wnd = fabs(wnd);
 
-    if(pot<eps)
+    if (pot < eps)
     {
-        if(wnd<0.5)
+        if (wnd < 0.5)
         {
-            phi(0)=-sqrt(-n/pot);
+            phi(0) = -sqrt(-n / pot);
         }
         else
         {
-            if(!init_.PositiveOnly)
+            if (!init_.PositiveOnly)
             {
-                phi(0)=sqrt(-n/pot);
+                phi(0) = sqrt(-n / pot);
             }
         }
     }
@@ -228,12 +225,12 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
         debug_msg.markers[0].pose.position.y = com(1);
         debug_msg.markers[0].pose.position.z = 0.0;
 
-        debug_msg.markers[1].points.resize(hull.size()+1);
-        int ii=0;
-        for(int i : hull)
+        debug_msg.markers[1].points.resize(hull.size() + 1);
+        int ii = 0;
+        for (int i : hull)
         {
-            debug_msg.markers[1].points[ii].x = supports(i,0);
-            debug_msg.markers[1].points[ii].y = supports(i,1);
+            debug_msg.markers[1].points[ii].x = supports(i, 0);
+            debug_msg.markers[1].points[ii].y = supports(i, 1);
             debug_msg.markers[1].points[ii++].z = 0.0;
         }
         debug_msg.markers[1].points[hull.size()] = debug_msg.markers[1].points[0];
@@ -254,10 +251,10 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     for (std::weak_ptr<KinematicElement> welement : scene_->getSolver().getTree())
     {
         std::shared_ptr<KinematicElement> element = welement.lock();
-        if (element->isRobotLink || element->ClosestRobotLink.lock()) // Only for robot links and attached objects
+        if (element->isRobotLink || element->ClosestRobotLink.lock())  // Only for robot links and attached objects
         {
             double mass = element->Segment.getInertia().getMass();
-            if (mass>0)
+            if (mass > 0)
             {
                 KDL::Frame cog = KDL::Frame(element->Segment.getInertia().getCOG());
                 KDL::Frame com_local = scene_->getSolver().FK(element, cog, nullptr, KDL::Frame());
@@ -275,50 +272,48 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     com(1) = KDLcom[1];
     Jcom = Jcom / M;
 
-
-
-    Eigen::MatrixXd supports(Kinematics.Phi.rows(),2);
-    Eigen::MatrixXd supportsJ(Kinematics.Phi.rows()*2,x.rows());
+    Eigen::MatrixXd supports(Kinematics.Phi.rows(), 2);
+    Eigen::MatrixXd supportsJ(Kinematics.Phi.rows() * 2, x.rows());
     for (int i = 0; i < Kinematics.Phi.rows(); i++)
     {
-        supports(i,0) = Kinematics.Phi(i).p[0];
-        supports(i,1) = Kinematics.Phi(i).p[1];
-        supportsJ.middleRows(i*2, 2) = Kinematics.J(i).data.topRows(2);
+        supports(i, 0) = Kinematics.Phi(i).p[0];
+        supports(i, 1) = Kinematics.Phi(i).p[1];
+        supportsJ.middleRows(i * 2, 2) = Kinematics.J(i).data.topRows(2);
     }
 
     std::list<int> hull = convexHull2D(supports);
 
     double n = hull.size();
     double wnd = 0.0;
-    double pot=0.0;
-    Eigen::VectorXd potJ=J.row(0);
+    double pot = 0.0;
+    Eigen::VectorXd potJ = J.row(0);
     double tmp;
-    Eigen::VectorXd tmpJ=J.row(0);
-    for (std::list<int>::iterator it=hull.begin(); it != hull.end(); )
+    Eigen::VectorXd tmpJ = J.row(0);
+    for (std::list<int>::iterator it = hull.begin(); it != hull.end();)
     {
         int a = *it;
-        int b = ++it==hull.end()?*hull.begin():*(it);
-        potential(tmp, tmpJ, supports.row(a), supports.row(b), com, supportsJ.middleRows(a*2,2), supportsJ.middleRows(b*2,2), Jcom);
-        pot+=tmp;
-        potJ+=tmpJ;
+        int b = ++it == hull.end() ? *hull.begin() : *(it);
+        potential(tmp, tmpJ, supports.row(a), supports.row(b), com, supportsJ.middleRows(a * 2, 2), supportsJ.middleRows(b * 2, 2), Jcom);
+        pot += tmp;
+        potJ += tmpJ;
         winding(tmp, supports.row(a), supports.row(b), com);
-        wnd+=tmp;
+        wnd += tmp;
     }
-    wnd=fabs(wnd);
+    wnd = fabs(wnd);
 
-    if(pot<eps)
+    if (pot < eps)
     {
-        if(wnd<0.5)
+        if (wnd < 0.5)
         {
-            phi(0)=sqrt(-n/pot);
-            J.row(0) = potJ*(n/(2*pot*pot*phi(0)));
+            phi(0) = sqrt(-n / pot);
+            J.row(0) = potJ * (n / (2 * pot * pot * phi(0)));
         }
         else
         {
-            if(!init_.PositiveOnly)
+            if (!init_.PositiveOnly)
             {
-                phi(0)=-sqrt(-n/pot);
-                J.row(0) = potJ*(n/(2*pot*pot*phi(0)));
+                phi(0) = -sqrt(-n / pot);
+                J.row(0) = potJ * (n / (2 * pot * pot * phi(0)));
             }
         }
     }
@@ -329,12 +324,12 @@ void QuasiStatic::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
         debug_msg.markers[0].pose.position.y = com(1);
         debug_msg.markers[0].pose.position.z = 0.0;
 
-        debug_msg.markers[1].points.resize(hull.size()+1);
-        int ii=0;
-        for(int i : hull)
+        debug_msg.markers[1].points.resize(hull.size() + 1);
+        int ii = 0;
+        for (int i : hull)
         {
-            debug_msg.markers[1].points[ii].x = supports(i,0);
-            debug_msg.markers[1].points[ii].y = supports(i,1);
+            debug_msg.markers[1].points[ii].x = supports(i, 0);
+            debug_msg.markers[1].points[ii].y = supports(i, 1);
             debug_msg.markers[1].points[ii++].z = 0.0;
         }
         debug_msg.markers[1].points[hull.size()] = debug_msg.markers[1].points[0];
@@ -392,5 +387,4 @@ void QuasiStatic::Instantiate(QuasiStaticInitializer& init)
 {
     init_ = init;
 }
-
 }


### PR DESCRIPTION
- New task map implementing signed distance of CoM inside a support polygon.
- The CoM is computed using all robot links.
- The support polygon is computed using quickhull from specified frames projected on the XY plane.
- The signed distance is a harmonic potential field based on the electrostatic field. The values inside the support polygon are negative and outside are positive. Inside/outside is distinguished using the winding number.
- The `PositiveOnly` caps the values to zero inside the support polygon. Use this for unconstrained optimisation. Inequality constraints can use the full equation.
- The debug mode will enable publishing a marker array showing the CoM and the support polygon.
- Test and example have been added.
- The example script requires the `val_description` package to be compiled but this is not an explicit dependency of the repo.