### PR TITLE
TimeIndexedProblem: Add maximum joint velocity limit

### DIFF
--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -108,9 +108,19 @@ public:
     int NumTasks;
     bool useBounds;
 
+    double getJointVelocityLimit() { return qdot_max; }
+    void setJointVelocityLimit(double qdot_max_in)
+    {
+        qdot_max = qdot_max_in;
+        xdiff_max = qdot_max * tau;
+    }
+
 private:
     int T;       //!< Number of time steps
     double tau;  //!< Time step duration
+
+    double qdot_max;   //!< Joint velocity limit (rad/s)
+    double xdiff_max;  //!< Maximum change in the variables in a single timestep tau. Gets set/updated via setTau().
 
     std::vector<Eigen::VectorXd> InitialTrajectory;
     TimeIndexedProblemInitializer init_;

--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -114,6 +114,7 @@ public:
         qdot_max = qdot_max_in;
         xdiff_max = qdot_max * tau;
     }
+    double getXdiffMax() { return xdiff_max; }
 
 private:
     int T;       //!< Number of time steps

--- a/exotica/init/TimeIndexedProblem.in
+++ b/exotica/init/TimeIndexedProblem.in
@@ -11,3 +11,4 @@ Optional Eigen::VectorXd UpperBound = Eigen::VectorXd();
 Optional bool UseBounds = true;
 Optional double InequalityFeasibilityTolerance = 1e-12;
 Optional double EqualityFeasibilityTolerance = 1e-6;
+Optional double JointVelocityLimit = -1;  // If set to a positive value, enforce joint velocity constraints (in radians/s).

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -96,6 +96,7 @@ void TimeIndexedProblem::Instantiate(TimeIndexedProblemInitializer& init)
     Equality.initialize(init_.Equality, shared_from_this(), EqualityPhi);
 
     T = init_.T;
+    qdot_max = init_.JointVelocityLimit;
     applyStartState(false);
     reinitializeVariables();
 }
@@ -154,6 +155,7 @@ void TimeIndexedProblem::setTau(double tau_in)
     if (tau_in <= 0.) throw_pretty("tau is expected to be greater than 0. (tau=" << tau_in << ")");
     tau = tau_in;
     ct = 1.0 / tau / T;
+    xdiff_max = qdot_max * tau;
 }
 
 void TimeIndexedProblem::preupdate()

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -689,6 +689,7 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedProblem.def_property("tau",
                                     &TimeIndexedProblem::getTau,
                                     &TimeIndexedProblem::setTau);
+    timeIndexedProblem.def_property("qDot_max", &TimeIndexedProblem::getJointVelocityLimit, &TimeIndexedProblem::setJointVelocityLimit);
     timeIndexedProblem.def_readwrite("W", &TimeIndexedProblem::W);
     timeIndexedProblem.def_property(
         "InitialTrajectory",


### PR DESCRIPTION
Adds a joint velocity limit to the ``TimeIndexedProblem`` and allows setting/updating it from Python.

This relates to #303 and implements the joint space constraint.