### PR TITLE
obtain joint limits after task initialisation

### DIFF
--- a/examples/exotica_examples/scripts/example_ompl_freebase_noros.py
+++ b/examples/exotica_examples/scripts/example_ompl_freebase_noros.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import pyexotica as exo
+import numpy as np
+from numpy import array
+from numpy import matrix
+from pyexotica.publish_trajectory import *
+
+solver = exo.Setup.loadSolver('{exotica_examples}/resources/configs/ompl_solver_demo_freebase.xml')
+
+# set planar base limits
+base_limits = np.array([[-10, 10], [-10, 10], [0, 2 * np.pi]])
+solver.getProblem().getScene().getSolver().setPlanarBaseLimitsPosXYEulerZ(base_limits[:,0], base_limits[:,1])
+
+print("joint limits:\n"+str(solver.getProblem().getScene().getSolver().getJointLimits()))
+
+solution = solver.solve()
+
+plot(solution)

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
@@ -57,10 +57,11 @@ namespace exotica
 class OMPLStateSpace : public ompl::base::CompoundStateSpace
 {
 public:
-    OMPLStateSpace(SamplingProblem_ptr &prob) : ompl::base::CompoundStateSpace(), prob_(prob)
+    OMPLStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : ompl::base::CompoundStateSpace(), prob_(prob), init_(init)
     {
     }
 
+    virtual void setBounds(SamplingProblem_ptr &prob) = 0;
     virtual void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const = 0;
     virtual void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const = 0;
 
@@ -69,6 +70,7 @@ public:
 
 protected:
     SamplingProblem_ptr prob_;
+    OMPLSolverInitializer init_;
 };
 
 class OMPLStateValidityChecker : public ompl::base::StateValidityChecker
@@ -107,6 +109,7 @@ public:
     OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
+    virtual void setBounds(SamplingProblem_ptr &prob);
     virtual void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const;
     virtual void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const;
     virtual void stateDebug(const Eigen::VectorXd &q) const;
@@ -144,6 +147,7 @@ public:
     OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
+    virtual void setBounds(SamplingProblem_ptr &prob);
     virtual void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const;
     virtual void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const;
     virtual void stateDebug(const Eigen::VectorXd &q) const;
@@ -181,6 +185,7 @@ public:
     OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
+    virtual void setBounds(SamplingProblem_ptr &prob);
     virtual void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const;
     virtual void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const;
     virtual void stateDebug(const Eigen::VectorXd &q) const;

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
@@ -90,7 +90,7 @@ protected:
     void SetGoalState(Eigen::VectorXdRefConst qT, const double eps = 0);
     void PreSolve();
     void PostSolve();
-    void GetPath(Eigen::MatrixXdRef traj, ompl::base::PlannerTerminationCondition &ptc);
+    void GetPath(Eigen::MatrixXd &traj, ompl::base::PlannerTerminationCondition &ptc);
     OMPLSolverInitializer init_;
     std::shared_ptr<ProblemType> prob_;
     ompl::geometric::SimpleSetupPtr ompl_simple_setup_;

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_exo.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_exo.cpp
@@ -63,9 +63,18 @@ bool OMPLStateValidityChecker::isValid(const ompl::base::State *state, double &d
     return true;
 }
 
-OMPLRNStateSpace::OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob)
+OMPLRNStateSpace::OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
 {
     setName("OMPLRNStateSpace");
+}
+
+ompl::base::StateSamplerPtr OMPLRNStateSpace::allocDefaultStateSampler() const
+{
+    return CompoundStateSpace::allocDefaultStateSampler();
+}
+
+void OMPLRNStateSpace::setBounds(SamplingProblem_ptr &prob)
+{
     unsigned int dim = prob->N;
     addSubspace(ompl::base::StateSpacePtr(new ompl::base::RealVectorStateSpace(dim)), 1.0);
     ompl::base::RealVectorBounds bounds(dim);
@@ -75,13 +84,8 @@ OMPLRNStateSpace::OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitiali
         bounds.setLow(i, prob->getBounds()[i]);
     }
     getSubspace(0)->as<ompl::base::RealVectorStateSpace>()->setBounds(bounds);
-    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
+    setLongestValidSegmentFraction(init_.LongestValidSegmentFraction);
     lock();
-}
-
-ompl::base::StateSamplerPtr OMPLRNStateSpace::allocDefaultStateSampler() const
-{
-    return CompoundStateSpace::allocDefaultStateSampler();
 }
 
 void OMPLRNStateSpace::ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const
@@ -113,9 +117,18 @@ void OMPLRNStateSpace::stateDebug(const Eigen::VectorXd &q) const
     //  TODO
 }
 
-OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob)
+OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
 {
     setName("OMPLSE3RNStateSpace");
+}
+
+ompl::base::StateSamplerPtr OMPLSE3RNStateSpace::allocDefaultStateSampler() const
+{
+    return CompoundStateSpace::allocDefaultStateSampler();
+}
+
+void OMPLSE3RNStateSpace::setBounds(SamplingProblem_ptr &prob)
+{
     unsigned int dim = prob->N;
     addSubspace(ompl::base::StateSpacePtr(new ompl::base::SE3StateSpace()), 1.0);
     addSubspace(ompl::base::StateSpacePtr(new ompl::base::RealVectorStateSpace(dim - 6)), 1.0);
@@ -145,13 +158,8 @@ OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverIn
         ERROR("State space bounds were not specified!\n"
               << prob->getBounds().size() << " " << n);
     }
-    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
+    setLongestValidSegmentFraction(init_.LongestValidSegmentFraction);
     lock();
-}
-
-ompl::base::StateSamplerPtr OMPLSE3RNStateSpace::allocDefaultStateSampler() const
-{
-    return CompoundStateSpace::allocDefaultStateSampler();
 }
 
 void OMPLSE3RNStateSpace::stateDebug(const Eigen::VectorXd &q) const
@@ -182,9 +190,18 @@ void OMPLSE3RNStateSpace::OMPLToExoticaState(const ompl::base::State *state, Eig
     tmp.GetRPY(q(3), q(4), q(5));
 }
 
-OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob)
+OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
 {
     setName("OMPLSE2RNStateSpace");
+}
+
+ompl::base::StateSamplerPtr OMPLSE2RNStateSpace::allocDefaultStateSampler() const
+{
+    return CompoundStateSpace::allocDefaultStateSampler();
+}
+
+void OMPLSE2RNStateSpace::setBounds(SamplingProblem_ptr &prob)
+{
     unsigned int dim = prob->N;
     addSubspace(ompl::base::StateSpacePtr(new ompl::base::SE2StateSpace()), 1.0);
     addSubspace(ompl::base::StateSpacePtr(new ompl::base::RealVectorStateSpace(dim - 3)), 1.0);
@@ -214,13 +231,8 @@ OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverIn
         ERROR("State space bounds were not specified!\n"
               << prob->getBounds().size() << " " << n);
     }
-    setLongestValidSegmentFraction(init.LongestValidSegmentFraction);
+    setLongestValidSegmentFraction(init_.LongestValidSegmentFraction);
     lock();
-}
-
-ompl::base::StateSamplerPtr OMPLSE2RNStateSpace::allocDefaultStateSampler() const
-{
-    return CompoundStateSpace::allocDefaultStateSampler();
 }
 
 void OMPLSE2RNStateSpace::stateDebug(const Eigen::VectorXd &q) const

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -74,19 +74,6 @@ void OMPLSolver<ProblemType>::specifyProblem(PlanningProblem_ptr pointer)
         else if (prob_->getScene()->getBaseType() == BASE_TYPE::FLOATING)
             ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ompl::base::ProjectionEvaluatorPtr(new OMPLSE3RNProjection(state_space_, project_vars)));
     }
-
-    ompl_simple_setup_->getSpaceInformation()->setup();
-    ompl_simple_setup_->setup();
-    if (ompl_simple_setup_->getPlanner()->params().hasParam("range"))
-        ompl_simple_setup_->getPlanner()->params().setParam("range", init_.Range);
-    if (ompl_simple_setup_->getPlanner()->params().hasParam("goal_bias"))
-        ompl_simple_setup_->getPlanner()->params().setParam("goal_bias", init_.GoalBias);
-
-    if (init_.RandomSeed != -1)
-    {
-        HIGHLIGHT_NAMED(algorithm_, "Setting random seed to " << init_.RandomSeed);
-        ompl::RNG::setSeed(init_.RandomSeed);
-    }
 }
 
 template <class ProblemType>
@@ -204,9 +191,28 @@ template <class ProblemType>
 void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
 {
     Eigen::VectorXd q0 = prob_->applyStartState();
+
+    state_space_->as<OMPLStateSpace>()->setBounds(prob_);
+
+    ompl_simple_setup_->getSpaceInformation()->setup();
+
+    ompl_simple_setup_->setup();
+
+    if (ompl_simple_setup_->getPlanner()->params().hasParam("range"))
+        ompl_simple_setup_->getPlanner()->params().setParam("range", init_.Range);
+    if (ompl_simple_setup_->getPlanner()->params().hasParam("goal_bias"))
+        ompl_simple_setup_->getPlanner()->params().setParam("goal_bias", init_.GoalBias);
+
+    if (init_.RandomSeed != -1)
+    {
+        HIGHLIGHT_NAMED(algorithm_, "Setting random seed to " << init_.RandomSeed);
+        ompl::RNG::setSeed(init_.RandomSeed);
+    }
+
     SetGoalState(prob_->getGoalState(), init_.Epsilon);
 
     ompl::base::ScopedState<> ompl_start_state(state_space_);
+
     state_space_->as<OMPLStateSpace>()->ExoticaToOMPLState(q0, ompl_start_state.get());
     ompl_simple_setup_->setStartState(ompl_start_state);
 

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -149,7 +149,7 @@ void OMPLSolver<ProblemType>::SetGoalState(Eigen::VectorXdRefConst qT, const dou
 }
 
 template <class ProblemType>
-void OMPLSolver<ProblemType>::GetPath(Eigen::MatrixXdRef traj, ompl::base::PlannerTerminationCondition &ptc)
+void OMPLSolver<ProblemType>::GetPath(Eigen::MatrixXd &traj, ompl::base::PlannerTerminationCondition &ptc)
 {
     ompl::geometric::PathSimplifierPtr psf = ompl_simple_setup_->getPathSimplifier();
     const ompl::base::SpaceInformationPtr &si = ompl_simple_setup_->getSpaceInformation();

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -192,6 +192,22 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
 {
     Eigen::VectorXd q0 = prob_->applyStartState();
 
+    // check joint limits
+    const std::vector<double> bounds = prob_->getBounds();
+    for (const double l : bounds)
+    {
+        if (!std::isfinite(l))
+        {
+            std::cerr << "Detected non-finite joint limits:" << std::endl;
+            const size_t nlim = bounds.size() / 2;
+            for (uint i = 0; i < nlim; i++)
+            {
+                std::cout << bounds[i] << ", " << bounds[nlim + i] << std::endl;
+            }
+            throw std::runtime_error("All joint limits need to be finite!");
+        }
+    }
+
     state_space_->as<OMPLStateSpace>()->setBounds(prob_);
 
     ompl_simple_setup_->getSpaceInformation()->setup();

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -65,7 +65,7 @@ private:
     Eigen::VectorXd low_limits_;   //	Lower joint limits
     Eigen::VectorXd high_limits_;  //	Higher joint limits
     Eigen::VectorXd tau_;          //	Joint limits tolerance
-    double percent;
+    double safe_percentage_;
     JointLimitInitializer init_;
     int N;
 };

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -62,9 +62,6 @@ public:
     virtual int taskSpaceDim();
 
 private:
-    Eigen::VectorXd low_limits_;   //	Lower joint limits
-    Eigen::VectorXd high_limits_;  //	Higher joint limits
-    Eigen::VectorXd tau_;          //	Joint limits tolerance
     double safe_percentage_;
     JointLimitInitializer init_;
     int N;

--- a/exotations/task_maps/task_map/include/task_map/JointLimit.h
+++ b/exotations/task_maps/task_map/include/task_map/JointLimit.h
@@ -65,6 +65,7 @@ private:
     Eigen::VectorXd low_limits_;   //	Lower joint limits
     Eigen::VectorXd high_limits_;  //	Higher joint limits
     Eigen::VectorXd tau_;          //	Joint limits tolerance
+    double percent;
     JointLimitInitializer init_;
     int N;
 };

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -52,7 +52,7 @@ void JointLimit::assignScene(Scene_ptr scene)
 
 void JointLimit::Initialize()
 {
-    percent = init_.SafePercentage;
+    safe_percentage_ = init_.SafePercentage;
 
     N = scene_->getSolver().getNumControlledJoints();
 
@@ -77,7 +77,7 @@ void JointLimit::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     {
         low_limits_(i) = limits(i, 0);
         high_limits_(i) = limits(i, 1);
-        tau_(i) = percent * (high_limits_(i) - low_limits_(i)) * 0.5;
+        tau_(i) = safe_percentage_ * (high_limits_(i) - low_limits_(i)) * 0.5;
     }
 
     for (int i = 0; i < N; i++)

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -162,6 +162,7 @@ public:
     void setJointLimitsLower(Eigen::VectorXdRefConst lower_in);
     void setJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
     void setFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
+    void setPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> getUsedJointLimits();
     int getNumControlledJoints();
     int getNumModelJoints();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -906,20 +906,22 @@ void KinematicTree::resetJointLimits()
 
     ///	Manually defined floating base limits
     ///	Should be done more systematically with robot model class
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    constexpr double pi = std::atan(1) * 4;
     if (ControlledBaseType == BASE_TYPE::FLOATING)
     {
-        ControlledJoints[0].lock()->JointLimits = {-0.05, 0.05};
-        ControlledJoints[1].lock()->JointLimits = {-0.05, 0.05};
-        ControlledJoints[2].lock()->JointLimits = {0.875, 1.075};
-        ControlledJoints[3].lock()->JointLimits = {-0.087 / 2, 0.087 / 2};
-        ControlledJoints[4].lock()->JointLimits = {-0.087 / 2, 0.2617 / 2};
-        ControlledJoints[5].lock()->JointLimits = {-M_PI / 8, M_PI / 8};
+        ControlledJoints[0].lock()->JointLimits = {-inf, inf};
+        ControlledJoints[1].lock()->JointLimits = {-inf, inf};
+        ControlledJoints[2].lock()->JointLimits = {-inf, inf};
+        ControlledJoints[3].lock()->JointLimits = {-pi, pi};
+        ControlledJoints[4].lock()->JointLimits = {-pi, pi};
+        ControlledJoints[5].lock()->JointLimits = {-pi, pi};
     }
     else if (ControlledBaseType == BASE_TYPE::PLANAR)
     {
-        ControlledJoints[0].lock()->JointLimits = {-10, 10};
-        ControlledJoints[1].lock()->JointLimits = {-10, 10};
-        ControlledJoints[2].lock()->JointLimits = {-1.57, 1.57};
+        ControlledJoints[0].lock()->JointLimits = {-inf, inf};
+        ControlledJoints[1].lock()->JointLimits = {-inf, inf};
+        ControlledJoints[2].lock()->JointLimits = {-pi, pi};
     }
 
     updateJointLimits();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -891,6 +891,25 @@ void KinematicTree::setFloatingBaseLimitsPosXYZEulerZYX(
     updateJointLimits();
 }
 
+void KinematicTree::setPlanarBaseLimitsPosXYEulerZ(
+    const std::vector<double>& lower, const std::vector<double>& upper)
+{
+    if (ControlledBaseType != BASE_TYPE::PLANAR)
+    {
+        throw_pretty("This is not a planar joint!");
+    }
+    if (lower.size() != 3 || upper.size() != 3)
+    {
+        throw_pretty("Wrong limit data size!");
+    }
+    for (int i = 0; i < 3; i++)
+    {
+        ControlledJoints[i].lock()->JointLimits = {lower[i], upper[i]};
+    }
+
+    updateJointLimits();
+}
+
 void KinematicTree::resetJointLimits()
 {
     std::vector<std::string> vars = Model->getVariableNames();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1078,6 +1078,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("setJointLimitsLower", &KinematicTree::setJointLimitsLower);
     kinematicTree.def("setJointLimitsUpper", &KinematicTree::setJointLimitsUpper);
     kinematicTree.def("setFloatingBaseLimitsPosXYZEulerZYX", &KinematicTree::setFloatingBaseLimitsPosXYZEulerZYX);
+    kinematicTree.def("setPlanarBaseLimitsPosXYEulerZ", &KinematicTree::setPlanarBaseLimitsPosXYEulerZ);
     kinematicTree.def("getUsedJointLimits", &KinematicTree::getUsedJointLimits);
 
     // TODO: KinematicRequestFlags


### PR DESCRIPTION
The joint limits get reset to their defaults when calling `specifyProblem(<problem>)`. Since the task maps are also initialised during this, there is no way to change the joint limits for the `JointLimit` task, which fixes the joint limits at initialisation.

This PR updates the joint limits when `JointLimit::update` is called, hence allowing to change the joints limits from defaults, between the setup (`specifyProblem`) and the optimisation (`solve`).