### PR TITLE
clean up time indexed rrtconnect

### DIFF
--- a/examples/exotica_examples/resources/configs/time_indexed_sampling_demo.xml
+++ b/examples/exotica_examples/resources/configs/time_indexed_sampling_demo.xml
@@ -4,6 +4,7 @@
   <TimeIndexedRRTConnect Name="MySolver">
     <Timeout>5</Timeout>
     <AddTimeIntoSolution>1</AddTimeIntoSolution>
+    <TrajectoryPointsPerSecond>30</TrajectoryPointsPerSecond>
   </TimeIndexedRRTConnect>
 
   <TimeIndexedSamplingProblem Name="MyProblem">
@@ -14,12 +15,10 @@
         <JointGroup>arm</JointGroup>
         <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
-        <LoadScene>{exotica_examples}/resources/scenes/example_moving_obstacle.scene</LoadScene>
+        <LoadScene>{exotica_examples}/resources/scenes/example_moving_obstacle.scene</LoadScene> -->
         <Trajectories>
           <Trajectory Link="Obstacle" File="{exotica_examples}/resources/scenes/example_moving_obstacle.traj" />
         </Trajectories>
-        <CollisionScene>CollisionSceneFCLLatest</CollisionScene>
-        <AlwaysUpdateCollisionScene>0</AlwaysUpdateCollisionScene>
       </Scene>
     </PlanningScene>
 
@@ -27,9 +26,9 @@
       <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
       <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <JointVelocityLimits>2 2 2 2 2 2 2</JointVelocityLimits>
     <Goal>2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>

--- a/examples/exotica_examples/resources/configs/time_indexed_sampling_demo_freebase.xml
+++ b/examples/exotica_examples/resources/configs/time_indexed_sampling_demo_freebase.xml
@@ -18,8 +18,6 @@
         <Trajectories>
           <Trajectory Link="Obstacle" File="{exotica_examples}/resources/scenes/example_moving_obstacle.traj" />
         </Trajectories>
-        <CollisionScene>CollisionSceneFCLLatest</CollisionScene>
-        <AlwaysUpdateCollisionScene>0</AlwaysUpdateCollisionScene>
       </Scene>
     </PlanningScene>
 
@@ -27,9 +25,9 @@
       <CollisionCheck Name="Collision" SelfCollision="1" />
     </Maps>
 
-    <Constraint>
+    <Equality>
       <Task Task="Collision"/>
-    </Constraint>
+    </Equality>
 
     <JointVelocityLimits>2 2 2 2 2 2 2 2 2 2</JointVelocityLimits>
     <Goal>0 0 0 2.16939  1.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>

--- a/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
+++ b/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
@@ -117,6 +117,7 @@ public:
     virtual void Solve(Eigen::MatrixXd &solution);
     virtual void specifyProblem(PlanningProblem_ptr pointer);
     void setPlannerTerminationCondition(const std::shared_ptr<ompl::base::PlannerTerminationCondition> &ptc);
+
 protected:
     template <typename T>
     static ompl::base::PlannerPtr allocatePlanner(const ompl::base::SpaceInformationPtr &si, const std::string &new_name)

--- a/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
+++ b/exotations/solvers/time_indexed_rrt_connect/include/time_indexed_rrt_connect/TimeIndexedRRTConnect.h
@@ -116,7 +116,7 @@ public:
     virtual void Instantiate(TimeIndexedRRTConnectInitializer &init);
     virtual void Solve(Eigen::MatrixXd &solution);
     virtual void specifyProblem(PlanningProblem_ptr pointer);
-
+    void setPlannerTerminationCondition(const std::shared_ptr<ompl::base::PlannerTerminationCondition> &ptc);
 protected:
     template <typename T>
     static ompl::base::PlannerPtr allocatePlanner(const ompl::base::SpaceInformationPtr &si, const std::string &new_name)
@@ -136,6 +136,7 @@ protected:
     ompl::base::StateSpacePtr state_space_;
     ConfiguredPlannerAllocator planner_allocator_;
     std::string algorithm_;
+    std::shared_ptr<ompl::base::PlannerTerminationCondition> ptc_;
 };
 
 using namespace ompl;

--- a/exotations/solvers/time_indexed_rrt_connect/init/TimeIndexedRRTConnect.in
+++ b/exotations/solvers/time_indexed_rrt_connect/init/TimeIndexedRRTConnect.in
@@ -5,3 +5,4 @@ Optional std::string Range = "1";
 Optional bool AddTimeIntoSolution = false;
 Optional double ValidityCheckResolution = 0.01;
 Optional int RandomSeed = -1;  // Sets random seed unless -1
+Optional int TrajectoryPointsPerSecond = 0;

--- a/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
+++ b/exotations/solvers/time_indexed_rrt_connect/src/TimeIndexedRRTConnect.cpp
@@ -228,12 +228,13 @@ void TimeIndexedRRTConnect::getPath(Eigen::MatrixXd &traj, ompl::base::PlannerTe
         for (int i = 0; i < n1; ++i)
             length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
     }
-    else{
+    else
+    {
         double tstart, tgoal;
-        Eigen::VectorXd qs,qg;
+        Eigen::VectorXd qs, qg;
         state_space_->as<OMPLTimeIndexedRNStateSpace>()->OMPLToExoticaState(pg.getState(0), qs, tstart);
-        state_space_->as<OMPLTimeIndexedRNStateSpace>()->OMPLToExoticaState(pg.getState(states.size()-1), qg, tgoal);
-        length = (tgoal-tstart)*init_.TrajectoryPointsPerSecond;
+        state_space_->as<OMPLTimeIndexedRNStateSpace>()->OMPLToExoticaState(pg.getState(states.size() - 1), qg, tgoal);
+        length = (tgoal - tstart) * init_.TrajectoryPointsPerSecond;
     }
     pg.interpolate(length);
 
@@ -260,7 +261,7 @@ void TimeIndexedRRTConnect::Solve(Eigen::MatrixXd &solution)
     preSolve();
     ompl::time::point start = ompl::time::now();
     if (!ptc_)
-    	ptc_.reset(new ompl::base::PlannerTerminationCondition(ompl::base::timedPlannerTerminationCondition(init_.Timeout - ompl::time::seconds(ompl::time::now() - start))));
+        ptc_.reset(new ompl::base::PlannerTerminationCondition(ompl::base::timedPlannerTerminationCondition(init_.Timeout - ompl::time::seconds(ompl::time::now() - start))));
     if (ompl_simple_setup_->solve(*ptc_) == ompl::base::PlannerStatus::EXACT_SOLUTION && ompl_simple_setup_->haveSolutionPath())
     {
         getPath(solution, *ptc_);


### PR DESCRIPTION
- enable multi threads (single threaded if the solver gets called directly)
- expose init param to specify trajectory rate, i.e. how many trajectory points per second
- fix example config file