### PR TITLE
OMPL console bridge fix

### DIFF
--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -34,6 +34,21 @@
 #include <ompl/util/RandomNumbers.h>
 #include <ompl_solver/ompl_solver.h>
 
+// Backwards compatible console macros
+#ifndef CONSOLE_BRIDGE_logDebug
+#define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logInform(fmt, ...) \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
+console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#endif
+
 namespace exotica
 {
 template <class ProblemType>

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -35,6 +35,21 @@
 #include <ompl/util/RandomNumbers.h>
 #include <time_indexed_rrt_connect/TimeIndexedRRTConnect.h>
 
+// Backwards compatible console macros
+#ifndef CONSOLE_BRIDGE_logDebug
+#define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logInform(fmt, ...) \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+
+#define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
+console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#endif
+
 REGISTER_MOTIONSOLVER_TYPE("TimeIndexedRRTConnect", exotica::TimeIndexedRRTConnect)
 
 namespace exotica


### PR DESCRIPTION
The OMPL packages fail compilation because the console bridge API changed in the newer version.
This fix adds backward compatibility.
Hopefully this will get deprecated soon.