### PR TITLE
Alpha vector for IKsolver

### DIFF
--- a/exotations/solvers/ik_solver/init/IKsolver.in
+++ b/exotations/solvers/ik_solver/init/IKsolver.in
@@ -3,4 +3,4 @@ Optional double Tolerance = 1e-5;
 Optional double Convergence = 0.0;
 Optional double MaxStep = 0.02;
 Optional double C = 0.0;
-Optional double Alpha = 1.0;
+Optional Eigen::VectorXd Alpha = Eigen::VectorXd(1);

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -111,6 +111,9 @@ void IKsolver::specifyProblem(PlanningProblem_ptr pointer)
 
     W = prob_->W;
     Winv = W.inverse();
+
+    if(parameters_.Alpha.size()!=1 && prob_->N!=parameters_.Alpha.size())
+        throw_named("Alpha must have length of 1 or N.");
 }
 
 UnconstrainedEndPoseProblem_ptr& IKsolver::getProblem()
@@ -162,7 +165,12 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
 
         ScaleToStepSize(qd);
 
-        q = q - qd * parameters_.Alpha;
+        if(parameters_.Alpha.size()==1) {
+            q -= qd * parameters_.Alpha[0];
+        }
+        else {
+            q -= qd.cwiseProduct(parameters_.Alpha);
+        }
 
         if (qd.norm() < parameters_.Convergence)
         {


### PR DESCRIPTION
This PR changes the scalar alpha to a vector to apply scales elementwise per state variable instead of scaling the whole state vector. The vector size must be 1 or N (state size).