### PR TITLE
IKSolver: initialise alpha to 1

### DIFF
--- a/exotations/solvers/exotica_ik_solver/init/IKSolver.in
+++ b/exotations/solvers/exotica_ik_solver/init/IKSolver.in
@@ -3,4 +3,4 @@ Optional double Tolerance = 1e-5;
 Optional double Convergence = 0.0;
 Optional double MaxStep = 0.02;
 Optional double C = 0.0;
-Optional Eigen::VectorXd Alpha = Eigen::VectorXd(1);
+Optional Eigen::VectorXd Alpha = Eigen::VectorXd::Ones(1);


### PR DESCRIPTION
This PR sets the default IKSolver alpha correctly to 1.

I intended to use the constructor [`Matrix (const Scalar &x)`](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html#a94173a014c2bdc8add568f43ddfd85af) which initialises a 1x1 matrix with x (1 in this case), but it appears that Eigen assumed that the provided 1 is a index and used constructor [`Matrix (Index dim)`](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html#a1c8627a7a051df98bdf6daab12852e02).

`Eigen::VectorXd::Ones(1)` makes it more explicite which value and dimension to use.