### PR TITLE
Fix segmentation fault when using joint limits

### DIFF
--- a/exotations/solvers/ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_solver/CMakeLists.txt
@@ -35,9 +35,10 @@ target_link_libraries(ompl_solver
   ${catkin_LIBRARIES} ${OMPL_LIBRARIES}
 )
 
-add_dependencies(ompl_solver ompl_solver_initializers)
+add_dependencies(ompl_solver ${PROJECT_NAME}_initializers)
 
 pybind_add_module(${PROJECT_NAME}_py MODULE src/ompl_solver/ompl_py.cpp ${SOURCES})
+add_dependencies(${PROJECT_NAME}_py ompl_solver ${PROJECT_NAME}_initializers)
 install(TARGETS ${PROJECT_NAME}_py LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})
 
 

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -59,14 +59,18 @@ void JointLimit::Initialize()
 {
     double percent = init_.SafePercentage;
 
-    std::vector<std::string> jnts = scene_->getJointNames();
-    N = jnts.size();
+    N = scene_->getSolver().getNumControlledJoints();
+
+    // TODO: Strictly speaking this is incorrect as joint limits can be changed during runtime.
     Eigen::MatrixXd limits = scene_->getSolver().getJointLimits();
-    low_limits_ = limits.col(0);
-    high_limits_ = limits.col(1);
+
+    low_limits_.resize(N);
+    high_limits_.resize(N);
     tau_.resize(N);
     for (int i = 0; i < N; i++)
     {
+        low_limits_(i) = limits(i, 0);
+        high_limits_(i) = limits(i, 1);
         tau_(i) = percent * (high_limits_(i) - low_limits_(i)) * 0.5;
     }
 }

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -157,7 +157,7 @@ public:
     std::shared_ptr<KinematicResponse> RequestFrames(const KinematicsRequest& request);
     void Update(Eigen::VectorXdRefConst x);
     void resetJointLimits();
-    Eigen::MatrixXdRef getJointLimits();
+    Eigen::MatrixXd getJointLimits() const { return jointLimits_; }
     void setJointLimitsLower(Eigen::VectorXdRefConst lower_in);
     void setJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
     void setFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -56,7 +56,7 @@ public:
     Eigen::VectorXd getGoal(const std::string& task_name);
     double getRho(const std::string& task_name);
     virtual void preupdate();
-    Eigen::MatrixXdRef getBounds();
+    Eigen::MatrixXd getBounds() const;
 
     bool isValid();
 

--- a/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
@@ -57,7 +57,7 @@ public:
     void setRho(const std::string& task_name, const double rho, int t = 0);
     Eigen::VectorXd getGoal(const std::string& task_name, int t = 0);
     double getRho(const std::string& task_name, int t = 0);
-    Eigen::MatrixXdRef getBounds();
+    Eigen::MatrixXd getBounds() const;
 
     int getT() const { return T; }
     void setT(int T_in);

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -65,7 +65,7 @@ public:
     Eigen::VectorXd getGoalNEQ(const std::string& task_name);
     double getRhoNEQ(const std::string& task_name);
     virtual void preupdate();
-    Eigen::MatrixXdRef getBounds();
+    Eigen::MatrixXd getBounds() const;
 
     double getScalarCost();
     Eigen::VectorXd getScalarJacobian();

--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -66,7 +66,7 @@ public:
     void setRhoNEQ(const std::string& task_name, const double rho, int t = 0);
     Eigen::VectorXd getGoalNEQ(const std::string& task_name, int t = 0);
     double getRhoNEQ(const std::string& task_name, int t = 0);
-    Eigen::MatrixXdRef getBounds();
+    Eigen::MatrixXd getBounds() const;
 
     int getT() const { return T; }
     void setT(int T_in);

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -285,6 +285,7 @@ void KinematicTree::BuildTree(const KDL::Tree& RobotKinematics)
     }
     ModelTree[0]->isRobotLink = false;
 
+    jointLimits_ = Eigen::MatrixXd::Zero(NumControlledJoints, 2);
     resetJointLimits();
 
     // Create random distributions for state sampling
@@ -773,11 +774,6 @@ void KinematicTree::UpdateJdot()
     }
 }
 
-Eigen::MatrixXdRef KinematicTree::getJointLimits()
-{
-    return jointLimits_;
-}
-
 exotica::BASE_TYPE KinematicTree::getModelBaseType()
 {
     return ModelBaseType;
@@ -897,7 +893,7 @@ void KinematicTree::resetJointLimits()
 
 void KinematicTree::updateJointLimits()
 {
-    jointLimits_ = Eigen::MatrixXd::Zero(getNumControlledJoints(), 2);
+    jointLimits_.setZero();
     for (int i = 0; i < ControlledJoints.size(); i++)
     {
         jointLimits_(i, 0) = ControlledJoints[i].lock()->JointLimits[0];

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -51,7 +51,7 @@ void BoundedEndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer
 {
 }
 
-Eigen::MatrixXdRef BoundedEndPoseProblem::getBounds()
+Eigen::MatrixXd BoundedEndPoseProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();
 }
@@ -230,7 +230,7 @@ double BoundedEndPoseProblem::getRho(const std::string& task_name)
 bool BoundedEndPoseProblem::isValid()
 {
     Eigen::VectorXd x = scene_->getSolver().getControlledState();
-    Eigen::MatrixXdRef bounds = scene_->getSolver().getJointLimits();
+    auto bounds = scene_->getSolver().getJointLimits();
     for (unsigned int i = 0; i < N; i++)
     {
         if (x(i) < bounds(i, 0) || x(i) > bounds(i, 1)) return false;

--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -47,7 +47,7 @@ BoundedTimeIndexedProblem::~BoundedTimeIndexedProblem()
 {
 }
 
-Eigen::MatrixXdRef BoundedTimeIndexedProblem::getBounds()
+Eigen::MatrixXd BoundedTimeIndexedProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();
 }

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -51,7 +51,7 @@ void EndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer>& init
 {
 }
 
-Eigen::MatrixXdRef EndPoseProblem::getBounds()
+Eigen::MatrixXd EndPoseProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();
 }
@@ -367,7 +367,7 @@ double EndPoseProblem::getRhoNEQ(const std::string& task_name)
 bool EndPoseProblem::isValid()
 {
     Eigen::VectorXd x = scene_->getSolver().getControlledState();
-    Eigen::MatrixXdRef bounds = scene_->getSolver().getJointLimits();
+    auto bounds = scene_->getSolver().getJointLimits();
 
     // Check joint limits
     for (unsigned int i = 0; i < N; i++)

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -50,7 +50,7 @@ SamplingProblem::~SamplingProblem()
 std::vector<double> SamplingProblem::getBounds()
 {
     std::vector<double> bounds;
-    Eigen::MatrixXdRef jointLimits = scene_->getSolver().getJointLimits();
+    auto jointLimits = scene_->getSolver().getJointLimits();
 
     bounds.resize(2 * N);
     for (unsigned int i = 0; i < N; i++)

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -47,7 +47,7 @@ TimeIndexedProblem::~TimeIndexedProblem()
 {
 }
 
-Eigen::MatrixXdRef TimeIndexedProblem::getBounds()
+Eigen::MatrixXd TimeIndexedProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();
 }
@@ -633,7 +633,7 @@ double TimeIndexedProblem::getRhoNEQ(const std::string& task_name, int t)
 bool TimeIndexedProblem::isValid()
 {
     bool succeeded = true;
-    Eigen::MatrixXdRef bounds = scene_->getSolver().getJointLimits();
+    auto bounds = scene_->getSolver().getJointLimits();
 
     // Check for every state
     for (unsigned int t = 0; t < T; t++)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -51,7 +51,7 @@ TimeIndexedSamplingProblem::~TimeIndexedSamplingProblem()
 std::vector<double> TimeIndexedSamplingProblem::getBounds()
 {
     std::vector<double> bounds;
-    Eigen::MatrixXdRef jointLimits = scene_->getSolver().getJointLimits();
+    auto jointLimits = scene_->getSolver().getJointLimits();
 
     bounds.resize(2 * N);
     for (unsigned int i = 0; i < N; i++)


### PR DESCRIPTION
Since 86894b343c898d4f8b5e397b404c9f0cb9df0fec using the ``JointLimit`` task map or directly indexing the column of ``KinematicTree::getJointLimits().col(0)`` caused an assignment segmentation fault. While I do not fully understand why changing the type to a copy (returning a ``Eigen::MatrixXd``) does not resolve the issue, the changes here fix the wrongly introduced ``Eigen::MatrixXdRef`` return type that should only be used as a function parameter (my bad).

In order to reproduce the before case, you can simply add a ``JointLimit`` taskmap to the IK example. It worked before 86894b343c898d4f8b5e397b404c9f0cb9df0fec and was broken thereafter.