### PR TITLE
Fix Python loading issue of taskmap/solver extensions

### DIFF
--- a/exotations/solvers/exotica_ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_ompl_solver/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OMPL_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers)
 
-pybind_add_module(${PROJECT_NAME}_py MODULE src/ompl_py.cpp ${SOURCES})
+pybind_add_module(${PROJECT_NAME}_py MODULE src/ompl_py.cpp)
+target_link_libraries(${PROJECT_NAME}_py PRIVATE ${PROJECT_NAME})
 add_dependencies(${PROJECT_NAME}_py ${PROJECT_NAME} ${PROJECT_NAME}_initializers)
 install(TARGETS ${PROJECT_NAME}_py LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})
 

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -69,7 +69,8 @@ add_library(${PROJECT_NAME} ${SOURCES})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
-pybind_add_module(${PROJECT_NAME}_py MODULE src/task_map_py.cpp ${SOURCES})
+pybind_add_module(${PROJECT_NAME}_py MODULE src/task_map_py.cpp)
+target_link_libraries(${PROJECT_NAME}_py PRIVATE ${PROJECT_NAME})
 add_dependencies(${PROJECT_NAME}_py ${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
 ## Install

--- a/exotations/task_maps/task_map/src/JointAccelerationBackwardDifference.cpp
+++ b/exotations/task_maps/task_map/src/JointAccelerationBackwardDifference.cpp
@@ -46,7 +46,7 @@ void JointAccelerationBackwardDifference::assignScene(Scene_ptr scene)
     // Get ndof
     N_ = scene_->getSolver().getNumControlledJoints();
 
-    // Set binomial cooeficient parameters
+    // Set binomial coefficient parameters
     backward_difference_params_ << -2, 1;
 
     // Frequency


### PR DESCRIPTION
When import `pyexotica` and either of `task_map_py` or `exotica_ompl_solver_py`, there are tons of warnings about double imports in the global namespace. This PR fixes this.
This also may speed up compilation a little bit as we are reusing the already built library to built the Python bindings.