### PR TITLE
Minor mod to smoothing example

### DIFF
--- a/examples/exotica_examples/resources/configs/ik_with_jnt_smoothing.xml
+++ b/examples/exotica_examples/resources/configs/ik_with_jnt_smoothing.xml
@@ -44,7 +44,7 @@
     </Maps>
 
     <Cost>
-      <Task Task="Position" Rho="1e3"/>
+      <Task Task="Position" Rho="1e2"/>
       <Task Task="JointVel" Rho="1"/>
       <Task Task="JointAcc" Rho="1"/>
       <Task Task="JointJerk" Rho="1"/>


### PR DESCRIPTION
* `Rho=1e3` -> `Rho=1e2` for `Position` task map cost
* With new `Rho` value for `Position` task the benefit of the smoothing task maps is clearer when the example is launched
* Before, when `Rho=1e3`, the motion looks essentially the same as without the smoothing