### PR TITLE
Taskmap updates, fixes & store state in KinematicResponse

### DIFF
--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -160,14 +160,14 @@ void AICOsolver::Solve(Eigen::MatrixXd& solution)
     // If the initial value of the initial trajectory does not equal the start
     // state, assume that no initial guess is provided and fill the trajectory
     // with the start state
-    if (!(q0 - q_init[0]).isMuchSmallerThan(1e-6))
+    if (!q0.isApprox(q_init[0]))
     {
-        HIGHLIGHT("AICO::Solve cold-started");
+        if (debug_) HIGHLIGHT("AICO::Solve cold-started");
         q_init.assign(prob_->getT(), q0);
     }
     else
     {
-        HIGHLIGHT("AICO::Solve called with initial trajectory guess");
+        if (debug_) HIGHLIGHT("AICO::Solve called with initial trajectory guess");
     }
 
     prob_->setStartState(q_init[0]);

--- a/exotations/task_maps/task_map/include/task_map/CoM.h
+++ b/exotations/task_maps/task_map/include/task_map/CoM.h
@@ -44,9 +44,6 @@ class CoM : public TaskMap, public Instantiable<CoMInitializer>
 {
 public:
     CoM();
-    virtual ~CoM()
-    {
-    }
 
     virtual void Instantiate(CoMInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/CoM.h
+++ b/exotations/task_maps/task_map/include/task_map/CoM.h
@@ -74,7 +74,6 @@ private:
     int dim_;
 
     CoMInitializer init_;
-    Scene_ptr scene_;
 };
 }
 

--- a/exotations/task_maps/task_map/include/task_map/CoM.h
+++ b/exotations/task_maps/task_map/include/task_map/CoM.h
@@ -44,6 +44,7 @@ class CoM : public TaskMap, public Instantiable<CoMInitializer>
 {
 public:
     CoM();
+    virtual ~CoM();
 
     virtual void Instantiate(CoMInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
+++ b/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
@@ -42,6 +42,7 @@ class CollisionCheck : public TaskMap, public Instantiable<CollisionCheckInitial
 {
 public:
     CollisionCheck();
+    virtual ~CollisionCheck();
 
     virtual void Instantiate(CollisionCheckInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
+++ b/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
@@ -42,9 +42,6 @@ class CollisionCheck : public TaskMap, public Instantiable<CollisionCheckInitial
 {
 public:
     CollisionCheck();
-    virtual ~CollisionCheck()
-    {
-    }
 
     virtual void Instantiate(CollisionCheckInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
+++ b/exotations/task_maps/task_map/include/task_map/CollisionCheck.h
@@ -56,7 +56,6 @@ public:
 
     virtual int taskSpaceDim();
 
-    Scene_ptr scene_;
     CollisionScene_ptr cscene_;
     CollisionCheckInitializer init_;
 };

--- a/exotations/task_maps/task_map/include/task_map/Distance.h
+++ b/exotations/task_maps/task_map/include/task_map/Distance.h
@@ -42,9 +42,6 @@ class Distance : public TaskMap, public Instantiable<DistanceInitializer>
 {
 public:
     Distance();
-    virtual ~Distance()
-    {
-    }
 
     virtual void Instantiate(DistanceInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/Distance.h
+++ b/exotations/task_maps/task_map/include/task_map/Distance.h
@@ -42,6 +42,7 @@ class Distance : public TaskMap, public Instantiable<DistanceInitializer>
 {
 public:
     Distance();
+    virtual ~Distance();
 
     virtual void Instantiate(DistanceInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
+++ b/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
@@ -70,7 +70,6 @@ private:
     EffAxisAlignmentInitializer init_;
     unsigned int NumberOfFrames;
     unsigned int N;
-    Scene_ptr scene_;
     void Initialize();
 
     Eigen::Matrix3Xd axis_, dir_;

--- a/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
+++ b/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
@@ -46,9 +46,6 @@ public:
        * \brief Default constructor
        */
     EffAxisAlignment();
-    virtual ~EffAxisAlignment()
-    {
-    }
 
     virtual void Instantiate(EffAxisAlignmentInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
+++ b/exotations/task_maps/task_map/include/task_map/EffAxisAlignment.h
@@ -42,10 +42,8 @@ namespace exotica  //!< Since this is part of the core library, it will be withi
 class EffAxisAlignment : public TaskMap, public Instantiable<EffAxisAlignmentInitializer>
 {
 public:
-    /**
-       * \brief Default constructor
-       */
     EffAxisAlignment();
+    virtual ~EffAxisAlignment();
 
     virtual void Instantiate(EffAxisAlignmentInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffFrame.h
+++ b/exotations/task_maps/task_map/include/task_map/EffFrame.h
@@ -41,13 +41,7 @@ namespace exotica  //!< Since this is part of the core library, it will be withi
 class EffFrame : public TaskMap, public Instantiable<EffFrameInitializer>
 {
 public:
-    /**
-       * \brief Default constructor
-       */
     EffFrame();
-    virtual ~EffFrame()
-    {
-    }
 
     virtual void Instantiate(EffFrameInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffFrame.h
+++ b/exotations/task_maps/task_map/include/task_map/EffFrame.h
@@ -42,6 +42,7 @@ class EffFrame : public TaskMap, public Instantiable<EffFrameInitializer>
 {
 public:
     EffFrame();
+    virtual ~EffFrame();
 
     virtual void Instantiate(EffFrameInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffOrientation.h
+++ b/exotations/task_maps/task_map/include/task_map/EffOrientation.h
@@ -42,6 +42,7 @@ class EffOrientation : public TaskMap, public Instantiable<EffOrientationInitial
 {
 public:
     EffOrientation();
+    virtual ~EffOrientation();
 
     virtual void Instantiate(EffOrientationInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffOrientation.h
+++ b/exotations/task_maps/task_map/include/task_map/EffOrientation.h
@@ -41,13 +41,7 @@ namespace exotica  //!< Since this is part of the core library, it will be withi
 class EffOrientation : public TaskMap, public Instantiable<EffOrientationInitializer>
 {
 public:
-    /**
-       * \brief Default constructor
-       */
     EffOrientation();
-    virtual ~EffOrientation()
-    {
-    }
 
     virtual void Instantiate(EffOrientationInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffPosition.h
+++ b/exotations/task_maps/task_map/include/task_map/EffPosition.h
@@ -42,6 +42,7 @@ class EffPosition : public TaskMap, public Instantiable<EffPositionInitializer>
 {
 public:
     EffPosition();
+    virtual ~EffPosition();
 
     virtual void Instantiate(EffPositionInitializer& init) {}
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/include/task_map/EffPosition.h
+++ b/exotations/task_maps/task_map/include/task_map/EffPosition.h
@@ -41,13 +41,7 @@ namespace exotica  //!< Since this is part of the core library, it will be withi
 class EffPosition : public TaskMap, public Instantiable<EffPositionInitializer>
 {
 public:
-    /**
-       * \brief Default constructor
-       */
     EffPosition();
-    virtual ~EffPosition()
-    {
-    }
 
     virtual void Instantiate(EffPositionInitializer& init) {}
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/include/task_map/EffVelocity.h
+++ b/exotations/task_maps/task_map/include/task_map/EffVelocity.h
@@ -42,9 +42,6 @@ class EffVelocity : public TaskMap, public Instantiable<EffVelocityInitializer>
 {
 public:
     EffVelocity();
-    virtual ~EffVelocity()
-    {
-    }
 
     virtual void Instantiate(EffVelocityInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/EffVelocity.h
+++ b/exotations/task_maps/task_map/include/task_map/EffVelocity.h
@@ -42,6 +42,7 @@ class EffVelocity : public TaskMap, public Instantiable<EffVelocityInitializer>
 {
 public:
     EffVelocity();
+    virtual ~EffVelocity();
 
     virtual void Instantiate(EffVelocityInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/IMesh.h
+++ b/exotations/task_maps/task_map/include/task_map/IMesh.h
@@ -44,6 +44,7 @@ class IMesh : public TaskMap, public Instantiable<IMeshInitializer>
 {
 public:
     IMesh();
+    virtual ~IMesh();
 
     virtual void Instantiate(IMeshInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/IMesh.h
+++ b/exotations/task_maps/task_map/include/task_map/IMesh.h
@@ -79,7 +79,6 @@ protected:
 
     ros::Publisher imesh_mark_pub_;
     visualization_msgs::Marker imesh_mark_;
-    Scene_ptr scene_;
 };
 typedef std::shared_ptr<IMesh> IMesh_Ptr;
 }

--- a/exotations/task_maps/task_map/include/task_map/IMesh.h
+++ b/exotations/task_maps/task_map/include/task_map/IMesh.h
@@ -47,8 +47,6 @@ public:
 
     virtual void Instantiate(IMeshInitializer& init);
 
-    virtual ~IMesh();
-
     virtual void assignScene(Scene_ptr scene);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
@@ -74,7 +72,7 @@ public:
 protected:
     Eigen::MatrixXd weights_;
 
-    int eff_size_;
+    int eff_size_ = 0;
     bool Debug;
 
     ros::Publisher imesh_mark_pub_;

--- a/exotations/task_maps/task_map/include/task_map/Identity.h
+++ b/exotations/task_maps/task_map/include/task_map/Identity.h
@@ -42,9 +42,6 @@ class Identity : public TaskMap, public Instantiable<IdentityInitializer>
 {
 public:
     Identity();
-    virtual ~Identity()
-    {
-    }
 
     virtual void Instantiate(IdentityInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/Identity.h
+++ b/exotations/task_maps/task_map/include/task_map/Identity.h
@@ -63,7 +63,6 @@ public:
     std::vector<int> jointMap;
     Eigen::VectorXd jointRef;
     int N;
-    Scene_ptr scene_;
     IdentityInitializer init_;
 };
 

--- a/exotations/task_maps/task_map/include/task_map/Identity.h
+++ b/exotations/task_maps/task_map/include/task_map/Identity.h
@@ -42,6 +42,7 @@ class Identity : public TaskMap, public Instantiable<IdentityInitializer>
 {
 public:
     Identity();
+    virtual ~Identity();
 
     virtual void Instantiate(IdentityInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -47,7 +47,6 @@ class JointLimit : public TaskMap, public Instantiable<JointLimitInitializer>
 {
 public:
     JointLimit();
-    ~JointLimit();
 
     virtual void Instantiate(JointLimitInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -47,6 +47,7 @@ class JointLimit : public TaskMap, public Instantiable<JointLimitInitializer>
 {
 public:
     JointLimit();
+    virtual ~JointLimit();
 
     virtual void Instantiate(JointLimitInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -46,9 +46,7 @@ namespace exotica
 class JointLimit : public TaskMap, public Instantiable<JointLimitInitializer>
 {
 public:
-    //	Default constructor
     JointLimit();
-    //	Default destructor
     ~JointLimit();
 
     virtual void Instantiate(JointLimitInitializer& init);
@@ -67,7 +65,6 @@ private:
     Eigen::VectorXd low_limits_;   //	Lower joint limits
     Eigen::VectorXd high_limits_;  //	Higher joint limits
     Eigen::VectorXd tau_;          //	Joint limits tolerance
-    Scene_ptr scene_;
     JointLimitInitializer init_;
     int N;
 };

--- a/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
+++ b/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
@@ -40,8 +40,7 @@ namespace exotica
 class Point2Line : public TaskMap, public Instantiable<Point2LineInitializer>
 {
 public:
-    Point2Line() {}
-    virtual ~Point2Line() {}
+    Point2Line();
     virtual void Instantiate(Point2LineInitializer& init);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
+++ b/exotations/task_maps/task_map/include/task_map/Point2Line.hpp
@@ -41,6 +41,8 @@ class Point2Line : public TaskMap, public Instantiable<Point2LineInitializer>
 {
 public:
     Point2Line();
+    virtual ~Point2Line();
+
     virtual void Instantiate(Point2LineInitializer& init);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/include/task_map/Point2Plane.h
+++ b/exotations/task_maps/task_map/include/task_map/Point2Plane.h
@@ -42,6 +42,7 @@ class Point2Plane : public TaskMap, public Instantiable<Point2PlaneInitializer>
 {
 public:
     Point2Plane();
+    virtual ~Point2Plane();
 
     virtual void Instantiate(Point2PlaneInitializer &init);
 

--- a/exotations/task_maps/task_map/include/task_map/Point2Plane.h
+++ b/exotations/task_maps/task_map/include/task_map/Point2Plane.h
@@ -54,8 +54,6 @@ public:
     virtual int taskSpaceDim();
 
 private:
-    Scene_ptr scene_;
-
     void publishDebug();
     ros::Publisher debug_pub_;
 };

--- a/exotations/task_maps/task_map/include/task_map/Point2Plane.h
+++ b/exotations/task_maps/task_map/include/task_map/Point2Plane.h
@@ -43,9 +43,7 @@ class Point2Plane : public TaskMap, public Instantiable<Point2PlaneInitializer>
 public:
     Point2Plane();
 
-    virtual ~Point2Plane() {}
     virtual void Instantiate(Point2PlaneInitializer &init);
-    virtual void assignScene(Scene_ptr scene);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
 

--- a/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
+++ b/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
@@ -60,7 +60,6 @@ public:
 
 private:
     QuasiStaticInitializer init_;
-    Scene_ptr scene_;
     visualization_msgs::MarkerArray debug_msg;
     ros::Publisher debug_pub;
 };

--- a/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
+++ b/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
@@ -44,7 +44,6 @@ class QuasiStatic : public TaskMap, public Instantiable<QuasiStaticInitializer>
 {
 public:
     QuasiStatic();
-    virtual ~QuasiStatic();
 
     virtual void Instantiate(QuasiStaticInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
+++ b/exotations/task_maps/task_map/include/task_map/QuasiStatic.h
@@ -44,6 +44,7 @@ class QuasiStatic : public TaskMap, public Instantiable<QuasiStaticInitializer>
 {
 public:
     QuasiStatic();
+    virtual ~QuasiStatic();
 
     virtual void Instantiate(QuasiStaticInitializer& init);
 

--- a/exotations/task_maps/task_map/include/task_map/SphereCollision.h
+++ b/exotations/task_maps/task_map/include/task_map/SphereCollision.h
@@ -44,6 +44,8 @@ class SphereCollision : public TaskMap, public Instantiable<SphereCollisionIniti
 {
 public:
     SphereCollision();
+    virtual ~SphereCollision();
+
     virtual void Instantiate(SphereCollisionInitializer& init);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/include/task_map/SphereCollision.h
+++ b/exotations/task_maps/task_map/include/task_map/SphereCollision.h
@@ -44,7 +44,6 @@ class SphereCollision : public TaskMap, public Instantiable<SphereCollisionIniti
 {
 public:
     SphereCollision();
-    virtual ~SphereCollision() {}
     virtual void Instantiate(SphereCollisionInitializer& init);
 
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);

--- a/exotations/task_maps/task_map/init/JointLimit.in
+++ b/exotations/task_maps/task_map/init/JointLimit.in
@@ -1,3 +1,2 @@
 extend <exotica/TaskMap>
 Optional double SafePercentage = 0.0;
-Optional std::string RobotDescription = "robot_description";

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("CoM", exotica::CoM);
 namespace exotica
 {
 CoM::CoM() = default;
+CoM::~CoM() = default;
 
 void CoM::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("CoM", exotica::CoM);
 
 namespace exotica
 {
-CoM::CoM()
-{
-}
+CoM::CoM() = default;
 
 void CoM::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("CollisionCheck", exotica::CollisionCheck);
 
 namespace exotica
 {
-CollisionCheck::CollisionCheck()
-{
-}
+CollisionCheck::CollisionCheck() = default;
 
 void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/CollisionCheck.cpp
+++ b/exotations/task_maps/task_map/src/CollisionCheck.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("CollisionCheck", exotica::CollisionCheck);
 namespace exotica
 {
 CollisionCheck::CollisionCheck() = default;
+CollisionCheck::~CollisionCheck() = default;
 
 void CollisionCheck::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/Distance.cpp
+++ b/exotations/task_maps/task_map/src/Distance.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("Distance", exotica::Distance);
 namespace exotica
 {
 Distance::Distance() = default;
+Distance::~Distance() = default;
 
 void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/Distance.cpp
+++ b/exotations/task_maps/task_map/src/Distance.cpp
@@ -36,10 +36,7 @@ REGISTER_TASKMAP_TYPE("Distance", exotica::Distance);
 
 namespace exotica
 {
-Distance::Distance()
-{
-    //!< Empty constructor
-}
+Distance::Distance() = default;
 
 void Distance::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/EffAxisAlignment.cpp
+++ b/exotations/task_maps/task_map/src/EffAxisAlignment.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("EffAxisAlignment", exotica::EffAxisAlignment);
 
 namespace exotica
 {
-EffAxisAlignment::EffAxisAlignment()
-{
-}
+EffAxisAlignment::EffAxisAlignment() = default;
 
 void EffAxisAlignment::Instantiate(EffAxisAlignmentInitializer& init)
 {

--- a/exotations/task_maps/task_map/src/EffAxisAlignment.cpp
+++ b/exotations/task_maps/task_map/src/EffAxisAlignment.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("EffAxisAlignment", exotica::EffAxisAlignment);
 namespace exotica
 {
 EffAxisAlignment::EffAxisAlignment() = default;
+EffAxisAlignment::~EffAxisAlignment() = default;
 
 void EffAxisAlignment::Instantiate(EffAxisAlignmentInitializer& init)
 {

--- a/exotations/task_maps/task_map/src/EffFrame.cpp
+++ b/exotations/task_maps/task_map/src/EffFrame.cpp
@@ -40,6 +40,8 @@ EffFrame::EffFrame() : rotationType(RotationType::RPY)
 {
 }
 
+EffFrame::~EffFrame() = default;
+
 void EffFrame::Instantiate(EffFrameInitializer& init)
 {
     if (init.Type == "Quaternion")

--- a/exotations/task_maps/task_map/src/EffOrientation.cpp
+++ b/exotations/task_maps/task_map/src/EffOrientation.cpp
@@ -40,6 +40,8 @@ EffOrientation::EffOrientation() : rotationType(RotationType::RPY)
 {
 }
 
+EffOrientation::~EffOrientation() = default;
+
 void EffOrientation::Instantiate(EffOrientationInitializer& init)
 {
     if (init.Type == "Quaternion")

--- a/exotations/task_maps/task_map/src/EffPosition.cpp
+++ b/exotations/task_maps/task_map/src/EffPosition.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("EffPosition", exotica::EffPosition);
 namespace exotica
 {
 EffPosition::EffPosition() = default;
+EffPosition::~EffPosition() = default;
 
 void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/EffPosition.cpp
+++ b/exotations/task_maps/task_map/src/EffPosition.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("EffPosition", exotica::EffPosition);
 
 namespace exotica
 {
-EffPosition::EffPosition()
-{
-}
+EffPosition::EffPosition() = default;
 
 void EffPosition::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/EffVelocity.cpp
+++ b/exotations/task_maps/task_map/src/EffVelocity.cpp
@@ -41,6 +41,8 @@ EffVelocity::EffVelocity()
     Kinematics.resize(2);
 }
 
+EffVelocity::~EffVelocity() = default;
+
 void EffVelocity::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (Kinematics.size() != 2) throw_named("Wrong size of Kinematics - requires 2, but got " << Kinematics.size());

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -37,13 +37,7 @@ REGISTER_TASKMAP_TYPE("IMesh", exotica::IMesh);
 
 namespace exotica
 {
-IMesh::IMesh() : eff_size_(0)
-{
-}
-
-IMesh::~IMesh()
-{
-}
+IMesh::IMesh() = default;
 
 void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -38,6 +38,7 @@ REGISTER_TASKMAP_TYPE("IMesh", exotica::IMesh);
 namespace exotica
 {
 IMesh::IMesh() = default;
+IMesh::~IMesh() = default;
 
 void IMesh::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/Identity.cpp
+++ b/exotations/task_maps/task_map/src/Identity.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("Identity", exotica::Identity);
 namespace exotica
 {
 Identity::Identity() = default;
+Identity::~Identity() = default;
 
 void Identity::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/Identity.cpp
+++ b/exotations/task_maps/task_map/src/Identity.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("Identity", exotica::Identity);
 
 namespace exotica
 {
-Identity::Identity()
-{
-}
+Identity::Identity() = default;
 
 void Identity::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -95,20 +95,10 @@ void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 
 void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
 {
-    if (phi.rows() != N) throw_named("Wrong size of phi!");
-    if (J.rows() != N || J.cols() != N) throw_named("Wrong size of J! " << N);
     phi.setZero();
+    update(x, phi);
+
+    if (J.rows() != N || J.cols() != N) throw_named("Wrong size of J! " << N);
     J = Eigen::MatrixXd::Identity(N, N);
-    for (int i = 0; i < N; i++)
-    {
-        if (x(i) < low_limits_(i) + tau_(i))
-        {
-            phi(i) = x(i) - low_limits_(i) - tau_(i);
-        }
-        if (x(i) > high_limits_(i) - tau_(i))
-        {
-            phi(i) = x(i) - high_limits_(i) + tau_(i);
-        }
-    }
 }
 }

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -38,8 +38,6 @@ namespace exotica
 {
 JointLimit::JointLimit() = default;
 
-JointLimit::~JointLimit() = default;
-
 void JointLimit::Instantiate(JointLimitInitializer& init)
 {
     init_ = init;

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("JointLimit", exotica::JointLimit);
 namespace exotica
 {
 JointLimit::JointLimit() = default;
+JointLimit::~JointLimit() = default;
 
 void JointLimit::Instantiate(JointLimitInitializer& init)
 {

--- a/exotations/task_maps/task_map/src/Point2Line.cpp
+++ b/exotations/task_maps/task_map/src/Point2Line.cpp
@@ -36,6 +36,8 @@ REGISTER_TASKMAP_TYPE("Point2Line", exotica::Point2Line);
 
 namespace exotica
 {
+Point2Line::Point2Line() = default;
+
 Eigen::Vector3d Point2Line::direction(const Eigen::Vector3d &point)
 {
     // http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html

--- a/exotations/task_maps/task_map/src/Point2Line.cpp
+++ b/exotations/task_maps/task_map/src/Point2Line.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("Point2Line", exotica::Point2Line);
 namespace exotica
 {
 Point2Line::Point2Line() = default;
+Point2Line::~Point2Line() = default;
 
 Eigen::Vector3d Point2Line::direction(const Eigen::Vector3d &point)
 {

--- a/exotations/task_maps/task_map/src/Point2Plane.cpp
+++ b/exotations/task_maps/task_map/src/Point2Plane.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("Point2Plane", exotica::Point2Plane);
 
 namespace exotica
 {
-Point2Plane::Point2Plane()
-{
-}
+Point2Plane::Point2Plane() = default;
 
 void Point2Plane::Instantiate(Point2PlaneInitializer& init)
 {
@@ -47,11 +45,6 @@ void Point2Plane::Instantiate(Point2PlaneInitializer& init)
         debug_pub_ = Server::advertise<visualization_msgs::MarkerArray>(
             object_name_ + "/planes", 1, true);
     }
-}
-
-void Point2Plane::assignScene(Scene_ptr scene)
-{
-    scene_ = scene;
 }
 
 void Point2Plane::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)

--- a/exotations/task_maps/task_map/src/Point2Plane.cpp
+++ b/exotations/task_maps/task_map/src/Point2Plane.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("Point2Plane", exotica::Point2Plane);
 namespace exotica
 {
 Point2Plane::Point2Plane() = default;
+Point2Plane::~Point2Plane() = default;
 
 void Point2Plane::Instantiate(Point2PlaneInitializer& init)
 {

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -40,13 +40,7 @@ namespace exotica
 {
 constexpr double eps = 1e-8;
 
-QuasiStatic::QuasiStatic()
-{
-}
-
-QuasiStatic::~QuasiStatic()
-{
-}
+QuasiStatic::QuasiStatic() = default;
 
 ///
 /// \brief cross 2D cross product (z coordinate of a 3D cross product of 2 vectors on a xy plane).

--- a/exotations/task_maps/task_map/src/QuasiStatic.cpp
+++ b/exotations/task_maps/task_map/src/QuasiStatic.cpp
@@ -41,6 +41,7 @@ namespace exotica
 constexpr double eps = 1e-8;
 
 QuasiStatic::QuasiStatic() = default;
+QuasiStatic::~QuasiStatic() = default;
 
 ///
 /// \brief cross 2D cross product (z coordinate of a 3D cross product of 2 vectors on a xy plane).

--- a/exotations/task_maps/task_map/src/SphereCollision.cpp
+++ b/exotations/task_maps/task_map/src/SphereCollision.cpp
@@ -36,9 +36,7 @@ REGISTER_TASKMAP_TYPE("SphereCollision", exotica::SphereCollision);
 
 namespace exotica
 {
-SphereCollision::SphereCollision()
-{
-}
+SphereCollision::SphereCollision() = default;
 
 void SphereCollision::Instantiate(SphereCollisionInitializer& init)
 {

--- a/exotations/task_maps/task_map/src/SphereCollision.cpp
+++ b/exotations/task_maps/task_map/src/SphereCollision.cpp
@@ -37,6 +37,7 @@ REGISTER_TASKMAP_TYPE("SphereCollision", exotica::SphereCollision);
 namespace exotica
 {
 SphereCollision::SphereCollision() = default;
+SphereCollision::~SphereCollision() = default;
 
 void SphereCollision::Instantiate(SphereCollisionInitializer& init)
 {

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -121,6 +121,7 @@ public:
     KinematicResponse(KinematicRequestFlags Flags, int Size, int N = 0);
     KinematicRequestFlags Flags;
     std::vector<KinematicFrame> Frame;
+    Eigen::VectorXd X;
     ArrayFrame Phi;
     ArrayTwist PhiDot;
     ArrayJacobian J;
@@ -138,6 +139,7 @@ public:
     void Create(std::shared_ptr<KinematicResponse> solution);
     int Start;
     int Length;
+    Eigen::Map<Eigen::VectorXd> X;
     Eigen::Map<ArrayFrame> Phi;
     Eigen::Map<ArrayTwist> PhiDot;
     Eigen::Map<ArrayJacobian> J;
@@ -148,7 +150,7 @@ class KinematicTree : public Uncopyable
 {
 public:
     KinematicTree();
-    ~KinematicTree() {}
+    ~KinematicTree() = default;
     void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model, const std::string& name);
     std::string getRootFrameName();
     std::string getRootJointName();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -92,7 +92,7 @@ class KinematicsRequest
 {
 public:
     KinematicsRequest();
-    KinematicRequestFlags Flags;
+    KinematicRequestFlags Flags = KinematicRequestFlags::KIN_FK;
     std::vector<KinematicFrameRequest> Frames;  //!< The segments to which the end-effectors are attached
 };
 
@@ -117,7 +117,7 @@ class KinematicResponse
 public:
     KinematicResponse();
     KinematicResponse(KinematicRequestFlags Flags, int Size, int N = 0);
-    KinematicRequestFlags Flags;
+    KinematicRequestFlags Flags = KinematicRequestFlags::KIN_FK;
     std::vector<KinematicFrame> Frame;
     Eigen::VectorXd X;
     ArrayFrame Phi;
@@ -135,13 +135,13 @@ public:
     KinematicSolution();
     KinematicSolution(int start, int length);
     void Create(std::shared_ptr<KinematicResponse> solution);
-    int Start;
-    int Length;
-    Eigen::Map<Eigen::VectorXd> X;
-    Eigen::Map<ArrayFrame> Phi;
-    Eigen::Map<ArrayTwist> PhiDot;
-    Eigen::Map<ArrayJacobian> J;
-    Eigen::Map<ArrayJacobian> JDot;
+    int Start = -1;
+    int Length = -1;
+    Eigen::Map<Eigen::VectorXd> X{nullptr, 0};
+    Eigen::Map<ArrayFrame> Phi{nullptr, 0};
+    Eigen::Map<ArrayTwist> PhiDot{nullptr, 0};
+    Eigen::Map<ArrayJacobian> J{nullptr, 0};
+    Eigen::Map<ArrayJacobian> JDot{nullptr, 0};
 };
 
 class KinematicTree : public Uncopyable
@@ -213,7 +213,7 @@ public:
     std::map<std::string, std::weak_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
     bool doesLinkWithNameExist(std::string name);  //!< Checks whether a link with this name exists in any of the trees
-    bool Debug;
+    bool Debug = false;
 
     std::map<std::string, shapes::ShapeType> getCollisionObjectTypes();
 
@@ -245,7 +245,7 @@ private:
     BASE_TYPE ControlledBaseType = BASE_TYPE::FIXED;
     int NumControlledJoints;  //!< Number of controlled joints in the joint group.
     int NumJoints;            //!< Number of joints of the model (including floating/planar base, passive joints, and uncontrolled joints).
-    int StateSize;
+    int StateSize = -1;
     Eigen::VectorXd TreeState;
     robot_model::RobotModelPtr Model;
     std::vector<std::weak_ptr<KinematicElement>> Tree;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -50,8 +50,6 @@
 
 #include <exotica/KinematicElement.h>
 
-#define ROOT -1  //!< The value of the parent for the root segment
-
 namespace exotica
 {
 enum BASE_TYPE

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -58,10 +58,10 @@ namespace exotica
 {
 struct AttachedObject
 {
-    AttachedObject() : Parent("") {}
+    AttachedObject() = default;
     AttachedObject(std::string parent) : Parent(parent) {}
     AttachedObject(std::string parent, KDL::Frame pose) : Parent(parent), Pose(pose) {}
-    std::string Parent;
+    std::string Parent = "";
     KDL::Frame Pose;
 };
 
@@ -178,7 +178,7 @@ public:
     std::map<std::string, std::vector<std::string>> getControlledLinkToCollisionLinkMap() { return controlledLink_to_collisionLink_map_; };
 private:
     /// The name of the scene
-    std::string name_;
+    std::string name_ = "Unnamed";
 
     /// The kinematica tree
     exotica::KinematicTree kinematica_;

--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -70,6 +70,8 @@ protected:
 class Server : public Uncopyable
 {
 public:
+    virtual ~Server();
+
     /*
        * \brief	Get the server
        */
@@ -78,14 +80,6 @@ public:
         if (!singleton_server_) singleton_server_.reset(new Server);
         return singleton_server_;
     }
-    virtual ~Server();
-
-    /*
-       * \brief	Check if a robot model exist
-       * @param	path	Robot model name
-       * @return	True if exist, false otherwise
-       */
-    bool hasModel(const std::string &path);
 
     /*
        * \brief	Get robot model
@@ -188,9 +182,6 @@ public:
     static void destroy();
 
 private:
-    /*
-       * \brief	Constructor
-       */
     Server();
     static std::shared_ptr<Server> singleton_server_;
     ///	\brief	Make sure the singleton does not get copied
@@ -199,9 +190,9 @@ private:
     robot_model::RobotModelPtr loadModel(std::string name, std::string urdf = "", std::string srdf = "");
 
     /// \brief	The name of this server
-    std::string name_;
+    std::string name_ = "EXOTicaServer";
 
-    std::shared_ptr<RosNode> node_;
+    std::shared_ptr<RosNode> node_ = std::make_shared<RosNode>(nullptr);
 
     /// \brief Robot model cache
     std::map<std::string, robot_model::RobotModelPtr> robot_models_;

--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -70,8 +70,6 @@ protected:
 class Server : public Uncopyable
 {
 public:
-    virtual ~Server();
-
     /*
        * \brief	Get the server
        */
@@ -80,6 +78,14 @@ public:
         if (!singleton_server_) singleton_server_.reset(new Server);
         return singleton_server_;
     }
+    virtual ~Server();
+
+    /*
+       * \brief	Check if a robot model exist
+       * @param	path	Robot model name
+       * @return	True if exist, false otherwise
+       */
+    bool hasModel(const std::string &path);
 
     /*
        * \brief	Get robot model
@@ -182,6 +188,9 @@ public:
     static void destroy();
 
 private:
+    /*
+       * \brief	Constructor
+       */
     Server();
     static std::shared_ptr<Server> singleton_server_;
     ///	\brief	Make sure the singleton does not get copied
@@ -190,9 +199,9 @@ private:
     robot_model::RobotModelPtr loadModel(std::string name, std::string urdf = "", std::string srdf = "");
 
     /// \brief	The name of this server
-    std::string name_ = "EXOTicaServer";
+    std::string name_;
 
-    std::shared_ptr<RosNode> node_ = std::make_shared<RosNode>(nullptr);
+    std::shared_ptr<RosNode> node_;
 
     /// \brief Robot model cache
     std::map<std::string, robot_model::RobotModelPtr> robot_models_;

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -37,7 +37,6 @@
 #include <exotica/Object.h>   //!< The EXOTica base class
 #include <exotica/Property.h>
 #include <exotica/Scene.h>
-#include <exotica/Server.h>
 #include <exotica/TaskSpaceVector.h>
 
 #include <Eigen/Dense>  //!< Generally dense manipulations should be enough
@@ -50,19 +49,14 @@
 
 namespace exotica
 {
-class PlanningProblem;
-
 class TaskMap : public Object, Uncopyable, public virtual InstantiableBase
 {
 public:
-    /**
-       * \brief Default Constructor
-       */
     TaskMap();
-    virtual ~TaskMap() {}
+    virtual ~TaskMap();
     virtual void InstantiateBase(const Initializer& init);
 
-    virtual void assignScene(Scene_ptr scene) {}
+    virtual void assignScene(Scene_ptr scene);
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) = 0;
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J) { throw_named("Not implemented"); }
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, HessianRef H);
@@ -78,16 +72,17 @@ public:
     std::vector<KinematicFrameRequest> GetFrames();
 
     virtual void debug() {}
-    std::vector<KinematicSolution> Kinematics;
-    int Id;
-    int Start;
-    int Length;
-    int StartJ;
-    int LengthJ;
-    bool isUsed;
+    std::vector<KinematicSolution> Kinematics = std::vector<KinematicSolution>(1);
+    int Id = -1;
+    int Start = -1;
+    int Length = -1;
+    int StartJ = -1;
+    int LengthJ = -1;
+    bool isUsed = false;
 
 protected:
     std::vector<KinematicFrameRequest> Frames;
+    Scene_ptr scene_ = nullptr;
 };
 
 //!< Typedefines for some common functionality

--- a/exotica/include/exotica/Tasks.h
+++ b/exotica/include/exotica/Tasks.h
@@ -30,12 +30,6 @@
  *
  */
 
-namespace exotica
-{
-struct TaskIndexing;
-class Task;
-}
-
 #ifndef EXOTICA_TASKS_H
 #define EXOTICA_TASKS_H
 

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -44,9 +44,7 @@
 
 namespace exotica
 {
-KinematicResponse::KinematicResponse() : Flags(KIN_FK)
-{
-}
+KinematicResponse::KinematicResponse() = default;
 
 KinematicResponse::KinematicResponse(KinematicRequestFlags flags, int size, int n)
 {
@@ -61,23 +59,17 @@ KinematicResponse::KinematicResponse(KinematicRequestFlags flags, int size, int 
     X.setZero(n);
 }
 
-KinematicsRequest::KinematicsRequest() : Flags(KIN_FK)
-{
-}
+KinematicsRequest::KinematicsRequest() = default;
 
-KinematicFrameRequest::KinematicFrameRequest()
-{
-}
+KinematicFrameRequest::KinematicFrameRequest() = default;
 
 KinematicFrameRequest::KinematicFrameRequest(std::string frameALinkName, KDL::Frame frameAOffset, std::string frameBLinkName, KDL::Frame frameBOffset) : FrameALinkName(frameALinkName), FrameAOffset(frameAOffset), FrameBLinkName(frameBLinkName), FrameBOffset(frameBOffset)
 {
 }
 
-KinematicSolution::KinematicSolution() : Start(-1), Length(-1), Phi(nullptr, 0), PhiDot(nullptr, 0), J(nullptr, 0), JDot(nullptr, 0), X(nullptr, 0)
-{
-}
+KinematicSolution::KinematicSolution() = default;
 
-KinematicSolution::KinematicSolution(int start, int length) : Start(start), Length(length), Phi(nullptr, 0), PhiDot(nullptr, 0), J(nullptr, 0), JDot(nullptr, 0), X(nullptr, 0)
+KinematicSolution::KinematicSolution(int start, int length) : Start(start), Length(length)
 {
 }
 
@@ -101,9 +93,7 @@ int KinematicTree::getNumModelJoints()
     return NumJoints;
 }
 
-KinematicTree::KinematicTree() : StateSize(-1), Debug(false)
-{
-}
+KinematicTree::KinematicTree() = default;
 
 void KinematicTree::Instantiate(std::string JointGroup, robot_model::RobotModelPtr model, const std::string& name)
 {

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -216,12 +216,11 @@ void TimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
     // Pass the corresponding number of relevant task kinematics to the TaskMaps
     // via the PlanningProblem::updateMultipleTaskKinematics method. For now we
     // support passing _two_ timesteps - this can be easily changed later on.
-    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions;
-    kinematics_solutions.push_back(KinematicSolutions[t]);
+    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions { KinematicSolutions[t] };
 
     // If the current timestep is 0, pass the 0th timestep's response twice.
     // Otherwise pass the (t-1)th response.
-    kinematics_solutions.push_back((t == 0) ? KinematicSolutions[t] : KinematicSolutions[t - 1]);
+    kinematics_solutions.emplace_back((t == 0) ? KinematicSolutions[t] : KinematicSolutions[t - 1]);
 
     // Actually update the tasks' kinematics mappings.
     PlanningProblem::updateMultipleTaskKinematics(kinematics_solutions);

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -216,7 +216,7 @@ void TimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)
     // Pass the corresponding number of relevant task kinematics to the TaskMaps
     // via the PlanningProblem::updateMultipleTaskKinematics method. For now we
     // support passing _two_ timesteps - this can be easily changed later on.
-    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions { KinematicSolutions[t] };
+    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions{KinematicSolutions[t]};
 
     // If the current timestep is 0, pass the 0th timestep's response twice.
     // Otherwise pass the (t-1)th response.

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -183,12 +183,11 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t
     // Pass the corresponding number of relevant task kinematics to the TaskMaps
     // via the PlanningProblem::updateMultipleTaskKinematics method. For now we
     // support passing _two_ timesteps - this can be easily changed later on.
-    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions;
-    kinematics_solutions.push_back(KinematicSolutions[t]);
+    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions { KinematicSolutions[t] };
 
     // If the current timestep is 0, pass the 0th timestep's response twice.
     // Otherwise pass the (t-1)th response.
-    kinematics_solutions.push_back((t == 0) ? KinematicSolutions[t] : KinematicSolutions[t - 1]);
+    kinematics_solutions.emplace_back((t == 0) ? KinematicSolutions[t] : KinematicSolutions[t - 1]);
 
     // Actually update the tasks' kinematics mappings.
     PlanningProblem::updateMultipleTaskKinematics(kinematics_solutions);

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -183,7 +183,7 @@ void UnconstrainedTimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t
     // Pass the corresponding number of relevant task kinematics to the TaskMaps
     // via the PlanningProblem::updateMultipleTaskKinematics method. For now we
     // support passing _two_ timesteps - this can be easily changed later on.
-    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions { KinematicSolutions[t] };
+    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions{KinematicSolutions[t]};
 
     // If the current timestep is 0, pass the 0th timestep's response twice.
     // Otherwise pass the (t-1)th response.

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -43,9 +43,7 @@ namespace exotica
 /////////////////////// EXOTica Scene ///////////////////////
 ///////////////////////////////////////////////////////////////
 
-Scene::Scene() : name_("Unnamed")
-{
-}
+Scene::Scene() = default;
 
 Scene::Scene(const std::string& name) : name_(name), requestNeedsUpdating(false)
 {

--- a/exotica/src/Server.cpp
+++ b/exotica/src/Server.cpp
@@ -45,8 +45,13 @@ RosNode::~RosNode()
     sp_.stop();
 }
 
-Server::Server() = default;
-Server::~Server() = default;
+Server::Server() : name_("EXOTicaServer"), node_(nullptr)
+{
+}
+
+Server::~Server()
+{
+}
 
 void Server::destroy()
 {
@@ -136,6 +141,11 @@ robot_model::RobotModelConstPtr Server::getModel(std::string path, std::string u
     {
         return loadModel(path, urdf, srdf);
     }
+}
+
+bool Server::hasModel(const std::string& path)
+{
+    return robot_models_.find(path) != robot_models_.end();
 }
 
 std::string Server::getName()

--- a/exotica/src/Server.cpp
+++ b/exotica/src/Server.cpp
@@ -45,13 +45,8 @@ RosNode::~RosNode()
     sp_.stop();
 }
 
-Server::Server() : name_("EXOTicaServer"), node_(nullptr)
-{
-}
-
-Server::~Server()
-{
-}
+Server::Server() = default;
+Server::~Server() = default;
 
 void Server::destroy()
 {
@@ -141,11 +136,6 @@ robot_model::RobotModelConstPtr Server::getModel(std::string path, std::string u
     {
         return loadModel(path, urdf, srdf);
     }
-}
-
-bool Server::hasModel(const std::string& path)
-{
-    return robot_models_.find(path) != robot_models_.end();
 }
 
 std::string Server::getName()

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -30,16 +30,19 @@
  *
  */
 
-#include <exotica/FrameInitializer.h>
-#include <exotica/PlanningProblem.h>
 #include <exotica/TaskMap.h>
+
+#include <exotica/FrameInitializer.h>
 #include <exotica/TaskMapInitializer.h>
 
 namespace exotica
 {
-TaskMap::TaskMap() : Id(-1), Start(-1), Length(-1), StartJ(-1), LengthJ(-1)
+TaskMap::TaskMap() = default;
+TaskMap::~TaskMap() = default;
+
+void TaskMap::assignScene(Scene_ptr scene)
 {
-    Kinematics.resize(1);
+    scene_ = scene;
 }
 
 std::string TaskMap::print(std::string prepend)


### PR DESCRIPTION
- Store the joint state of a kinematicsolution in its response/solution (X) => enables multi-timestep dependent taskmaps

And many changes in taskmaps making compilation and computation faster:

- Remove predeclarations from previous cyclic dependencies, remove unnecessary headers
- Use static member initialisation
- Remove all trivial constructors/destructors and use default constructors where possible
- Scene_ptr is now directly owned by the abstract base class
- Minor: JointLimit: Re-use code instead of copy paste, remove dead initialiser values
- Minor: AICO debug print-outs