### PR TITLE
Add Visualization module

### DIFF
--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   moveit_core
   moveit_ros_planning
+  moveit_msgs
   tf
   eigen_conversions
   kdl_parser
@@ -75,6 +76,7 @@ add_library(${PROJECT_NAME}
   src/MotionSolver.cpp
   src/Setup.cpp
   src/Server.cpp
+  src/Visualization.cpp
   src/Scene.cpp
   src/Trajectory.cpp
   src/Property.cpp
@@ -93,7 +95,8 @@ add_library(${PROJECT_NAME}
   src/Problems/BoundedEndPoseProblem.cpp
   src/Problems/SamplingProblem.cpp
   src/Problems/TimeIndexedSamplingProblem.cpp
-  ${exotica_BINARY_DIR}/generated/Version.cpp)
+  ${exotica_BINARY_DIR}/generated/Version.cpp
+)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML2_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers)
 

--- a/exotica/include/exotica/Visualization.h
+++ b/exotica/include/exotica/Visualization.h
@@ -33,7 +33,6 @@
 #ifndef EXOTICA_VISUALIZATION_H_
 #define EXOTICA_VISUALIZATION_H_
 
-#include <exotica/Object.h>
 #include <exotica/Scene.h>
 #include <exotica/Server.h>
 #include <exotica/Tools/Uncopyable.h>
@@ -41,12 +40,12 @@
 
 namespace exotica
 {
-class Visualization : public Object, Uncopyable
+class Visualization : public Uncopyable
 {
 public:
     Visualization(Scene_ptr scene);
+    virtual ~Visualization();
 
-    //    void assignScene(Scene_ptr scene);
     void Initialize();
 
     void displayTrajectory(Eigen::MatrixXdRefConst trajectory);

--- a/exotica/include/exotica/Visualization.h
+++ b/exotica/include/exotica/Visualization.h
@@ -1,0 +1,60 @@
+/*
+ *      Author: Wolfgang Merkt
+ *
+ * Copyright (c) 2016, Wolfgang Merkt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef EXOTICA_VISUALIZATION_H_
+#define EXOTICA_VISUALIZATION_H_
+
+#include <exotica/Object.h>
+#include <exotica/Scene.h>
+#include <exotica/Server.h>
+#include <exotica/Tools/Uncopyable.h>
+#include <moveit_msgs/DisplayTrajectory.h>
+
+namespace exotica
+{
+class Visualization : public Object, Uncopyable
+{
+public:
+    Visualization(Scene_ptr scene);
+
+    //    void assignScene(Scene_ptr scene);
+    void Initialize();
+
+    void displayTrajectory(Eigen::MatrixXdRefConst trajectory);
+
+private:
+    Scene_ptr scene_ = std::make_shared<Scene>(nullptr);
+    ros::Publisher trajectory_pub_;
+};
+}
+
+#endif  //EXOTICA_VISUALIZATION_H_

--- a/exotica/include/exotica/Visualization.h
+++ b/exotica/include/exotica/Visualization.h
@@ -36,6 +36,7 @@
 #include <exotica/Scene.h>
 #include <exotica/Server.h>
 #include <exotica/Tools/Uncopyable.h>
+#include <geometry_msgs/Transform.h>
 #include <moveit_msgs/DisplayTrajectory.h>
 
 namespace exotica

--- a/exotica/package.xml
+++ b/exotica/package.xml
@@ -22,6 +22,7 @@
   <depend>message_runtime</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
+  <depend>moveit_msgs</depend>
   <depend>tf</depend>
   <depend>kdl_parser</depend>
   <depend>pluginlib</depend>

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -668,6 +668,7 @@ KDL::Frame KinematicTree::FK(KinematicFrame& frame)
 
 KDL::Frame KinematicTree::FK(std::shared_ptr<KinematicElement> elementA, const KDL::Frame& offsetA, std::shared_ptr<KinematicElement> elementB, const KDL::Frame& offsetB)
 {
+    if (!elementA) throw_pretty("The pointer to KinematicElement A is dead.");
     KinematicFrame frame;
     frame.FrameA = elementA;
     frame.FrameB = (elementB == nullptr) ? Root : elementB;
@@ -699,6 +700,7 @@ void KinematicTree::UpdateFK()
 
 Eigen::MatrixXd KinematicTree::Jacobian(std::shared_ptr<KinematicElement> elementA, const KDL::Frame& offsetA, std::shared_ptr<KinematicElement> elementB, const KDL::Frame& offsetB)
 {
+    if (!elementA) throw_pretty("The pointer to KinematicElement A is dead.");
     KinematicFrame frame;
     frame.FrameA = elementA;
     frame.FrameB = (elementB == nullptr) ? Root : elementB;

--- a/exotica/src/Visualization.cpp
+++ b/exotica/src/Visualization.cpp
@@ -57,7 +57,7 @@ void Visualization::displayTrajectory(Eigen::MatrixXdRefConst trajectory)
         throw_pretty("Number of DoFs in trajectory does not match number of controlled joints of robot.");
 
     moveit_msgs::DisplayTrajectory traj_msg;
-    traj_msg.model_id = scene_->getRobotModel()->getName();
+    traj_msg.model_id = scene_->getSolver().getRobotModel()->getName();
 
     // TODO:
     //   http://docs.ros.org/melodic/api/moveit_msgs/html/msg/DisplayTrajectory.html

--- a/exotica/src/Visualization.cpp
+++ b/exotica/src/Visualization.cpp
@@ -1,0 +1,84 @@
+/*
+ *      Author: Wolfgang Merkt
+ *
+ * Copyright (c) 2016, Wolfgang Merkt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <exotica/Visualization.h>
+
+namespace exotica
+{
+Visualization::Visualization(Scene_ptr scene)
+{
+    scene_ = scene;
+    Initialize();
+
+    HIGHLIGHT_NAMED("Visualization", "Initializing visualization");
+}
+
+void Visualization::Initialize()
+{
+    if (Server::isRos())
+    {
+        trajectory_pub_ = Server::advertise<moveit_msgs::DisplayTrajectory>(scene_->getName() + (scene_->getName().empty() ? "" : "/") + "Trajectory", 1, true);
+    }
+}
+
+void Visualization::displayTrajectory(Eigen::MatrixXdRefConst trajectory)
+{
+    if (!Server::isRos()) return;
+
+    if (trajectory.cols() != scene_->getSolver().getNumControlledJoints())
+        throw_named("Number of DoFs in trajectory does not match number of controlled joints of robot.");
+
+    moveit_msgs::DisplayTrajectory traj_msg;
+    traj_msg.model_id = scene_->getRobotModel()->getName();
+
+    // TODO:
+    //   http://docs.ros.org/melodic/api/moveit_msgs/html/msg/DisplayTrajectory.html
+    // TODO: Support for fixed and floating base! - multi_dof_joint_trajectory
+    // TODO: Support for uncontrolled joints: trajectory_start
+
+    traj_msg.trajectory.resize(1);
+    traj_msg.trajectory[0].joint_trajectory.header.frame_id = scene_->getRootFrameName();
+    traj_msg.trajectory[0].joint_trajectory.header.stamp = ros::Time::now();
+    traj_msg.trajectory[0].joint_trajectory.joint_names = scene_->getSolver().getJointNames();
+    traj_msg.trajectory[0].joint_trajectory.points.resize(trajectory.rows());
+
+    for (int i = 0; i < trajectory.rows(); i++)
+    {
+        traj_msg.trajectory[0].joint_trajectory.points[i].positions.resize(trajectory.cols());
+        for (int n = 0; n < trajectory.cols(); n++)
+        {
+            traj_msg.trajectory[0].joint_trajectory.points[i].positions[n] = trajectory(i, n);
+        }
+    }
+    trajectory_pub_.publish(traj_msg);
+}
+}

--- a/exotica/src/Visualization.cpp
+++ b/exotica/src/Visualization.cpp
@@ -74,14 +74,14 @@ void Visualization::displayTrajectory(Eigen::MatrixXdRefConst trajectory)
     switch (scene_->getSolver().getControlledBaseType())
     {
         case BASE_TYPE::FIXED:
-            HIGHLIGHT("Fixed base, no offset");
+            // HIGHLIGHT("Fixed base, no offset");
             break;
         case BASE_TYPE::PLANAR:
-            HIGHLIGHT("Planar, offset 3");
+            // HIGHLIGHT("Planar, offset 3");
             base_offset = 3;
             break;
         case BASE_TYPE::FLOATING:
-            HIGHLIGHT("Floating, offset 6");
+            // HIGHLIGHT("Floating, offset 6");
             base_offset = 6;
             break;
         default:

--- a/exotica/src/Visualization.cpp
+++ b/exotica/src/Visualization.cpp
@@ -34,13 +34,12 @@
 
 namespace exotica
 {
-Visualization::Visualization(Scene_ptr scene)
+Visualization::Visualization(Scene_ptr scene) : scene_(scene)
 {
-    scene_ = scene;
+    HIGHLIGHT_NAMED("Visualization", "Initialising visualizer");
     Initialize();
-
-    HIGHLIGHT_NAMED("Visualization", "Initializing visualization");
 }
+Visualization::~Visualization() = default;
 
 void Visualization::Initialize()
 {
@@ -55,7 +54,7 @@ void Visualization::displayTrajectory(Eigen::MatrixXdRefConst trajectory)
     if (!Server::isRos()) return;
 
     if (trajectory.cols() != scene_->getSolver().getNumControlledJoints())
-        throw_named("Number of DoFs in trajectory does not match number of controlled joints of robot.");
+        throw_pretty("Number of DoFs in trajectory does not match number of controlled joints of robot.");
 
     moveit_msgs::DisplayTrajectory traj_msg;
     traj_msg.model_id = scene_->getRobotModel()->getName();

--- a/exotica/src/Visualization.cpp
+++ b/exotica/src/Visualization.cpp
@@ -51,33 +51,110 @@ void Visualization::Initialize()
 
 void Visualization::displayTrajectory(Eigen::MatrixXdRefConst trajectory)
 {
+    // TODO: Correctly handle dt for time_from_start
+    // TODO:
+    //   http://docs.ros.org/melodic/api/moveit_msgs/html/msg/DisplayTrajectory.html
+
     if (!Server::isRos()) return;
 
     if (trajectory.cols() != scene_->getSolver().getNumControlledJoints())
-        throw_pretty("Number of DoFs in trajectory does not match number of controlled joints of robot.");
+        throw_pretty("Number of DoFs in trajectory does not match number of controlled joints of robot. Got " << trajectory.cols() << " but expected " << scene_->getSolver().getNumControlledJoints());
 
     moveit_msgs::DisplayTrajectory traj_msg;
     traj_msg.model_id = scene_->getSolver().getRobotModel()->getName();
 
-    // TODO:
-    //   http://docs.ros.org/melodic/api/moveit_msgs/html/msg/DisplayTrajectory.html
-    // TODO: Support for fixed and floating base! - multi_dof_joint_trajectory
-    // TODO: Support for uncontrolled joints: trajectory_start
+    const int num_trajectory_points = trajectory.rows();
 
     traj_msg.trajectory.resize(1);
     traj_msg.trajectory[0].joint_trajectory.header.frame_id = scene_->getRootFrameName();
     traj_msg.trajectory[0].joint_trajectory.header.stamp = ros::Time::now();
-    traj_msg.trajectory[0].joint_trajectory.joint_names = scene_->getSolver().getJointNames();
-    traj_msg.trajectory[0].joint_trajectory.points.resize(trajectory.rows());
 
-    for (int i = 0; i < trajectory.rows(); i++)
+    // Floating base support
+    int base_offset = 0;
+    switch (scene_->getSolver().getControlledBaseType())
     {
-        traj_msg.trajectory[0].joint_trajectory.points[i].positions.resize(trajectory.cols());
-        for (int n = 0; n < trajectory.cols(); n++)
+        case BASE_TYPE::FIXED:
+            HIGHLIGHT("Fixed base, no offset");
+            break;
+        case BASE_TYPE::PLANAR:
+            HIGHLIGHT("Planar, offset 3");
+            base_offset = 3;
+            break;
+        case BASE_TYPE::FLOATING:
+            HIGHLIGHT("Floating, offset 6");
+            base_offset = 6;
+            break;
+        default:
+            throw_pretty("Unknown base type.");
+    }
+
+    // Insert floating base if not a fixed-base controlled robot
+    if (scene_->getSolver().getControlledBaseType() != BASE_TYPE::FIXED)
+    {
+        traj_msg.trajectory[0].multi_dof_joint_trajectory.header.frame_id = scene_->getRootFrameName();
+        traj_msg.trajectory[0].multi_dof_joint_trajectory.joint_names.push_back(scene_->getSolver().getRootJointName());
+        traj_msg.trajectory[0].multi_dof_joint_trajectory.points.resize(num_trajectory_points);
+
+        geometry_msgs::Transform base_transform;
+        Eigen::Quaterniond quat;
+        for (int i = 0; i < num_trajectory_points; i++)
         {
-            traj_msg.trajectory[0].joint_trajectory.points[i].positions[n] = trajectory(i, n);
+            base_transform.translation.x = trajectory(i, 0);
+            base_transform.translation.y = trajectory(i, 1);
+
+            if (scene_->getSolver().getControlledBaseType() == BASE_TYPE::FLOATING)
+            {
+                base_transform.translation.z = trajectory(i, 2);
+                quat = Eigen::AngleAxisd(trajectory(i, 3), Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(trajectory(i, 4), Eigen::Vector3d::UnitY()) * Eigen::AngleAxisd(trajectory(i, 5), Eigen::Vector3d::UnitZ());
+            }
+            else if (scene_->getSolver().getControlledBaseType() == BASE_TYPE::PLANAR)
+            {
+                base_transform.translation.z = 0.0;  // TODO: Technically: trans_z
+                quat = Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) * Eigen::AngleAxisd(trajectory(i, 2), Eigen::Vector3d::UnitZ());
+            }
+
+            base_transform.rotation.x = quat.x();
+            base_transform.rotation.y = quat.y();
+            base_transform.rotation.z = quat.z();
+            base_transform.rotation.w = quat.w();
+
+            traj_msg.trajectory[0].multi_dof_joint_trajectory.points[i].transforms.push_back(base_transform);
         }
     }
+
+    // Handle unactuated joints, i.e., joints whose values are not part of the trajectory:
+    // TODO: How to handle unactuated floating-base?
+    traj_msg.trajectory_start.joint_state.header.frame_id = scene_->getRootFrameName();
+
+    // Insert all starting joint states - including the floating base
+    auto model_state_map = scene_->getSolver().getModelStateMap();
+    for (const auto& pair : model_state_map)
+    {
+        // Only push back if not part of the floating base - i.e., the joint name includes the root frame name.
+        if (pair.first.find(scene_->getRootFrameName()) == std::string::npos)
+        {
+            traj_msg.trajectory_start.joint_state.name.push_back(pair.first);
+            traj_msg.trajectory_start.joint_state.position.push_back(pair.second);
+        }
+    }
+
+    // Handle actuated joints - the joint names need to _exclude_ the base joints.
+    const int num_actuated_joints_without_base = trajectory.cols() - base_offset;
+    traj_msg.trajectory[0].joint_trajectory.points.resize(num_trajectory_points);
+    traj_msg.trajectory[0].joint_trajectory.joint_names.resize(num_actuated_joints_without_base);
+    for (int i = 0; i < num_actuated_joints_without_base; i++)
+        traj_msg.trajectory[0].joint_trajectory.joint_names[i] = scene_->getSolver().getJointNames()[base_offset + i];
+
+    // Insert actuated joints without base
+    for (int i = 0; i < num_trajectory_points; i++)
+    {
+        traj_msg.trajectory[0].joint_trajectory.points[i].positions.resize(num_actuated_joints_without_base);
+        for (int n = 0; n < num_actuated_joints_without_base; n++)
+        {
+            traj_msg.trajectory[0].joint_trajectory.points[i].positions[n] = trajectory(i, n + base_offset);
+        }
+    }
+
     trajectory_pub_.publish(traj_msg);
 }
 }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -1,4 +1,5 @@
 #include <exotica/Exotica.h>
+#include <exotica/Visualization.h>
 #undef NDEBUG
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -1057,6 +1058,10 @@ PYBIND11_MODULE(_pyexotica, module)
     collisionScene.def_property("worldLinkPadding", &CollisionScene::getWorldLinkPadding, &CollisionScene::setWorldLinkPadding);
     collisionScene.def("updateCollisionObjectTransforms", &CollisionScene::updateCollisionObjectTransforms);
     collisionScene.def("continuousCollisionCheck", &CollisionScene::continuousCollisionCheck);
+
+    py::class_<Visualization> visualization(module, "Visualization");
+    visualization.def(py::init<Scene_ptr>());
+    visualization.def("displayTrajectory", &Visualization::displayTrajectory);
 
     py::module kin = module.def_submodule("Kinematics", "Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");


### PR DESCRIPTION
Adds a visualization module using the `moveit_msgs::DisplayTrajectory` message. Standalone, can be initialised by passing a Scene. Will be extended in the future. Works with both floating and fixed-base robots.