### PR TITLE
fix non-catkin ompl dependency

### DIFF
--- a/exotations/solvers/ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_solver/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ompl_solver)
 
-find_package(OMPL REQUIRED)
+find_package(ompl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   exotica
@@ -11,7 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ompl_solver
-  CATKIN_DEPENDS exotica ompl
+  CATKIN_DEPENDS exotica
+  DEPENDS ompl
 )
 
 AddInitializer(OMPLsolver RRT RRTConnect PRM LazyPRM EST KPIECE BKPIECE RRTStar LBTRRT)

--- a/exotations/solvers/time_indexed_rrt_connect/CMakeLists.txt
+++ b/exotations/solvers/time_indexed_rrt_connect/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(time_indexed_rrt_connect)
 
-find_package(OMPL REQUIRED)
+find_package(ompl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   exotica
@@ -10,7 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES time_indexed_rrt_connect
-  CATKIN_DEPENDS exotica ompl
+  CATKIN_DEPENDS exotica
+  DEPENDS ompl
 )
 
 AddInitializer(TimeIndexedRRTConnect)


### PR DESCRIPTION
I get the error:
```
CMake Error at [...]/exotica/exotations/solvers/time_indexed_rrt_connect/CMakeLists.txt:4 (find_package):
  By not providing "FindOMPL.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OMPL", but
  CMake did not find one.
```
Renaming the dependency correctly to `ompl` (lower case) and setting it as system dependency solve this issue.

Note: This is on Ubuntu 18.04 / ROS melodic