### PR TITLE
throw if unsupported rotation type has been selected

### DIFF
--- a/exotations/exotica_core_task_maps/src/eff_orientation.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_orientation.cpp
@@ -42,6 +42,10 @@ void EffOrientation::Instantiate(EffOrientationInitializer& init)
     {
         rotation_type_ = RotationType::QUATERNION;
     }
+    else if (init.Type == "RPY")
+    {
+        rotation_type_ = RotationType::RPY;
+    }
     else if (init.Type == "ZYX")
     {
         rotation_type_ = RotationType::ZYX;
@@ -57,6 +61,10 @@ void EffOrientation::Instantiate(EffOrientationInitializer& init)
     else if (init.Type == "Matrix")
     {
         rotation_type_ = RotationType::MATRIX;
+    }
+    else
+    {
+        ThrowNamed("Unsupported rotation type '" << init.Type << "'");
     }
     stride_ = GetRotationTypeLength(rotation_type_);
 }


### PR DESCRIPTION
Throw an exception if an unsupported rotation type is selected (e.g. for catching typos like "rpy" or "Quaternions") instead of using RPY by default.