### PR TITLE
More fine-grained treatment of Goal and JointVelocityLimits initialisers

### DIFF
--- a/examples/exotica_examples/resources/robots/valkyrie_sim.srdf
+++ b/examples/exotica_examples/resources/robots/valkyrie_sim.srdf
@@ -69,6 +69,40 @@
         <joint name="rightWristRoll" />
         <joint name="rightWristPitch" />
     </group>
+    <group name="whole_body_fixed">
+        <joint name="leftHipYaw" />
+        <joint name="leftHipRoll" />
+        <joint name="leftHipPitch" />
+        <joint name="leftKneePitch" />
+        <joint name="leftAnklePitch" />
+        <joint name="leftAnkleRoll" />
+        <joint name="rightHipYaw" />
+        <joint name="rightHipRoll" />
+        <joint name="rightHipPitch" />
+        <joint name="rightKneePitch" />
+        <joint name="rightAnklePitch" />
+        <joint name="rightAnkleRoll" />
+        <joint name="torsoYaw" />
+        <joint name="torsoPitch" />
+        <joint name="torsoRoll" />
+        <joint name="leftShoulderPitch" />
+        <joint name="leftShoulderRoll" />
+        <joint name="leftShoulderYaw" />
+        <joint name="leftElbowPitch" />
+        <joint name="leftForearmYaw" />
+        <joint name="leftWristRoll" />
+        <joint name="leftWristPitch" />
+        <joint name="lowerNeckPitch" />
+        <joint name="neckYaw" />
+        <joint name="upperNeckPitch" />
+        <joint name="rightShoulderPitch" />
+        <joint name="rightShoulderRoll" />
+        <joint name="rightShoulderYaw" />
+        <joint name="rightElbowPitch" />
+        <joint name="rightForearmYaw" />
+        <joint name="rightWristRoll" />
+        <joint name="rightWristPitch" />
+    </group>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="world_joint" type="floating" parent_frame="world_frame" child_link="pelvis" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->

--- a/exotations/task_maps/task_map/include/task_map/CoM.h
+++ b/exotations/task_maps/task_map/include/task_map/CoM.h
@@ -44,7 +44,9 @@ class CoM : public TaskMap, public Instantiable<CoMInitializer>
 {
 public:
     CoM();
-    virtual ~CoM();
+    virtual ~CoM()
+    {
+    }
 
     virtual void Instantiate(CoMInitializer& init);
 

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -40,10 +40,6 @@ CoM::CoM()
 {
 }
 
-CoM::~CoM()
-{
-}
-
 void CoM::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != dim_) throw_named("Wrong size of phi!");

--- a/exotica/init/SamplingProblem.in
+++ b/exotica/init/SamplingProblem.in
@@ -1,5 +1,5 @@
 extend <exotica/PlanningProblem>
-Required Eigen::VectorXd Goal;
+Optional Eigen::VectorXd Goal = Eigen::VectorXd();
 Optional std::string LocalPlannerConfig = "";
 Optional Eigen::VectorXd FloatingBaseLowerLimits = Eigen::VectorXd();
 Optional Eigen::VectorXd FloatingBaseUpperLimits = Eigen::VectorXd();

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -70,7 +70,18 @@ void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
         local_planner_config_ = init.LocalPlannerConfig;
     }
 
-    goal_ = init.Goal;
+    if (init.Goal.size() == N)
+    {
+        goal_ = init.Goal;
+    }
+    else if (init.Goal.size() == 0)
+    {
+        goal_ = Eigen::VectorXd::Zero(N);
+    }
+    else
+    {
+        throw_named("Dimension mismatch: problem N=" << N << ", but goal state has dimension " << goal_.rows());
+    }
 
     if (scene_->getBaseType() != exotica::BASE_TYPE::FIXED)
         compound_ = true;

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -88,9 +88,19 @@ void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializ
         throw_named("Invalid goal time tGoal= " << tGoal << ">T_(" << T << ")");
     if (tGoal == -1.0)
         tGoal = T;
-    vel_limits_ = init.JointVelocityLimits;
-    if (vel_limits_.rows() != N)
+
+    if (init.JointVelocityLimits.size() == N)
+    {
+        vel_limits_ = init.JointVelocityLimits;
+    }
+    else if (init.JointVelocityLimits.size() == 1)
+    {
+        vel_limits_ = init.JointVelocityLimits(0) * Eigen::VectorXd::Ones(N);
+    }
+    else
+    {
         throw_named("Dimension mismatch: problem N=" << N << ", but joint velocity limits has dimension " << vel_limits_.rows());
+    }
 
     NumTasks = Tasks.size();
     PhiN = 0;

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -66,9 +66,20 @@ std::vector<double> TimeIndexedSamplingProblem::getBounds()
 void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializer& init)
 {
     Parameters = init;
-    goal_ = init.Goal;
-    if (goal_.rows() != N)
+
+    if (init.Goal.size() == N)
+    {
+        goal_ = init.Goal;
+    }
+    else if (init.Goal.size() == 0)
+    {
+        goal_ = Eigen::VectorXd::Zero(N);
+    }
+    else
+    {
         throw_named("Dimension mismatch: problem N=" << N << ", but goal state has dimension " << goal_.rows());
+    }
+
     T = init.T;
     if (T < 0)
         throw_named("Invalid problem duration T: " << T);


### PR DESCRIPTION
- In sampling-based problems, ``Goal`` with the correct number of dummy values had to be set for every problem, even if the sampling goal was set later in the script (e.g. from IK). This will provide an automatic 0-vector of correct length fr mior the goal if none is provided. 
- Further for the ``TimeIndexedSamplingProblem``, if only a single element for ``JointVelocityLimits`` is specified, the same velocity limit is assumed for all joints.