### PR TITLE
prevent change of OMPL state space after locking

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -70,4 +70,6 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(test_problems ${catkin_EXPORTED_TARGETS})
 
   add_rostest(test/python_tests.launch)
+
+  catkin_add_nosetests(test/run_tests.py)
 endif()

--- a/examples/exotica_examples/test/run_tests.py
+++ b/examples/exotica_examples/test/run_tests.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import rosunit
+
+rosunit.unitrun('exotica_examples', 'ompl_solver_bounds', 'test.test_ompl_solver_bounds.OMPLLockedBoundsCase')

--- a/examples/exotica_examples/test/test_ompl_solver_bounds.py
+++ b/examples/exotica_examples/test/test_ompl_solver_bounds.py
@@ -1,0 +1,49 @@
+import unittest
+
+import pyexotica as exo
+
+class OMPLLockedBoundsCase(unittest.TestCase):
+
+    def test_lock_bounds(self):
+        # self.assertTrue(True)
+        ompl=exo.Setup.loadSolver('{exotica_examples}/resources/configs/example_manipulate_ompl.xml')
+
+        # set start and goal state
+        ompl.getProblem().startState = [1.5035205538438838, 0.8730168650583787, -1.6298590879018438, 1.7106630821349438, -0.8789956712153559, 0.1278222471656531, 0.0]
+        ompl.getProblem().goalState = [-1.5035205538442702, 0.8730168650583671, 1.6298590879018415, 1.7106630821349786, 0.8789956712153525, 0.12782224716566898, 0.0]
+
+        # 1st solve call
+        solution = None
+        try:
+            solution = ompl.solve()
+        except Exception:
+            pass
+        self.assertTrue(solution is not None)
+
+        # 2nd solve call
+        solution = None
+        try:
+            solution = ompl.solve()
+        except Exception:
+            pass
+        self.assertTrue(solution is not None)
+
+        # get and change current bounds
+        jl = ompl.getProblem().getScene().getSolver().getJointLimits()
+        jl[0] += 1
+        ompl.getProblem().getScene().getSolver().setJointLimitsLower(jl[:,0])
+        ompl.getProblem().getScene().getSolver().setJointLimitsUpper(jl[:,1])
+
+        # 3rd call with changed bounds
+        solution = None
+        failed = False
+        try:
+            solution = ompl.solve()
+        except Exception:
+            failed = True
+            pass
+        # the solve call wit changed bounds should throw an exception
+        self.assertTrue(failed)
+        # ... and there should be no solution
+        self.assertTrue(solution is None)
+

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
@@ -57,7 +57,7 @@ namespace exotica
 class OMPLStateSpace : public ompl::base::CompoundStateSpace
 {
 public:
-    OMPLStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : ompl::base::CompoundStateSpace(), prob_(prob), init_(init)
+    OMPLStateSpace(OMPLSolverInitializer init) : ompl::base::CompoundStateSpace(), init_(init)
     {
     }
 
@@ -69,7 +69,6 @@ public:
     virtual void stateDebug(const Eigen::VectorXd &q) const = 0;
 
 protected:
-    SamplingProblem_ptr prob_;
     OMPLSolverInitializer init_;
 };
 
@@ -106,7 +105,7 @@ public:
             return *as<ompl::base::RealVectorStateSpace::StateType>(0);
         }
     };
-    OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
+    OMPLRNStateSpace(OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
     virtual void setBounds(SamplingProblem_ptr &prob);
@@ -144,7 +143,7 @@ public:
             return *as<ompl::base::SE3StateSpace::StateType>(0);
         }
     };
-    OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
+    OMPLSE3RNStateSpace(OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
     virtual void setBounds(SamplingProblem_ptr &prob);
@@ -182,7 +181,7 @@ public:
             return *as<ompl::base::SE2StateSpace::StateType>(0);
         }
     };
-    OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init);
+    OMPLSE2RNStateSpace(OMPLSolverInitializer init);
 
     virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
     virtual void setBounds(SamplingProblem_ptr &prob);

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
@@ -98,6 +98,7 @@ protected:
     ConfiguredPlannerAllocator planner_allocator_;
     std::string algorithm_;
     bool multi_query_ = false;
+    std::vector<double> bounds_;  // original bounds for locked state space
 };
 }
 

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_exo.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_exo.cpp
@@ -63,7 +63,7 @@ bool OMPLStateValidityChecker::isValid(const ompl::base::State *state, double &d
     return true;
 }
 
-OMPLRNStateSpace::OMPLRNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
+OMPLRNStateSpace::OMPLRNStateSpace(OMPLSolverInitializer init) : OMPLStateSpace(init)
 {
     setName("OMPLRNStateSpace");
 }
@@ -117,7 +117,7 @@ void OMPLRNStateSpace::stateDebug(const Eigen::VectorXd &q) const
     //  TODO
 }
 
-OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
+OMPLSE3RNStateSpace::OMPLSE3RNStateSpace(OMPLSolverInitializer init) : OMPLStateSpace(init)
 {
     setName("OMPLSE3RNStateSpace");
 }
@@ -190,7 +190,7 @@ void OMPLSE3RNStateSpace::OMPLToExoticaState(const ompl::base::State *state, Eig
     tmp.GetRPY(q(3), q(4), q(5));
 }
 
-OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(SamplingProblem_ptr &prob, OMPLSolverInitializer init) : OMPLStateSpace(prob, init)
+OMPLSE2RNStateSpace::OMPLSE2RNStateSpace(OMPLSolverInitializer init) : OMPLStateSpace(init)
 {
     setName("OMPLSE2RNStateSpace");
 }

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -211,6 +211,11 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
     if (!state_space_->as<OMPLStateSpace>()->isLocked())
     {
         state_space_->as<OMPLStateSpace>()->setBounds(prob_);
+        bounds_ = prob_->getBounds();
+    }
+    else if (!bounds_.empty() && bounds_ != prob_->getBounds())
+    {
+        throw_pretty("Cannot set new bounds on locked state space!");
     }
 
     ompl_simple_setup_->getSpaceInformation()->setup();

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -208,7 +208,10 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
         }
     }
 
-    state_space_->as<OMPLStateSpace>()->setBounds(prob_);
+    if (!state_space_->as<OMPLStateSpace>()->isLocked())
+    {
+        state_space_->as<OMPLStateSpace>()->setBounds(prob_);
+    }
 
     ompl_simple_setup_->getSpaceInformation()->setup();
 

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -48,11 +48,11 @@ void OMPLSolver<ProblemType>::specifyProblem(PlanningProblem_ptr pointer)
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<ProblemType>(pointer);
     if (prob_->getScene()->getBaseType() == BASE_TYPE::FIXED)
-        state_space_.reset(new OMPLRNStateSpace(prob_, init_));
+        state_space_.reset(new OMPLRNStateSpace(init_));
     else if (prob_->getScene()->getBaseType() == BASE_TYPE::PLANAR)
-        state_space_.reset(new OMPLSE2RNStateSpace(prob_, init_));
+        state_space_.reset(new OMPLSE2RNStateSpace(init_));
     else if (prob_->getScene()->getBaseType() == BASE_TYPE::FLOATING)
-        state_space_.reset(new OMPLSE3RNStateSpace(prob_, init_));
+        state_space_.reset(new OMPLSE3RNStateSpace(init_));
     else
         throw_named("Unsupported base type " << prob_->getScene()->getBaseType());
     ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(state_space_));

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -310,8 +310,9 @@ void KinematicTree::resetModel()
     // Remove all CollisionShapes
     if (Server::isRos())
     {
-        marker_array_msg_.markers.emplace_back();
-        marker_array_msg_.markers.end()->action = 3;  // visualization_msgs::Marker::DELETEALL; // NB: enum only defined in ROS-J and newer, functionality still there
+        visualization_msgs::Marker mrk;
+        mrk.action = 3;  // visualization_msgs::Marker::DELETEALL; // NB: enum only defined in ROS-J and newer, functionality still there
+        marker_array_msg_.markers.push_back(mrk);
     }
 }
 


### PR DESCRIPTION
This checks that the OMPL state space is not locked before attempting to change it during multipel calls to `Solve()`.
Fixes https://github.com/ipab-slmc/exotica/issues/444