### PR TITLE
Scene::addObject with shapes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+# Checklist
+
+- [ ] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -183,6 +183,7 @@ public:
     {
         return ModelLinkNames;
     }
+    bool hasModelLink(const std::string& link);
 
     Eigen::VectorXd getControlledLinkMass();
 

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -125,6 +125,9 @@ public:
     void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
 
     void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shapeResourcePath = "", Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
+
+    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const bool updateCollisionScene = true);
+
     void removeObject(const std::string& name);
 
     /**

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -621,8 +621,7 @@ void KinematicTree::publishFrames()
             visualization_msgs::MarkerArray msg;
             for (int i = 0; i < Tree.size(); i++)
             {
-                // TODO: This is an incorrect check - we may have shapes that are attached to rootFrame
-                if (Tree[i].lock()->Shape && Tree[i].lock()->Parent.lock()->Id >= ModelTree.size())
+                if (Tree[i].lock()->Shape)
                 {
                     visualization_msgs::Marker mrk;
                     shapes::constructMarkerFromShape(Tree[i].lock()->Shape.get(), mrk);

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -1015,6 +1015,11 @@ Eigen::VectorXd KinematicTree::getControlledState()
     return x;
 }
 
+bool KinematicTree::hasModelLink(const std::string& link)
+{
+    return std::find(std::begin(ModelLinkNames), std::end(ModelLinkNames), link) != std::end(ModelLinkNames);
+}
+
 Eigen::VectorXd KinematicTree::getControlledLinkMass()
 {
     Eigen::VectorXd x(NumControlledJoints);

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -621,7 +621,7 @@ void KinematicTree::publishFrames()
             visualization_msgs::MarkerArray msg;
             for (int i = 0; i < Tree.size(); i++)
             {
-                if (Tree[i].lock()->Shape)
+                if (Tree[i].lock()->Shape && (!Tree[i].lock()->ClosestRobotLink.lock() || !Tree[i].lock()->ClosestRobotLink.lock()->isRobotLink))
                 {
                     visualization_msgs::Marker mrk;
                     shapes::constructMarkerFromShape(Tree[i].lock()->Shape.get(), mrk);

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -689,6 +689,15 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
     if (updateCollisionScene) updateCollisionObjects();
 }
 
+void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const bool updateCollisionScene)
+{
+    Eigen::Isometry3d pose;
+    tf::transformKDLToEigen(transform, pose);
+    ps_->getWorldNonConst()->addToObject(name, shape, pose);
+    updateSceneFrames();
+    if (updateCollisionScene) updateInternalFrames();
+}
+
 void Scene::removeObject(const std::string& name)
 {
     auto it = std::begin(custom_links_);

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -691,6 +691,10 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
 
 void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const bool updateCollisionScene)
 {
+    if (kinematica_.hasModelLink(name))
+    {
+        throw std::runtime_error("link '" + name + "' already exists in kinematic tree");
+    }
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
     ps_->getWorldNonConst()->addToObject(name, shape, pose);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -601,6 +601,35 @@ PYBIND11_MODULE(_pyexotica, module)
     py::implicitly_convertible<Eigen::MatrixXd, KDL::Frame>();
     py::implicitly_convertible<Eigen::VectorXd, KDL::Frame>();
 
+    py::class_<KDL::Vector>(module, "KDLVector")
+            .def(py::init())
+            .def(py::init<double, double, double>(),
+                 py::arg("x") = 0,
+                 py::arg("y") = 0,
+                 py::arg("z") = 0)
+            .def("x", [](KDL::Vector& v)->double&{ return v[0]; })
+            .def("y", [](KDL::Vector& v)->double&{ return v[1]; })
+            .def("z", [](KDL::Vector& v)->double&{ return v[2]; })
+            .def_static("Zero", &KDL::Vector::Zero);
+
+    py::class_<KDL::RotationalInertia>(module, "KDLRotationalInertia")
+            .def(py::init<double, double, double, double, double, double>(),
+                 py::arg("Ixx") = 0,
+                 py::arg("Iyy") = 0,
+                 py::arg("Izz") = 0,
+                 py::arg("Ixy") = 0,
+                 py::arg("Ixz") = 0,
+                 py::arg("Iyz") = 0)
+            .def_static("Zero", &KDL::RotationalInertia::Zero);
+
+    py::class_<KDL::RigidBodyInertia>(module, "KDLRigidBodyInertia")
+            .def(py::init<double, KDL::Vector&, KDL::RotationalInertia&>(),
+                 py::arg("m") = 0,
+                 py::arg("oc") = KDL::Vector::Zero(),
+                 py::arg("Ic") = KDL::RotationalInertia::Zero())
+            .def_static("Zero", &KDL::RigidBodyInertia::Zero);
+
+
     py::class_<TaskMap, std::shared_ptr<TaskMap>, Object> taskMap(module, "TaskMap");
     taskMap.def_readonly("id", &TaskMap::Id);
     taskMap.def_readonly("start", &TaskMap::Start);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1081,6 +1081,57 @@ PYBIND11_MODULE(_pyexotica, module)
         return vec;
     });
 
+    ////////////////////////////////////////////////////////////////////////////
+    /// Shapes
+
+    // shape base class
+    py::class_<shapes::Shape, shapes::ShapePtr>(module, "Shape")
+            .def("scale", &shapes::Shape::scale)
+            .def("padd", &shapes::Shape::padd)
+            .def("scaleAndPadd", &shapes::Shape::scaleAndPadd)
+            .def("isFixed", &shapes::Shape::isFixed)
+            .def_readwrite("type", &shapes::Shape::type);
+
+    py::class_<shapes::Sphere, shapes::Shape, std::shared_ptr<shapes::Sphere>>(module, "Sphere")
+            .def(py::init())
+            .def(py::init<double>())
+            .def_readonly_static("name", &shapes::Sphere::STRING_NAME)
+            .def("scaleAndPadd", &shapes::Sphere::scaleAndPadd)
+            .def_readwrite("radius", &shapes::Sphere::radius);
+
+    py::class_<shapes::Cylinder, shapes::Shape, std::shared_ptr<shapes::Cylinder>>(module, "Cylinder")
+            .def(py::init())
+            .def(py::init<double, double>())
+            .def_readonly_static("name", &shapes::Cylinder::STRING_NAME)
+            .def("scaleAndPadd", &shapes::Cylinder::scaleAndPadd)
+            .def_readwrite("radius", &shapes::Cylinder::radius)
+            .def_readwrite("length", &shapes::Cylinder::length);
+
+    py::class_<shapes::Cone, shapes::Shape, std::shared_ptr<shapes::Cone>>(module, "Cone")
+            .def(py::init())
+            .def(py::init<double, double>())
+            .def_readonly_static("name", &shapes::Cone::STRING_NAME)
+            .def("scaleAndPadd", &shapes::Cone::scaleAndPadd)
+            .def_readwrite("radius", &shapes::Cone::radius)
+            .def_readwrite("length", &shapes::Cone::length);
+
+    py::class_<shapes::Box, shapes::Shape, std::shared_ptr<shapes::Box>>(module, "Box")
+            .def(py::init())
+            .def(py::init<double, double, double>())
+            .def_readonly_static("name", &shapes::Box::STRING_NAME)
+            .def("scaleAndPadd", &shapes::Box::scaleAndPadd);
+
+    py::class_<shapes::Plane, shapes::Shape, std::shared_ptr<shapes::Plane>>(module, "Plane")
+            .def(py::init())
+            .def(py::init<double, double, double, double>())
+            .def_readonly_static("name", &shapes::Plane::STRING_NAME)
+            .def("scaleAndPadd", &shapes::Plane::scaleAndPadd)
+            .def("isFixed", &shapes::Plane::isFixed)
+            .def_readwrite("a", &shapes::Plane::a)
+            .def_readwrite("b", &shapes::Plane::b)
+            .def_readwrite("c", &shapes::Plane::c)
+            .def_readwrite("d", &shapes::Plane::d);
+
     py::enum_<shapes::ShapeType>(module, "ShapeType")
         .value("UNKNOWN_SHAPE", shapes::ShapeType::UNKNOWN_SHAPE)
         .value("SPHERE", shapes::ShapeType::SPHERE)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1030,6 +1030,13 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("shapeResourcePath"),
               py::arg("scale") = Eigen::Vector3d::Ones(),
               py::arg("updateCollisionScene") = true);
+    scene.def("addObject", (void(Scene::*)(const std::string&, const KDL::Frame&, const std::string&, shapes::ShapeConstPtr, const KDL::RigidBodyInertia&, bool)) &Scene::addObject,
+              py::arg("name"),
+              py::arg("transform") = KDL::Frame(),
+              py::arg("parent") = std::string(),
+              py::arg("shape"),
+              py::arg("inertia") = KDL::RigidBodyInertia::Zero(),
+              py::arg("updateCollisionScene") = true);
     scene.def("removeObject", &Scene::removeObject);
     scene.def_property_readonly("modelLinkToCollisionLinkMap", &Scene::getModelLinkToCollisionLinkMap);
     scene.def_property_readonly("controlledLinkToCollisionLinkMap", &Scene::getControlledLinkToCollisionLinkMap);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1037,6 +1037,11 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("shape"),
               py::arg("inertia") = KDL::RigidBodyInertia::Zero(),
               py::arg("updateCollisionScene") = true);
+    scene.def("addObjectToEnvironment", &Scene::addObjectToEnvironment,
+              py::arg("name"),
+              py::arg("transform") = KDL::Frame(),
+              py::arg("shape"),
+              py::arg("updateCollisionScene") = true);
     scene.def("removeObject", &Scene::removeObject);
     scene.def_property_readonly("modelLinkToCollisionLinkMap", &Scene::getModelLinkToCollisionLinkMap);
     scene.def_property_readonly("controlledLinkToCollisionLinkMap", &Scene::getControlledLinkToCollisionLinkMap);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -598,6 +598,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kdlFrame.def("getFrame", [](KDL::Frame* me) { return getFrame(*me); });
     kdlFrame.def("inverse", (KDL::Frame(KDL::Frame::*)() const) & KDL::Frame::Inverse);
     kdlFrame.def("__mul__", [](const KDL::Frame& A, const KDL::Frame& B) { return A * B; }, py::is_operator());
+    kdlFrame.def_readwrite("p", &KDL::Frame::p);
     py::implicitly_convertible<Eigen::MatrixXd, KDL::Frame>();
     py::implicitly_convertible<Eigen::VectorXd, KDL::Frame>();
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1102,7 +1102,7 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("padd", &shapes::Shape::padd)
         .def("scaleAndPadd", &shapes::Shape::scaleAndPadd)
         .def("isFixed", &shapes::Shape::isFixed)
-        .def_readwrite("type", &shapes::Shape::type);
+        .def_readonly("type", &shapes::Shape::type);
 
     py::class_<shapes::Sphere, shapes::Shape, std::shared_ptr<shapes::Sphere>>(module, "Sphere")
         .def(py::init())

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -603,33 +603,32 @@ PYBIND11_MODULE(_pyexotica, module)
     py::implicitly_convertible<Eigen::VectorXd, KDL::Frame>();
 
     py::class_<KDL::Vector>(module, "KDLVector")
-            .def(py::init())
-            .def(py::init<double, double, double>(),
-                 py::arg("x") = 0,
-                 py::arg("y") = 0,
-                 py::arg("z") = 0)
-            .def("x", [](KDL::Vector& v)->double&{ return v[0]; })
-            .def("y", [](KDL::Vector& v)->double&{ return v[1]; })
-            .def("z", [](KDL::Vector& v)->double&{ return v[2]; })
-            .def_static("Zero", &KDL::Vector::Zero);
+        .def(py::init())
+        .def(py::init<double, double, double>(),
+             py::arg("x") = 0,
+             py::arg("y") = 0,
+             py::arg("z") = 0)
+        .def("x", [](KDL::Vector& v) -> double& { return v[0]; })
+        .def("y", [](KDL::Vector& v) -> double& { return v[1]; })
+        .def("z", [](KDL::Vector& v) -> double& { return v[2]; })
+        .def_static("Zero", &KDL::Vector::Zero);
 
     py::class_<KDL::RotationalInertia>(module, "KDLRotationalInertia")
-            .def(py::init<double, double, double, double, double, double>(),
-                 py::arg("Ixx") = 0,
-                 py::arg("Iyy") = 0,
-                 py::arg("Izz") = 0,
-                 py::arg("Ixy") = 0,
-                 py::arg("Ixz") = 0,
-                 py::arg("Iyz") = 0)
-            .def_static("Zero", &KDL::RotationalInertia::Zero);
+        .def(py::init<double, double, double, double, double, double>(),
+             py::arg("Ixx") = 0,
+             py::arg("Iyy") = 0,
+             py::arg("Izz") = 0,
+             py::arg("Ixy") = 0,
+             py::arg("Ixz") = 0,
+             py::arg("Iyz") = 0)
+        .def_static("Zero", &KDL::RotationalInertia::Zero);
 
     py::class_<KDL::RigidBodyInertia>(module, "KDLRigidBodyInertia")
-            .def(py::init<double, KDL::Vector&, KDL::RotationalInertia&>(),
-                 py::arg("m") = 0,
-                 py::arg("oc") = KDL::Vector::Zero(),
-                 py::arg("Ic") = KDL::RotationalInertia::Zero())
-            .def_static("Zero", &KDL::RigidBodyInertia::Zero);
-
+        .def(py::init<double, KDL::Vector&, KDL::RotationalInertia&>(),
+             py::arg("m") = 0,
+             py::arg("oc") = KDL::Vector::Zero(),
+             py::arg("Ic") = KDL::RotationalInertia::Zero())
+        .def_static("Zero", &KDL::RigidBodyInertia::Zero);
 
     py::class_<TaskMap, std::shared_ptr<TaskMap>, Object> taskMap(module, "TaskMap");
     taskMap.def_readonly("id", &TaskMap::Id);
@@ -1031,7 +1030,7 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("shapeResourcePath"),
               py::arg("scale") = Eigen::Vector3d::Ones(),
               py::arg("updateCollisionScene") = true);
-    scene.def("addObject", (void(Scene::*)(const std::string&, const KDL::Frame&, const std::string&, shapes::ShapeConstPtr, const KDL::RigidBodyInertia&, bool)) &Scene::addObject,
+    scene.def("addObject", (void (Scene::*)(const std::string&, const KDL::Frame&, const std::string&, shapes::ShapeConstPtr, const KDL::RigidBodyInertia&, bool)) & Scene::addObject,
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("parent") = std::string(),
@@ -1094,51 +1093,51 @@ PYBIND11_MODULE(_pyexotica, module)
 
     // shape base class
     py::class_<shapes::Shape, shapes::ShapePtr>(module, "Shape")
-            .def("scale", &shapes::Shape::scale)
-            .def("padd", &shapes::Shape::padd)
-            .def("scaleAndPadd", &shapes::Shape::scaleAndPadd)
-            .def("isFixed", &shapes::Shape::isFixed)
-            .def_readwrite("type", &shapes::Shape::type);
+        .def("scale", &shapes::Shape::scale)
+        .def("padd", &shapes::Shape::padd)
+        .def("scaleAndPadd", &shapes::Shape::scaleAndPadd)
+        .def("isFixed", &shapes::Shape::isFixed)
+        .def_readwrite("type", &shapes::Shape::type);
 
     py::class_<shapes::Sphere, shapes::Shape, std::shared_ptr<shapes::Sphere>>(module, "Sphere")
-            .def(py::init())
-            .def(py::init<double>())
-            .def_readonly_static("name", &shapes::Sphere::STRING_NAME)
-            .def("scaleAndPadd", &shapes::Sphere::scaleAndPadd)
-            .def_readwrite("radius", &shapes::Sphere::radius);
+        .def(py::init())
+        .def(py::init<double>())
+        .def_readonly_static("name", &shapes::Sphere::STRING_NAME)
+        .def("scaleAndPadd", &shapes::Sphere::scaleAndPadd)
+        .def_readwrite("radius", &shapes::Sphere::radius);
 
     py::class_<shapes::Cylinder, shapes::Shape, std::shared_ptr<shapes::Cylinder>>(module, "Cylinder")
-            .def(py::init())
-            .def(py::init<double, double>())
-            .def_readonly_static("name", &shapes::Cylinder::STRING_NAME)
-            .def("scaleAndPadd", &shapes::Cylinder::scaleAndPadd)
-            .def_readwrite("radius", &shapes::Cylinder::radius)
-            .def_readwrite("length", &shapes::Cylinder::length);
+        .def(py::init())
+        .def(py::init<double, double>())
+        .def_readonly_static("name", &shapes::Cylinder::STRING_NAME)
+        .def("scaleAndPadd", &shapes::Cylinder::scaleAndPadd)
+        .def_readwrite("radius", &shapes::Cylinder::radius)
+        .def_readwrite("length", &shapes::Cylinder::length);
 
     py::class_<shapes::Cone, shapes::Shape, std::shared_ptr<shapes::Cone>>(module, "Cone")
-            .def(py::init())
-            .def(py::init<double, double>())
-            .def_readonly_static("name", &shapes::Cone::STRING_NAME)
-            .def("scaleAndPadd", &shapes::Cone::scaleAndPadd)
-            .def_readwrite("radius", &shapes::Cone::radius)
-            .def_readwrite("length", &shapes::Cone::length);
+        .def(py::init())
+        .def(py::init<double, double>())
+        .def_readonly_static("name", &shapes::Cone::STRING_NAME)
+        .def("scaleAndPadd", &shapes::Cone::scaleAndPadd)
+        .def_readwrite("radius", &shapes::Cone::radius)
+        .def_readwrite("length", &shapes::Cone::length);
 
     py::class_<shapes::Box, shapes::Shape, std::shared_ptr<shapes::Box>>(module, "Box")
-            .def(py::init())
-            .def(py::init<double, double, double>())
-            .def_readonly_static("name", &shapes::Box::STRING_NAME)
-            .def("scaleAndPadd", &shapes::Box::scaleAndPadd);
+        .def(py::init())
+        .def(py::init<double, double, double>())
+        .def_readonly_static("name", &shapes::Box::STRING_NAME)
+        .def("scaleAndPadd", &shapes::Box::scaleAndPadd);
 
     py::class_<shapes::Plane, shapes::Shape, std::shared_ptr<shapes::Plane>>(module, "Plane")
-            .def(py::init())
-            .def(py::init<double, double, double, double>())
-            .def_readonly_static("name", &shapes::Plane::STRING_NAME)
-            .def("scaleAndPadd", &shapes::Plane::scaleAndPadd)
-            .def("isFixed", &shapes::Plane::isFixed)
-            .def_readwrite("a", &shapes::Plane::a)
-            .def_readwrite("b", &shapes::Plane::b)
-            .def_readwrite("c", &shapes::Plane::c)
-            .def_readwrite("d", &shapes::Plane::d);
+        .def(py::init())
+        .def(py::init<double, double, double, double>())
+        .def_readonly_static("name", &shapes::Plane::STRING_NAME)
+        .def("scaleAndPadd", &shapes::Plane::scaleAndPadd)
+        .def("isFixed", &shapes::Plane::isFixed)
+        .def_readwrite("a", &shapes::Plane::a)
+        .def_readwrite("b", &shapes::Plane::b)
+        .def_readwrite("c", &shapes::Plane::c)
+        .def_readwrite("d", &shapes::Plane::d);
 
     py::enum_<shapes::ShapeType>(module, "ShapeType")
         .value("UNKNOWN_SHAPE", shapes::ShapeType::UNKNOWN_SHAPE)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1082,14 +1082,14 @@ PYBIND11_MODULE(_pyexotica, module)
     });
 
     py::enum_<shapes::ShapeType>(module, "ShapeType")
-        .value("UnknownShape", shapes::ShapeType::UNKNOWN_SHAPE)
-        .value("Sphere", shapes::ShapeType::SPHERE)
-        .value("Cylinder", shapes::ShapeType::CYLINDER)
-        .value("Cone", shapes::ShapeType::CONE)
-        .value("Box", shapes::ShapeType::BOX)
-        .value("Plane", shapes::ShapeType::PLANE)
-        .value("Mesh", shapes::ShapeType::MESH)
-        .value("Octree", shapes::ShapeType::OCTREE)
+        .value("UNKNOWN_SHAPE", shapes::ShapeType::UNKNOWN_SHAPE)
+        .value("SPHERE", shapes::ShapeType::SPHERE)
+        .value("CYLINDER", shapes::ShapeType::CYLINDER)
+        .value("CONE", shapes::ShapeType::CONE)
+        .value("BOX", shapes::ShapeType::BOX)
+        .value("PLANE", shapes::ShapeType::PLANE)
+        .value("MESH", shapes::ShapeType::MESH)
+        .value("OCTREE", shapes::ShapeType::OCTREE)
         .export_values();
 
     module.attr("version") = version();


### PR DESCRIPTION
I am working on a pybind wrapper for `Scene::addObject` that takes generic shapes.

I am using the `example_attach.py` as an example to add collision objects to a scene:
```Python
exo.Setup.initRos()
ik=exo.Setup.loadSolver('{exotica_examples}/resources/configs/example_manipulate_ik.xml')
ompl=exo.Setup.loadSolver('{exotica_examples}/resources/configs/example_manipulate_ompl.xml')

# add new collision object
sph = exo.Sphere(0.5)
T = exo.KDLFrame()
T.p = exo.KDLVector(0,0,-0.5)
ompl.getProblem().getScene().addObject(name="another_box", shape=sph, transform=T, parent="base")
ompl.getProblem().getScene().updateSceneFrames()
```

The last line (`ompl.getProblem().getScene().updateSceneFrames()`) is important, since the example will randomly crash otherwise (even though `updateCollisionScene` is set true).

It seems to work in so far, that planning fails/crashes if the object is too large (`Object: MySolver: Goal state is not valid!`).
However, I expect the sphere to be located right underneath the Kuka base, but I only see the boxes from the .scene file in the markers on topic `/exotica/CollisionShapes`.

How do I properly add another object to the scene, such that it is considered for collision avoidance and is also visible?