### PR TITLE
Exposing getTaskMaps to Python.

### DIFF
--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -666,6 +666,7 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<PlanningProblem, std::shared_ptr<PlanningProblem>, Object> planningProblem(module, "PlanningProblem");
     planningProblem.def("getTasks", &PlanningProblem::getTasks, py::return_value_policy::reference_internal);
+    planningProblem.def("getTaskMaps", &PlanningProblem::getTaskMaps, py::return_value_policy::reference_internal);
     planningProblem.def("getScene", &PlanningProblem::getScene, py::return_value_policy::reference_internal);
     planningProblem.def("__repr__", &PlanningProblem::print, "String representation of the object", py::arg("prepend") = std::string(""));
     planningProblem.def_property("startState", &PlanningProblem::getStartState, &PlanningProblem::setStartState);


### PR DESCRIPTION
* Easier to call task map methods from Python with `getTaskMaps` than `getTasks`.
* Before `problem.getTasks()[IDX].callMyMethod()` where `IDX` is some integer, requiring user to know which index of the returned list the task they wish to interact with is at.
* Now `problem.getTasks()[TASKMAPNAME].callMyMethod()` where `TASKMAPNAME` is the name of the task map as defined in the xml.