### PR TITLE
operator for Hessian difference

### DIFF
--- a/examples/exotica_examples/tests/test_problems.cpp
+++ b/examples/exotica_examples/tests/test_problems.cpp
@@ -7,6 +7,24 @@ using namespace exotica;
 #define CREATE_PROBLEM(X, I) std::shared_ptr<X> problem = createProblem<X>(#X, I);
 #define NUM_TRIALS 100
 
+// workaround for "error: ambiguous overload for ‘operator-’" that appear in newer Eigen versions
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+Hessian operator-(const Hessian& A, const Hessian& B)
+{
+    if (A.rows() != B.rows())
+    {
+        throw std::runtime_error("Hessian dimension mismatch");
+    }
+
+    Hessian ret(A.rows());
+    for (size_t i = 0; i < A.rows(); i++)
+    {
+        ret[i] = A[i] - B[i];
+    }
+    return ret;
+}
+#endif
+
 template <class T>
 std::shared_ptr<T> createProblem(const std::string& name, int derivative)
 {


### PR DESCRIPTION
On newer Eigen versions (>=3.3) I get the error: `error: ambiguous overload for ‘operator-’` for difference of Hessians. This is probably caused by additional new subtraction operators in Eigen.
Full log: [exotica_eigen_error.txt](https://github.com/ipab-slmc/exotica/files/2421335/exotica_eigen_error.txt)

A workaround for now is the spcialisation of the Hessian difference.
It's not a proper solution, but I could not find an alternative solution that makes it explicite to Eigen which operator to use.