### PR TITLE
P2l visualisation and fixes

### DIFF
--- a/examples/exotica_examples/tests/test_maps.cpp
+++ b/examples/exotica_examples/tests/test_maps.cpp
@@ -713,6 +713,30 @@ void testIMesh()
     testJacobian(problem);
 }
 
+void testPoint2Line()
+{
+    HIGHLIGHT("Point2Line Test");
+    Initializer map("exotica/Point2Line",{
+        {"Name", std::string("MyTask")},
+        // {"EndPoint", std::string("0.5 0.5 1")},
+        {"EndPoint", std::string("0.5 0.5 0")},
+        {"EndEffector", std::vector<Initializer>(
+            {Initializer("Frame", {
+                {"Link", std::string("endeff")},
+                {"LinkOffset", std::string("0.5 0 0.5")},
+                {"Base", std::string("base")},
+                {"BaseOffset", std::string("0.5 0.5 0")}
+            })
+            })
+        }
+    });
+    UnconstrainedEndPoseProblem_ptr problem = setupProblem(map);
+    testRandom(problem);
+    // TODO: Add testValues
+
+    testJacobian(problem);
+}
+
 void testPoint2Plane()
 {
     {
@@ -813,6 +837,7 @@ int main(int argc, char** argv)
     testIdentity();
     testCoM();
     testIMesh();
+    testPoint2Line();
     testPoint2Plane();
     testQuasiStatic();
     Setup::Destroy();

--- a/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
+++ b/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
@@ -35,13 +35,13 @@
 #include <exotica/TaskMap.h>
 #include <task_map/Point2LineInitializer.h>
 
-namespace exotica  {
-class Point2Line : public TaskMap, public Instantiable<Point2LineInitializer> {
+namespace exotica
+{
+class Point2Line : public TaskMap, public Instantiable<Point2LineInitializer>
+{
 public:
-    Point2Line();
-
-    virtual ~Point2Line() { }
-
+    Point2Line() {}
+    virtual ~Point2Line() {}
     virtual void Instantiate(Point2LineInitializer& init);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
@@ -51,16 +51,28 @@ public:
     virtual int taskSpaceDim();
 
 private:
-    Eigen::Vector3d line;   //<! point that defines the end of the line relative to the starting point
-    // Eigen::VectorXd point;  //<! point in link frame
-    // Eigen::VectorXd start;  //<! start point in base frame
-    // Eigen::VectorXd end;    //<! end point in base frame
-    bool infinite;          //<! true: consider the line from 'start' to 'end' as segment
-                            //<! false: consider the vector from 'start' to 'end' as direction of line
+    Eigen::Vector3d line_start;  //<! start point of line in base frame
+    Eigen::Vector3d line_end;    //<! end point of line in base frame
+    Eigen::Vector3d line;        //<! vector from start to end point of line
+    bool infinite;               //<! true: vector from start to end defines the direction of and infinite line
+                                 //<! false: start and end define a line segment
 
-    static Eigen::Vector3d distance(const Eigen::Vector3d &point, const Eigen::Vector3d &line, const bool infinite, const bool dbg);
+    /**
+     * @brief direction computes the vector from a point to its projection on a line
+     * @param point point in base frame
+     * @return 3D vector from #point to its projection on #line
+     */
+    Eigen::Vector3d direction(const Eigen::Vector3d& point);
+
+    std::string link_name;  //<! frame of defined point
+    std::string base_name;  //<! frame of defined line
+
+    ros::Publisher pub_marker;        //<! publish marker for RViz
+    ros::Publisher pub_marker_label;  //<! marker label
+
+    bool visualise;
 };
 
 typedef std::shared_ptr<Point2Line> Point2Line_Ptr;
 
-} // namespace exotica
+}  // namespace exotica

--- a/exotations/task_maps/task_map/init/Point2Line.in
+++ b/exotations/task_maps/task_map/init/Point2Line.in
@@ -6,4 +6,5 @@ extend <exotica/TaskMap>
 // VectorXd BaseOffset   > starting point of line in Base frame
 
 Required Eigen::Vector3d EndPoint;  // point in 'Base' frame that defines the end of the line segment
-Optional bool infinite = true;      // true: interpret 'EndPoint' as the direction of an infinite line
+Optional bool Infinite = true;      // true: interpret 'EndPoint' as the direction of an infinite line
+Optional bool Visualise = false;    // true: publish points and lines as visualization_msgs/MarkerArray

--- a/exotations/task_maps/task_map/src/Point2Line.cpp
+++ b/exotations/task_maps/task_map/src/Point2Line.cpp
@@ -36,7 +36,7 @@ REGISTER_TASKMAP_TYPE("Point2Line", exotica::Point2Line);
 
 namespace exotica
 {
-Eigen::Vector3d Point2Line::distance(const Eigen::Vector3d &point, const Eigen::Vector3d &line, const bool infinite, const bool dbg)
+Eigen::Vector3d Point2Line::direction(const Eigen::Vector3d &point)
 {
     // http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
     // let:
@@ -44,60 +44,195 @@ Eigen::Vector3d Point2Line::distance(const Eigen::Vector3d &point, const Eigen::
     //      e: end of line
     //      p: point
     // then the point on vector v = e-s that is closest to p is vp = s + t*(e-s) with
-    // t = ((s-p)*(e-s)) / (|e-s|^2)    (* denotes the dot product)
-
-    // the line starts at the origin of BaseOffset, hence s=0, v='line', vp=t*'line'
-    double t = (-point).dot(line) / line.norm();
-    if (dbg) HIGHLIGHT_NAMED("P2L", "t " << t);
+    // t = -((s-p)*(e-s)) / (|e-s|^2)    (* denotes the dot product)
+    if (debug_) HIGHLIGHT_NAMED("P2L", "\e[4m" << link_name << "\e[0m");
+    if (debug_) HIGHLIGHT_NAMED("P2L", "p " << point.transpose());
+    if (debug_) HIGHLIGHT_NAMED("P2L", "ls " << line_start.transpose());
+    if (debug_) HIGHLIGHT_NAMED("P2L", "le " << line_end.transpose());
+    double t = -(line_start - point).dot(line) / line.squaredNorm();
+    std::stringstream ss;
+    ss << "t " << t;
     if (!infinite)
     {
         // clip to to range [0,1]
         t = std::min(std::max(0.0, t), 1.0);
-        if (dbg) HIGHLIGHT_NAMED("P2L", "|t| " << t);
+        ss << ", clipped |t| " << t;
     }
+    if (debug_) HIGHLIGHT_NAMED("P2L", ss.str());
 
     // vector from point 'p' to point 'vp' on line
-    const Eigen::Vector3d dv = (t * line) - point;
-    if (dbg) HIGHLIGHT_NAMED("P2L", "dv " << dv.transpose());
+    // vp = line_start + t * (line_end-line_start)
+    const Eigen::Vector3d dv = line_start + (t * line) - point;
+    if (debug_) HIGHLIGHT_NAMED("P2L", "vp " << (line_start + (t * line)).transpose());
+    if (debug_) HIGHLIGHT_NAMED("P2L", "dv " << dv.transpose());
     return dv;
 }
 
-Point2Line::Point2Line() {}
 void Point2Line::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
-    if (phi.rows() != Kinematics[0].Phi.rows()) throw_named("Wrong size of phi!");
+    if (phi.rows() != Kinematics[0].Phi.rows() * 3) throw_named("Wrong size of phi!");
 
     for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
     {
-        phi(i) = distance(Eigen::Map<const Eigen::Vector3d>(Kinematics[0].Phi(i).p.data), line, infinite, debug_).norm();
+        const Eigen::Vector3d p = line_start + Eigen::Map<const Eigen::Vector3d>(Kinematics[0].Phi(i).p.data);
+        phi.segment<3>(i * 3) = -direction(p);
     }
 }
 
 void Point2Line::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
 {
-    if (phi.rows() != Kinematics[0].Phi.rows()) throw_named("Wrong size of phi!");
-    if (J.rows() != Kinematics[0].J.rows() || J.cols() != Kinematics[0].J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics[0].J(0).data.cols());
+    if (phi.rows() != Kinematics[0].Phi.rows() * 3) throw_named("Wrong size of phi!");
+    if (J.rows() != Kinematics[0].J.rows() * 3 || J.cols() != Kinematics[0].J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics[0].J(0).data.cols());
 
     for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
     {
+        // point in base frame
+        const Eigen::Vector3d p = line_start + Eigen::Map<const Eigen::Vector3d>(Kinematics[0].Phi(i).p.data);
         // direction from point to line
-        const Eigen::Vector3d dv = distance(Eigen::Map<const Eigen::Vector3d>(Kinematics[0].Phi(i).p.data), line, infinite, debug_);
-        phi(i) = dv.norm();
+        const Eigen::Vector3d dv = direction(p);
+        phi.segment<3>(i * 3) = dv;
         for (int j = 0; j < J.cols(); j++)
         {
-            J(i, j) = -dv.dot(Eigen::Map<const Eigen::Vector3d>(Kinematics[0].J[i].getColumn(j).vel.data)) / dv.norm();
+            J.middleRows<3>(i * 3).col(j) = Kinematics[0].J[i].data.topRows<3>().col(j).dot(line/line.squaredNorm()) * line - Kinematics[0].J[i].data.topRows<3>().col(j);
+        }
+
+        // visualisation of point, line and their distance
+        if (visualise && Server::isRos())
+        {
+            const ros::Time t = ros::Time::now();
+            const std::string common_frame = "exotica/" + base_name;
+            visualization_msgs::MarkerArray ma;
+            {
+                // line in base frame
+                visualization_msgs::Marker mc;
+                mc.header.stamp = t;
+                mc.frame_locked = true;
+                mc.header.frame_id = common_frame;
+                mc.ns = "cam/line/" + object_name_;
+                mc.type = visualization_msgs::Marker::ARROW;
+                mc.scale.x = 0.01;
+                mc.scale.y = 0.01;
+                mc.scale.z = 0.01;
+                // line start
+                geometry_msgs::Point pp;
+                pp.x = line_start.x();
+                pp.y = line_start.y();
+                pp.z = line_start.z();
+                mc.points.push_back(pp);
+                // line end
+                const Eigen::Vector3d pe = p + dv;
+                pp.x = pe.x();
+                pp.y = pe.y();
+                pp.z = pe.z();
+                mc.points.push_back(pp);
+                mc.color.r = 1;
+                mc.color.g = 1;
+                mc.color.b = 0;
+                mc.color.a = 1;
+                ma.markers.push_back(mc);
+            }
+            {
+                // point in link frame
+                visualization_msgs::Marker ml;
+                ml.header.stamp = t;
+                ml.frame_locked = true;
+                ml.header.frame_id = common_frame;
+                ml.ns = "lnk/point/" + object_name_;
+                ml.type = visualization_msgs::Marker::SPHERE;
+                ml.scale.x = 0.03;
+                ml.scale.y = 0.03;
+                ml.scale.z = 0.03;
+                ml.color.r = 1;
+                ml.color.g = 0;
+                ml.color.b = 0;
+                ml.color.a = 1;
+                ml.pose.position.x = p.x();
+                ml.pose.position.y = p.y();
+                ml.pose.position.z = p.z();
+                ma.markers.push_back(ml);
+            }
+            {
+                // draw 'dv' starting at 'p' in base frame
+                visualization_msgs::Marker mdv;
+                mdv.header.stamp = t;
+                mdv.frame_locked = true;
+                mdv.header.frame_id = common_frame;
+                mdv.ns = "dv/" + object_name_;
+                mdv.type = visualization_msgs::Marker::ARROW;
+                mdv.scale.x = 0.001;
+                mdv.scale.y = 0.01;
+                mdv.scale.z = 0.01;
+                mdv.pose.position.x = p.x();
+                mdv.pose.position.y = p.y();
+                mdv.pose.position.z = p.z();
+                mdv.points.push_back(geometry_msgs::Point());
+                geometry_msgs::Point pdv;
+                pdv.x = dv.x();
+                pdv.y = dv.y();
+                pdv.z = dv.z();
+                mdv.points.push_back(pdv);
+                mdv.color.r = 0;
+                mdv.color.g = 1;
+                mdv.color.b = 0;
+                mdv.color.a = 0.5;
+                ma.markers.push_back(mdv);
+            }
+            pub_marker.publish(ma);
+            {
+                visualization_msgs::MarkerArray ma;
+                visualization_msgs::Marker mt;
+                mt.header.stamp = t;
+                mt.frame_locked = true;
+                mt.header.frame_id = common_frame;
+                mt.ns = "lnk/label/" + object_name_;
+                mt.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+                mt.text = link_name;
+                mt.pose.position.x = p.x();
+                mt.pose.position.y = p.y();
+                mt.pose.position.z = p.z();
+                mt.scale.x = 0.05;
+                mt.scale.y = 0.05;
+                mt.scale.z = 0.05;
+                mt.color.r = 1;
+                mt.color.g = 1;
+                mt.color.b = 1;
+                mt.color.a = 1;
+                ma.markers.push_back(mt);
+                pub_marker_label.publish(ma);
+            }
         }
     }
 }
 
 void Point2Line::Instantiate(Point2LineInitializer &init)
 {
-    line = init.EndPoint.head<3>() - boost::any_cast<Eigen::VectorXd>(init.EndEffector[0].getProperty("BaseOffset")).head<3>();
-    infinite = init.infinite;
+    link_name = Frames[0].FrameALinkName;
+    base_name = Frames[0].FrameBLinkName;
+
+    line_start = Eigen::Map<Eigen::Vector3d>(Frames[0].FrameBOffset.p.data);
+    line_end = init.EndPoint;
+
+    line = line_end - line_start;
+    infinite = init.Infinite;
+
+    visualise = init.Visualise;
+
+    if (visualise && Server::isRos())
+    {
+        pub_marker = Server::advertise<visualization_msgs::MarkerArray>("p2l", 1, true);
+        pub_marker_label = Server::advertise<visualization_msgs::MarkerArray>("p2l_label", 1, true);
+        // delete previous markers
+        visualization_msgs::Marker md;
+        md.action = 3;  // DELETEALL
+        visualization_msgs::MarkerArray ma;
+        ma.markers.push_back(md);
+        pub_marker.publish(ma);
+        pub_marker_label.publish(ma);
+    }
 }
 
 int Point2Line::taskSpaceDim()
 {
-    return Kinematics[0].Phi.rows();
+    return Kinematics[0].Phi.rows() * 3;
 }
 }  // namespace exotica


### PR DESCRIPTION
This PR:
- fixes for the Point2Line task map
- visualisation (RViz Marker) for point, line and their shortest distance

Before merging:
- Is there way to obtain the TF prefix `exotica/` from the API or is it constant?
- Is there a commons epsilon defined, that I can access in the task maps?