### PR TITLE
[exotica_levenberg_marquardt_solver] Use colPivHouseholderQr if Eigen < 3.3.0 (fix 16.04 bug)

### DIFF
--- a/examples/exotica_examples/launch/PythonPlanLevenbergMarquardtIK.launch
+++ b/examples/exotica_examples/launch/PythonPlanLevenbergMarquardtIK.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_levenbergmarquardt.py" name="IKPlannerPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/examples/exotica_examples/resources/configs/example_levenbergmarquardt.xml
+++ b/examples/exotica_examples/resources/configs/example_levenbergmarquardt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+  <LevenbergMarquardtSolver Name="MySolver" />
+
+  <UnconstrainedEndPoseProblem Name="MyProblem">
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+    
+    <Maps>
+      <EffFrame Name="Position">
+        <EndEffector>
+            <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+        </EndEffector>
+      </EffFrame>
+    </Maps>
+
+    <Cost>
+      <Task Task="Position"/>
+    </Cost>
+
+    <StartState>0 0 0 0 0 0 0</StartState>
+    <W> 7 6 5 4 3 2 1 </W>
+  </UnconstrainedEndPoseProblem>
+</IKSolverDemoConfig>

--- a/examples/exotica_examples/resources/configs/example_levenbergmarquardt.xml
+++ b/examples/exotica_examples/resources/configs/example_levenbergmarquardt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <IKSolverDemoConfig>
-  <LevenbergMarquardtSolver Name="MySolver" />
+  <LevenbergMarquardtSolver Name="MySolver" Damping="0.01" />
 
   <UnconstrainedEndPoseProblem Name="MyProblem">
     <PlanningScene>

--- a/examples/exotica_examples/scripts/example_levenbergmarquardt.py
+++ b/examples/exotica_examples/scripts/example_levenbergmarquardt.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from pyexotica.publish_trajectory import *
+from time import sleep
+
+
+def figureEight(t):
+    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2, 0, 0, 0])
+
+
+exo.Setup.initRos()
+solver = exo.Setup.loadSolver('{exotica_examples}/resources/configs/example_levenbergmarquardt.xml')
+problem = solver.getProblem()
+
+dt = 0.002
+t = 0.0
+q = array([0.0]*7)
+print('Publishing IK')
+signal.signal(signal.SIGINT, sigIntHandler)
+while True:
+    try:
+        problem.setGoal('Position', figureEight(t))
+        problem.startState = q
+        q = solver.solve()[0]
+        publishPose(q, problem)
+        sleep(dt)
+        t = t+dt
+    except KeyboardInterrupt:
+        del solver, problem
+        break

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
@@ -3,11 +3,9 @@ project(exotica_levenberg_marquardt_solver)
 
 find_package(catkin REQUIRED COMPONENTS exotica)
 
-find_package(Eigen3 3.3 QUIET)
-
+find_package(Eigen3 REQUIRED)
 if(NOT TARGET Eigen3::Eigen)
-    message(WARNING "The Levenberg-Marquardt solver requires at least Eigen version 3.3.")
-    return()
+    message(WARNING "For best performance, the Levenberg-Marquardt solver requires at least Eigen version 3.3. Using an alternative linear solver.")
 endif()
 
 AddInitializer(LevenbergMarquardtSolver)
@@ -17,7 +15,6 @@ catkin_package(
     LIBRARIES ${PROJECT_NAME}
     CATKIN_DEPENDS exotica
 )
-
 include_directories(${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/LevenbergMarquardtSolver.cpp)

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/src/LevenbergMarquardtSolver.cpp
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/src/LevenbergMarquardtSolver.cpp
@@ -110,7 +110,7 @@ void LevenbergMarquardtSolver::Solve(Eigen::MatrixXd& solution)
             throw std::runtime_error("no ScaleProblem of type " + parameters_.ScaleProblem);
         }
 
-#if EIGEN_VERSION_AT_LEAST(3,3,0)
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
         qd = (J.transpose() * J + lambda_ * M).completeOrthogonalDecomposition().solve(J.transpose() * yd);
 #else
         qd = (J.transpose() * J + lambda_ * M).colPivHouseholderQr().solve(J.transpose() * yd);

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/src/LevenbergMarquardtSolver.cpp
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/src/LevenbergMarquardtSolver.cpp
@@ -110,7 +110,11 @@ void LevenbergMarquardtSolver::Solve(Eigen::MatrixXd& solution)
             throw std::runtime_error("no ScaleProblem of type " + parameters_.ScaleProblem);
         }
 
+#if EIGEN_VERSION_AT_LEAST(3,3,0)
         qd = (J.transpose() * J + lambda_ * M).completeOrthogonalDecomposition().solve(J.transpose() * yd);
+#else
+        qd = (J.transpose() * J + lambda_ * M).colPivHouseholderQr().solve(J.transpose() * yd);
+#endif
 
         if (parameters_.Alpha.size() == 1)
         {


### PR DESCRIPTION
As reported in #453: As we are not building the Levenberg-Marquardt solver on 16.04 _but_ maintain a `exotica_plugins.xml` file, `pyexotica` won't run any example. We have two solutions hereto (provide newer Eigen, or create the plugin-export file during configuration). This PR _may_ fix this issue but I do not have a way to test right now as I am on 16.04 over the holidays.
