### PR TITLE
use RPY task space vector for all rotation types

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_orientation.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_orientation.h
@@ -50,10 +50,6 @@ public:
     int TaskSpaceJacobianDim() override;
 
     std::vector<TaskVectorEntry> GetLieGroupIndices() override;
-    RotationType rotation_type_ = RotationType::RPY;  // TODO: Make private with getter
-
-private:
-    int stride_;
 };
 }
 

--- a/exotations/exotica_core_task_maps/init/eff_orientation.in
+++ b/exotations/exotica_core_task_maps/init/eff_orientation.in
@@ -1,5 +1,3 @@
 class EffOrientation
 
 extend <exotica_core/task_map>
-
-Optional std::string Type = "RPY";

--- a/exotations/exotica_core_task_maps/src/task_map_py.cpp
+++ b/exotations/exotica_core_task_maps/src/task_map_py.cpp
@@ -63,8 +63,7 @@ PYBIND11_MODULE(exotica_core_task_maps_py, module)
 
     py::class_<EffPosition, std::shared_ptr<EffPosition>, TaskMap>(module, "EffPosition");
 
-    py::class_<EffOrientation, std::shared_ptr<EffOrientation>, TaskMap>(module, "EffOrientation")
-        .def_readonly("rotation_type", &EffOrientation::rotation_type_);
+    py::class_<EffOrientation, std::shared_ptr<EffOrientation>, TaskMap>(module, "EffOrientation");
 
     py::class_<EffAxisAlignment, std::shared_ptr<EffAxisAlignment>, TaskMap>(module, "EffAxisAlignment")
         .def("get_axis", &EffAxisAlignment::GetAxis)


### PR DESCRIPTION
Convert all orientations to RPY and use this as 3D task space vector. Fixes #483 .

This would also invalidate PR https://github.com/ipab-slmc/exotica/pull/482.