### PR TITLE
issue225_kinematictree_memory_leak.py: Fix leak on 16.04

### DIFF
--- a/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
+++ b/examples/exotica_examples/tests/issue225_kinematictree_memory_leak.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import time
 import resource
 import numpy as np
@@ -17,7 +18,7 @@ memory_usage_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 print(">>> Before:", e-s, " - Memory Usage Before:", memory_usage_before)
 
 print(">>> Loading and cleaning scene 500 times")
-for _ in range(500):
+for _ in xrange(500):
     ompl.getProblem().update(np.zeros(7,))
     sc.cleanScene()
     sc.loadSceneFile(
@@ -31,7 +32,7 @@ print(">>> LEAK:", memory_usage_intermediate - memory_usage_before)
 assert (memory_usage_intermediate - memory_usage_before) == 0
 
 print(">>> updateSceneFrames 10000 times")
-for _ in range(10000):
+for _ in xrange(10000):
     sc.updateSceneFrames()
     sc.updateCollisionObjects()
 

--- a/examples/exotica_examples/tests/runtest.py
+++ b/examples/exotica_examples/tests/runtest.py
@@ -17,8 +17,8 @@ pytests = ['core.py',
          'valkyrie_collision_check_fcl_latest.py',
          'collision_scene_distances.py',
          'test_continuous_collision_check.py',
-         'scene_creation.py'
-         #'issue225_kinematictree_memory_leak.py'
+         'scene_creation.py',
+         'issue225_kinematictree_memory_leak.py'
         ]
 
 for test in cpptests:


### PR DESCRIPTION
The leak wasn't in Exotica but by using range() in Python2 rather than Python3. The other points listed in #333 are non-issues: the collision one is known as faulty (#364) and the collision failure is due to different val_description meshes on the Valkyrie operator workstation.

Resolves #333.