### PR TITLE
Fix C matrix size in IK solver

### DIFF
--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -103,9 +103,9 @@ void IKsolver::specifyProblem(PlanningProblem_ptr pointer)
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedEndPoseProblem>(pointer);
 
-    C = Eigen::MatrixXd::Identity(prob_->JN, prob_->JN) * parameters_.C;
+    C = Eigen::MatrixXd::Identity(prob_->Cost.JN, prob_->Cost.JN) * parameters_.C;
     if (parameters_.C == 0.0)
-        Cinv = Eigen::MatrixXd::Zero(prob_->JN, prob_->JN);
+        Cinv = Eigen::MatrixXd::Zero(prob_->Cost.JN, prob_->Cost.JN);
     else
         Cinv = C.inverse();
 


### PR DESCRIPTION
 - Fixes #375 .
 - This is an isolated issue for IK solver only.