### PR TITLE
Equality and inequality constraints for sampling problems

### DIFF
--- a/examples/exotica_examples/resources/configs/example_lazy_prm.xml
+++ b/examples/exotica_examples/resources/configs/example_lazy_prm.xml
@@ -21,9 +21,9 @@
         <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
         <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <Goal>2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>

--- a/examples/exotica_examples/resources/configs/example_manipulate_ompl.xml
+++ b/examples/exotica_examples/resources/configs/example_manipulate_ompl.xml
@@ -23,9 +23,9 @@
       <CollisionCheck Name="Collision" SelfCollision="0" />
     </Maps>
 
-    <Constraint>
+    <Equality>
       <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
 
     <Goal>0 0 0 0 0 0 0</Goal>

--- a/examples/exotica_examples/resources/configs/example_prm.xml
+++ b/examples/exotica_examples/resources/configs/example_prm.xml
@@ -21,9 +21,9 @@
         <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
         <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <Goal>2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>

--- a/examples/exotica_examples/resources/configs/example_projections.xml
+++ b/examples/exotica_examples/resources/configs/example_projections.xml
@@ -21,9 +21,9 @@
         <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
         <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <Goal>2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>

--- a/examples/exotica_examples/resources/configs/ompl_solver_demo.xml
+++ b/examples/exotica_examples/resources/configs/ompl_solver_demo.xml
@@ -21,9 +21,9 @@
       </Distance>
     </Maps>
 
-    <Constraint>
+    <Inequality>
       <Task Task="Distance" Rho="-1" Goal="0.42"/>
-    </Constraint>
+    </Inequality>
 
     <Goal>2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>

--- a/examples/exotica_examples/resources/configs/ompl_solver_demo_freebase.xml
+++ b/examples/exotica_examples/resources/configs/ompl_solver_demo_freebase.xml
@@ -22,9 +22,9 @@
       </Distance>
     </Maps>
 
-    <Constraint>
+    <Inequality>
       <Task Task="Distance" Rho="-1" Goal="0.42"/>
-    </Constraint>
+    </Inequality>
 
     <Goal>2 0 0.5 2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>

--- a/examples/exotica_examples/resources/configs/test_problems.xml
+++ b/examples/exotica_examples/resources/configs/test_problems.xml
@@ -80,10 +80,11 @@
         </Distance>
     </Maps>
 
-    <Constraint>
+    <Inequality>
         <Task Task="Distance" Rho="-1" Goal="0.42"/>
-    </Constraint>
+    </Inequality>
 
+    <ConstraintTolerance>1e-12</ConstraintTolerance>
     <Goal>2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
 </SamplingProblem>
 
@@ -104,9 +105,9 @@
         <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
         <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <T>3</T>
     <GoalTime>3</GoalTime>

--- a/examples/exotica_examples/scripts/example_attach.py
+++ b/examples/exotica_examples/scripts/example_attach.py
@@ -34,7 +34,7 @@ start_pose = [[0]*len(goal_pose[0]),goal_pose[0],goal_pose[1]]
 solution = []
 for i in range(0,3):
     ompl.getProblem().startState = start_pose[i]
-    ompl.getProblem().setGoalState(goal_pose[i])
+    ompl.getProblem().goalState = goal_pose[i]
     handleAttaching(i, start_pose[i], ompl.getProblem().getScene())
     solution.append(ompl.solve().tolist())
 

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -202,7 +202,7 @@ template <class ProblemType>
 void OMPLsolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
 {
     Eigen::VectorXd q0 = prob_->applyStartState();
-    setGoalState(prob_->goal_, init_.Epsilon);
+    setGoalState(prob_->getGoalState(), init_.Epsilon);
 
     ompl::base::ScopedState<> ompl_start_state(state_space_);
     state_space_->as<OMPLStateSpace>()->ExoticaToOMPLState(q0, ompl_start_state.get());

--- a/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
+++ b/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
@@ -290,7 +290,7 @@ protected:
         }
         else
             changed = false;
-        if (tb < si_->getStateSpace()->as<OMPLTimeIndexedRNStateSpace>()->prob_->tStart || tb > si_->getStateSpace()->as<OMPLTimeIndexedRNStateSpace>()->prob_->tGoal) return false;
+        if (tb < si_->getStateSpace()->as<OMPLTimeIndexedRNStateSpace>()->prob_->tStart || tb > si_->getStateSpace()->as<OMPLTimeIndexedRNStateSpace>()->prob_->getGoalTime()) return false;
         si_->getStateSpace()->as<OMPLTimeIndexedRNStateSpace>()->ExoticaToOMPLState(qb, tb, b->state);
         return true;
     }

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -240,7 +240,7 @@ void TimeIndexedRRTConnect::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTe
 void TimeIndexedRRTConnect::Solve(Eigen::MatrixXd &solution)
 {
     Eigen::VectorXd q0 = prob_->applyStartState();
-    setGoalState(prob_->goal_, prob_->tGoal);
+    setGoalState(prob_->getGoalState(), prob_->getGoalTime());
 
     ompl::base::ScopedState<> ompl_start_state(state_space_);
     state_space_->as<OMPLTimeIndexedRNStateSpace>()->ExoticaToOMPLState(q0, prob_->tStart, ompl_start_state.get());

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -44,7 +44,7 @@ void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != 1) throw_named("Wrong size of phi!");
     if (!scene_->alwaysUpdatesCollisionScene()) cscene_->updateCollisionObjectTransforms();
-    phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance) ? -1.0 : 0.0;
+    phi(0) = cscene_->isStateValid(init_.SelfCollision, init_.SafeDistance) ? 0.0 : 1.0;
 }
 
 void CollisionCheck::Instantiate(CollisionCheckInitializer& init)

--- a/exotica/include/exotica/Problems/SamplingProblem.h
+++ b/exotica/include/exotica/Problems/SamplingProblem.h
@@ -53,31 +53,37 @@ public:
 
     int getSpaceDim();
 
-    void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setThreshold(const std::string& task_name, Eigen::VectorXdRefConst threshold);
-    void setRho(const std::string& task_name, const double rho);
-    Eigen::VectorXd getGoal(const std::string& task_name);
-    Eigen::VectorXd getThreshold(const std::string& task_name);
-    double getRho(const std::string& task_name);
+    void setGoalEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    Eigen::VectorXd getGoalEQ(const std::string& task_name);
+    void setRhoEQ(const std::string& task_name, const double rho);
+    double getRhoEQ(const std::string& task_name);
+
+    void setGoalNEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    Eigen::VectorXd getGoalNEQ(const std::string& task_name);
+    void setRhoNEQ(const std::string& task_name, const double rho);
+    double getRhoNEQ(const std::string& task_name);
 
     std::vector<double> getBounds();
     bool isCompoundStateSpace();
+
+    // TODO(wxm): Implement or remove in clean-up (left-over from constrained sampling, ROBIO 2016)
     std::string local_planner_config_;
     bool full_body_plan_;
 
     SamplingProblemInitializer Parameters;
 
     void setGoalState(Eigen::VectorXdRefConst qT);
-
-    Eigen::VectorXd goal_;
+    const Eigen::VectorXd& getGoalState() { return goal_; }
     TaskSpaceVector Phi;
-    SamplingTask Constraint;
+    SamplingTask Inequality;
+    SamplingTask Equality;
 
     int PhiN;
     int JN;
     int NumTasks;
 
 private:
+    Eigen::VectorXd goal_;
     bool compound_;
 };
 

--- a/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
@@ -54,12 +54,15 @@ public:
 
     int getSpaceDim();
 
-    void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setThreshold(const std::string& task_name, Eigen::VectorXdRefConst threshold);
-    void setRho(const std::string& task_name, const double rho);
-    Eigen::VectorXd getGoal(const std::string& task_name);
-    Eigen::VectorXd getThreshold(const std::string& task_name);
-    double getRho(const std::string& task_name);
+    void setGoalEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    Eigen::VectorXd getGoalEQ(const std::string& task_name);
+    void setRhoEQ(const std::string& task_name, const double rho);
+    double getRhoEQ(const std::string& task_name);
+
+    void setGoalNEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
+    Eigen::VectorXd getGoalNEQ(const std::string& task_name);
+    void setRhoNEQ(const std::string& task_name, const double rho);
+    double getRhoNEQ(const std::string& task_name);
 
     std::vector<double> getBounds();
 
@@ -71,11 +74,10 @@ public:
     void setGoalTime(double t);
 
     double T;
-    double tGoal;
     Eigen::VectorXd vel_limits_;
-    Eigen::VectorXd goal_;
     TaskSpaceVector Phi;
-    SamplingTask Constraint;
+    SamplingTask Inequality;
+    SamplingTask Equality;
 
     TaskSpaceVector ConstraintPhi;
 
@@ -84,6 +86,8 @@ public:
     int NumTasks;
 
 private:
+    double tGoal;
+    Eigen::VectorXd goal_;
 };
 
 typedef std::shared_ptr<exotica::TimeIndexedSamplingProblem> TimeIndexedSamplingProblem_ptr;

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -76,6 +76,7 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
+    double Tolerance = 0.0;  // To avoid numerical issues consider all values below this as 0.0.
 
 protected:
     std::vector<TaskInitializer> TaskInitializers;

--- a/exotica/init/SamplingProblem.in
+++ b/exotica/init/SamplingProblem.in
@@ -3,5 +3,6 @@ Required Eigen::VectorXd Goal;
 Optional std::string LocalPlannerConfig = "";
 Optional Eigen::VectorXd FloatingBaseLowerLimits = Eigen::VectorXd();
 Optional Eigen::VectorXd FloatingBaseUpperLimits = Eigen::VectorXd();
-Optional std::vector<exotica::Initializer> Constraint = std::vector<exotica::Initializer>();
+Optional std::vector<exotica::Initializer> Inequality = std::vector<exotica::Initializer>();
+Optional std::vector<exotica::Initializer> Equality = std::vector<exotica::Initializer>();
 Optional double ConstraintTolerance = 0.0;  // To avoid numerical issues, e.g., in sampling tasks, consider (and set) zero if below this threshold.

--- a/exotica/init/SamplingProblem.in
+++ b/exotica/init/SamplingProblem.in
@@ -4,5 +4,4 @@ Optional std::string LocalPlannerConfig = "";
 Optional Eigen::VectorXd FloatingBaseLowerLimits = Eigen::VectorXd();
 Optional Eigen::VectorXd FloatingBaseUpperLimits = Eigen::VectorXd();
 Optional std::vector<exotica::Initializer> Constraint = std::vector<exotica::Initializer>();
-
-
+Optional double ConstraintTolerance = 0.0;  // To avoid numerical issues, e.g., in sampling tasks, consider (and set) zero if below this threshold.

--- a/exotica/init/TimeIndexedSamplingProblem.in
+++ b/exotica/init/TimeIndexedSamplingProblem.in
@@ -2,4 +2,3 @@ extend <exotica/SamplingProblem>
 Required Eigen::VectorXd JointVelocityLimits;
 Optional double T = 1.0;
 Optional double GoalTime = -1.0; # If goal time is not defined in xml, it will be set to T
-Optional double ConstraintTolerance = 0.0;  // To avoid numerical issues, e.g., in sampling tasks, consider (and set) zero if below this threshold.

--- a/exotica/init/TimeIndexedSamplingProblem.in
+++ b/exotica/init/TimeIndexedSamplingProblem.in
@@ -2,3 +2,4 @@ extend <exotica/SamplingProblem>
 Required Eigen::VectorXd JointVelocityLimits;
 Optional double T = 1.0;
 Optional double GoalTime = -1.0; # If goal time is not defined in xml, it will be set to T
+Optional double ConstraintTolerance = 0.0;  // To avoid numerical issues, e.g., in sampling tasks, consider (and set) zero if below this threshold.

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -125,7 +125,7 @@ void KinematicTree::Instantiate(std::string JointGroup, robot_model::RobotModelP
 
     if (Server::isRos())
     {
-        shapes_pub_ = Server::advertise<visualization_msgs::MarkerArray>(name_ + (name_ == "" ? "" : "/") + "CollisionShapes", 100, true);
+        shapes_pub_ = Server::advertise<visualization_msgs::MarkerArray>(name_ + (name_ == "" ? "" : "/") + "CollisionShapes", 1, true);
         debugSceneChanged = true;
     }
 }

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -90,6 +90,7 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
     Phi.setZero(PhiN);
     TaskSpaceVector dummy;
     Constraint.initialize(init.Constraint, shared_from_this(), dummy);
+    Constraint.Tolerance = init.ConstraintTolerance;
     applyStartState(false);
     preupdate();
 }

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -119,7 +119,7 @@ bool SamplingProblem::isValid(Eigen::VectorXdRefConst x)
     }
     Constraint.update(Phi);
     numberOfProblemUpdates++;
-    return ((Constraint.S * Constraint.ydiff).array() < 0.0).all();
+    return ((Constraint.S * Constraint.ydiff).array().abs() <= 0.0).all();
 }
 
 void SamplingProblem::Update(Eigen::VectorXdRefConst x)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -120,6 +120,58 @@ void TimeIndexedSamplingProblem::setGoalTime(double t)
     tGoal = t;
 }
 
+void TimeIndexedSamplingProblem::setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal)
+{
+    for (int i = 0; i < Constraint.Indexing.size(); i++)
+    {
+        if (Constraint.Tasks[i]->getObjectName() == task_name)
+        {
+            if (goal.rows() != Constraint.Indexing[i].Length) throw_pretty("Expected length of " << Constraint.Indexing[i].Length << " and got " << goal.rows());
+            Constraint.y.data.segment(Constraint.Indexing[i].Start, Constraint.Indexing[i].Length) = goal;
+            return;
+        }
+    }
+    throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
+}
+
+void TimeIndexedSamplingProblem::setRho(const std::string& task_name, const double rho)
+{
+    for (int i = 0; i < Constraint.Indexing.size(); i++)
+    {
+        if (Constraint.Tasks[i]->getObjectName() == task_name)
+        {
+            Constraint.Rho(Constraint.Indexing[i].Id) = rho;
+            preupdate();
+            return;
+        }
+    }
+    throw_pretty("Cannot set Rho. Task map '" << task_name << "' does not exist.");
+}
+
+Eigen::VectorXd TimeIndexedSamplingProblem::getGoal(const std::string& task_name)
+{
+    for (int i = 0; i < Constraint.Indexing.size(); i++)
+    {
+        if (Constraint.Tasks[i]->getObjectName() == task_name)
+        {
+            return Constraint.y.data.segment(Constraint.Indexing[i].Start, Constraint.Indexing[i].Length);
+        }
+    }
+    throw_pretty("Cannot get Goal. Task map '" << task_name << "' does not exist.");
+}
+
+double TimeIndexedSamplingProblem::getRho(const std::string& task_name)
+{
+    for (int i = 0; i < Constraint.Indexing.size(); i++)
+    {
+        if (Constraint.Tasks[i]->getObjectName() == task_name)
+        {
+            return Constraint.Rho(Constraint.Indexing[i].Id);
+        }
+    }
+    throw_pretty("Cannot get Rho. Task map '" << task_name << "' does not exist.");
+}
+
 bool TimeIndexedSamplingProblem::isValid(Eigen::VectorXdRefConst x, double t)
 {
     scene_->Update(x, t);

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -183,7 +183,7 @@ bool TimeIndexedSamplingProblem::isValid(Eigen::VectorXdRefConst x, double t)
     }
     Constraint.update(Phi);
     numberOfProblemUpdates++;
-    return ((Constraint.S * Constraint.ydiff).array() < 0.0).all();
+    return ((Constraint.S * Constraint.ydiff).array().abs() <= 0.0).all();
 }
 
 void TimeIndexedSamplingProblem::preupdate()

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -93,6 +93,7 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
     Phi.setZero(PhiN);
 
     Constraint.initialize(init.Constraint, shared_from_this(), ConstraintPhi);
+    Constraint.Tolerance = init.ConstraintTolerance;
 
     applyStartState(false);
     preupdate();

--- a/exotica/src/Tasks.cpp
+++ b/exotica/src/Tasks.cpp
@@ -341,5 +341,8 @@ void SamplingTask::update(const TaskSpaceVector& bigPhi)
         Phi.data.segment(task.Start, task.Length) = bigPhi.data.segment(Tasks[task.Id]->Start, Tasks[task.Id]->Length);
     }
     ydiff = Phi - y;
+
+    for (unsigned int i = 0; i < ydiff.size(); i++)
+        if (std::abs(ydiff[i]) < Tolerance) ydiff[i] = 0.0;
 }
 }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -839,7 +839,6 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<SamplingProblem, std::shared_ptr<SamplingProblem>, PlanningProblem> samplingProblem(prob, "SamplingProblem");
     samplingProblem.def("update", &SamplingProblem::Update);
-    samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);  // To be deprecated
     samplingProblem.def_property("goalState", &SamplingProblem::getGoalState, &SamplingProblem::setGoalState);
     samplingProblem.def("getSpaceDim", &SamplingProblem::getSpaceDim);
     samplingProblem.def("getBounds", &SamplingProblem::getBounds);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -857,6 +857,10 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedSamplingProblem.def_readonly("NumTasks", &TimeIndexedSamplingProblem::NumTasks);
     timeIndexedSamplingProblem.def_readonly("Phi", &TimeIndexedSamplingProblem::Phi);
     timeIndexedSamplingProblem.def_readonly("Constraint", &TimeIndexedSamplingProblem::Constraint);
+    timeIndexedSamplingProblem.def("setGoal", &TimeIndexedSamplingProblem::setGoal);
+    timeIndexedSamplingProblem.def("setRho", &TimeIndexedSamplingProblem::setRho);
+    timeIndexedSamplingProblem.def("getGoal", &TimeIndexedSamplingProblem::getGoal);
+    timeIndexedSamplingProblem.def("getRho", &TimeIndexedSamplingProblem::getRho);
 
     py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> proxy(module, "CollisionProxy");
     proxy.def(py::init());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -865,11 +865,16 @@ PYBIND11_MODULE(_pyexotica, module)
     timeIndexedSamplingProblem.def_readonly("N", &TimeIndexedSamplingProblem::N);
     timeIndexedSamplingProblem.def_readonly("NumTasks", &TimeIndexedSamplingProblem::NumTasks);
     timeIndexedSamplingProblem.def_readonly("Phi", &TimeIndexedSamplingProblem::Phi);
-    timeIndexedSamplingProblem.def_readonly("Constraint", &TimeIndexedSamplingProblem::Constraint);
-    timeIndexedSamplingProblem.def("setGoal", &TimeIndexedSamplingProblem::setGoal);
-    timeIndexedSamplingProblem.def("setRho", &TimeIndexedSamplingProblem::setRho);
-    timeIndexedSamplingProblem.def("getGoal", &TimeIndexedSamplingProblem::getGoal);
-    timeIndexedSamplingProblem.def("getRho", &TimeIndexedSamplingProblem::getRho);
+    timeIndexedSamplingProblem.def_readonly("Inequality", &TimeIndexedSamplingProblem::Inequality);
+    timeIndexedSamplingProblem.def_readonly("Equality", &TimeIndexedSamplingProblem::Equality);
+    timeIndexedSamplingProblem.def("setGoalEQ", &TimeIndexedSamplingProblem::setGoalEQ);
+    timeIndexedSamplingProblem.def("setRhoEQ", &TimeIndexedSamplingProblem::setRhoEQ);
+    timeIndexedSamplingProblem.def("getGoalEQ", &TimeIndexedSamplingProblem::getGoalEQ);
+    timeIndexedSamplingProblem.def("getRhoEQ", &TimeIndexedSamplingProblem::getRhoEQ);
+    timeIndexedSamplingProblem.def("setGoalNEQ", &TimeIndexedSamplingProblem::setGoalNEQ);
+    timeIndexedSamplingProblem.def("setRhoNEQ", &TimeIndexedSamplingProblem::setRhoNEQ);
+    timeIndexedSamplingProblem.def("getGoalNEQ", &TimeIndexedSamplingProblem::getGoalNEQ);
+    timeIndexedSamplingProblem.def("getRhoNEQ", &TimeIndexedSamplingProblem::getRhoNEQ);
 
     py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> proxy(module, "CollisionProxy");
     proxy.def(py::init());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -839,13 +839,23 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<SamplingProblem, std::shared_ptr<SamplingProblem>, PlanningProblem> samplingProblem(prob, "SamplingProblem");
     samplingProblem.def("update", &SamplingProblem::Update);
-    samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);
+    samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);  // To be deprecated
+    samplingProblem.def_property("goalState", &SamplingProblem::getGoalState, &SamplingProblem::setGoalState);
     samplingProblem.def("getSpaceDim", &SamplingProblem::getSpaceDim);
     samplingProblem.def("getBounds", &SamplingProblem::getBounds);
     samplingProblem.def_readonly("N", &SamplingProblem::N);
     samplingProblem.def_readonly("NumTasks", &SamplingProblem::NumTasks);
     samplingProblem.def_readonly("Phi", &SamplingProblem::Phi);
-    samplingProblem.def_readonly("Constraint", &SamplingProblem::Constraint);
+    samplingProblem.def_readonly("Inequality", &SamplingProblem::Inequality);
+    samplingProblem.def_readonly("Equality", &SamplingProblem::Equality);
+    samplingProblem.def("setGoalEQ", &SamplingProblem::setGoalEQ);
+    samplingProblem.def("setRhoEQ", &SamplingProblem::setRhoEQ);
+    samplingProblem.def("getGoalEQ", &SamplingProblem::getGoalEQ);
+    samplingProblem.def("getRhoEQ", &SamplingProblem::getRhoEQ);
+    samplingProblem.def("setGoalNEQ", &SamplingProblem::setGoalNEQ);
+    samplingProblem.def("setRhoNEQ", &SamplingProblem::setRhoNEQ);
+    samplingProblem.def("getGoalNEQ", &SamplingProblem::getGoalNEQ);
+    samplingProblem.def("getRhoNEQ", &SamplingProblem::getRhoNEQ);
 
     py::class_<TimeIndexedSamplingProblem, std::shared_ptr<TimeIndexedSamplingProblem>, PlanningProblem> timeIndexedSamplingProblem(prob, "TimeIndexedSamplingProblem");
     timeIndexedSamplingProblem.def("update", &TimeIndexedSamplingProblem::Update);


### PR DESCRIPTION
This PR fixes the ``Constraint`` handling in sampling problems (``SamplingProblem`` and ``TimeIndexedSamplingProblem``) and introduces the explicit handling of both inequality and equality constraints. It further adds a ``ConstraintTolerance`` to ``SamplingTask``s below which values are considered zero (to avoid numerical issues with equality constraints).

**Breaking changes:**

1. ``Constraint`` in initializers needs to be replaced with either ``Equality`` or ``Inequality``
2. The ``CollisionCheck`` task map now returns 0 for valid/collision-free and 1 for in-collision. This is in contrast to -1 and 0 before. It can still be used as an ``Equality`` constraint without setting ``Rho`` and ``Goal``.
3. The Python ``setGoalState`` for ``SamplingProblem`` has been deprecated and replaced with a property getter-setter ``goalState``. This is in line with ``TimeIndexedSamplingProblem``'s ``goalState`` property and all problems' ``startState`` property.

**Additions:**

1. Equality and inequality constraints for sampling problems.
2. Implementations of getters and setters for Rho and Goal for both inequality and equality constraints, and exposing these to Python. This wasn't the case before for ``SamplingProblem`` and caused segmentation faults.
3. Move goal state and time to getter/setter and make private (lots more clean-up to do in future).

Closes #368 