### PR TITLE
Add support for SE(2) and SE(3) only OMPL problems, fix SE(2) yaw limit bug

### DIFF
--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
@@ -122,12 +122,12 @@ public:
 
         const ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace() const
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
         }
 
         ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace()
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
         }
 
         const ompl::base::SE3StateSpace::StateType &SE3StateSpace() const
@@ -146,6 +146,9 @@ public:
     void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const override;
     void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const override;
     void StateDebug(const Eigen::VectorXd &q) const override;
+
+private:
+    unsigned int dim_ = 6;
 };
 
 class OMPLSE2RNStateSpace : public OMPLStateSpace

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
@@ -163,12 +163,12 @@ public:
 
         const ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace() const
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
         }
 
         ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace()
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
         }
 
         const ompl::base::SE2StateSpace::StateType &SE2StateSpace() const
@@ -187,6 +187,9 @@ public:
     void ExoticaToOMPLState(const Eigen::VectorXd &q, ompl::base::State *state) const override;
     void OMPLToExoticaState(const ompl::base::State *state, Eigen::VectorXd &q) const override;
     void StateDebug(const Eigen::VectorXd &q) const override;
+
+private:
+    unsigned int dim_ = 3;
 };
 
 class OMPLRNProjection : public ompl::base::ProjectionEvaluator

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_exo.h
@@ -122,12 +122,12 @@ public:
 
         const ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace() const
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
         }
 
         ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace()
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
         }
 
         const ompl::base::SE3StateSpace::StateType &SE3StateSpace() const
@@ -163,12 +163,12 @@ public:
 
         const ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace() const
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
         }
 
         ompl::base::RealVectorStateSpace::StateType &RealVectorStateSpace()
         {
-            return *as<ompl::base::RealVectorStateSpace::StateType>(0);
+            return *as<ompl::base::RealVectorStateSpace::StateType>(1);
         }
 
         const ompl::base::SE2StateSpace::StateType &SE2StateSpace() const

--- a/exotica_examples/launch/python_ompl_freebase.launch
+++ b/exotica_examples/launch/python_ompl_freebase.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified_freebase.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_ompl_freebase" name="example_ompl_freebase_node" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/exotica_examples/scripts/example_ompl_freebase
+++ b/exotica_examples/scripts/example_ompl_freebase
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from pyexotica.publish_trajectory import *
+
+exo.Setup.init_ros()
+solver = exo.Setup.load_solver(
+    '{exotica_examples}/resources/configs/example_ompl_freebase.xml')
+
+solution = solver.solve()
+
+plot(solution)
+
+publish_trajectory(solution, 3.0, solver.get_problem())


### PR DESCRIPTION
- Adds support for sampling SE(2) and SE(3) only problems
- Fixes bug in SE(2) state bounds (never set the yaw bound due to wrong iterator limit)
- Resolves #492 