### PR TITLE
task_map: Add EffVelocity task map incl. example and test

### DIFF
--- a/examples/exotica_examples/resources/configs/aico_effvelocity_demo.xml
+++ b/examples/exotica_examples/resources/configs/aico_effvelocity_demo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<PlannerDemoConfig>
+  <AICOsolver Name="MySolver" Debug="1" Damping="100" MaxBacktrackIterations="500" />
+
+  <UnconstrainedTimeIndexedProblem Name="MyProblem">
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+
+    <Maps>
+      <EffVelocity Name="EffVelocity">
+        <EndEffector>
+            <Frame Link="lwr_arm_7_link" />
+        </EndEffector>
+      </EffVelocity>
+      <Identity Name="Identity" />
+    </Maps>
+
+    <Cost>
+      <Task Task="EffVelocity" Rho="1e2"/>
+      <Task Task="Identity" Rho="0"/>
+    </Cost>
+   
+    <T>100</T>
+    <Tau>0.05</Tau>
+    <Wrate>1e0</Wrate>
+  </UnconstrainedTimeIndexedProblem>
+</PlannerDemoConfig>

--- a/examples/exotica_examples/scripts/PythonPlanAICOEffVelocity.launch
+++ b/examples/exotica_examples/scripts/PythonPlanAICOEffVelocity.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_aico_effvelocity.py" name="AICOPlannerPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"  args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/examples/exotica_examples/scripts/example_aico_effvelocity.py
+++ b/examples/exotica_examples/scripts/example_aico_effvelocity.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import numpy as np
+import pyexotica as exo
+from pyexotica.publish_trajectory import *
+
+exo.Setup.initRos()
+solver = exo.Setup.loadSolver('{exotica_examples}/resources/configs/aico_effvelocity_demo.xml')
+problem = solver.getProblem()
+
+problem.setRho('Identity', 1e3, 0)
+problem.setGoal('Identity', np.array([-1.57, -1.57, 0, 0, 0, 0, 0]), 0)
+
+problem.setRho('Identity', 1e3, -1)
+problem.setGoal('Identity', np.array([1.57, -1.57, 0, 0, 0, 0, 0]), -1)
+
+for i in range(problem.T):
+    problem.update(np.array([-1.57, -1.57, 0, 0, 0, 0, 0]), i)
+
+for i in range(problem.T):
+    print(i, problem.getScalarTaskCost(i))
+
+initial_traj = np.array([-1.57, -1.57, 0, 0, 0, 0, 0]).reshape(problem.N, 1).repeat(problem.T,1)
+
+problem.InitialTrajectory = initial_traj.T
+solution = solver.solve()
+
+# for i in range(problem.T):
+#     print(problem.KinematicSolutions[i].Phi)
+
+plot(solution)
+
+publishTrajectory(solution, problem.T*problem.tau, problem)

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -15,6 +15,7 @@ AddInitializer(
   EffFrame
   FrameWithAxisAndDirection
   EffAxisAlignment
+  EffVelocity
   JointLimit
   Distance
   Point2Line
@@ -44,6 +45,7 @@ set(SOURCES
     src/EffOrientation.cpp
     src/EffFrame.cpp
     src/EffAxisAlignment.cpp
+    src/EffVelocity.cpp
     src/JointLimit.cpp
     src/Distance.cpp
     src/Point2Line.cpp

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -23,6 +23,9 @@
   <class name="exotica/EffAxisAlignment" type="exotica::EffAxisAlignment" base_class_type="exotica::TaskMap">
     <description>End-effector axis alignment</description>
   </class>
+  <class name="exotica/EffVelocity" type="exotica::EffVelocity" base_class_type="exotica::TaskMap">
+    <description>End-effector velocity (requires time-indexed problems)</description>
+  </class>
   <class name="exotica/SphereCollision" type="exotica::SphereCollision" base_class_type="exotica::TaskMap">
     <description>Sphere collision avoidance</description>
   </class>

--- a/exotations/task_maps/task_map/include/task_map/EffVelocity.h
+++ b/exotations/task_maps/task_map/include/task_map/EffVelocity.h
@@ -1,0 +1,60 @@
+/*
+ *      Author: Wolfgang Merkt
+ *
+ * Copyright (c) 2018, Wolfgang Merkt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef EXOTICA_TASKMAP_EFFVELOCITY_H
+#define EXOTICA_TASKMAP_EFFVELOCITY_H
+
+#include <exotica/TaskMap.h>
+#include <task_map/EffVelocityInitializer.h>
+
+namespace exotica  //!< Since this is part of the core library, it will be within the same namespace
+{
+class EffVelocity : public TaskMap, public Instantiable<EffVelocityInitializer>
+{
+public:
+    EffVelocity();
+    virtual ~EffVelocity()
+    {
+    }
+
+    virtual void Instantiate(EffVelocityInitializer& init);
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+
+    virtual int taskSpaceDim();
+};
+typedef std::shared_ptr<EffVelocity> EffVelocity_Ptr;
+}
+
+#endif

--- a/exotations/task_maps/task_map/init/EffVelocity.in
+++ b/exotations/task_maps/task_map/init/EffVelocity.in
@@ -1,0 +1,1 @@
+extend <exotica/TaskMap>

--- a/exotations/task_maps/task_map/src/EffVelocity.cpp
+++ b/exotations/task_maps/task_map/src/EffVelocity.cpp
@@ -1,0 +1,90 @@
+/*
+ *      Author: Wolfgang Merkt
+ *
+ * Copyright (c) 2018, Wolfgang Merkt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "task_map/EffVelocity.h"
+
+REGISTER_TASKMAP_TYPE("EffVelocity", exotica::EffVelocity);
+
+namespace exotica
+{
+EffVelocity::EffVelocity()
+{
+    Kinematics.resize(2);
+}
+
+void EffVelocity::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (Kinematics.size() != 2) throw_named("Wrong size of Kinematics - requires 2, but got " << Kinematics.size());
+    if (phi.rows() != Kinematics[0].Phi.rows()) throw_named("Wrong size of phi!");
+
+    Eigen::Vector3d p_t, p_t_prev;
+    for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
+    {
+        tf::vectorKDLToEigen(Kinematics[0].Phi(i).p, p_t);
+        tf::vectorKDLToEigen(Kinematics[1].Phi(i).p, p_t_prev);
+        phi(i) = (p_t_prev - p_t).norm();
+    }
+}
+
+void EffVelocity::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (Kinematics.size() != 2) throw_named("Wrong size of Kinematics - requires 2, but got " << Kinematics.size());
+    if (phi.rows() != Kinematics[0].Phi.rows()) throw_named("Wrong size of phi!");
+    if (J.rows() != Kinematics[0].J.rows() || J.cols() != Kinematics[0].J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics[0].J(0).data.cols());
+
+    J.setZero();
+    Eigen::Vector3d p_t, p_t_prev;
+    for (int i = 0; i < Kinematics[0].Phi.rows(); i++)
+    {
+        tf::vectorKDLToEigen(Kinematics[0].Phi(i).p, p_t);
+        tf::vectorKDLToEigen(Kinematics[1].Phi(i).p, p_t_prev);
+        phi(i) = (p_t - p_t_prev).norm();
+
+        if (phi(i) != 0.0)
+        {
+            J.row(i) = ((p_t(0) - p_t_prev(0)) * Kinematics[0].J[i].data.row(0) +
+                        (p_t(1) - p_t_prev(1)) * Kinematics[0].J[i].data.row(1) +
+                        (p_t(2) - p_t_prev(2)) * Kinematics[0].J[i].data.row(2)) /
+                       phi(i);
+        }
+    }
+}
+
+void EffVelocity::Instantiate(EffVelocityInitializer& init)
+{
+}
+
+int EffVelocity::taskSpaceDim()
+{
+    return Kinematics[0].Phi.rows();
+}
+}


### PR DESCRIPTION
Adds the first example validating the multi-timestep taskmap support added in #342.

A slight caveat, the Python example isn't tuned properly - it works better with a constrained ``TimeIndexedProblem``.