### PR TITLE
CollisionScene: Add option to replace cylinders with capsules

### DIFF
--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -153,7 +153,8 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
         case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
-            if (!replaceCylindersWithCapsules)
+            bool degenerateCapsule = (s->length <= 2 * s->radius);
+            if (!replaceCylindersWithCapsules || degenerateCapsule)
             {
                 geometry.reset(new fcl::Cylinder(s->radius, s->length));
             }

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -47,6 +47,7 @@ namespace exotica
 {
 CollisionSceneFCL::CollisionSceneFCL()
 {
+    HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCL::~CollisionSceneFCL()

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -152,7 +152,14 @@ std::shared_ptr<fcl::CollisionObject> CollisionSceneFCL::constructFclCollisionOb
         case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
-            geometry.reset(new fcl::Cylinder(s->radius, s->length));
+            if (!replaceCylindersWithCapsules)
+            {
+                geometry.reset(new fcl::Cylinder(s->radius, s->length));
+            }
+            else
+            {
+                geometry.reset(new fcl::Capsule(s->radius, s->length - 2 * s->radius));
+            }
         }
         break;
         case shapes::CONE:

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -157,7 +157,6 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
             }
             else
             {
-                // TODO: handle degenerate cases, i.e. where 2*radius >= length
                 geometry.reset(new fcl::Capsuled(s->radius, s->length - 2 * s->radius));
             }
         }

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -49,7 +49,7 @@ namespace exotica
 {
 CollisionSceneFCLLatest::CollisionSceneFCLLatest()
 {
-    HIGHLIGHT("FCL version: " << FCL_VERSION);
+    HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCLLatest::~CollisionSceneFCLLatest()

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -150,12 +150,14 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
         case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
-            if (!replaceCylindersWithCapsules)
+            bool degenerateCapsule = (s->length <= 2 * s->radius);
+            if (!replaceCylindersWithCapsules || degenerateCapsule)
             {
                 geometry.reset(new fcl::Cylinderd(s->radius, s->length));
             }
             else
             {
+                // TODO: handle degenerate cases, i.e. where 2*radius >= length
                 geometry.reset(new fcl::Capsuled(s->radius, s->length - 2 * s->radius));
             }
         }

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -323,13 +323,13 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
     KDL::Vector c1, c2;
 
     // Case 1: Mesh vs Mesh - already in world frame
-    if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+    if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_BVH && o2->getObjectType() == fcl::OBJECT_TYPE::OT_BVH)
     {
         c1 = KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));
         c2 = KDL::Vector(data->Result.nearest_points[1](0), data->Result.nearest_points[1](1), data->Result.nearest_points[1](2));
     }
     // Case 2: Primitive vs Primitive - convert from both local frames to world frame
-    else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+    else if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM && o2->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM)
     {
         // Use shape centres as nearest point when in penetration - otherwise use the nearest point.
         // INDEP has a further caveat when in penetration: it will return the
@@ -378,7 +378,7 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
         }
     }
     // Case 3: Primitive vs Mesh - primitive returned in flipped local frame (tbc), mesh returned in global frame
-    else if (p.e1->Shape->type != shapes::ShapeType::MESH && p.e2->Shape->type == shapes::ShapeType::MESH)
+    else if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM && o2->getObjectType() == fcl::OBJECT_TYPE::OT_BVH)
     {
         // Flipping contacts is a workaround for issue #184
         // Cf. https://github.com/ipab-slmc/exotica/issues/184#issuecomment-341916457
@@ -399,7 +399,7 @@ void CollisionSceneFCLLatest::computeDistance(fcl::CollisionObjectd* o1, fcl::Co
         }
     }
     // Case 4: Mesh vs Primitive - both are returned in the local frame (works with both LIBCCD and INDEP)
-    else if (p.e1->Shape->type == shapes::ShapeType::MESH && p.e2->Shape->type != shapes::ShapeType::MESH)
+    else if (o1->getObjectType() == fcl::OBJECT_TYPE::OT_BVH && o2->getObjectType() == fcl::OBJECT_TYPE::OT_GEOM)
     {
         // e1 is mesh, i.e. nearest points are fine
         c1 = p.e1->Frame * KDL::Vector(data->Result.nearest_points[0](0), data->Result.nearest_points[0](1), data->Result.nearest_points[0](2));

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -150,7 +150,14 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
         case shapes::CYLINDER:
         {
             const shapes::Cylinder* s = static_cast<const shapes::Cylinder*>(shape.get());
-            geometry.reset(new fcl::Cylinderd(s->radius, s->length));
+            if (!replaceCylindersWithCapsules)
+            {
+                geometry.reset(new fcl::Cylinderd(s->radius, s->length));
+            }
+            else
+            {
+                geometry.reset(new fcl::Capsuled(s->radius, s->length - 2 * s->radius));
+            }
         }
         break;
         case shapes::CONE:

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -593,7 +593,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::getCollisionDistance(
         }
     }
 
-    if (shapes1.size() == 0) throw_pretty("Can't find object '" << o1 << "'!");
+    if (shapes1.size() == 0) return data.Proxies; //throw_pretty("Can't find object '" << o1 << "'!");
 
     // There are no objects o1 is allowed to collide with, return the empty proxies vector
     if (shapes2.size() == 0) return data.Proxies;

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -186,6 +186,8 @@ public:
     ///
     virtual void updateCollisionObjectTransforms() = 0;
 
+    bool replaceCylindersWithCapsules = false;
+
 protected:
     /// The allowed collision matrix
     AllowedCollisionMatrix acm_;

--- a/exotica/init/Scene.in
+++ b/exotica/init/Scene.in
@@ -6,6 +6,7 @@ Optional std::string SRDF = "";
 Optional bool SetRobotDescriptionRosParams = false;  // to be used in conjunction with URDF or SRDF to set the robot_description and robot_description_semantic from the files/string in URDF/SRDF
 Optional std::string CollisionScene = "CollisionSceneFCL";
 Optional bool AlwaysUpdateCollisionScene = false;
+Optional bool ReplaceCylindersWithCapsules = false;
 Optional std::string LoadScene = "";
 Optional std::vector<exotica::Initializer> Links = std::vector<exotica::Initializer>();
 Optional std::vector<exotica::Initializer> Trajectories = std::vector<exotica::Initializer>();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -123,6 +123,7 @@ void Scene::Instantiate(SceneInitializer& init)
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
+    collision_scene_->replaceCylindersWithCapsules = init.ReplaceCylindersWithCapsules;
     updateSceneFrames();
     updateInternalFrames(false);
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -931,6 +931,7 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
     // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation
     collisionScene.def_property("alwaysExternallyUpdatedCollisionScene", &CollisionScene::getAlwaysExternallyUpdatedCollisionScene, &CollisionScene::setAlwaysExternallyUpdatedCollisionScene);
+    collisionScene.def_readwrite("replaceCylindersWithCapsules", &CollisionScene::replaceCylindersWithCapsules);
     collisionScene.def_property("robotLinkScale", &CollisionScene::getRobotLinkScale, &CollisionScene::setRobotLinkScale);
     collisionScene.def_property("worldLinkScale", &CollisionScene::getWorldLinkScale, &CollisionScene::setWorldLinkScale);
     collisionScene.def_property("robotLinkPadding", &CollisionScene::getRobotLinkPadding, &CollisionScene::setRobotLinkPadding);


### PR DESCRIPTION
Option to internally replace cylinders by capsules. The convention is that a cylinder of length ``l`` will be replaced with an **inscribed** capsule.