### PR TITLE
Fixed 2D convex hull and quasi static task map

### DIFF
--- a/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
+++ b/examples/exotica_examples/resources/configs/ik_quasistatic_valkyrie.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
-  <!--<BayesianIK Name="Bayesian" MaxIterations="20" MaxBacktrackIterations="10" />-->
+  <!--<BayesianIK Name="Bayesian" MaxIterations="10" MaxBacktrackIterations="10" />-->
   <IKsolver Name="IK">
-    <MaxIterations>100</MaxIterations>
+    <MaxIterations>10</MaxIterations>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-8</Tolerance>
-    <Alpha>0.05</Alpha>
+    <Alpha>0.1</Alpha>
     <C>1e-3</C>
   </IKsolver>
 

--- a/exotations/task_maps/task_map/include/task_map/ConvexHull.h
+++ b/exotations/task_maps/task_map/include/task_map/ConvexHull.h
@@ -6,10 +6,13 @@
 
 namespace exotica
 {
-double lineDist2D(Eigen::VectorXdRefConst p1, Eigen::VectorXdRefConst p2, Eigen::VectorXdRefConst p)
+
+///
+/// \brief detDiff2d Computes the 2D determinant (analogous to a 2D cross product) of a two vectors defined by P_1P_2 and P_1P.
+///
+double detDiff2d(Eigen::VectorXdRefConst p1, Eigen::VectorXdRefConst p2, Eigen::VectorXdRefConst p)
 {
-    return (p(1) - p1(1)) * (p2(0) - p1(0)) -
-           (p2(1) - p1(1)) * (p(0) - p1(0));
+    return (p(1) - p1(1)) * (p2(0) - p1(0)) - (p2(1) - p1(1)) * (p(0) - p1(0));
 }
 
 std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoints, int p1, int p2)
@@ -19,7 +22,7 @@ std::list<int> quickHull(Eigen::MatrixXdRefConst points, std::list<int>& halfPoi
     std::list<int> newHalfPoints;
     for (int i : halfPoints)
     {
-        double d = lineDist2D(points.row(p1), points.row(p2), points.row(i));
+        double d = detDiff2d(points.row(p1).transpose(), points.row(p2).transpose(), points.row(i).transpose());
         if (d >= 0.0)
         {
             newHalfPoints.push_back(i);


### PR DESCRIPTION
- Fixes #347 
- This was caused by `Eigen::Ref<Eigen::VectorXd>` messing up the indexing when constructed from `matrix.row(i)`. The fix is to use `matrix.row(i).transpose()`.
- `lineDist2D()` was renamed to `detDiff2d` (determinant of two 2D vector differences).