### PR TITLE
Server: connect as client to a ROS service

### DIFF
--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -161,6 +161,12 @@ public:
         return Instance()->getNodeHandle().advertise<T>(ops);
     }
 
+    template <typename T>
+    static ros::ServiceClient serviceClient(const std::string &service_name, bool persistent = false)
+    {
+        return Instance()->serviceClient<T>(service_name, persistent);
+    }
+
     static void sendTransform(const tf::StampedTransform &transform)
     {
         if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");


### PR DESCRIPTION
Adds a method to the `Server` to register ROS clients:
```C++
ros::ServiceClient srv_rendering = Server::serviceClient<robot_state_renderer::RenderRobotState>(init.render_service_name, true);
```