### PR TITLE
get kinematic chain

### DIFF
--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -44,10 +44,10 @@ namespace exotica
 /// \f[
 ///   (SJW)x=y
 /// \f]
-/// Where S is a diagonal matrix of task scaling factors Rho for each task, J is the Jacobian, W is a diagonal matrix 
+/// Where S is a diagonal matrix of task scaling factors Rho for each task, J is the Jacobian, W is a diagonal matrix
 /// of the joint space weights.
 ///
-/// When regularisation term C is used, it gets appended to the Jacobian and distance to the nominal pose is appended 
+/// When regularisation term C is used, it gets appended to the Jacobian and distance to the nominal pose is appended
 /// to the y vector. For more details see:
 /// https://github.com/ipab-slmc/exotica/pull/465#issuecomment-449021817
 ///
@@ -66,7 +66,7 @@ public:
 private:
     IKSolverInitializer parameters_;
 
-    void ScaleToStepSize(Eigen::VectorXdRef xd); //!< \brief Scale the state change vector so that the largest dimension is max. step or smaller.
+    void ScaleToStepSize(Eigen::VectorXdRef xd);  //!< \brief Scale the state change vector so that the largest dimension is max. step or smaller.
 
     UnconstrainedEndPoseProblem_ptr prob_;  // Shared pointer to the planning problem.
 

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -207,6 +207,13 @@ public:
 
     Eigen::VectorXd getModelState();
     std::map<std::string, double> getModelStateMap();
+    /**
+     * @brief getKinematicChain get list of joints in a kinematic chain
+     * @param begin link name from which the chain starts
+     * @param end link name at which the chain ends
+     * @return list joints between begin and end
+     */
+    std::vector<std::string> getKinematicChain(const std::string& begin, const std::string& end);
     void setModelState(Eigen::VectorXdRefConst x);
     void setModelState(std::map<std::string, double> x);
     Eigen::VectorXd getControlledState();

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1020,6 +1020,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematic_tree.def("publish_frames", &KinematicTree::publishFrames);
     kinematic_tree.def("get_root_frame_name", &KinematicTree::getRootFrameName);
     kinematic_tree.def("get_root_joint_name", &KinematicTree::getRootJointName);
+    kinematic_tree.def("get_kinematic_chain", &KinematicTree::getKinematicChain);
     kinematic_tree.def("get_model_base_type", &KinematicTree::getModelBaseType);
     kinematic_tree.def("get_controlled_base_type", &KinematicTree::getControlledBaseType);
     kinematic_tree.def("get_controlled_link_mass", &KinematicTree::getControlledLinkMass);


### PR DESCRIPTION
This PR implements the method `getKinematicChain` to provide the list of joints that connect two links.
It throws if links do not exist, or if there is no connection, e.g. if searching in parallel branches of the tree.

E.g.
```Python
self.problem.get_scene().get_kinematic_tree().get_kinematic_chain("fubar", "robotiq_tool0")
```
will throw:
`Link 'fubar' does not exist.`

```Python
self.problem.get_scene().get_kinematic_tree().get_kinematic_chain("robotiq_finger_middle_link_3", "robotiq_finger_middle_link_2")
```
will throw:
`There is no connection between 'robotiq_finger_middle_link_3' and 'robotiq_finger_middle_link_2'!`