### PR TITLE
IKsolver: use the provided solution optionally as start state

### DIFF
--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -133,7 +133,7 @@ void IKsolver::Solve(Eigen::MatrixXd& solution)
     Timer timer;
 
     if (!prob_) throw_named("Solver has not been initialized!");
-    const Eigen::VectorXd q0 = prob_->applyStartState();
+    const Eigen::VectorXd q0 = (solution.cols() == prob_->N) ? solution.row(0) : prob_->applyStartState();
 
     if (prob_->N != q0.rows()) throw_named("Wrong size q0 size=" << q0.rows() << ", required size=" << prob_->N);
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -662,6 +662,8 @@ PYBIND11_MODULE(_pyexotica, module)
     motionSolver.def(
         "solve", [](std::shared_ptr<MotionSolver> sol) { return Solve(sol); },
         "Solve the problem");
+    motionSolver.def("solve", [](MotionSolver& solver, Eigen::MatrixXd& solution) -> Eigen::MatrixXd& {solver.Solve(solution); return solution; },
+                     "Solve the problem", py::arg("start state"));
     motionSolver.def("getProblem", &MotionSolver::getProblem, py::return_value_policy::reference_internal);
 
     py::class_<PlanningProblem, std::shared_ptr<PlanningProblem>, Object> planningProblem(module, "PlanningProblem");


### PR DESCRIPTION
Via this PR, it is possible to directly set a start state `q0` for the `IKsolver::Solve` by providing the start state as `solution`. If the dimension of `solution` matches the dimension of the optimised state, it is assumed that the provided solution contains a starting state from which the optimisation should start.

Example:
```Python
self.solver = exo.Setup.createSolver(self.sol_conf)
solution = self.solver.solve(start).flatten()
```

The alternative way to set the start state (set `StartState` in xml) requires to recreate the problem every time a new starting state is to be used (e.g. `exo.Setup.createProblem(self.prob_conf)`). I used this functionality to continue optimisation on a sequence of images and reinitialising the problems 15 times a second is not resonable.

This might not be the preferred way to do this, especially since it only applies to the `IKsolver` for now. However, setting the starting state for a optimisation should not require to redefine the problems.

Do you see alternative ways to efficiently set the start configuration `q0` in a generic way for other solvers, without requiring to reinitialise the problems?