### PR TITLE
CollisionScene: Re-add "replace primitives with meshes"

### DIFF
--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -105,6 +105,16 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
 
     shapes::ShapeConstPtr shape = element->Shape;
 
+    // Replace primitive shapes with meshes if desired (e.g. if primitives are unstable)
+    if (replacePrimitiveShapesWithMeshes_)
+    {
+        if (shape->type != shapes::MESH || shape->type != shapes::OCTREE)
+        {
+            shapes::ShapePtr mesh_shape((shapes::Shape*)shapes::createMeshFromShape(shape->clone()));
+            shape = mesh_shape;
+        }
+    }
+
     // Apply scaling and padding
     if (element->isRobotLink || element->ClosestRobotLink.lock())
     {

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -105,16 +105,6 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
 
     shapes::ShapeConstPtr shape = element->Shape;
 
-    // Replace primitive shapes with meshes if desired (e.g. if primitives are unstable)
-    if (replacePrimitiveShapesWithMeshes_)
-    {
-        if (shape->type != shapes::MESH || shape->type != shapes::OCTREE)
-        {
-            shapes::ShapePtr mesh_shape((shapes::Shape*)shapes::createMeshFromShape(shape->clone()));
-            shape = mesh_shape;
-        }
-    }
-
     // Apply scaling and padding
     if (element->isRobotLink || element->ClosestRobotLink.lock())
     {
@@ -132,6 +122,16 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::constructFclColl
             shapes::ShapePtr scaled_shape(shape->clone());
             scaled_shape->scaleAndPadd(worldLinkScale_, worldLinkPadding_);
             shape = scaled_shape;
+        }
+    }
+
+    // Replace primitive shapes with meshes if desired (e.g. if primitives are unstable)
+    if (replacePrimitiveShapesWithMeshes_)
+    {
+        if (shape->type != shapes::MESH || shape->type != shapes::OCTREE)
+        {
+            shapes::ShapePtr mesh_shape((shapes::Shape*)shapes::createMeshFromShape(shape->clone()));
+            shape = mesh_shape;
         }
     }
 

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -221,6 +221,12 @@ public:
         worldLinkPadding_ = padding;
     }
 
+    inline bool getReplacePrimitiveShapesWithMeshes() { return replacePrimitiveShapesWithMeshes_; }
+    inline void setReplacePrimitiveShapesWithMeshes(const bool& value)
+    {
+        replacePrimitiveShapesWithMeshes_ = value;
+    }
+
     ///
     /// \brief Creates the collision scene from kinematic elements.
     /// \param objects Vector kinematic element pointers of collision objects.
@@ -252,6 +258,9 @@ protected:
 
     /// World link padding
     double worldLinkPadding_ = 0.0;
+
+    /// Replace primitive shapes with meshes internally (e.g. when primitive shape algorithms are brittle, i.e. in FCL)
+    bool replacePrimitiveShapesWithMeshes_ = false;
 };
 
 typedef exotica::Factory<exotica::CollisionScene> CollisionScene_fac;

--- a/exotica/init/Scene.in
+++ b/exotica/init/Scene.in
@@ -6,6 +6,7 @@ Optional std::string SRDF = "";
 Optional bool SetRobotDescriptionRosParams = false;  // to be used in conjunction with URDF or SRDF to set the robot_description and robot_description_semantic from the files/string in URDF/SRDF
 Optional std::string CollisionScene = "CollisionSceneFCL";
 Optional bool AlwaysUpdateCollisionScene = false;
+Optional bool ReplacePrimitiveShapesWithMeshes = false;
 Optional bool ReplaceCylindersWithCapsules = false;
 Optional std::string LoadScene = "";
 Optional std::vector<exotica::Initializer> Links = std::vector<exotica::Initializer>();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -123,6 +123,7 @@ void Scene::Instantiate(SceneInitializer& init)
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
+    collision_scene_->setReplacePrimitiveShapesWithMeshes(init.ReplacePrimitiveShapesWithMeshes);
     collision_scene_->replaceCylindersWithCapsules = init.ReplaceCylindersWithCapsules;
     updateSceneFrames();
     updateInternalFrames(false);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -950,6 +950,7 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
     // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation
     collisionScene.def_property("alwaysExternallyUpdatedCollisionScene", &CollisionScene::getAlwaysExternallyUpdatedCollisionScene, &CollisionScene::setAlwaysExternallyUpdatedCollisionScene);
+    collisionScene.def_property("replacePrimitiveShapesWithMeshes", &CollisionScene::getReplacePrimitiveShapesWithMeshes, &CollisionScene::setReplacePrimitiveShapesWithMeshes);
     collisionScene.def_readwrite("replaceCylindersWithCapsules", &CollisionScene::replaceCylindersWithCapsules);
     collisionScene.def_property("robotLinkScale", &CollisionScene::getRobotLinkScale, &CollisionScene::setRobotLinkScale);
     collisionScene.def_property("worldLinkScale", &CollisionScene::getWorldLinkScale, &CollisionScene::setWorldLinkScale);


### PR DESCRIPTION
Adds the option to replace primitives with meshes internally - makes computation slower but in some cases allows for more accurate computation of contact points. Off by default.