### PR TITLE
Adding a new task map Point2Point

### DIFF
--- a/examples/exotica_examples/launch/PythonPlanIKPoint2Point.launch
+++ b/examples/exotica_examples/launch/PythonPlanIKPoint2Point.launch
@@ -1,0 +1,22 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <!-- joy node -->
+  <node respawn="true" pkg="joy"
+        type="joy_node" name="joy_node" >
+    <param name="dev" type="string" value="/dev/input/js0" />
+    <param name="deadzone" value="0.12" />
+    <param name="autorepeat_rate" value="120.0"/>
+  </node>
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+  
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_point2point.py" name="IKPlannerPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz-point2point.rviz" />
+  
+</launch>

--- a/examples/exotica_examples/resources/configs/example_point2point.xml
+++ b/examples/exotica_examples/resources/configs/example_point2point.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+
+  <IKsolver Name="MySolver">
+    <MaxIterations>100</MaxIterations>
+    <MaxStep>0.1</MaxStep>
+    <Tolerance>1e-5</Tolerance>
+    <Alpha>1.0</Alpha>
+    <C>1e-3</C>
+  </IKsolver>
+
+  <UnconstrainedEndPoseProblem Name="MyProblem">
+
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+    
+    <Maps>
+      <Point2Point Name="Point2Point" Point="0.75 0 0.5">
+        <EndEffector>
+	  <!-- Do not modify this transform -->
+          <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 0  0.7071067811865475 0"/>
+        </EndEffector>
+      </Point2Point>
+    </Maps>
+
+    <Cost>
+      <Task Task="Point2Point" Rho="1"/>
+    </Cost>
+
+    <W> 7 6 5 4 3 2 1 </W>
+  </UnconstrainedEndPoseProblem>
+
+</IKSolverDemoConfig>

--- a/examples/exotica_examples/resources/rviz-point2point.rviz
+++ b/examples/exotica_examples/resources/rviz-point2point.rviz
@@ -1,0 +1,318 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1
+        - /RobotModel1/Links1
+        - /Marker1
+        - /TF1
+        - /TF1/Frames1
+      Splitter Ratio: 0.801152766
+    Tree Height: 717
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: false
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: false
+        lwr_arm_0_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_1_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_2_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_3_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_4_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_5_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_6_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: true
+          Value: true
+        lwr_arm_7_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: exotica
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /exotica/CollisionShapes
+      Name: SceneObjects
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /teleop_point
+      Name: Marker
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        exotica/Frame0Alwr_arm_6_link:
+          Value: true
+        exotica/Frame0Bworld_frame:
+          Value: false
+        exotica/base:
+          Value: false
+        exotica/base_collision_0:
+          Value: false
+        exotica/lwr_arm_0_link:
+          Value: false
+        exotica/lwr_arm_0_link_collision_0:
+          Value: false
+        exotica/lwr_arm_0_link_collision_1:
+          Value: false
+        exotica/lwr_arm_1_link:
+          Value: false
+        exotica/lwr_arm_1_link_collision_0:
+          Value: false
+        exotica/lwr_arm_1_link_collision_1:
+          Value: false
+        exotica/lwr_arm_2_link:
+          Value: false
+        exotica/lwr_arm_2_link_collision_0:
+          Value: false
+        exotica/lwr_arm_2_link_collision_1:
+          Value: false
+        exotica/lwr_arm_3_link:
+          Value: false
+        exotica/lwr_arm_3_link_collision_0:
+          Value: false
+        exotica/lwr_arm_3_link_collision_1:
+          Value: false
+        exotica/lwr_arm_4_link:
+          Value: false
+        exotica/lwr_arm_4_link_collision_0:
+          Value: false
+        exotica/lwr_arm_4_link_collision_1:
+          Value: false
+        exotica/lwr_arm_5_link:
+          Value: false
+        exotica/lwr_arm_5_link_collision_0:
+          Value: false
+        exotica/lwr_arm_5_link_collision_1:
+          Value: false
+        exotica/lwr_arm_6_link:
+          Value: false
+        exotica/lwr_arm_6_link_collision_0:
+          Value: false
+        exotica/lwr_arm_6_link_collision_1:
+          Value: false
+        exotica/lwr_arm_7_link:
+          Value: false
+        exotica/lwr_arm_7_link_collision_0:
+          Value: false
+        exotica/world_frame:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        exotica/world_frame:
+          exotica/Frame0Bworld_frame:
+            exotica/Frame0Alwr_arm_6_link:
+              {}
+          exotica/base:
+            {}
+          exotica/base_collision_0:
+            {}
+          exotica/lwr_arm_0_link:
+            {}
+          exotica/lwr_arm_0_link_collision_0:
+            {}
+          exotica/lwr_arm_0_link_collision_1:
+            {}
+          exotica/lwr_arm_1_link:
+            {}
+          exotica/lwr_arm_1_link_collision_0:
+            {}
+          exotica/lwr_arm_1_link_collision_1:
+            {}
+          exotica/lwr_arm_2_link:
+            {}
+          exotica/lwr_arm_2_link_collision_0:
+            {}
+          exotica/lwr_arm_2_link_collision_1:
+            {}
+          exotica/lwr_arm_3_link:
+            {}
+          exotica/lwr_arm_3_link_collision_0:
+            {}
+          exotica/lwr_arm_3_link_collision_1:
+            {}
+          exotica/lwr_arm_4_link:
+            {}
+          exotica/lwr_arm_4_link_collision_0:
+            {}
+          exotica/lwr_arm_4_link_collision_1:
+            {}
+          exotica/lwr_arm_5_link:
+            {}
+          exotica/lwr_arm_5_link_collision_0:
+            {}
+          exotica/lwr_arm_5_link_collision_1:
+            {}
+          exotica/lwr_arm_6_link:
+            {}
+          exotica/lwr_arm_6_link_collision_0:
+            {}
+          exotica/lwr_arm_6_link_collision_1:
+            {}
+          exotica/lwr_arm_7_link:
+            {}
+          exotica/lwr_arm_7_link_collision_0:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: exotica/world_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 3.1662848
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.334838122
+        Y: -0.0484804511
+        Z: 0.218060613
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 0.269797564
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.112208381
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1028
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a0000035cfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000003c000000200000002e20000029ffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000280000035c000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c0000026100000001000001630000035cfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000000280000035c000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000005cfc0100000002fb0000000800540069006d006501000000000000073f0000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000004660000035c00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1855
+  X: 1025
+  Y: 536

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -26,6 +26,7 @@ AddInitializer(
   CollisionCheck
   Point2Plane
   QuasiStatic
+  Point2Point
 )
 GenInitializers()
 
@@ -56,7 +57,9 @@ set(SOURCES
     src/Identity.cpp
     src/SphereCollision.cpp
     src/CollisionCheck.cpp
-    src/QuasiStatic.cpp)
+    src/QuasiStatic.cpp
+    src/Point2Point.cpp
+    )
 
 add_library(${PROJECT_NAME} ${SOURCES})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -47,4 +47,7 @@
   <class name="exotica/QuasiStatic" type="exotica::QuasiStatic" base_class_type="exotica::TaskMap">
     <description>Plannar quasi static cost/constraint</description>
   </class>
+  <class name="exotica/Point2Point" type="exotica::Point2Point" base_class_type="exotica::TaskMap">
+    <description>Points end-effector at a given point.</description>
+  </class>
 </library>

--- a/exotations/task_maps/task_map/include/task_map/Point2Point.h
+++ b/exotations/task_maps/task_map/include/task_map/Point2Point.h
@@ -1,0 +1,89 @@
+/*
+ *      Author: Christopher E. Mower
+ *
+ * Copyright (c) 2018, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef EXOTICA_TASKMAP_POINT_TO_POINT_H
+#define EXOTICA_TASKMAP_POINT_TO_POINT_H
+
+#include <exotica/TaskMap.h>
+#include <task_map/Point2PointInitializer.h>
+
+namespace exotica
+{
+  class Point2Point : public TaskMap, public Instantiable<Point2PointInitializer>
+  {
+  public:
+  
+    Point2Point();
+    virtual ~Point2Point() {}
+    
+    virtual void Instantiate(Point2PointInitializer& init);
+
+    virtual void assignScene(Scene_ptr scene);
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+
+    virtual int taskSpaceDim();
+
+    void setPoint(Eigen::Vector3d point);
+    
+    Eigen::Vector3d getPoint();
+
+    void Initialize();
+    
+  private:
+
+    Eigen::Vector3d point_;
+
+    unsigned int N;
+
+    Scene_ptr scene_;
+
+    Eigen::Vector3d getEffPosition(int i);
+
+    Eigen::Matrix3d getEffRotation(int i);
+    Eigen::Matrix3d getEffRotation(double roll, double pitch, double yaw);
+
+    Eigen::Vector3d getApproachVector(int i);
+    Eigen::Vector3d getApproachVector(double roll, double pitch, double yaw);
+
+    Eigen::Matrix3d getApproachVectorJacobian(double roll, double pitch, double yaw);
+
+
+  };
+
+  typedef std::shared_ptr<Point2Point> Point2Point_ptr;
+
+}  // namespace exotica
+
+#endif

--- a/exotations/task_maps/task_map/include/task_map/Point2Point.h
+++ b/exotations/task_maps/task_map/include/task_map/Point2Point.h
@@ -38,13 +38,11 @@
 
 namespace exotica
 {
-  class Point2Point : public TaskMap, public Instantiable<Point2PointInitializer>
-  {
-  public:
-  
+class Point2Point : public TaskMap, public Instantiable<Point2PointInitializer>
+{
+public:
     Point2Point();
     virtual ~Point2Point() {}
-    
     virtual void Instantiate(Point2PointInitializer& init);
 
     virtual void assignScene(Scene_ptr scene);
@@ -56,13 +54,12 @@ namespace exotica
     virtual int taskSpaceDim();
 
     void setPoint(Eigen::Vector3d point);
-    
+
     Eigen::Vector3d getPoint();
 
     void Initialize();
-    
-  private:
 
+private:
     Eigen::Vector3d point_;
 
     unsigned int N;
@@ -78,11 +75,9 @@ namespace exotica
     Eigen::Vector3d getApproachVector(double roll, double pitch, double yaw);
 
     Eigen::Matrix3d getApproachVectorJacobian(double roll, double pitch, double yaw);
+};
 
-
-  };
-
-  typedef std::shared_ptr<Point2Point> Point2Point_ptr;
+typedef std::shared_ptr<Point2Point> Point2Point_ptr;
 
 }  // namespace exotica
 

--- a/exotations/task_maps/task_map/init/Point2Point.in
+++ b/exotations/task_maps/task_map/init/Point2Point.in
@@ -1,0 +1,3 @@
+extend <exotica/TaskMap>
+
+Required Eigen::Vector3d Point; # The point for the end-effector to point at in the base frame.

--- a/exotations/task_maps/task_map/src/Point2Point.cpp
+++ b/exotations/task_maps/task_map/src/Point2Point.cpp
@@ -36,37 +36,36 @@ REGISTER_TASKMAP_TYPE("Point2Point", exotica::Point2Point);
 
 namespace exotica
 {
-
-  Point2Point::Point2Point(){} // <<--- never ever forget the constructor!!
-
-  Eigen::Vector3d Point2Point::getPoint() {
+Point2Point::Point2Point() {}  // <<--- never ever forget the constructor!!
+Eigen::Vector3d Point2Point::getPoint()
+{
     return point_;
-  }
+}
 
-  void Point2Point::setPoint(Eigen::Vector3d point) {
+void Point2Point::setPoint(Eigen::Vector3d point)
+{
     point_ = point;
-  }
+}
 
-
-
-  void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
-  {
+void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
     phi(0) = 0.0;
-  
-  }
+}
 
-  Eigen::Vector3d Point2Point::getEffPosition(int i) {
+Eigen::Vector3d Point2Point::getEffPosition(int i)
+{
     return Eigen::Map<Eigen::Vector3d>(Kinematics[0].Phi(i).p.data);
-  }
-  
-  Eigen::Matrix3d Point2Point::getEffRotation(double roll, double pitch, double yaw) {
+}
+
+Eigen::Matrix3d Point2Point::getEffRotation(double roll, double pitch, double yaw)
+{
     // Computes the rotation matrix uing rpy as returned by getEffRotation(i)
     // This is unused, here only for reference.
 
     Eigen::Matrix3d R;
-    double cr, sr; // cos/sin(roll)
-    double cp, sp; // cos/sin(roll)
-    double cy, sy; // cos/sin(roll)
+    double cr, sr;  // cos/sin(roll)
+    double cp, sp;  // cos/sin(roll)
+    double cy, sy;  // cos/sin(roll)
 
     cr = std::cos(roll);
     sr = std::sin(roll);
@@ -78,33 +77,33 @@ namespace exotica
     sy = std::sin(yaw);
 
     // Row 1
-    R(0,0) = cr*cp;
-    R(0,1) = cr*sp*sy - sr*cy;
-    R(0,2) = cr*sp*cy + sr*sy;
+    R(0, 0) = cr * cp;
+    R(0, 1) = cr * sp * sy - sr * cy;
+    R(0, 2) = cr * sp * cy + sr * sy;
 
     // Row 2
-    R(1,0) = sr*cp;
-    R(1,1) = sr*sp*sy + cr*cy;
-    R(1,2) = sr*sp*cy - cr*sy;
+    R(1, 0) = sr * cp;
+    R(1, 1) = sr * sp * sy + cr * cy;
+    R(1, 2) = sr * sp * cy - cr * sy;
 
     // Row 3
-    R(2,0) = -sp;
-    R(2,1) = cp*sy;
-    R(2,2) = cp*cy;
+    R(2, 0) = -sp;
+    R(2, 1) = cp * sy;
+    R(2, 2) = cp * cy;
 
     return R;
-    
-  }
+}
 
-  Eigen::Vector3d Point2Point::getApproachVector(double roll, double pitch, double yaw) {
+Eigen::Vector3d Point2Point::getApproachVector(double roll, double pitch, double yaw)
+{
     // Computes approach vector using rpy, as getApproachVector(i) does.
-    // This is unused and left only for reference. 
-    
+    // This is unused and left only for reference.
+
     Eigen::Vector3d ahat;
-    
-    double cr, sr; // cos/sin(roll)
-    double cp, sp; // cos/sin(roll)
-    double cy, sy; // cos/sin(roll)
+
+    double cr, sr;  // cos/sin(roll)
+    double cp, sp;  // cos/sin(roll)
+    double cy, sy;  // cos/sin(roll)
 
     // This is col(0) of rotation matrix as returned by Kinematics
 
@@ -117,34 +116,37 @@ namespace exotica
     cy = std::cos(yaw);
     sy = std::sin(yaw);
 
-    ahat(0) = cr*cp;
-    ahat(1) = sr*cp;
+    ahat(0) = cr * cp;
+    ahat(1) = sr * cp;
     ahat(2) = -sp;
 
     return ahat;
-  }
+}
 
-  Eigen::Vector3d Point2Point::getApproachVector(int i) {
-    return getEffRotation(i).col(0); // approach vector is x axis or exotica/Frame0Alwr_arm_6_link! 
-  }
+Eigen::Vector3d Point2Point::getApproachVector(int i)
+{
+    return getEffRotation(i).col(0);  // approach vector is x axis or exotica/Frame0Alwr_arm_6_link!
+}
 
-  Eigen::Matrix3d Point2Point::getEffRotation(int i) {
-    return Eigen::Map<Eigen::Matrix3d>(Kinematics[0].Phi(i).M.data).transpose(); // note, exotica/kdl returns transpose of matrix required
-  }
+Eigen::Matrix3d Point2Point::getEffRotation(int i)
+{
+    return Eigen::Map<Eigen::Matrix3d>(Kinematics[0].Phi(i).M.data).transpose();  // note, exotica/kdl returns transpose of matrix required
+}
 
-  Eigen::Matrix3d Point2Point::getApproachVectorJacobian(double roll, double pitch, double yaw) {
+Eigen::Matrix3d Point2Point::getApproachVectorJacobian(double roll, double pitch, double yaw)
+{
     // Approach vector jacobian (aJ)
     //
     // Let Phi = (r, p, y) be rpy euler angles
-    //     ahat = ahat(Phi) be approach vector of eff 
+    //     ahat = ahat(Phi) be approach vector of eff
     //
-    // Then aJ = d ahat(Phi) / d Phi 
+    // Then aJ = d ahat(Phi) / d Phi
 
     Eigen::Matrix3d J;
-    
-    double cr, sr; // cos/sin(roll)
-    double cp, sp; // cos/sin(roll)
-    double cy, sy; // cos/sin(roll)
+
+    double cr, sr;  // cos/sin(roll)
+    double cp, sp;  // cos/sin(roll)
+    double cy, sy;  // cos/sin(roll)
 
     cr = std::cos(roll);
     sr = std::sin(roll);
@@ -156,23 +158,21 @@ namespace exotica
     sy = std::sin(yaw);
 
     // Row 1
-    J(0,0) = -sr*cp;
-    J(0,1) = -cr*sp;
+    J(0, 0) = -sr * cp;
+    J(0, 1) = -cr * sp;
 
     // Row 2
-    J(1,0) = cr*cp;
-    J(1,1) = -sr*sp;
+    J(1, 0) = cr * cp;
+    J(1, 1) = -sr * sp;
 
     // Row 3
-    J(2,1) = -cp;
+    J(2, 1) = -cp;
 
     return J;
-    
-  }
+}
 
-  void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
-  {
-
+void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
     // Collect rpy angles
     double roll, pitch, yaw;
     Kinematics[0].Phi(0).M.GetRPY(roll, pitch, yaw);
@@ -187,46 +187,44 @@ namespace exotica
     Eigen::Vector3d K = ahat.cross(eap);
     Eigen::Matrix3d J_rpy = getApproachVectorJacobian(roll, pitch, yaw);
     double LL = L.squaredNorm();
-    double LL2 = LL*LL;
+    double LL2 = LL * LL;
     double KK = K.squaredNorm();
     Eigen::MatrixXd J_q = Kinematics[0].J(0).data;
-    
+
     // Compute phi
     phi(0) = KK / LL;
 
     // Compute J
-    for (int i=0; i<N; i++){
+    for (int i = 0; i < N; i++)
+    {
+        // Setup
+        Eigen::Vector3d ed = J_q.col(i).topRows(3);
+        Eigen::Vector3d ahatd = J_rpy * J_q.col(i).bottomRows(3);
+        Eigen::Vector3d Kd = ahatd.cross(eap) + ahat.cross(ed + ahatd);
+        Eigen::Vector3d Ld = -ed;
 
-      // Setup
-      Eigen::Vector3d ed = J_q.col(i).topRows(3);
-      Eigen::Vector3d ahatd = J_rpy * J_q.col(i).bottomRows(3);
-      Eigen::Vector3d Kd = ahatd.cross(eap) + ahat.cross(ed + ahatd);
-      Eigen::Vector3d Ld = -ed;
-
-      J(0, i) = 2.0 * (Kd.dot(K)*LL - KK*Ld.dot(L)) / LL2;
-      
+        J(0, i) = 2.0 * (Kd.dot(K) * LL - KK * Ld.dot(L)) / LL2;
     }
-    
-  }
-  
-  void Point2Point::assignScene(Scene_ptr scene)
-  {
+}
+
+void Point2Point::assignScene(Scene_ptr scene)
+{
     scene_ = scene;
     Initialize();
-  }
+}
 
-  void Point2Point::Initialize() {
+void Point2Point::Initialize()
+{
     N = scene_->getSolver().getNumControlledJoints();
-  }
+}
 
+void Point2Point::Instantiate(Point2PointInitializer &init)
+{
+    point_ = init.Point;
+}
 
-  void Point2Point::Instantiate(Point2PointInitializer &init)
-  {
-    point_ = init.Point; 
-  }
-
-  int Point2Point::taskSpaceDim()
-  {
+int Point2Point::taskSpaceDim()
+{
     return 1;
-  }
+}
 }  // namespace exotica

--- a/exotations/task_maps/task_map/src/Point2Point.cpp
+++ b/exotations/task_maps/task_map/src/Point2Point.cpp
@@ -1,0 +1,232 @@
+/*
+ *      Author: Christopher E. Mower
+ *
+ * Copyright (c) 2018, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "task_map/Point2Point.h"
+
+REGISTER_TASKMAP_TYPE("Point2Point", exotica::Point2Point);
+
+namespace exotica
+{
+
+  Point2Point::Point2Point(){} // <<--- never ever forget the constructor!!
+
+  Eigen::Vector3d Point2Point::getPoint() {
+    return point_;
+  }
+
+  void Point2Point::setPoint(Eigen::Vector3d point) {
+    point_ = point;
+  }
+
+
+
+  void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+  {
+    phi(0) = 0.0;
+  
+  }
+
+  Eigen::Vector3d Point2Point::getEffPosition(int i) {
+    return Eigen::Map<Eigen::Vector3d>(Kinematics[0].Phi(i).p.data);
+  }
+  
+  Eigen::Matrix3d Point2Point::getEffRotation(double roll, double pitch, double yaw) {
+    // Computes the rotation matrix uing rpy as returned by getEffRotation(i)
+    // This is unused, here only for reference.
+
+    Eigen::Matrix3d R;
+    double cr, sr; // cos/sin(roll)
+    double cp, sp; // cos/sin(roll)
+    double cy, sy; // cos/sin(roll)
+
+    cr = std::cos(roll);
+    sr = std::sin(roll);
+
+    cp = std::cos(pitch);
+    sp = std::sin(pitch);
+
+    cy = std::cos(yaw);
+    sy = std::sin(yaw);
+
+    // Row 1
+    R(0,0) = cr*cp;
+    R(0,1) = cr*sp*sy - sr*cy;
+    R(0,2) = cr*sp*cy + sr*sy;
+
+    // Row 2
+    R(1,0) = sr*cp;
+    R(1,1) = sr*sp*sy + cr*cy;
+    R(1,2) = sr*sp*cy - cr*sy;
+
+    // Row 3
+    R(2,0) = -sp;
+    R(2,1) = cp*sy;
+    R(2,2) = cp*cy;
+
+    return R;
+    
+  }
+
+  Eigen::Vector3d Point2Point::getApproachVector(double roll, double pitch, double yaw) {
+    // Computes approach vector using rpy, as getApproachVector(i) does.
+    // This is unused and left only for reference. 
+    
+    Eigen::Vector3d ahat;
+    
+    double cr, sr; // cos/sin(roll)
+    double cp, sp; // cos/sin(roll)
+    double cy, sy; // cos/sin(roll)
+
+    // This is col(0) of rotation matrix as returned by Kinematics
+
+    cr = std::cos(roll);
+    sr = std::sin(roll);
+
+    cp = std::cos(pitch);
+    sp = std::sin(pitch);
+
+    cy = std::cos(yaw);
+    sy = std::sin(yaw);
+
+    ahat(0) = cr*cp;
+    ahat(1) = sr*cp;
+    ahat(2) = -sp;
+
+    return ahat;
+  }
+
+  Eigen::Vector3d Point2Point::getApproachVector(int i) {
+    return getEffRotation(i).col(0); // approach vector is x axis or exotica/Frame0Alwr_arm_6_link! 
+  }
+
+  Eigen::Matrix3d Point2Point::getEffRotation(int i) {
+    return Eigen::Map<Eigen::Matrix3d>(Kinematics[0].Phi(i).M.data).transpose(); // note, exotica/kdl returns transpose of matrix required
+  }
+
+  Eigen::Matrix3d Point2Point::getApproachVectorJacobian(double roll, double pitch, double yaw) {
+    // Approach vector jacobian (aJ)
+    //
+    // Let Phi = (r, p, y) be rpy euler angles
+    //     ahat = ahat(Phi) be approach vector of eff 
+    //
+    // Then aJ = d ahat(Phi) / d Phi 
+
+    Eigen::Matrix3d J;
+    
+    double cr, sr; // cos/sin(roll)
+    double cp, sp; // cos/sin(roll)
+    double cy, sy; // cos/sin(roll)
+
+    cr = std::cos(roll);
+    sr = std::sin(roll);
+
+    cp = std::cos(pitch);
+    sp = std::sin(pitch);
+
+    cy = std::cos(yaw);
+    sy = std::sin(yaw);
+
+    // Row 1
+    J(0,0) = -sr*cp;
+    J(0,1) = -cr*sp;
+
+    // Row 2
+    J(1,0) = cr*cp;
+    J(1,1) = -sr*sp;
+
+    // Row 3
+    J(2,1) = -cp;
+
+    return J;
+    
+  }
+
+  void Point2Point::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+  {
+
+    // Collect rpy angles
+    double roll, pitch, yaw;
+    Kinematics[0].Phi(0).M.GetRPY(roll, pitch, yaw);
+
+    // Compute eff postion and approach vector
+    Eigen::Vector3d e = getEffPosition(0);
+    Eigen::Vector3d ahat = getApproachVector(0);
+
+    // Setup
+    Eigen::Vector3d eap = e + ahat - point_;
+    Eigen::Vector3d L = point_ - e;
+    Eigen::Vector3d K = ahat.cross(eap);
+    Eigen::Matrix3d J_rpy = getApproachVectorJacobian(roll, pitch, yaw);
+    double LL = L.squaredNorm();
+    double LL2 = LL*LL;
+    double KK = K.squaredNorm();
+    Eigen::MatrixXd J_q = Kinematics[0].J(0).data;
+    
+    // Compute phi
+    phi(0) = KK / LL;
+
+    // Compute J
+    for (int i=0; i<N; i++){
+
+      // Setup
+      Eigen::Vector3d ed = J_q.col(i).topRows(3);
+      Eigen::Vector3d ahatd = J_rpy * J_q.col(i).bottomRows(3);
+      Eigen::Vector3d Kd = ahatd.cross(eap) + ahat.cross(ed + ahatd);
+      Eigen::Vector3d Ld = -ed;
+
+      J(0, i) = 2.0 * (Kd.dot(K)*LL - KK*Ld.dot(L)) / LL2;
+      
+    }
+    
+  }
+  
+  void Point2Point::assignScene(Scene_ptr scene)
+  {
+    scene_ = scene;
+    Initialize();
+  }
+
+  void Point2Point::Initialize() {
+    N = scene_->getSolver().getNumControlledJoints();
+  }
+
+
+  void Point2Point::Instantiate(Point2PointInitializer &init)
+  {
+    point_ = init.Point; 
+  }
+
+  int Point2Point::taskSpaceDim()
+  {
+    return 1;
+  }
+}  // namespace exotica

--- a/exotations/task_maps/task_map/src/task_map_py.cpp
+++ b/exotations/task_maps/task_map/src/task_map_py.cpp
@@ -14,8 +14,8 @@
 #include <task_map/Identity.h>
 #include <task_map/JointLimit.h>
 #include <task_map/Point2Line.h>
-#include <task_map/SphereCollision.h>
 #include <task_map/Point2Point.h>
+#include <task_map/SphereCollision.h>
 
 using namespace exotica;
 namespace py = pybind11;

--- a/exotations/task_maps/task_map/src/task_map_py.cpp
+++ b/exotations/task_maps/task_map/src/task_map_py.cpp
@@ -15,6 +15,7 @@
 #include <task_map/JointLimit.h>
 #include <task_map/Point2Line.h>
 #include <task_map/SphereCollision.h>
+#include <task_map/Point2Point.h>
 
 using namespace exotica;
 namespace py = pybind11;
@@ -41,6 +42,10 @@ PYBIND11_MODULE(task_map_py, module)
 
     py::class_<Point2Line, std::shared_ptr<Point2Line>, TaskMap> point2Line(module, "Point2Line");
     point2Line.def_property("endPoint", &Point2Line::getEndPoint, &Point2Line::setEndPoint);
+
+    py::class_<Point2Point, std::shared_ptr<Point2Point>, TaskMap> point2Point(module, "Point2Point");
+    point2Point.def("getPoint", &Point2Point::getPoint);
+    point2Point.def("setPoint", &Point2Point::setPoint);
 
     py::class_<CoM, std::shared_ptr<CoM>, TaskMap> com(module, "CoM");
 


### PR DESCRIPTION
* Points end-effector towards a given point, see [here](https://www.youtube.com/watch?v=nmgU18-6Ooc). 
* Uses chain rule to compute jacobian of approach vector that transforms rpy manipulator jacobian to approach vector jacobian in order to compute task map jacobian. I have a detailed derivation if required.
* Whilst this achieves a similar goal to `Point2Line` the derivation of task map jacobian is different. 
* Example script demonstrates new task map. 