### PR TITLE
ROS server publisher, node handle, string vector for pyexotica

### DIFF
--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -143,22 +143,16 @@ public:
         }
     }
 
-    template <typename T>
-    static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, bool latch = false)
+    template <typename T, typename... Args>
+    static ros::Publisher advertise(Args &&... args)
     {
-        return Instance()->getNodeHandle().advertise<T>(topic, queue_size, latch);
+        return Instance()->getNodeHandle().advertise<T>(std::forward<Args>(args)...);
     }
 
-    template <typename T>
-    static ros::Publisher advertise(const std::string &topic, uint32_t queue_size, const ros::SubscriberStatusCallback &connect_cb, const ros::SubscriberStatusCallback &disconnect_cb = ros::SubscriberStatusCallback(), const ros::VoidConstPtr &tracked_object = ros::VoidConstPtr(), bool latch = false)
+    template <typename T, typename... Args>
+    static ros::Subscriber subscribe(Args &&... args)
     {
-        return Instance()->getNodeHandle().advertise<T>(topic, queue_size, connect_cb, disconnect_cb, tracked_object, latch);
-    }
-
-    template <typename T>
-    static ros::Publisher advertise(ros::AdvertiseOptions &ops)
-    {
-        return Instance()->getNodeHandle().advertise<T>(ops);
+        return Instance()->getNodeHandle().subscribe<T>(std::forward<Args>(args)...);
     }
 
     template <typename T>

--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -113,10 +113,10 @@ public:
     }
 
     inline static bool isRos() { return Instance()->node_ != nullptr; }
-    inline ros::NodeHandle &getNodeHandle()
+    inline static ros::NodeHandle &getNodeHandle()
     {
         if (!isRos()) throw_pretty("EXOTica server not initialized as ROS node!");
-        return node_->getNodeHandle();
+        return Instance()->node_->getNodeHandle();
     }
 
     template <typename T>

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -271,6 +271,18 @@ public:
             }
             return true;
         }
+        else if (target.getType() == getTypeName(typeid(std::vector<std::string>)))
+        {
+            if (isPyString(value_py))
+            {
+                target.set(parseList(pyAsString(value_py)));
+            }
+            else
+            {
+                target.set(py::cast<std::vector<std::string>>(value_py));
+            }
+            return true;
+        }
         else if (target.getType() == "bool")
         {
             if (isPyString(value_py))
@@ -431,6 +443,10 @@ public:
         else if (prop.getType() == getTypeName(typeid(std::vector<int>)))
         {
             PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<std::vector<int>>(prop.get())).ptr());
+        }
+        else if (prop.getType() == getTypeName(typeid(std::vector<std::string>)))
+        {
+            PyDict_SetItemString(dict, name.c_str(), py::cast(boost::any_cast<std::vector<std::string>>(prop.get())).ptr());
         }
         else if (prop.getType() == "bool")
         {


### PR DESCRIPTION
This PR collects some commits that I used to interface with the `Server`.

- reduce code by using perfect forwarding for ROS publisher instantiation
- make `getNodeHandle` static, since Server is singleton anyway
- add support for `std::vector<std::string>`