### PR TITLE
[ik_solver] Fix missing f2c dependency

### DIFF
--- a/exotations/solvers/ik_solver/package.xml
+++ b/exotations/solvers/ik_solver/package.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0"?>
 <package>
   <name>ik_solver</name>
-  <version>3.0.0</version>
+  <version>5.0.0</version>
   <description>The ik_solver package</description>
 
   <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
   <maintainer email="yiming.yang@ed.ac.uk">Yiming Yang</maintainer>
-  <author email="mcamnadur@gmail.com">Michael Camilleri</author>
+  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
+  <author>Michael Camilleri</author>
 
   <license>BSD</license>
 
-  <url type="website">https://bitbucket.org/IPAB-SLMC/exotica</url>
+  <url type="website">https://github.com/ipab-slmc/exotica</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>exotica</build_depend>
+  <build_depend>f2c</build_depend>
   <build_depend>liblapack-dev</build_depend>
   <run_depend>exotica</run_depend>
-
 
   <export>
     <exotica plugin="${prefix}/exotica_plugins.xml" />


### PR DESCRIPTION
Fixes issue on clean install on Ubuntu 18.04 ROS Melodic as reported by @cmower.