### PR TITLE
Taskmap: backward finite differencing support

### DIFF
--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -71,8 +71,6 @@ public:
     virtual int taskSpaceJacobianDim() { return taskSpaceDim(); }
     virtual void preupdate() {}
     virtual std::vector<TaskVectorEntry> getLieGroupIndices() { return std::vector<TaskVectorEntry>(); }
-    void taskSpaceDim(int& task_dim);
-
     virtual std::string print(std::string prepend);
 
     std::vector<KinematicFrameRequest> GetFrames();

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -64,7 +64,7 @@ public:
 
     virtual void assignScene(Scene_ptr scene) {}
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) = 0;
-    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J) { throw_named("Not implemented"); }
+    virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
     virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, HessianRef H);
     virtual int taskSpaceDim() = 0;
 

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -77,13 +77,6 @@ void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::M
     Eigen::VectorXd x_original(x);
     update(x_original, phi);
 
-    // Do not run finite differencing if phi is zero.
-    if (phi.isApprox(Eigen::VectorXd::Zero(taskSpaceDim())))
-    {
-        J.setZero();
-        return;
-    }
-
     // Backward finite differencing.
     constexpr double h = 1e-6;
     Eigen::VectorXd x_tmp;

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -76,11 +76,18 @@ void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::M
     // Store original x (needs to be reset later).
     Eigen::VectorXd x_original(x);
     update(x_original, phi);
-    Eigen::VectorXd phi_original(phi);
+
+    // Do not run finite differencing if phi is zero.
+    if (phi.isApprox(Eigen::VectorXd::Zero(taskSpaceDim())))
+    {
+        J.setZero();
+        return;
+    }
 
     // Backward finite differencing.
-    const double h = 1e-6;
+    constexpr double h = 1e-6;
     Eigen::VectorXd x_tmp;
+    Eigen::VectorXd phi_original(phi);
     for (int i = 0; i < taskSpaceDim(); i++)
     {
         x_tmp = x;

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -68,11 +68,6 @@ std::vector<KinematicFrameRequest> TaskMap::GetFrames()
     return Frames;
 }
 
-void TaskMap::taskSpaceDim(int& task_dim)
-{
-    task_dim = taskSpaceDim();
-}
-
 void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
 {
     if (J.rows() != taskSpaceDim() && J.cols() != x.rows())

--- a/exotica/src/TaskMap.cpp
+++ b/exotica/src/TaskMap.cpp
@@ -73,6 +73,31 @@ void TaskMap::taskSpaceDim(int& task_dim)
     task_dim = taskSpaceDim();
 }
 
+void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+{
+    if (J.rows() != taskSpaceDim() && J.cols() != x.rows())
+        throw_named("Jacobian dimension mismatch!");
+
+    // Store original x (needs to be reset later).
+    Eigen::VectorXd x_original(x);
+    update(x_original, phi);
+    Eigen::VectorXd phi_original(phi);
+
+    // Backward finite differencing.
+    const double h = 1e-6;
+    Eigen::VectorXd x_tmp;
+    for (int i = 0; i < taskSpaceDim(); i++)
+    {
+        x_tmp = x;
+        x_tmp(i) -= h;
+        update(x_tmp, phi);
+        J.row(i) = (1 / h) * (phi_original - phi);
+    }
+
+    // Finally, reset with original value again.
+    update(x_original, phi);
+}
+
 void TaskMap::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, HessianRef H)
 {
     update(x, phi, J);


### PR DESCRIPTION
Computes Taskmap Jacobians by backward finite differencing if no explicit Jacobian is defined. The default behaviour is now as follows for Taskmaps:

- 0th-order update _needs_ to be defined (``update(x, phi)``).
- 1st-order update _should_ be defined where possible (``update(x, phi, J)``; do not avoid to do chain rule or use the corresponding functions that can compute Jdot for instance (``KinematicTree::ComputeJdot``)) - if it is not defined, the default behaviour is to compute J by backward finite differencing. [This is very, very expensive and will slow things down quite a bit]
- 2nd-order updates can be specified if desired - where they are not, the Hessian will be approximates as ``J^T * J``.

cc: @cmower 