### PR TITLE
Pass by const reference instead of pass by value, change from Affine to Isometry transforms

### DIFF
--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -103,7 +103,7 @@ public:
        */
     void saveCosts(std::string file_name);
 
-    void getStats(std::vector<SinglePassMeanCoviariance>& q_stat_);
+    void getStats(std::vector<SinglePassMeanCovariance>& q_stat_);
 
 protected:
     /** \brief Initializes message data.
@@ -133,7 +133,7 @@ private:
     bool sweepImprovedCost;                     //!< Whether the last sweep improved the cost (for backtrack iterations count)
     int iterationCount;                         //!< Iteration counter
 
-    std::vector<SinglePassMeanCoviariance> q_stat;  //!< Cost weighted normal distribution of configurations across sweeps.
+    std::vector<SinglePassMeanCovariance> q_stat;  //!< Cost weighted normal distribution of configurations across sweeps.
 
     std::vector<Eigen::VectorXd> s;     //!< Forward message mean
     std::vector<Eigen::MatrixXd> Sinv;  //!< Forward message covariance inverse

--- a/exotations/solvers/aico/include/aico/incremental_gaussian.h
+++ b/exotations/solvers/aico/include/aico/incremental_gaussian.h
@@ -42,26 +42,19 @@ Chan, Tony F.; Golub, Gene H.; LeVeque, Randall J. (1979), “Updating Formulae 
 #include <Eigen/Dense>
 #include <vector>
 
-class SinglePassMeanCoviariance
+class SinglePassMeanCovariance
 {
-    int D;
-    int D2;
-    double W;
-    Eigen::VectorXd T;
-    Eigen::VectorXd dX;
-    Eigen::MatrixXd S;
+private:
+    int D = 0;
+    double W = 0;
+    Eigen::VectorXd T = Eigen::VectorXd(0);
+    Eigen::VectorXd dX = Eigen::VectorXd(0);
+    Eigen::MatrixXd S = Eigen::MatrixXd(0, 0);
 
 public:
-    SinglePassMeanCoviariance()
-    {
-        D = 0;
-        D2 = 0;
-        T.resize(0);
-        dX.resize(0);
-        S.resize(0, 0);
-    }
+    SinglePassMeanCovariance() = default;
 
-    SinglePassMeanCoviariance(int D_)
+    SinglePassMeanCovariance(int D_)
     {
         resize(D_);
     }
@@ -69,7 +62,6 @@ public:
     void resize(int D_)
     {
         D = D_;
-        D2 = (D_ * (D_ + 1) / 2);
 
         T.resize(D_);
         dX.resize(D_);
@@ -108,7 +100,7 @@ public:
         }
     }
 
-    inline void add(SinglePassMeanCoviariance& M)
+    inline void add(SinglePassMeanCovariance& M)
     {
         add(M.W, M.T, M.S);
     }

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -128,7 +128,7 @@ AICOsolver::AICOsolver()
 {
 }
 
-void AICOsolver::getStats(std::vector<SinglePassMeanCoviariance>& q_stat_)
+void AICOsolver::getStats(std::vector<SinglePassMeanCovariance>& q_stat_)
 {
     q_stat_ = q_stat;
 }

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -56,7 +56,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp message_runtime moveit_core moveit_ros_planning tf kdl_parser pluginlib tf_conversions eigen_conversions
   CFG_EXTRAS Exotica.cmake AddInitializer.cmake
-  DEPENDS TinyXML2 Eigen3
+  DEPENDS TinyXML2
 )
 
 ## Build ##

--- a/exotica/cmake/Exotica.cmake
+++ b/exotica/cmake/Exotica.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Compiling using c++ 11 (required by EXOTica)")
-add_compile_options(-std=c++11 -O2)
+add_compile_options(-std=c++11)
 
 # MoveIt Core Robot Model isnt aligned :'(
-add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)
+#add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)

--- a/exotica/cmake/Exotica.cmake
+++ b/exotica/cmake/Exotica.cmake
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Compiling using c++ 11 (required by EXOTica)")
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++11 -O2)
+
+# MoveIt Core Robot Model isnt aligned :'(
+add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -33,22 +33,22 @@
 #ifndef KINEMATIC_TREE_H
 #define KINEMATIC_TREE_H
 
-#include <exotica/Tools.h>
-#include <moveit/robot_model/robot_model.h>
-#include <Eigen/Eigen>
-#include <kdl/jacobian.hpp>
-#include <kdl/tree.hpp>
-#include <kdl_parser/kdl_parser.hpp>
 #include <map>
 #include <random>
 #include <set>
 #include <string>
 #include <vector>
 
-#include <exotica/Server.h>
+#include <moveit/robot_model/robot_model.h>
 #include <tf_conversions/tf_kdl.h>
+#include <Eigen/Eigen>
+#include <kdl/jacobian.hpp>
+#include <kdl/tree.hpp>
+#include <kdl_parser/kdl_parser.hpp>
 
 #include <exotica/KinematicElement.h>
+#include <exotica/Server.h>
+#include <exotica/Tools.h>
 
 namespace exotica
 {
@@ -148,7 +148,7 @@ class KinematicTree : public Uncopyable
 {
 public:
     KinematicTree();
-    ~KinematicTree() = default;
+    virtual ~KinematicTree() = default;
     void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model, const std::string& name);
     std::string getRootFrameName();
     std::string getRootJointName();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -152,6 +152,7 @@ public:
     void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model, const std::string& name);
     std::string getRootFrameName();
     std::string getRootJointName();
+    robot_model::RobotModelPtr getRobotModel();
     BASE_TYPE getModelBaseType();
     BASE_TYPE getControlledBaseType();
     std::shared_ptr<KinematicResponse> RequestFrames(const KinematicsRequest& request);
@@ -162,7 +163,6 @@ public:
     void setJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
     void setFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> getUsedJointLimits();
-    int getEffSize();
     int getNumControlledJoints();
     int getNumModelJoints();
     void publishFrames();
@@ -193,9 +193,9 @@ public:
     Eigen::MatrixXd Jacobian(const std::string& elementA, const KDL::Frame& offsetA, const std::string& elementB, const KDL::Frame& offsetB);
 
     void resetModel();
-    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
-    void AddEnvironmentElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
-    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Affine3d& transform, const std::string& parent, const std::string& shapeResourcePath, Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
+    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Isometry3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
+    void AddEnvironmentElement(const std::string& name, Eigen::Isometry3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
+    std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Isometry3d& transform, const std::string& parent, const std::string& shapeResourcePath, Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& Color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool isControlled = false);
     void UpdateModel();
     void changeParent(const std::string& name, const std::string& parent, const KDL::Frame& pose, bool relative);
     int IsControlled(std::shared_ptr<KinematicElement> Joint);
@@ -248,6 +248,7 @@ private:
     int StateSize = -1;
     Eigen::VectorXd TreeState;
     robot_model::RobotModelPtr Model;
+    std::string root_joint_name_ = "";
     std::vector<std::weak_ptr<KinematicElement>> Tree;
     std::vector<std::shared_ptr<KinematicElement>> ModelTree;
     std::vector<std::shared_ptr<KinematicElement>> EnvironmentTree;

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -47,7 +47,7 @@ class MotionSolver : public Object, Uncopyable, public virtual InstantiableBase
 {
 public:
     MotionSolver();
-    virtual ~MotionSolver() {}
+    virtual ~MotionSolver() = default;
     virtual void InstantiateBase(const Initializer& init);
     virtual void specifyProblem(PlanningProblem_ptr pointer);
     virtual void Solve(Eigen::MatrixXd& solution) = 0;

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -33,13 +33,6 @@
 #ifndef EXOTICA_MOTION_PLANNING_PROBLEM_H
 #define EXOTICA_MOTION_PLANNING_PROBLEM_H
 
-#include <exotica/Object.h>
-#include <exotica/Scene.h>
-#include <exotica/Server.h>
-#include <exotica/TaskMap.h>
-#include <exotica/TaskSpaceVector.h>
-#include <exotica/Tools.h>
-
 #include <algorithm>
 #include <chrono>
 #include <limits>
@@ -47,6 +40,13 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <exotica/Object.h>
+#include <exotica/Scene.h>
+#include <exotica/Server.h>
+#include <exotica/TaskMap.h>
+#include <exotica/TaskSpaceVector.h>
+#include <exotica/Tools.h>
 
 #define REGISTER_PROBLEM_TYPE(TYPE, DERIV) EXOTICA_REGISTER_CORE(exotica::PlanningProblem, TYPE, DERIV)
 
@@ -70,7 +70,7 @@ class PlanningProblem : public Object, Uncopyable, public virtual InstantiableBa
 {
 public:
     PlanningProblem();
-    virtual ~PlanningProblem() {}
+    virtual ~PlanningProblem() = default;
     virtual void InstantiateBase(const Initializer& init);
     TaskMap_map& getTaskMaps();
     TaskMap_vec& getTasks();

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -75,9 +75,6 @@ public:
     int PhiN;
     int JN;
     int NumTasks;
-
-protected:
-    void initTaskTerms(const std::vector<exotica::Initializer>& inits);
 };
 typedef std::shared_ptr<exotica::BoundedEndPoseProblem> BoundedEndPoseProblem_ptr;
 }

--- a/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/BoundedEndPoseProblem.h
@@ -32,6 +32,7 @@
 
 #ifndef BOUNDEDENDPOSEPROBLEM_H_
 #define BOUNDEDENDPOSEPROBLEM_H_
+
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
 
@@ -52,7 +53,7 @@ public:
     void Update(Eigen::VectorXdRefConst x);
 
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setRho(const std::string& task_name, const double rho);
+    void setRho(const std::string& task_name, const double& rho);
     Eigen::VectorXd getGoal(const std::string& task_name);
     double getRho(const std::string& task_name);
     virtual void preupdate();

--- a/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/BoundedTimeIndexedProblem.h
@@ -32,6 +32,7 @@
 
 #ifndef BOUNDEDTIMEINDEXEDPROBLEM_H_
 #define BOUNDEDTIMEINDEXEDPROBLEM_H_
+
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
 
@@ -51,7 +52,7 @@ public:
     double getDuration();
     void Update(Eigen::VectorXdRefConst x, int t);
     std::vector<Eigen::VectorXd> getInitialTrajectory();
-    void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
+    void setInitialTrajectory(const std::vector<Eigen::VectorXd>& q_init_in);
     virtual void preupdate();
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t = 0);
     void setRho(const std::string& task_name, const double rho, int t = 0);
@@ -60,10 +61,10 @@ public:
     Eigen::MatrixXd getBounds() const;
 
     int getT() const { return T; }
-    void setT(int T_in);
+    void setT(const int& T_in);
 
     double getTau() const { return tau; }
-    void setTau(double tau_in);
+    void setTau(const double& tau_in);
 
     double getScalarTaskCost(int t);
     Eigen::VectorXd getScalarTaskJacobian(int t);
@@ -71,8 +72,8 @@ public:
     Eigen::VectorXd getScalarTransitionJacobian(int t);
 
     double ct;  //!< Normalisation of scalar cost and Jacobian over trajectory length
-    TimeIndexedTask Cost;
 
+    TimeIndexedTask Cost;
     TaskSpaceVector CostPhi;
 
     double W_rate;  //!< Kinematic system transition error covariance multiplier (constant throughout the trajectory)

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -53,15 +53,15 @@ public:
     bool isValid();
 
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setRho(const std::string& task_name, const double rho);
+    void setRho(const std::string& task_name, const double& rho);
     Eigen::VectorXd getGoal(const std::string& task_name);
     double getRho(const std::string& task_name);
     void setGoalEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setRhoEQ(const std::string& task_name, const double rho);
+    void setRhoEQ(const std::string& task_name, const double& rho);
     Eigen::VectorXd getGoalEQ(const std::string& task_name);
     double getRhoEQ(const std::string& task_name);
     void setGoalNEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setRhoNEQ(const std::string& task_name, const double rho);
+    void setRhoNEQ(const std::string& task_name, const double& rho);
     Eigen::VectorXd getGoalNEQ(const std::string& task_name);
     double getRhoNEQ(const std::string& task_name);
     virtual void preupdate();

--- a/exotica/include/exotica/Problems/EndPoseProblem.h
+++ b/exotica/include/exotica/Problems/EndPoseProblem.h
@@ -90,9 +90,6 @@ public:
     bool useBounds;
 
     EndPoseProblemInitializer init_;
-
-protected:
-    void initTaskTerms(const std::vector<exotica::Initializer>& inits);
 };
 typedef std::shared_ptr<exotica::EndPoseProblem> EndPoseProblem_ptr;
 }

--- a/exotica/include/exotica/Problems/SamplingProblem.h
+++ b/exotica/include/exotica/Problems/SamplingProblem.h
@@ -55,15 +55,15 @@ public:
 
     void setGoalEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
     Eigen::VectorXd getGoalEQ(const std::string& task_name);
-    void setRhoEQ(const std::string& task_name, const double rho);
+    void setRhoEQ(const std::string& task_name, const double& rho);
     double getRhoEQ(const std::string& task_name);
 
     void setGoalNEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
     Eigen::VectorXd getGoalNEQ(const std::string& task_name);
-    void setRhoNEQ(const std::string& task_name, const double rho);
+    void setRhoNEQ(const std::string& task_name, const double& rho);
     double getRhoNEQ(const std::string& task_name);
 
-    std::vector<double> getBounds();
+    std::vector<double> getBounds();  // TODO: Upgrade to Eigen::MatrixXd
     bool isCompoundStateSpace();
 
     // TODO(wxm): Implement or remove in clean-up (left-over from constrained sampling, ROBIO 2016)
@@ -73,7 +73,7 @@ public:
     SamplingProblemInitializer Parameters;
 
     void setGoalState(Eigen::VectorXdRefConst qT);
-    const Eigen::VectorXd& getGoalState() { return goal_; }
+    const Eigen::VectorXd& getGoalState() const { return goal_; }
     TaskSpaceVector Phi;
     SamplingTask Inequality;
     SamplingTask Equality;

--- a/exotica/include/exotica/Problems/TimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedProblem.h
@@ -35,6 +35,7 @@
 
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
+
 #include <exotica/TimeIndexedProblemInitializer.h>
 
 namespace exotica
@@ -52,7 +53,7 @@ public:
     void Update(Eigen::VectorXdRefConst x, int t);
     bool isValid();
     std::vector<Eigen::VectorXd> getInitialTrajectory();
-    void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
+    void setInitialTrajectory(const std::vector<Eigen::VectorXd>& q_init_in);
     virtual void preupdate();
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t = 0);
     void setRho(const std::string& task_name, const double rho, int t = 0);
@@ -69,10 +70,10 @@ public:
     Eigen::MatrixXd getBounds() const;
 
     int getT() const { return T; }
-    void setT(int T_in);
+    void setT(const int& T_in);
 
     double getTau() const { return tau; }
-    void setTau(double tau_in);
+    void setTau(const double& tau_in);
 
     double getScalarTaskCost(int t);
     Eigen::VectorXd getScalarTaskJacobian(int t);
@@ -108,7 +109,7 @@ public:
     bool useBounds;
 
     double getJointVelocityLimit() { return qdot_max; }
-    void setJointVelocityLimit(double qdot_max_in)
+    void setJointVelocityLimit(const double& qdot_max_in)
     {
         qdot_max = qdot_max_in;
         xdiff_max = qdot_max * tau;

--- a/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
+++ b/exotica/include/exotica/Problems/TimeIndexedSamplingProblem.h
@@ -1,5 +1,4 @@
 /*
- *  Created on: 7 Nov 2017
  *      Author: Yiming Yang
  *
  * Copyright (c) 2017, University of Edinburgh
@@ -36,6 +35,7 @@
 
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
+
 #include <exotica/TimeIndexedSamplingProblemInitializer.h>
 
 namespace exotica
@@ -48,20 +48,20 @@ public:
 
     virtual void Instantiate(TimeIndexedSamplingProblemInitializer& init);
 
-    void Update(Eigen::VectorXdRefConst x, double t);
-    bool isValid(Eigen::VectorXdRefConst x, double t);
+    void Update(Eigen::VectorXdRefConst x, const double& t);
+    bool isValid(Eigen::VectorXdRefConst x, const double& t);
     virtual void preupdate();
 
     int getSpaceDim();
 
     void setGoalEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
     Eigen::VectorXd getGoalEQ(const std::string& task_name);
-    void setRhoEQ(const std::string& task_name, const double rho);
+    void setRhoEQ(const std::string& task_name, const double& rho);
     double getRhoEQ(const std::string& task_name);
 
     void setGoalNEQ(const std::string& task_name, Eigen::VectorXdRefConst goal);
     Eigen::VectorXd getGoalNEQ(const std::string& task_name);
-    void setRhoNEQ(const std::string& task_name, const double rho);
+    void setRhoNEQ(const std::string& task_name, const double& rho);
     double getRhoNEQ(const std::string& task_name);
 
     std::vector<double> getBounds();
@@ -71,8 +71,9 @@ public:
     Eigen::VectorXd getGoalState();
     double getGoalTime();
     void setGoalState(Eigen::VectorXdRefConst qT);
-    void setGoalTime(double t);
+    void setGoalTime(const double& t);
 
+    // TODO(wxm): Make private and expose getter/setter where required.
     double T;
     Eigen::VectorXd vel_limits_;
     TaskSpaceVector Phi;

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -32,6 +32,7 @@
 
 #ifndef UNCONSTRAINEDENDPOSEPROBLEM_H_
 #define UNCONSTRAINEDENDPOSEPROBLEM_H_
+
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
 
@@ -52,7 +53,7 @@ public:
     void Update(Eigen::VectorXdRefConst x);
 
     void setGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
-    void setRho(const std::string& task_name, const double rho);
+    void setRho(const std::string& task_name, const double& rho);
     Eigen::VectorXd getGoal(const std::string& task_name);
     double getRho(const std::string& task_name);
     Eigen::VectorXd getNominalPose();

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -78,9 +78,6 @@ public:
     int NumTasks;
 
     int getTaskId(const std::string& task_name);
-
-protected:
-    void initTaskTerms(const std::vector<exotica::Initializer>& inits);
 };
 typedef std::shared_ptr<exotica::UnconstrainedEndPoseProblem> UnconstrainedEndPoseProblem_ptr;
 }

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -35,6 +35,7 @@
 
 #include <exotica/PlanningProblem.h>
 #include <exotica/Tasks.h>
+
 #include <exotica/UnconstrainedTimeIndexedProblemInitializer.h>
 
 namespace exotica
@@ -55,14 +56,14 @@ public:
     Eigen::VectorXd getGoal(const std::string& task_name, int t = 0);
     double getRho(const std::string& task_name, int t = 0);
     std::vector<Eigen::VectorXd> getInitialTrajectory();
-    void setInitialTrajectory(const std::vector<Eigen::VectorXd> q_init_in);
+    void setInitialTrajectory(const std::vector<Eigen::VectorXd>& q_init_in);
     virtual void preupdate();
 
     int getT() const { return T; }
-    void setT(int T_in);
+    void setT(const int& T_in);
 
     double getTau() const { return tau; }
-    void setTau(double tau_in);
+    void setTau(const double& tau_in);
 
     double getScalarTaskCost(int t);
     Eigen::VectorXd getScalarTaskJacobian(int t);

--- a/exotica/include/exotica/Property.h
+++ b/exotica/include/exotica/Property.h
@@ -1,16 +1,17 @@
 #ifndef PROPERTY_H
 #define PROPERTY_H
 
-#include <exotica/Tools.h>
-#include <exotica/Tools/Conversions.h>
-#include <exotica/Tools/Exception.h>
-#include <exotica/Tools/Printable.h>
 #include <boost/any.hpp>
 #include <initializer_list>
 #include <map>
 #include <memory>
 #include <typeinfo>
 #include <vector>
+
+#include <exotica/Tools.h>
+#include <exotica/Tools/Conversions.h>
+#include <exotica/Tools/Exception.h>
+#include <exotica/Tools/Printable.h>
 
 namespace exotica
 {

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -80,10 +80,8 @@ public:
     CollisionScene_ptr& getCollisionScene();
     std::string getRootFrameName();
     std::string getRootJointName();
-    std::string getModelRootLinkName();
     moveit_msgs::PlanningScene getPlanningSceneMsg();
     exotica::KinematicTree& getSolver();
-    robot_model::RobotModelPtr getRobotModel();
     void getJointNames(std::vector<std::string>& joints);
     std::vector<std::string> getJointNames();
     std::vector<std::string> getModelJointNames();
@@ -149,9 +147,9 @@ public:
     void publishScene();
     void publishProxies(const std::vector<CollisionProxy>& proxies);
     visualization_msgs::Marker proxyToMarker(const std::vector<CollisionProxy>& proxies, const std::string& frame);
-    void loadScene(const std::string& scene, const Eigen::Affine3d& offset = Eigen::Affine3d::Identity(), bool updateCollisionScene = true);
+    void loadScene(const std::string& scene, const Eigen::Isometry3d& offset = Eigen::Isometry3d::Identity(), bool updateCollisionScene = true);
     void loadScene(const std::string& scene, const KDL::Frame& offset = KDL::Frame(), bool updateCollisionScene = true);
-    void loadSceneFile(const std::string& file_name, const Eigen::Affine3d& offset = Eigen::Affine3d::Identity(), bool updateCollisionScene = true);
+    void loadSceneFile(const std::string& file_name, const Eigen::Isometry3d& offset = Eigen::Isometry3d::Identity(), bool updateCollisionScene = true);
     void loadSceneFile(const std::string& file_name, const KDL::Frame& offset = KDL::Frame(), bool updateCollisionScene = true);
     std::string getScene();
     void cleanScene();
@@ -183,9 +181,6 @@ private:
     /// The kinematica tree
     exotica::KinematicTree kinematica_;
 
-    /// Robot model
-    robot_model::RobotModelPtr model_;
-
     ///   Joint group
     robot_model::JointModelGroup* group;
 
@@ -195,7 +190,7 @@ private:
     /// The collision scene
     CollisionScene_ptr collision_scene_;
 
-    /// Internal moveit planning scene
+    /// Internal MoveIt planning scene
     planning_scene::PlanningScenePtr ps_;
 
     /// Visual debug
@@ -234,7 +229,7 @@ private:
      */
     void updateMoveItPlanningScene();
 
-    void loadSceneFromStringStream(std::istream& in, const Eigen::Affine3d& offset, bool updateCollisionScene);
+    void loadSceneFromStringStream(std::istream& in, const Eigen::Isometry3d& offset, bool updateCollisionScene);
 };
 typedef std::shared_ptr<Scene> Scene_ptr;
 

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -33,19 +33,17 @@
 #ifndef EXOTICA_EXOTICA_INCLUDE_EXOTICA_SCENE_H_
 #define EXOTICA_EXOTICA_INCLUDE_EXOTICA_SCENE_H_
 
-#include <eigen_conversions/eigen_kdl.h>
-#include <moveit/planning_scene/planning_scene.h>
-#include <moveit_msgs/PlanningScene.h>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <string>
 
+#include <eigen_conversions/eigen_kdl.h>
 #include <geometric_shapes/mesh_operations.h>
 #include <geometric_shapes/shape_operations.h>
 #include <geometric_shapes/shapes.h>
-
-#include <exotica/SceneInitializer.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit_msgs/PlanningScene.h>
 
 #include "exotica/CollisionScene.h"
 #include "exotica/KinematicTree.h"
@@ -53,6 +51,8 @@
 #include "exotica/Property.h"
 #include "exotica/Server.h"
 #include "exotica/Trajectory.h"
+
+#include <exotica/SceneInitializer.h>
 
 namespace exotica
 {

--- a/exotica/include/exotica/Server.h
+++ b/exotica/include/exotica/Server.h
@@ -33,23 +33,17 @@
 #ifndef EXOTICA_INCLUDE_EXOTICA_SERVER_H_
 #define EXOTICA_INCLUDE_EXOTICA_SERVER_H_
 
-#include <ros/ros.h>
-#include <Eigen/Dense>
-#include <boost/any.hpp>
 #include <map>
 #include <typeinfo>
-#include "Tools.h"
 
-#include <eigen_conversions/eigen_msg.h>
-#include <exotica/Tools.h>
+#include <boost/any.hpp>
+
 #include <moveit/robot_model_loader/robot_model_loader.h>
-#include <std_msgs/Bool.h>
-#include <std_msgs/Float64.h>
-#include <std_msgs/Float64MultiArray.h>
-#include <std_msgs/Int64.h>
-#include <std_msgs/String.h>
+#include <ros/ros.h>
 #include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
+
+#include <exotica/Tools.h>
+
 namespace exotica
 {
 class RosNode

--- a/exotica/include/exotica/Tools/Timer.h
+++ b/exotica/include/exotica/Tools/Timer.h
@@ -1,5 +1,6 @@
 #ifndef TIMER_H
 #define TIMER_H
+
 #include <chrono>
 #include <thread>
 

--- a/exotica/include/exotica/Tools/Uncopyable.h
+++ b/exotica/include/exotica/Tools/Uncopyable.h
@@ -7,7 +7,6 @@ class Uncopyable
 {
 public:
     Uncopyable() = default;
-
     ~Uncopyable() = default;
 
 private:

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -34,10 +34,10 @@
 #include <iostream>
 #include <queue>
 
-#include <moveit/robot_model/robot_model.h>
 #include <eigen_conversions/eigen_kdl.h>
 #include <geometric_shapes/mesh_operations.h>
 #include <geometric_shapes/shape_operations.h>
+#include <moveit/robot_model/robot_model.h>
 #include <visualization_msgs/MarkerArray.h>
 #include <kdl/frames_io.hpp>
 

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -45,7 +45,6 @@ BoundedEndPoseProblem::BoundedEndPoseProblem()
 
 BoundedEndPoseProblem::~BoundedEndPoseProblem() = default;
 
-
 Eigen::MatrixXd BoundedEndPoseProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -45,9 +45,6 @@ BoundedEndPoseProblem::BoundedEndPoseProblem()
 
 BoundedEndPoseProblem::~BoundedEndPoseProblem() = default;
 
-void BoundedEndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer>& inits)
-{
-}
 
 Eigen::MatrixXd BoundedEndPoseProblem::getBounds() const
 {

--- a/exotica/src/Problems/BoundedEndPoseProblem.cpp
+++ b/exotica/src/Problems/BoundedEndPoseProblem.cpp
@@ -187,7 +187,7 @@ void BoundedEndPoseProblem::setGoal(const std::string& task_name, Eigen::VectorX
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void BoundedEndPoseProblem::setRho(const std::string& task_name, const double rho)
+void BoundedEndPoseProblem::setRho(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {

--- a/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/BoundedTimeIndexedProblem.cpp
@@ -86,7 +86,7 @@ void BoundedTimeIndexedProblem::preupdate()
 }
 
 void BoundedTimeIndexedProblem::setInitialTrajectory(
-    const std::vector<Eigen::VectorXd> q_init_in)
+    const std::vector<Eigen::VectorXd>& q_init_in)
 {
     if (q_init_in.size() != T)
         throw_pretty("Expected initial trajectory of length "
@@ -265,7 +265,7 @@ double BoundedTimeIndexedProblem::getRho(const std::string& task_name, int t)
     throw_pretty("Cannot get Rho. Task map '" << task_name << "' does not exist.");
 }
 
-void BoundedTimeIndexedProblem::setT(int T_in)
+void BoundedTimeIndexedProblem::setT(const int& T_in)
 {
     if (T_in <= 2)
     {
@@ -275,7 +275,7 @@ void BoundedTimeIndexedProblem::setT(int T_in)
     reinitializeVariables();
 }
 
-void BoundedTimeIndexedProblem::setTau(double tau_in)
+void BoundedTimeIndexedProblem::setTau(const double& tau_in)
 {
     if (tau_in <= 0.) throw_pretty("tau is expected to be greater than 0. (tau=" << tau_in << ")");
     tau = tau_in;

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -45,10 +45,6 @@ EndPoseProblem::EndPoseProblem()
 
 EndPoseProblem::~EndPoseProblem() = default;
 
-void EndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer>& inits)
-{
-}
-
 Eigen::MatrixXd EndPoseProblem::getBounds() const
 {
     return scene_->getSolver().getJointLimits();

--- a/exotica/src/Problems/EndPoseProblem.cpp
+++ b/exotica/src/Problems/EndPoseProblem.cpp
@@ -220,7 +220,7 @@ void EndPoseProblem::setGoal(const std::string& task_name, Eigen::VectorXdRefCon
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void EndPoseProblem::setRho(const std::string& task_name, const double rho)
+void EndPoseProblem::setRho(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {
@@ -272,7 +272,7 @@ void EndPoseProblem::setGoalEQ(const std::string& task_name, Eigen::VectorXdRefC
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void EndPoseProblem::setRhoEQ(const std::string& task_name, const double rho)
+void EndPoseProblem::setRhoEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Equality.Indexing.size(); i++)
     {
@@ -324,7 +324,7 @@ void EndPoseProblem::setGoalNEQ(const std::string& task_name, Eigen::VectorXdRef
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void EndPoseProblem::setRhoNEQ(const std::string& task_name, const double rho)
+void EndPoseProblem::setRhoNEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Inequality.Indexing.size(); i++)
     {

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -131,7 +131,7 @@ void SamplingProblem::setGoalEQ(const std::string& task_name, Eigen::VectorXdRef
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void SamplingProblem::setRhoEQ(const std::string& task_name, const double rho)
+void SamplingProblem::setRhoEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Equality.Indexing.size(); i++)
     {
@@ -183,7 +183,7 @@ void SamplingProblem::setGoalNEQ(const std::string& task_name, Eigen::VectorXdRe
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void SamplingProblem::setRhoNEQ(const std::string& task_name, const double rho)
+void SamplingProblem::setRhoNEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Inequality.Indexing.size(); i++)
     {

--- a/exotica/src/Problems/TimeIndexedProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedProblem.cpp
@@ -138,7 +138,7 @@ void TimeIndexedProblem::reinitializeVariables()
     preupdate();
 }
 
-void TimeIndexedProblem::setT(int T_in)
+void TimeIndexedProblem::setT(const int& T_in)
 {
     if (T_in <= 2)
     {
@@ -148,7 +148,7 @@ void TimeIndexedProblem::setT(int T_in)
     reinitializeVariables();
 }
 
-void TimeIndexedProblem::setTau(double tau_in)
+void TimeIndexedProblem::setTau(const double& tau_in)
 {
     if (tau_in <= 0.) throw_pretty("tau is expected to be greater than 0. (tau=" << tau_in << ")");
     tau = tau_in;
@@ -169,11 +169,10 @@ void TimeIndexedProblem::preupdate()
     // updates etc.
     KinematicSolutions.clear();
     KinematicSolutions.resize(T);
-    for (unsigned int i = 0; i < T; i++) KinematicSolutions[i] = std::make_shared<KinematicResponse>(*scene_->getSolver().getKinematicResponse());
+    for (int i = 0; i < T; i++) KinematicSolutions[i] = std::make_shared<KinematicResponse>(*scene_->getSolver().getKinematicResponse());
 }
 
-void TimeIndexedProblem::setInitialTrajectory(
-    const std::vector<Eigen::VectorXd> q_init_in)
+void TimeIndexedProblem::setInitialTrajectory(const std::vector<Eigen::VectorXd>& q_init_in)
 {
     if (q_init_in.size() != T)
         throw_pretty("Expected initial trajectory of length "
@@ -193,7 +192,7 @@ std::vector<Eigen::VectorXd> TimeIndexedProblem::getInitialTrajectory()
 
 double TimeIndexedProblem::getDuration()
 {
-    return tau * (double)T;
+    return tau * static_cast<double>(T);
 }
 
 void TimeIndexedProblem::Update(Eigen::VectorXdRefConst x_in, int t)

--- a/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
+++ b/exotica/src/Problems/TimeIndexedSamplingProblem.cpp
@@ -136,7 +136,7 @@ void TimeIndexedSamplingProblem::setGoalState(Eigen::VectorXdRefConst qT)
     goal_ = qT;
 }
 
-void TimeIndexedSamplingProblem::setGoalTime(double t)
+void TimeIndexedSamplingProblem::setGoalTime(const double& t)
 {
     tGoal = t;
 }
@@ -155,7 +155,7 @@ void TimeIndexedSamplingProblem::setGoalEQ(const std::string& task_name, Eigen::
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void TimeIndexedSamplingProblem::setRhoEQ(const std::string& task_name, const double rho)
+void TimeIndexedSamplingProblem::setRhoEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Equality.Indexing.size(); i++)
     {
@@ -207,7 +207,7 @@ void TimeIndexedSamplingProblem::setGoalNEQ(const std::string& task_name, Eigen:
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void TimeIndexedSamplingProblem::setRhoNEQ(const std::string& task_name, const double rho)
+void TimeIndexedSamplingProblem::setRhoNEQ(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Inequality.Indexing.size(); i++)
     {
@@ -245,7 +245,7 @@ double TimeIndexedSamplingProblem::getRhoNEQ(const std::string& task_name)
     throw_pretty("Cannot get Rho. Task map '" << task_name << "' does not exist.");
 }
 
-bool TimeIndexedSamplingProblem::isValid(Eigen::VectorXdRefConst x, double t)
+bool TimeIndexedSamplingProblem::isValid(Eigen::VectorXdRefConst x, const double& t)
 {
     scene_->Update(x, t);
     for (int i = 0; i < NumTasks; i++)
@@ -271,7 +271,7 @@ void TimeIndexedSamplingProblem::preupdate()
     Equality.updateS();
 }
 
-void TimeIndexedSamplingProblem::Update(Eigen::VectorXdRefConst x, double t)
+void TimeIndexedSamplingProblem::Update(Eigen::VectorXdRefConst x, const double& t)
 {
     isValid(x, t);
     numberOfProblemUpdates++;

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -32,7 +32,6 @@
 
 #include <exotica/Problems/UnconstrainedEndPoseProblem.h>
 #include <exotica/Setup.h>
-#include <exotica/TaskInitializer.h>
 
 REGISTER_PROBLEM_TYPE("UnconstrainedEndPoseProblem", exotica::UnconstrainedEndPoseProblem)
 
@@ -44,10 +43,6 @@ UnconstrainedEndPoseProblem::UnconstrainedEndPoseProblem()
 }
 
 UnconstrainedEndPoseProblem::~UnconstrainedEndPoseProblem() = default;
-
-void UnconstrainedEndPoseProblem::initTaskTerms(const std::vector<exotica::Initializer>& inits)
-{
-}
 
 void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitializer& init)
 {

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -167,7 +167,7 @@ void UnconstrainedEndPoseProblem::setGoal(const std::string& task_name, Eigen::V
     throw_pretty("Cannot set Goal. Task map '" << task_name << "' does not exist.");
 }
 
-void UnconstrainedEndPoseProblem::setRho(const std::string& task_name, const double rho)
+void UnconstrainedEndPoseProblem::setRho(const std::string& task_name, const double& rho)
 {
     for (int i = 0; i < Cost.Indexing.size(); i++)
     {

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -108,7 +108,7 @@ void UnconstrainedTimeIndexedProblem::reinitializeVariables()
     preupdate();
 }
 
-void UnconstrainedTimeIndexedProblem::setT(int T_in)
+void UnconstrainedTimeIndexedProblem::setT(const int& T_in)
 {
     if (T_in <= 2)
     {
@@ -118,7 +118,7 @@ void UnconstrainedTimeIndexedProblem::setT(int T_in)
     reinitializeVariables();
 }
 
-void UnconstrainedTimeIndexedProblem::setTau(double tau_in)
+void UnconstrainedTimeIndexedProblem::setTau(const double& tau_in)
 {
     if (tau_in <= 0.) throw_pretty("tau is expected to be greater than 0. (tau=" << tau_in << ")");
     tau = tau_in;
@@ -139,8 +139,7 @@ void UnconstrainedTimeIndexedProblem::preupdate()
     for (unsigned int i = 0; i < T; i++) KinematicSolutions[i] = std::make_shared<KinematicResponse>(*scene_->getSolver().getKinematicResponse());
 }
 
-void UnconstrainedTimeIndexedProblem::setInitialTrajectory(
-    const std::vector<Eigen::VectorXd> q_init_in)
+void UnconstrainedTimeIndexedProblem::setInitialTrajectory(const std::vector<Eigen::VectorXd>& q_init_in)
 {
     if (q_init_in.size() != T)
         throw_pretty("Expected initial trajectory of length "

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -979,7 +979,6 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getCollisionWorldLinks", [](Scene* instance) { return instance->getCollisionScene()->getCollisionWorldLinks(); });
     scene.def("getRootFrameName", &Scene::getRootFrameName);
     scene.def("getRootJointName", &Scene::getRootJointName);
-    scene.def("getModelRootLinkName", &Scene::getModelRootLinkName);
     scene.def("attachObject", &Scene::attachObject);
     scene.def("attachObjectLocal", &Scene::attachObjectLocal);
     scene.def("detachObject", &Scene::detachObject);


### PR DESCRIPTION
A bunch of fixes from debugging the memory issue which are confirmed to work on different machines with the various compilation settings (release, debug, optimisation, platform targeting). My original issue appears to come down to a defective/broken CPU in my workstation [works just fine on two other machines of same generation/model and software setup].

- Moves from pass by value to pass by const reference where possible in problems
- Cleans up some AICO computation and removes typo
- Moves from Affine3d to Isometry3d (resolves #414)
- Removed dead code from old initialisation
- Removes ownership of RobotModel in Scene - now only in KinematicTree and implicitly in the planning scene inside the scene