### PR TITLE
Set fixed joints

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -212,6 +212,7 @@ public:
     std::vector<std::shared_ptr<KinematicElement>> getModelTree() { return ModelTree; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getTreeMap() { return TreeMap; }
     std::map<std::string, std::weak_ptr<KinematicElement>> getCollisionTreeMap() { return CollisionTreeMap; }
+    std::map<std::string, std::weak_ptr<KinematicElement>>& getModelJointsMap() { return ModelJointsMap; }
     bool doesLinkWithNameExist(std::string name);  //!< Checks whether a link with this name exists in any of the trees
     bool Debug = false;
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -189,9 +189,9 @@ void setJointsControlled(KinematicTree& tree, const std::set<std::string>& joint
 
 void setLinksControlled(KinematicTree& tree, const std::set<std::string>& links, const bool negate = false)
 {
-    for (auto & [ name, joint ] : tree.getModelJointsMap())
+    for (auto & [ name, link ] : tree.getTreeMap())
     {
-        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && (negate ^ bool(links.count(joint.lock()->Segment.getName())));
+        link.lock()->IsControlled = (link.lock()->ControlId != -1) && (negate ^ bool(links.count(name)));
     }
 }
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -179,6 +179,14 @@ Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
     return ret;
 }
 
+void setJointsFixed(KinematicTree& tree, const std::set<std::string> joints)
+{
+    for (auto & [ name, joint ] : tree.getModelJointsMap())
+    {
+        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && !bool(joints.count(name));
+    }
+}
+
 namespace pybind11
 {
 namespace detail
@@ -1030,6 +1038,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getRandomControlledState", &KinematicTree::getRandomControlledState);
     kinematicTree.def("getNumModelJoints", &KinematicTree::getNumModelJoints);
     kinematicTree.def("getNumControlledJoints", &KinematicTree::getNumControlledJoints);
+    kinematicTree.def("setJointsFixed", &setJointsFixed);
 
     // Joint Limits
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -187,6 +187,14 @@ void setJointsFixed(KinematicTree& tree, const std::set<std::string> joints)
     }
 }
 
+void setLinksFixed(KinematicTree& tree, const std::set<std::string> links)
+{
+    for (auto & [ name, joint ] : tree.getModelJointsMap())
+    {
+        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && !bool(links.count(joint.lock()->Segment.getName()));
+    }
+}
+
 namespace pybind11
 {
 namespace detail
@@ -1039,6 +1047,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getNumModelJoints", &KinematicTree::getNumModelJoints);
     kinematicTree.def("getNumControlledJoints", &KinematicTree::getNumControlledJoints);
     kinematicTree.def("setJointsFixed", &setJointsFixed);
+    kinematicTree.def("setLinksFixed", &setLinksFixed);
 
     // Joint Limits
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -179,19 +179,19 @@ Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
     return ret;
 }
 
-void setJointsFixed(KinematicTree& tree, const std::set<std::string> joints)
+void setJointsControlled(KinematicTree& tree, const std::set<std::string>& joints, const bool negate = false)
 {
     for (auto & [ name, joint ] : tree.getModelJointsMap())
     {
-        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && !bool(joints.count(name));
+        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && (negate ^ bool(joints.count(name)));
     }
 }
 
-void setLinksFixed(KinematicTree& tree, const std::set<std::string> links)
+void setLinksControlled(KinematicTree& tree, const std::set<std::string>& links, const bool negate = false)
 {
     for (auto & [ name, joint ] : tree.getModelJointsMap())
     {
-        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && !bool(links.count(joint.lock()->Segment.getName()));
+        joint.lock()->IsControlled = (joint.lock()->ControlId != -1) && (negate ^ bool(links.count(joint.lock()->Segment.getName())));
     }
 }
 
@@ -1046,8 +1046,10 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getRandomControlledState", &KinematicTree::getRandomControlledState);
     kinematicTree.def("getNumModelJoints", &KinematicTree::getNumModelJoints);
     kinematicTree.def("getNumControlledJoints", &KinematicTree::getNumControlledJoints);
-    kinematicTree.def("setJointsFixed", &setJointsFixed);
-    kinematicTree.def("setLinksFixed", &setLinksFixed);
+    kinematicTree.def("setJointsControlled", [](KinematicTree& tree, const std::set<std::string>& joints) { return setJointsControlled(tree, joints, false); });
+    kinematicTree.def("setLinksControlled", [](KinematicTree& tree, const std::set<std::string>& links) { return setLinksControlled(tree, links, false); });
+    kinematicTree.def("setJointsFixed", [](KinematicTree& tree, const std::set<std::string>& joints) { return setJointsControlled(tree, joints, true); });
+    kinematicTree.def("setLinksFixed", [](KinematicTree& tree, const std::set<std::string>& links) { return setLinksControlled(tree, links, true); });
 
     // Joint Limits
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);


### PR DESCRIPTION
This PR implements functions to fix model joints during the optimisation. This is implemented by setting `IsControlled` to false for a given set of links or joints.

An example use for fixing the 6D pose of the robot base:
```Python
self.problem_conf = ('exotica/UnconstrainedEndPoseProblem', {...})
self.problem = exo.Setup.createProblem(self.problem_conf)
# fix 6D base pose
self.problem.getScene().getSolver().setLinksFixed(set(self.problem.getScene().getJointNames()[:6]))
```