### PR TITLE
Add default colour for addObjectToEnvironment

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -126,7 +126,7 @@ public:
 
     void addObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shapeResourcePath = "", Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool updateCollisionScene = true);
 
-    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const Eigen::Vector4d& colour = Eigen::Vector4d(), const bool updateCollisionScene = true);
+    void addObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const Eigen::Vector4d& colour = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), const bool& updateCollisionScene = true);
 
     void removeObject(const std::string& name);
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -689,7 +689,7 @@ void Scene::addObject(const std::string& name, const KDL::Frame& transform, cons
     if (updateCollisionScene) updateCollisionObjects();
 }
 
-void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const Eigen::Vector4d& colour, const bool updateCollisionScene)
+void Scene::addObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const Eigen::Vector4d& colour, const bool& updateCollisionScene)
 {
     if (kinematica_.hasModelLink(name))
     {

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -992,7 +992,7 @@ PYBIND11_MODULE(_pyexotica, module)
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("shape"),
-              py::arg("colour") = Eigen::Vector4d(),
+              py::arg("colour") = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0),
               py::arg("update_collision_scene") = true);
     scene.def("remove_object", &Scene::removeObject);
     scene.def_property_readonly("model_link_to_collision_link_map", &Scene::getModelLinkToCollisionLinkMap);


### PR DESCRIPTION
`Eigen::Vector4d()` is pointing to uninitialised memory. We should use a default colour, and here we use the same as as in the `KinematicTree` (a grey; noticed when generating Python documentation)