### PR TITLE
OMPL Solver Changes for ORCA demo

### DIFF
--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -15,3 +15,4 @@ Optional std::string GoalBias = "0.05";
 Optional int RandomSeed = -1;  // Only set if not -1
 Optional Eigen::VectorXd Projection = Eigen::VectorXd();
 Optional double Epsilon = 0.0;
+Optional int FinalInterpolationLength = 0;

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -183,7 +183,7 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
     }
     std::vector<ompl::base::State *> &states = pg.getStates();
     unsigned int length = 0;
-    if(init_.FinalInterpolationLength > 3)
+    if (init_.FinalInterpolationLength > 3)
         length = init_.FinalInterpolationLength;
     else
     {

--- a/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
+++ b/exotations/solvers/ompl_solver/src/ompl_solver/ompl_solver.cpp
@@ -183,9 +183,14 @@ void OMPLsolver<ProblemType>::getPath(Eigen::MatrixXd &traj, ompl::base::Planner
     }
     std::vector<ompl::base::State *> &states = pg.getStates();
     unsigned int length = 0;
-    const int n1 = states.size() - 1;
-    for (int i = 0; i < n1; ++i)
-        length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
+    if(init_.FinalInterpolationLength > 3)
+        length = init_.FinalInterpolationLength;
+    else
+    {
+        const int n1 = states.size() - 1;
+        for (int i = 0; i < n1; ++i)
+            length += si->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
+    }
     pg.interpolate(int(length * init_.SmoothnessFactor));
 
     traj.resize(pg.getStateCount(), prob_->getSpaceDim());


### PR DESCRIPTION
Changes from ORCA demo to specify particular interpolation length (instead of determining by segments).