### PR TITLE
CollisionScene: Add continuous collision check

### DIFF
--- a/examples/exotica_examples/tests/collision_scene_distances.py
+++ b/examples/exotica_examples/tests/collision_scene_distances.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import pyexotica as exo
 import math
 import time

--- a/examples/exotica_examples/tests/runtest.py
+++ b/examples/exotica_examples/tests/runtest.py
@@ -15,6 +15,7 @@ pytests = ['core.py',
          'valkyrie_collision_check_fcl_default.py',
          'valkyrie_collision_check_fcl_latest.py',
          'collision_scene_distances.py',
+         'test_continuous_collision_check.py',
          'scene_creation.py'
          #'issue225_kinematictree_memory_leak.py'
         ]

--- a/examples/exotica_examples/tests/test_continuous_collision_check.py
+++ b/examples/exotica_examples/tests/test_continuous_collision_check.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import pyexotica as exo
+import math
+import time
+import numpy as np
+
+def getProblemInitializer(collisionScene, URDF):
+    return ('exotica/UnconstrainedEndPoseProblem',
+            {'Name': 'TestProblem',
+             'PlanningScene': [('exotica/Scene',
+                                {'CollisionScene': collisionScene,
+                                 'JointGroup': 'group1',
+                                 'Name': 'TestScene',
+                                 'Debug': '0',
+                                 'SRDF': '{exotica_examples}/tests/resources/A_vs_B.srdf',
+                                 'SetRobotDescriptionRosParams': '1',
+                                 'URDF': URDF})]})
+
+collisionScene = "CollisionSceneFCLLatest"
+
+urdfs_to_test = ['{exotica_examples}/tests/resources/PrimitiveSphere_vs_PrimitiveSphere_Distance.urdf', '{exotica_examples}/tests/resources/Mesh_vs_Mesh_Distance.urdf']
+
+for urdf in urdfs_to_test:
+    print("Testing", urdf)
+    
+    initializer = getProblemInitializer(collisionScene, urdf)
+    prob = exo.Setup.createProblem(initializer)
+    prob.update(np.zeros(prob.N,))
+    scene = prob.getScene()
+    cs = scene.getCollisionScene()
+
+    # Should collide at -2
+    p = cs.continuousCollisionCheck(
+            "A_collision_0", exo.KDLFrame([-3., 0.0, 0.0]), exo.KDLFrame([-1.0, 0.0, 0.0]),
+            "B_collision_0", exo.KDLFrame([0, 0, 0]), exo.KDLFrame([0, 0, 0]))
+    assert(p.InCollision == True)
+    assert((p.TimeOfContact - 0.5) < 0.1)
+    assert(np.isclose(p.ContactTransform1.getTranslation(), np.array([-2, 0, 0]), atol=0.15).all())
+    assert(np.isclose(p.ContactTransform2.getTranslation(), np.array([0, 0, 0])).all())
+    print(p)
+
+print('>>SUCCESS<<')
+exit(0)

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -97,6 +97,20 @@ public:
     virtual std::vector<CollisionProxy> getCollisionDistance(const std::string& o1, const bool& self = true, const bool& disableCollisionSceneUpdate = false);
 
     /**
+     * @brief      Performs a continuous collision check between two objects with a linear interpolation between two given 
+     *
+     * @param[in]  o1       The first collision object, by name.
+     * @param[in]  tf1_beg  The beginning transform for o1.
+     * @param[in]  tf1_end  The end transform for o1.
+     * @param[in]  o2       The second collision object, by name.
+     * @param[in]  tf2_beg  The beginning transform for o2.
+     * @param[in]  tf2_end  The end transform for o2.
+     *
+     * @return     CollisionProxy.
+     */
+    virtual CollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end);
+
+    /**
        * @brief      Gets the collision world links.
        *
        * @return     The collision world links.

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -106,9 +106,9 @@ public:
      * @param[in]  tf2_beg  The beginning transform for o2.
      * @param[in]  tf2_end  The end transform for o2.
      *
-     * @return     CollisionProxy.
+     * @return     ContinuousCollisionProxy.
      */
-    virtual CollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end);
+    virtual ContinuousCollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end);
 
     /**
        * @brief      Gets the collision world links.

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -665,4 +665,55 @@ std::vector<std::string> CollisionSceneFCLLatest::getCollisionRobotLinks()
     }
     return tmp;
 }
+
+CollisionProxy CollisionSceneFCLLatest::continuousCollisionCheck(
+    const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end,
+    const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end)
+{
+    HIGHLIGHT_NAMED("continuousCollisionCheck", o1 << " vs " << o2);
+
+    if (!alwaysExternallyUpdatedCollisionScene_) updateCollisionObjectTransforms();
+
+    std::shared_ptr<const fcl::CollisionGeometryd> shape1 = nullptr;
+    std::shared_ptr<const fcl::CollisionGeometryd> shape2 = nullptr;
+
+    for (fcl::CollisionObjectd* o : fcl_objects_)
+    {
+        std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())].lock();
+        if (e->Segment.getName() == o1)
+        {
+            shape1 = o->collisionGeometry();
+        }
+
+        if (e->Segment.getName() == o2)
+        {
+            shape2 = o->collisionGeometry();
+        }
+    }
+
+    if (shape1 == nullptr) throw_pretty("o1 not found.");
+    if (shape2 == nullptr) throw_pretty("o2 not found.");
+
+    // CollisionData data(this);
+    // bool allowedToCollide = isAllowedToCollide(shape1, shape2, data.Self, data.Scene);
+
+    fcl::ContinuousCollisionRequestd request = fcl::ContinuousCollisionRequestd();
+    request.ccd_motion_type = fcl::CCDM_LINEAR;
+    request.ccd_solver_type = fcl::CCDC_CONSERVATIVE_ADVANCEMENT;
+
+    fcl::ContinuousCollisionResultd result;
+
+    double cc_out = fcl::continuousCollide(
+        shape1.get(), fcl_convert::KDL2fcl(tf1_beg), fcl_convert::KDL2fcl(tf1_end),
+        shape2.get(), fcl_convert::KDL2fcl(tf2_beg), fcl_convert::KDL2fcl(tf2_end),
+        request, result);
+
+    HIGHLIGHT_NAMED("cc_out", cc_out);
+    HIGHLIGHT_NAMED("ContinuousCollisionResult", "is_collide: " << result.is_collide << " time_of_contact: " << result.time_of_contact << " contact_tf1: " << result.contact_tf1.translation().transpose() << " contact_tf2: " << result.contact_tf2.translation().transpose());
+
+    // TODO: if !allowedToCollide reset is_collide;
+
+    CollisionProxy ret;
+    return ret;
+}
 }

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -42,6 +42,31 @@ private:
     std::unordered_map<std::string, std::unordered_set<std::string>> entries_;
 };
 
+struct ContinuousCollisionProxy
+{
+    ContinuousCollisionProxy() : e1(nullptr), e2(nullptr), in_collision(false), time_of_contact(-1) {}
+    std::shared_ptr<KinematicElement> e1;
+    std::shared_ptr<KinematicElement> e2;
+    KDL::Frame contact_tf1;
+    KDL::Frame contact_tf2;
+    bool in_collision;
+    double time_of_contact;
+
+    inline std::string print() const
+    {
+        std::stringstream ss;
+        if (e1 && e2)
+        {
+            ss << "ContinuousCollisionProxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << " in_collision: " << in_collision << " time_of_contact " << time_of_contact;
+        }
+        else
+        {
+            ss << "ContinuousCollisionProxy (empty)";
+        }
+        return ss.str();
+    }
+};
+
 struct CollisionProxy
 {
     CollisionProxy() : e1(nullptr), e2(nullptr), distance(0), inCollision(false), timeOfContact(-1) {}
@@ -150,9 +175,9 @@ public:
      * @param[in]  tf2_beg  The beginning transform for o2.
      * @param[in]  tf2_end  The end transform for o2.
      *
-     * @return     CollisionProxy.
+     * @return     ContinuousCollisionProxy.
      */
-    virtual CollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end) { throw_pretty("Not implemented!"); }
+    virtual ContinuousCollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end) { throw_pretty("Not implemented!"); }
     virtual Eigen::Vector3d getTranslation(const std::string& name) = 0;
 
     inline void setACM(const AllowedCollisionMatrix& acm)

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -69,7 +69,7 @@ struct ContinuousCollisionProxy
 
 struct CollisionProxy
 {
-    CollisionProxy() : e1(nullptr), e2(nullptr), distance(0), inCollision(false), timeOfContact(-1) {}
+    CollisionProxy() : e1(nullptr), e2(nullptr), distance(0) {}
     std::shared_ptr<KinematicElement> e1;
     std::shared_ptr<KinematicElement> e2;
     Eigen::Vector3d contact1;
@@ -77,15 +77,13 @@ struct CollisionProxy
     Eigen::Vector3d contact2;
     Eigen::Vector3d normal2;
     double distance;
-    bool inCollision;
-    double timeOfContact;
 
     inline std::string print() const
     {
         std::stringstream ss;
         if (e1 && e2)
         {
-            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " n1: " << normal1.transpose() << " n2: " << normal2.transpose() << " d: " << distance << " inCollision: " << inCollision << " timeOfContact " << timeOfContact;
+            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " n1: " << normal1.transpose() << " n2: " << normal2.transpose() << " d: " << distance;
         }
         else
         {

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -44,7 +44,7 @@ private:
 
 struct CollisionProxy
 {
-    CollisionProxy() : e1(nullptr), e2(nullptr), distance(0) {}
+    CollisionProxy() : e1(nullptr), e2(nullptr), distance(0), inCollision(false), timeOfContact(-1) {}
     std::shared_ptr<KinematicElement> e1;
     std::shared_ptr<KinematicElement> e2;
     Eigen::Vector3d contact1;
@@ -52,13 +52,15 @@ struct CollisionProxy
     Eigen::Vector3d contact2;
     Eigen::Vector3d normal2;
     double distance;
+    bool inCollision;
+    double timeOfContact;
 
     inline std::string print() const
     {
         std::stringstream ss;
         if (e1 && e2)
         {
-            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " n1: " << normal1.transpose() << " n2: " << normal2.transpose() << " d: " << distance;
+            ss << "Proxy: '" << e1->Segment.getName() << "' - '" << e2->Segment.getName() << "', c1: " << contact1.transpose() << " c2: " << contact2.transpose() << " n1: " << normal1.transpose() << " n2: " << normal2.transpose() << " d: " << distance << " inCollision: " << inCollision << " timeOfContact " << timeOfContact;
         }
         else
         {
@@ -138,6 +140,19 @@ public:
        */
     virtual std::vector<std::string> getCollisionRobotLinks() = 0;
 
+    /**
+     * @brief      Performs a continuous collision check between two objects with a linear interpolation between two given 
+     *
+     * @param[in]  o1       The first collision object, by name.
+     * @param[in]  tf1_beg  The beginning transform for o1.
+     * @param[in]  tf1_end  The end transform for o1.
+     * @param[in]  o2       The second collision object, by name.
+     * @param[in]  tf2_beg  The beginning transform for o2.
+     * @param[in]  tf2_end  The end transform for o2.
+     *
+     * @return     CollisionProxy.
+     */
+    virtual CollisionProxy continuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end) { throw_pretty("Not implemented!"); }
     virtual Eigen::Vector3d getTranslation(const std::string& name) = 0;
 
     inline void setACM(const AllowedCollisionMatrix& acm)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -849,6 +849,8 @@ PYBIND11_MODULE(_pyexotica, module)
     proxy.def_readonly("Normal1", &CollisionProxy::normal1);
     proxy.def_readonly("Normal2", &CollisionProxy::normal2);
     proxy.def_readonly("Distance", &CollisionProxy::distance);
+    proxy.def_readonly("InCollision", &CollisionProxy::inCollision);
+    proxy.def_readonly("TimeOfContact", &CollisionProxy::timeOfContact);
     proxy.def_property_readonly("Object1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Segment.getName() : std::string(""); });
     proxy.def_property_readonly("Object2", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Segment.getName() : std::string(""); });
     proxy.def_property_readonly("Transform1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Frame : KDL::Frame(); });
@@ -944,6 +946,9 @@ PYBIND11_MODULE(_pyexotica, module)
     collisionScene.def_property("robotLinkPadding", &CollisionScene::getRobotLinkPadding, &CollisionScene::setRobotLinkPadding);
     collisionScene.def_property("worldLinkPadding", &CollisionScene::getWorldLinkPadding, &CollisionScene::setWorldLinkPadding);
     collisionScene.def("updateCollisionObjectTransforms", &CollisionScene::updateCollisionObjectTransforms);
+
+    // Continuous collision check
+    collisionScene.def("continuousCollisionCheck", &CollisionScene::updateCollisionObjectTransforms);
 
     py::module kin = module.def_submodule("Kinematics", "Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -842,20 +842,30 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedSamplingProblem.def_readonly("Phi", &TimeIndexedSamplingProblem::Phi);
     timeIndexedSamplingProblem.def_readonly("Constraint", &TimeIndexedSamplingProblem::Constraint);
 
-    py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> proxy(module, "Proxy");
+    py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> proxy(module, "CollisionProxy");
     proxy.def(py::init());
     proxy.def_readonly("Contact1", &CollisionProxy::contact1);
     proxy.def_readonly("Contact2", &CollisionProxy::contact2);
     proxy.def_readonly("Normal1", &CollisionProxy::normal1);
     proxy.def_readonly("Normal2", &CollisionProxy::normal2);
     proxy.def_readonly("Distance", &CollisionProxy::distance);
-    proxy.def_readonly("InCollision", &CollisionProxy::inCollision);
-    proxy.def_readonly("TimeOfContact", &CollisionProxy::timeOfContact);
     proxy.def_property_readonly("Object1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Segment.getName() : std::string(""); });
     proxy.def_property_readonly("Object2", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Segment.getName() : std::string(""); });
     proxy.def_property_readonly("Transform1", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Frame : KDL::Frame(); });
     proxy.def_property_readonly("Transform2", [](CollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Frame : KDL::Frame(); });
     proxy.def("__repr__", &CollisionProxy::print);
+
+    py::class_<ContinuousCollisionProxy, std::shared_ptr<ContinuousCollisionProxy>> continuous_proxy(module, "ContinuousCollisionProxy");
+    continuous_proxy.def(py::init());
+    continuous_proxy.def_readonly("ContactTransform1", &ContinuousCollisionProxy::contact_tf1);
+    continuous_proxy.def_readonly("ContactTransform2", &ContinuousCollisionProxy::contact_tf2);
+    continuous_proxy.def_readonly("InCollision", &ContinuousCollisionProxy::in_collision);
+    continuous_proxy.def_readonly("TimeOfContact", &ContinuousCollisionProxy::time_of_contact);
+    continuous_proxy.def_property_readonly("Object1", [](ContinuousCollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Segment.getName() : std::string(""); });
+    continuous_proxy.def_property_readonly("Object2", [](ContinuousCollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Segment.getName() : std::string(""); });
+    continuous_proxy.def_property_readonly("Transform1", [](ContinuousCollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e1->Frame : KDL::Frame(); });
+    continuous_proxy.def_property_readonly("Transform2", [](ContinuousCollisionProxy* instance) { return (instance->e1 && instance->e2) ? instance->e2->Frame : KDL::Frame(); });
+    continuous_proxy.def("__repr__", &ContinuousCollisionProxy::print);
 
     py::class_<Scene, std::shared_ptr<Scene>, Object> scene(module, "Scene");
     scene.def("Update", &Scene::Update, py::arg("x"), py::arg("t") = 0.0);
@@ -946,9 +956,7 @@ PYBIND11_MODULE(_pyexotica, module)
     collisionScene.def_property("robotLinkPadding", &CollisionScene::getRobotLinkPadding, &CollisionScene::setRobotLinkPadding);
     collisionScene.def_property("worldLinkPadding", &CollisionScene::getWorldLinkPadding, &CollisionScene::setWorldLinkPadding);
     collisionScene.def("updateCollisionObjectTransforms", &CollisionScene::updateCollisionObjectTransforms);
-
-    // Continuous collision check
-    collisionScene.def("continuousCollisionCheck", &CollisionScene::updateCollisionObjectTransforms);
+    collisionScene.def("continuousCollisionCheck", &CollisionScene::continuousCollisionCheck);
 
     py::module kin = module.def_submodule("Kinematics", "Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");


### PR DESCRIPTION
Adds the required functions to perform continuous collision checks between two collision objects given start and end transforms.

It further adds the first implementation with FCL which as of now uses their default settings using naive interpolation - any more advanced treatment (e.g., conservative advancement) only works for a subset of queries (e.g., primitives) and we'd thus have to treat the checking on a case-by-case basis.

Python test included.