### PR TITLE
CollisionSceneFCL: suppress version output at every contruction

### DIFF
--- a/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
+++ b/exotations/collision_scene_fcl/include/collision_scene_fcl/CollisionSceneFCL.h
@@ -67,6 +67,8 @@ public:
        */
     virtual ~CollisionSceneFCL();
 
+    void setup();
+
     static bool isAllowedToCollide(fcl::CollisionObject* o1, fcl::CollisionObject* o2, bool self, CollisionSceneFCL* scene);
     static bool collisionCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data);
     static bool collisionCallbackDistance(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void* data, double& dist);

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -47,7 +47,7 @@ namespace exotica
 {
 CollisionSceneFCL::CollisionSceneFCL()
 {
-    HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
+    // HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCL::~CollisionSceneFCL()

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -47,7 +47,7 @@ namespace exotica
 {
 CollisionSceneFCL::CollisionSceneFCL()
 {
-    // HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
+    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCL::~CollisionSceneFCL()

--- a/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
+++ b/exotations/collision_scene_fcl/src/CollisionSceneFCL.cpp
@@ -45,13 +45,14 @@ fcl::Transform3f KDL2fcl(const KDL::Frame& frame)
 
 namespace exotica
 {
-CollisionSceneFCL::CollisionSceneFCL()
-{
-    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
-}
-
+CollisionSceneFCL::CollisionSceneFCL() {}
 CollisionSceneFCL::~CollisionSceneFCL()
 {
+}
+
+void CollisionSceneFCL::setup()
+{
+    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
 }
 
 void CollisionSceneFCL::updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)

--- a/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
+++ b/exotations/collision_scene_fcl_latest/include/collision_scene_fcl_latest/CollisionSceneFCLLatest.h
@@ -73,6 +73,8 @@ public:
        */
     virtual ~CollisionSceneFCLLatest();
 
+    void setup();
+
     static bool isAllowedToCollide(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, bool self, CollisionSceneFCLLatest* scene);
     static bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data);
     static bool collisionCallbackDistance(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& dist);

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -49,7 +49,7 @@ namespace exotica
 {
 CollisionSceneFCLLatest::CollisionSceneFCLLatest()
 {
-    // HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
+    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCLLatest::~CollisionSceneFCLLatest()

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -49,7 +49,7 @@ namespace exotica
 {
 CollisionSceneFCLLatest::CollisionSceneFCLLatest()
 {
-    HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
+    // HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
 }
 
 CollisionSceneFCLLatest::~CollisionSceneFCLLatest()

--- a/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
+++ b/exotations/collision_scene_fcl_latest/src/CollisionSceneFCLLatest.cpp
@@ -47,13 +47,14 @@ fcl::Transform3d KDL2fcl(const KDL::Frame& frame)
 
 namespace exotica
 {
-CollisionSceneFCLLatest::CollisionSceneFCLLatest()
-{
-    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
-}
-
+CollisionSceneFCLLatest::CollisionSceneFCLLatest() {}
 CollisionSceneFCLLatest::~CollisionSceneFCLLatest()
 {
+}
+
+void CollisionSceneFCLLatest::setup()
+{
+    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
 }
 
 void CollisionSceneFCLLatest::updateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -103,6 +103,10 @@ public:
        */
     virtual ~CollisionScene() {}
     /**
+     * @brief setup additional construction that requires initialiser parameter
+     */
+    virtual void setup() {}
+    /**
        * \brief Checks if the whole robot is valid (collision only).
        * @param self Indicate if self collision check is required.
        * @return True, if the state is collision free..

--- a/exotica/include/exotica/CollisionScene.h
+++ b/exotica/include/exotica/CollisionScene.h
@@ -234,6 +234,8 @@ public:
 
     bool replaceCylindersWithCapsules = false;
 
+    bool debug_ = false;
+
 protected:
     /// The allowed collision matrix
     AllowedCollisionMatrix acm_;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -122,6 +122,7 @@ void Scene::Instantiate(SceneInitializer& init)
     }
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
+    collision_scene_->debug_ = this->debug_;
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
     collision_scene_->replaceCylindersWithCapsules = init.ReplaceCylindersWithCapsules;
     updateSceneFrames();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -123,6 +123,7 @@ void Scene::Instantiate(SceneInitializer& init)
 
     collision_scene_ = Setup::createCollisionScene(init.CollisionScene);
     collision_scene_->debug_ = this->debug_;
+    collision_scene_->setup();
     collision_scene_->setAlwaysExternallyUpdatedCollisionScene(force_collision_);
     collision_scene_->replaceCylindersWithCapsules = init.ReplaceCylindersWithCapsules;
     updateSceneFrames();


### PR DESCRIPTION
This simply removes the output `FCL version:` at every construction of `CollisionSceneFCL` or `CollisionSceneFCLLatest`. It does not change during runtime anyway.