### PR TITLE
[exotica_levenberg_marquardt_solver] Split into source and header

### DIFF
--- a/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
@@ -12,16 +12,18 @@ AddInitializer(LevenbergMarquardtSolver)
 GenInitializers()
 
 catkin_package(
+    INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
     CATKIN_DEPENDS exotica
 )
-include_directories(${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} src/LevenbergMarquardtSolver.cpp)
+add_library(${PROJECT_NAME} src/levenberg_marquardt_solver.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers)
 
 install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(DIRECTORY include/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 install(FILES exotica_plugins.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
@@ -1,0 +1,28 @@
+#ifndef EXOTICA_LEVENBERG_MARQUARDT_SOLVER_LEVENBERG_MARQUARDT_SOLVER_H_
+#define EXOTICA_LEVENBERG_MARQUARDT_SOLVER_LEVENBERG_MARQUARDT_SOLVER_H_
+
+#include <exotica/MotionSolver.h>
+#include <exotica/Problems/UnconstrainedEndPoseProblem.h>
+#include <exotica_levenberg_marquardt_solver/LevenbergMarquardtSolverInitializer.h>
+
+namespace exotica
+{
+class LevenbergMarquardtSolver : public MotionSolver, public Instantiable<LevenbergMarquardtSolverInitializer>
+{
+public:
+    void Instantiate(LevenbergMarquardtSolverInitializer& init) override;
+
+    void Solve(Eigen::MatrixXd& solution) override;
+
+    void specifyProblem(PlanningProblem_ptr pointer) override;
+
+private:
+    LevenbergMarquardtSolverInitializer parameters_;
+
+    UnconstrainedEndPoseProblem_ptr prob_;  ///< Shared pointer to the planning problem.
+
+    double lambda_ = 0;  ///< Damping factor
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_LEVENBERG_MARQUARDT_SOLVER_LEVENBERG_MARQUARDT_SOLVER_H_

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
@@ -1,28 +1,9 @@
-#include <exotica/MotionSolver.h>
-#include <exotica/Problems/UnconstrainedEndPoseProblem.h>
-#include <exotica_levenberg_marquardt_solver/LevenbergMarquardtSolverInitializer.h>
-
-namespace exotica
-{
-class LevenbergMarquardtSolver : public MotionSolver, public Instantiable<LevenbergMarquardtSolverInitializer>
-{
-public:
-    void Instantiate(LevenbergMarquardtSolverInitializer& init) override;
-
-    void Solve(Eigen::MatrixXd& solution) override;
-
-    void specifyProblem(PlanningProblem_ptr pointer) override;
-
-private:
-    LevenbergMarquardtSolverInitializer parameters_;
-
-    UnconstrainedEndPoseProblem_ptr prob_;  // Shared pointer to the planning problem.
-
-    double lambda_ = 0;  // damping factor
-};
+#include "exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h"
 
 REGISTER_MOTIONSOLVER_TYPE("LevenbergMarquardtSolverSolver", exotica::LevenbergMarquardtSolver)
 
+namespace exotica
+{
 void LevenbergMarquardtSolver::Instantiate(LevenbergMarquardtSolverInitializer& init) { parameters_ = init; }
 void LevenbergMarquardtSolver::specifyProblem(PlanningProblem_ptr pointer)
 {


### PR DESCRIPTION
Such that the header can be included for embedding in C++ projects.