### PR TITLE
require C++11 only for EXOTica, not for importing projects

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exotica_examples)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED COMPONENTS
   exotica
   exotica_ik_solver

--- a/exotations/solvers/exotica_aico_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_aico_solver/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(exotica_aico_solver)
 
+set(CMAKE_CXX_STANDARD 11)
+
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   exotica

--- a/exotations/solvers/exotica_ik_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_ik_solver/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exotica_ik_solver)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED COMPONENTS
   exotica
 )

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exotica_time_indexed_rrt_connect_solver)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(ompl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/exotations/solvers/ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_solver/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ompl_solver)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(ompl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(task_map)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED COMPONENTS
   exotica
   exotica_python

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(exotica)
 
+set(CMAKE_CXX_STANDARD 11)
+
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules

--- a/exotica/cmake/Exotica.cmake
+++ b/exotica/cmake/Exotica.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-message(STATUS "Compiling using c++ 11 (required by EXOTica)")
-add_compile_options(-std=c++11)
+# message(STATUS "Compiling using c++ 11 (required by EXOTica)")
+# add_compile_options(-std=c++11)
 
 # MoveIt Core Robot Model isnt aligned :'(
 #add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)


### PR DESCRIPTION
This PR removes `add_compile_options(-std=c++11)` from the exported cmake project so that projects that use EXOTica can set their own (higher) C++ standards (14, 17, 20, ...).
C++11 will still be required to build EXOTica itself.

Fixes https://github.com/ipab-slmc/exotica/issues/426