### PR TITLE
Fixes indexing of S matrix update

### DIFF
--- a/exotica/src/Tasks.cpp
+++ b/exotica/src/Tasks.cpp
@@ -121,7 +121,7 @@ void EndPoseTask::updateS()
     {
         for (int i = 0; i < task.LengthJ; i++)
         {
-            S(i + task.Start, i + task.Start) = Rho(task.Id);
+            S(i + task.StartJ, i + task.StartJ) = Rho(task.Id);
         }
         if (Rho(task.Id) != 0.0) Tasks[task.Id]->isUsed = true;
     }
@@ -175,7 +175,7 @@ void TimeIndexedTask::updateS()
         {
             for (int i = 0; i < task.LengthJ; i++)
             {
-                S[t](i + task.Start, i + task.Start) = Rho[t](task.Id);
+                S[t](i + task.StartJ, i + task.StartJ) = Rho[t](task.Id);
             }
             if (Rho[t](task.Id) != 0.0) Tasks[task.Id]->isUsed = true;
         }
@@ -328,7 +328,7 @@ void SamplingTask::updateS()
     {
         for (int i = 0; i < task.LengthJ; i++)
         {
-            S(i + task.Start, i + task.Start) = Rho(task.Id);
+            S(i + task.StartJ, i + task.StartJ) = Rho(task.Id);
         }
         if (Rho(task.Id) != 0.0) Tasks[task.Id]->isUsed = true;
     }


### PR DESCRIPTION
 - Fixes indexing of `S` in `updateS` of  `EndPoseTask`/`SamplingTask`/`TimeIndexedTask`.
 - Added testing of multiple cost terms to the task map tests (thus catching the above issue). This would have come back with a decent error message in the Debug build if this test was in place before.
 - Changed `eps` for tests using rotation types (AngleAxis now requires 1.1e-5).

Fixes #436