### PR TITLE
Remove pybind11_catkin submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ The library itself consists of two major specifications, both of which are abstr
 * Ubuntu 14.04 or 16.04 (16.04 not covered by continuous integration)
 * [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/) (```catkin_make``` is no longer supported)
 * [rosdep](http://wiki.ros.org/rosdep)
-* [ROS](http://wiki.ros.org/Installation) (```ros-[release]-desktop-full``` is recommended but more minimal versions may be sufficient in conjunction with rosdep)
+* [ROS](http://wiki.ros.org/Installation) (```ros-[release]-desktop``` is recommended but more minimal versions work in conjunction with rosdep)
 * ``moveit-ros-planning-interface``
-* [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) > 3.2.7. For Ubuntu 14.04, we recommend system-installing 3.2.10 or newer, for which we provide a [Debian](http://terminator.robots.inf.ed.ac.uk/apt/libeigen3-dev.deb).
-* gcc > [4.9](https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu) -- the 14.04 system-installed 4.8.4 won't work.
+* [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) >3.2.7. On Ubuntu 14.04, we recommend system-installing 3.2.10 or newer, for which we provide a [Debian](http://terminator.robots.inf.ed.ac.uk/apt/libeigen3-dev.deb). On Ubuntu 16.04, you can use the system-provided ``libeigen3-dev`` package.
+* gcc >[4.9](https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu) -- the 14.04 system-installed 4.8.4 won't work. On Ubuntu 16.04, you can use the system-provided gcc/g++.
+* ``pybind11_catkin``, which can be installed from Debians on Indigo and Kinetic (``ros-[release]-pybind11-catkin``). For other ROS versions, please clone into your source directory from [here](https://github.com/ipab-slmc/pybind11_catkin).
 
 # Installation
 
@@ -27,7 +28,7 @@ The library itself consists of two major specifications, both of which are abstr
 1. Install dependencies
   1. If running the rosdep for the first time start by running:
      ```sudo rosdep init```
-  1. ```rosdep update ; rosdep install --from-paths ./ -i ```
+  1. ```rosdep update ; rosdep install --from-paths ./ -iy ```
 1. Compile the code ```catkin build -s```.
 1. Source the config file (ideally inside ```~/.bashrc```): ```source path_to_workspace/devel/setup.bash```. You may have to source the config file from your installspace if your workspace is configured for installation.
 


### PR DESCRIPTION
It can now be installed from ROS binaries.