### PR TITLE
Add maps between model links and collision links and controlled links and collision links

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -199,6 +199,8 @@ public:
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);
     int IsControlled(std::shared_ptr<KinematicElement> Joint);
+    int IsControlled(std::string jointName);
+    int IsControlledLink(std::string linkName);
 
     Eigen::VectorXd getModelState();
     std::map<std::string, double> getModelStateMap();

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -161,6 +161,16 @@ public:
      * @return     Whether collision scene transforms are force updated on every scene update.
      */
     bool alwaysUpdatesCollisionScene() { return force_collision_; }
+    /**
+     * @brief      Returns a map between a model link name and the names of associated collision links.
+     * @return     Map between model links and all associated collision links.
+     */
+    std::map<std::string, std::vector<std::string>> getModelLinkToCollisionLinkMap() { return modelLink_to_collisionLink_map_; };
+    /**
+     * @brief      Returns a map between controlled robot link names and associated collision link names. Here we consider all fixed links between controlled links as belonging to the previous controlled link (as if the collision links had been fused).
+     * @return     Map between controlled links and associated collision links.
+     */
+    std::map<std::string, std::vector<std::string>> getControlledLinkToCollisionLinkMap() { return controlledLink_to_collisionLink_map_; };
 private:
     /// The name of the scene
     std::string name_;
@@ -197,6 +207,12 @@ private:
     std::map<std::string, std::pair<std::weak_ptr<KinematicElement>, std::shared_ptr<Trajectory>>> trajectory_generators_;
 
     bool force_collision_;
+
+    /// \brief Mapping between model link names and collision links.
+    std::map<std::string, std::vector<std::string>> modelLink_to_collisionLink_map_;
+
+    /// \brief Mapping between controlled link name and collision links
+    std::map<std::string, std::vector<std::string>> controlledLink_to_collisionLink_map_;
 
     KinematicsRequest kinematicRequest;
     std::shared_ptr<KinematicResponse> kinematicSolution;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -471,6 +471,25 @@ int KinematicTree::IsControlled(std::shared_ptr<KinematicElement> Joint)
     return -1;
 }
 
+int KinematicTree::IsControlled(std::string jointName)
+{
+    for (int i = 0; i < ControlledJointsNames.size(); i++)
+    {
+        if (ControlledJointsNames[i] == jointName) return i;
+    }
+    return -1;
+}
+
+int KinematicTree::IsControlledLink(std::string linkName)
+{
+    for (int i = 0; i < ControlledJoints.size(); i++)
+    {
+        auto joint = ControlledJoints[i].lock();
+        if (joint->Segment.getName() == linkName) return i;
+    }
+    return -1;
+}
+
 std::shared_ptr<KinematicResponse> KinematicTree::RequestFrames(const KinematicsRequest& request)
 {
     Flags = request.Flags;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -545,7 +545,7 @@ void KinematicTree::Update(Eigen::VectorXdRefConst x)
 {
     if (x.rows() != StateSize) throw_pretty("Wrong state vector size! Got " << x.rows() << " expected " << StateSize);
 
-    for (int i = 0; i < ControlledJoints.size(); i++)
+    for (int i = 0; i < NumControlledJoints; i++)
         TreeState(ControlledJoints[i].lock()->Id) = x(i);
 
     UpdateTree();
@@ -913,7 +913,7 @@ void KinematicTree::resetJointLimits()
 void KinematicTree::updateJointLimits()
 {
     jointLimits_.setZero();
-    for (int i = 0; i < ControlledJoints.size(); i++)
+    for (int i = 0; i < NumControlledJoints; i++)
     {
         jointLimits_(i, 0) = ControlledJoints[i].lock()->JointLimits[0];
         jointLimits_(i, 1) = ControlledJoints[i].lock()->JointLimits[1];

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -599,7 +599,7 @@ void Scene::updateSceneFrames()
     ps_->getCurrentStateNonConst().update(true);
     const std::vector<const robot_model::LinkModel*>& links =
         ps_->getCollisionRobot()->getRobotModel()->getLinkModelsWithCollisionGeometry();
-    bool lastControlledJointId = -1;
+    int lastControlledJointId = -1;
     std::string lastControlledLinkName;
     for (int i = 0; i < links.size(); ++i)
     {
@@ -608,9 +608,9 @@ void Scene::updateSceneFrames()
         int jointId = getSolver().IsControlledLink(links[i]->getName());
         if (jointId != -1)
         {
-            HIGHLIGHT_NAMED(links[i], "jointId=" << jointId << ", lastControlledJointId=" << lastControlledJointId);
+            HIGHLIGHT_NAMED(links[i]->getName(), "jointId=" << jointId << ", lastControlledJointId=" << lastControlledJointId);
 
-            if (jointId != lastControlledJointId)
+            if (lastControlledJointId != jointId)
             {
                 HIGHLIGHT("Last lastControlledJointId was " << lastControlledJointId << " now setting it to " << jointId);
                 lastControlledLinkName = links[i]->getName();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -608,11 +608,8 @@ void Scene::updateSceneFrames()
         int jointId = getSolver().IsControlledLink(links[i]->getName());
         if (jointId != -1)
         {
-            HIGHLIGHT_NAMED(links[i]->getName(), "jointId=" << jointId << ", lastControlledJointId=" << lastControlledJointId);
-
             if (lastControlledJointId != jointId)
             {
-                HIGHLIGHT("Last lastControlledJointId was " << lastControlledJointId << " now setting it to " << jointId);
                 lastControlledLinkName = links[i]->getName();
                 lastControlledJointId = jointId;
             }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -962,6 +962,8 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("scale") = Eigen::Vector3d::Ones(),
               py::arg("updateCollisionScene") = true);
     scene.def("removeObject", &Scene::removeObject);
+    scene.def_property_readonly("modelLinkToCollisionLinkMap", &Scene::getModelLinkToCollisionLinkMap);
+    scene.def_property_readonly("controlledLinkToCollisionLinkMap", &Scene::getControlledLinkToCollisionLinkMap);
 
     py::class_<CollisionScene, std::shared_ptr<CollisionScene>> collisionScene(module, "CollisionScene");
     // TODO: expose isStateValid, isCollisionFree, getCollisionDistance, getCollisionWorldLinks, getCollisionRobotLinks, getTranslation


### PR DESCRIPTION
Adds two maps during Scene creation which map model and controlled links to corresponding collision links. This information is required for more advanced collision task maps.