### PR TITLE
Coloured shapes

### DIFF
--- a/examples/exotica_examples/launch/PythonShapesDemo.launch
+++ b/examples/exotica_examples/launch/PythonShapesDemo.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_shapes.py" name="AttachPythonExampleNode" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz-shapes.rviz" />
+</launch>

--- a/examples/exotica_examples/resources/rviz-shapes.rviz
+++ b/examples/exotica_examples/resources/rviz-shapes.rviz
@@ -1,0 +1,122 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /SceneObjects1
+      Splitter Ratio: 0.512871265411377
+    Tree Height: 725
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /shape_example/CollisionShapes
+      Name: SceneObjects
+      Namespaces:
+        CollisionObjects: true
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: exotica/world_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.6986238956451416
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.024005303159356117
+        Y: 0.15745650231838226
+        Z: 0.8605707883834839
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.14979827404022217
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.5022072792053223
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1052
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001fb00000360fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed00000199000002e20000029ffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000360000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000016300000360fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000360000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000005cfc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004160000036000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/examples/exotica_examples/scripts/example_shapes.py
+++ b/examples/exotica_examples/scripts/example_shapes.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import pyexotica as exo
+from pyexotica.publish_trajectory import *
+import signal
+import time
+
+if __name__ == '__main__':
+    exo.Setup.init_ros("shape_example")
+    solver = exo.Setup.load_solver('{exotica_examples}/resources/configs/ompl_solver_demo.xml')
+
+    # colours are given in tuples (red, green, blue, alpha) in range 0.0...1.0
+    alpha = 1.0
+    black = exo.msgColorRGBA(0, 0, 0, alpha)
+    white = exo.msgColorRGBA(1, 1, 1, alpha)
+    green = exo.msgColorRGBA(0, 1, 0, alpha)
+    orange = exo.msgColorRGBA(1, 0.5, 0, alpha)
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="plane", colour=green, shape=exo.Box(2, 2, 0.01))
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="sphere1", colour=white,
+                shape=exo.Sphere(0.4), transform=exo.KDLFrame([0, 0, 0.4]))
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="sphere2", colour=white,
+                shape=exo.Sphere(0.25), transform=exo.KDLFrame([0, 0, 0.95]))
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="sphere3", colour=white,
+                shape=exo.Sphere(0.15), transform=exo.KDLFrame([0, 0, 1.3]))
+
+    dots = ( [0, 0.375, 0.55], [0, 0.28, 0.68], [0, 0.203, 0.812], [0, 0.25, 0.95], [0, 0.21, 1.07])
+    for idot, coord in enumerate(dots):
+        solver.get_problem().get_scene().add_object_to_environment(
+                    name="dotb"+str(idot), colour=black,
+                    shape=exo.Sphere(0.01), transform=exo.KDLFrame(coord))
+
+    # transformation given as position (x,y,z) + quaternion (w,x,y,z)
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="cone1", colour=orange,
+                shape=exo.Cone(0.01, 0.1), transform=exo.KDLFrame([0, 0.15, 1.3, 1, 0, 0, 1]))
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="cylinder1", colour=black,
+                shape=exo.Cylinder(0.15, 0.01), transform=exo.KDLFrame([0, 0, 1.43]))
+
+    solver.get_problem().get_scene().add_object_to_environment(
+                name="cylinder2", colour=black,
+                shape=exo.Cylinder(0.08, 0.1), transform=exo.KDLFrame([0, 0, 1.48]))
+
+    dots = ([0.036, 0.132, 1.36], [-0.036, 0.132, 1.36])
+    for idot, coord in enumerate(dots):
+        solver.get_problem().get_scene().add_object_to_environment(
+                    name="dote"+str(idot), colour=black,
+                    shape=exo.Sphere(0.015), transform=exo.KDLFrame(coord))
+
+    dots = ([0, 0.142, 1.252], [0.022, 0.143, 1.256], [-0.022, 0.143, 1.256], [0.043, 0.141, 1.263], [-0.043, 0.141, 1.263])
+    for idot, coord in enumerate(dots):
+        solver.get_problem().get_scene().add_object_to_environment(
+                    name="dotm"+str(idot), colour=black,
+                    shape=exo.Sphere(0.01), transform=exo.KDLFrame(coord))
+
+    # publish shapes until SIGINT (e.g. Ctrl+C) is received
+    signal.signal(signal.SIGINT, sig_int_handler)
+    while True:
+        try:
+            solver.get_problem().get_scene().get_kinematic_tree().publish_frames()
+            time.sleep(0.1)
+        except KeyboardInterrupt:
+            break

--- a/examples/exotica_examples/scripts/example_shapes.py
+++ b/examples/exotica_examples/scripts/example_shapes.py
@@ -10,10 +10,10 @@ if __name__ == '__main__':
 
     # colours are given in tuples (red, green, blue, alpha) in range 0.0...1.0
     alpha = 1.0
-    black = exo.msgColorRGBA(0, 0, 0, alpha)
-    white = exo.msgColorRGBA(1, 1, 1, alpha)
-    green = exo.msgColorRGBA(0, 1, 0, alpha)
-    orange = exo.msgColorRGBA(1, 0.5, 0, alpha)
+    black = (0, 0, 0, alpha)
+    white = (1, 1, 1, alpha)
+    green = (0, 1, 0, alpha)
+    orange = (1, 0.5, 0, alpha)
 
     solver.get_problem().get_scene().add_object_to_environment(
                 name="plane", colour=green, shape=exo.Box(2, 2, 0.01))

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -126,7 +126,7 @@ public:
 
     void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shapeResourcePath = "", Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
 
-    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const std_msgs::ColorRGBA& colour = std_msgs::ColorRGBA(), const bool updateCollisionScene = true);
+    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const Eigen::Vector4d& colour = Eigen::Vector4d(), const bool updateCollisionScene = true);
 
     void removeObject(const std::string& name);
 

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -126,7 +126,7 @@ public:
 
     void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shapeResourcePath = "", Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
 
-    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const bool updateCollisionScene = true);
+    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const std_msgs::ColorRGBA& colour = std_msgs::ColorRGBA(), const bool updateCollisionScene = true);
 
     void removeObject(const std::string& name);
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -689,7 +689,7 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
     if (updateCollisionScene) updateCollisionObjects();
 }
 
-void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const std_msgs::ColorRGBA& colour, const bool updateCollisionScene)
+void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const Eigen::Vector4d& colour, const bool updateCollisionScene)
 {
     if (kinematica_.hasModelLink(name))
     {
@@ -698,7 +698,7 @@ void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& tr
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
     ps_->getWorldNonConst()->addToObject(name, shape, pose);
-    ps_->setObjectColor(name, colour);
+    ps_->setObjectColor(name, getColor(colour));
     updateSceneFrames();
     if (updateCollisionScene) updateInternalFrames();
 }

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -689,7 +689,7 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
     if (updateCollisionScene) updateCollisionObjects();
 }
 
-void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const bool updateCollisionScene)
+void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const std_msgs::ColorRGBA& colour, const bool updateCollisionScene)
 {
     if (kinematica_.hasModelLink(name))
     {
@@ -698,6 +698,7 @@ void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& tr
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
     ps_->getWorldNonConst()->addToObject(name, shape, pose);
+    ps_->setObjectColor(name, colour);
     updateSceneFrames();
     if (updateCollisionScene) updateInternalFrames();
 }

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -599,6 +599,21 @@ PYBIND11_MODULE(_pyexotica, module)
              py::arg("Ic") = KDL::RotationalInertia::Zero())
         .def_static("Zero", &KDL::RigidBodyInertia::Zero);
 
+    py::class_<std_msgs::ColorRGBA>(module, "msgColorRGBA")
+        .def(py::init())
+        .def(py::init([](float r, float g, float b, float a) {
+            std_msgs::ColorRGBA c;
+            c.r = r;
+            c.g = g;
+            c.b = b;
+            c.a = a;
+            return c;
+        }))
+        .def_readwrite("r", &std_msgs::ColorRGBA::r)
+        .def_readwrite("g", &std_msgs::ColorRGBA::g)
+        .def_readwrite("b", &std_msgs::ColorRGBA::b)
+        .def_readwrite("a", &std_msgs::ColorRGBA::a);
+
     py::class_<TaskMap, std::shared_ptr<TaskMap>, Object>(module, "TaskMap")
         .def_readonly("id", &TaskMap::Id)
         .def_readonly("start", &TaskMap::Start)
@@ -992,6 +1007,7 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("shape"),
+              py::arg("colour") = std_msgs::ColorRGBA(),
               py::arg("update_collision_scene") = true);
     scene.def("remove_object", &Scene::removeObject);
     scene.def_property_readonly("model_link_to_collision_link_map", &Scene::getModelLinkToCollisionLinkMap);

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -599,21 +599,6 @@ PYBIND11_MODULE(_pyexotica, module)
              py::arg("Ic") = KDL::RotationalInertia::Zero())
         .def_static("Zero", &KDL::RigidBodyInertia::Zero);
 
-    py::class_<std_msgs::ColorRGBA>(module, "msgColorRGBA")
-        .def(py::init())
-        .def(py::init([](float r, float g, float b, float a) {
-            std_msgs::ColorRGBA c;
-            c.r = r;
-            c.g = g;
-            c.b = b;
-            c.a = a;
-            return c;
-        }))
-        .def_readwrite("r", &std_msgs::ColorRGBA::r)
-        .def_readwrite("g", &std_msgs::ColorRGBA::g)
-        .def_readwrite("b", &std_msgs::ColorRGBA::b)
-        .def_readwrite("a", &std_msgs::ColorRGBA::a);
-
     py::class_<TaskMap, std::shared_ptr<TaskMap>, Object>(module, "TaskMap")
         .def_readonly("id", &TaskMap::Id)
         .def_readonly("start", &TaskMap::Start)
@@ -1007,7 +992,7 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("shape"),
-              py::arg("colour") = std_msgs::ColorRGBA(),
+              py::arg("colour") = Eigen::Vector4d(),
               py::arg("update_collision_scene") = true);
     scene.def("remove_object", &Scene::removeObject);
     scene.def_property_readonly("model_link_to_collision_link_map", &Scene::getModelLinkToCollisionLinkMap);


### PR DESCRIPTION
This PR implements a colour option for programmatically added collision shapes, which resembles the functionality from scene files.

It also adds an example for demonstrating different shapes and colours added to the environment:
![exotica_frosty](https://user-images.githubusercontent.com/8226248/50283092-c6274a00-044c-11e9-9105-cc94877a554c.png)

Unfortunately, the `Cone` is represented as `Cylinder` since the Cone shape is not available as RViz marker.