### PR TITLE
Disallow overwriting / corrupting exposed parameters without checks in Python

### DIFF
--- a/exotations/solvers/ompl_solver/include/ompl_solver/ompl_exo.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/ompl_exo.h
@@ -47,7 +47,7 @@
 #if OMPL_VERSION_VALUE >= 1004000  // Version greater than 1.4.0
 typedef Eigen::Ref<Eigen::VectorXd> OMPLProjection;
 #else  // All other versions
-typedef ompl::base::EuclideanProjection& OMPLProjection;
+typedef ompl::base::EuclideanProjection &OMPLProjection;
 #endif
 
 namespace exotica

--- a/exotations/solvers/ompl_solver/include/ompl_solver/ompl_solver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/ompl_solver.h
@@ -39,7 +39,7 @@
 
 typedef boost::function<ompl::base::PlannerPtr(const ompl::base::SpaceInformationPtr &si, const std::string &name)> ConfiguredPlannerAllocator;
 
-#if ROS_VERSION_MINIMUM(1, 12, 0) // if ROS version >= ROS_KINETIC
+#if ROS_VERSION_MINIMUM(1, 12, 0)  // if ROS version >= ROS_KINETIC
 template <class T, class T1>
 std::shared_ptr<T> ompl_cast(std::shared_ptr<T1> ptr)
 {

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_exo.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_exo.cpp
@@ -49,7 +49,7 @@ bool OMPLStateValidityChecker::isValid(const ompl::base::State *state, double &d
 {
     Eigen::VectorXd q(prob_->N);
 
-#if ROS_VERSION_MINIMUM(1, 12, 0) // if ROS version >= ROS_KINETIC
+#if ROS_VERSION_MINIMUM(1, 12, 0)  // if ROS version >= ROS_KINETIC
     std::static_pointer_cast<OMPLStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q);
 #else
     boost::static_pointer_cast<OMPLStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q);

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -91,7 +91,7 @@ bool OMPLTimeIndexedStateValidityChecker::isValid(const ompl::base::State *state
 {
     Eigen::VectorXd q(prob_->N);
     double t;
-#if ROS_VERSION_MINIMUM(1, 12, 0) // if ROS version >= ROS_KINETIC
+#if ROS_VERSION_MINIMUM(1, 12, 0)  // if ROS version >= ROS_KINETIC
     std::static_pointer_cast<OMPLTimeIndexedRNStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q, t);
 #else
     boost::static_pointer_cast<OMPLTimeIndexedRNStateSpace>(si_->getStateSpace())->OMPLToExoticaState(state, q, t);
@@ -278,7 +278,7 @@ void OMPLTimeIndexedRRTConnect::setup()
     tools::SelfConfig sc(si_, getName());
     sc.configurePlannerRange(maxDistance_);
 
-#if ROS_VERSION_MINIMUM(1, 12, 0) // if ROS version >= ROS_KINETIC
+#if ROS_VERSION_MINIMUM(1, 12, 0)  // if ROS version >= ROS_KINETIC
     if (!tStart_) tStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
     if (!tGoal_) tGoal_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
 #else

--- a/exotica/src/Server.cpp
+++ b/exotica/src/Server.cpp
@@ -61,7 +61,7 @@ void Server::destroy()
 robot_model::RobotModelPtr loadModelImpl(const std::string& urdf, const std::string& srdf)
 {
     rdf_loader::RDFLoader loader(urdf, srdf);
-#if ROS_VERSION_MINIMUM(1, 14, 0) // if ROS version >= ROS_MELODIC
+#if ROS_VERSION_MINIMUM(1, 14, 0)  // if ROS version >= ROS_MELODIC
     const std::shared_ptr<srdf::Model>& srdf_ = loader.getSRDF() ? loader.getSRDF() : std::shared_ptr<srdf::Model>(new srdf::Model());
 #else
     const boost::shared_ptr<srdf::Model>& srdf_ = loader.getSRDF() ? loader.getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -614,7 +614,7 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<TaskSpaceVector, std::shared_ptr<TaskSpaceVector>> taskSpaceVector(module, "TaskSpaceVector");
     taskSpaceVector.def("setZero", &TaskSpaceVector::setZero);
-    taskSpaceVector.def_readwrite("data", &TaskSpaceVector::data);
+    taskSpaceVector.def_readonly("data", &TaskSpaceVector::data);
     taskSpaceVector.def("__sub__", &TaskSpaceVector::operator-, py::is_operator());
     taskSpaceVector.def("__repr__", [](TaskSpaceVector* instance) { return ((std::ostringstream&)(std::ostringstream("") << "TaskSpaceVector (" << instance->data.transpose() << ")")).str(); });
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -651,7 +651,6 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedTimeIndexedProblem.def_property("tau",
                                                  &UnconstrainedTimeIndexedProblem::getTau,
                                                  &UnconstrainedTimeIndexedProblem::setTau);
-    unconstrainedTimeIndexedProblem.def_readwrite("W_rate", &UnconstrainedTimeIndexedProblem::W_rate);
     unconstrainedTimeIndexedProblem.def_readwrite("W", &UnconstrainedTimeIndexedProblem::W);
     unconstrainedTimeIndexedProblem.def_property(
         "InitialTrajectory",
@@ -690,7 +689,6 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedProblem.def_property("tau",
                                     &TimeIndexedProblem::getTau,
                                     &TimeIndexedProblem::setTau);
-    timeIndexedProblem.def_readwrite("W_rate", &TimeIndexedProblem::W_rate);
     timeIndexedProblem.def_readwrite("W", &TimeIndexedProblem::W);
     timeIndexedProblem.def_property(
         "InitialTrajectory",
@@ -726,7 +724,6 @@ PYBIND11_MODULE(_pyexotica, module)
     boundedTimeIndexedProblem.def_property("tau",
                                            &BoundedTimeIndexedProblem::getTau,
                                            &BoundedTimeIndexedProblem::setTau);
-    boundedTimeIndexedProblem.def_readwrite("W_rate", &BoundedTimeIndexedProblem::W_rate);
     boundedTimeIndexedProblem.def_readwrite("W", &BoundedTimeIndexedProblem::W);
     boundedTimeIndexedProblem.def_property(
         "InitialTrajectory",


### PR DESCRIPTION
Next stop towards addressing #209. After this only the ``W`` dimensions need to be checked. 