### PR TITLE
Adding manipulability task map

### DIFF
--- a/exotations/exotica_core_task_maps/CMakeLists.txt
+++ b/exotations/exotica_core_task_maps/CMakeLists.txt
@@ -31,6 +31,7 @@ AddInitializer(
   joint_acceleration_backward_difference
   joint_jerk_backward_difference
   look_at
+  manipulability
 )
 GenInitializers()
 
@@ -66,6 +67,7 @@ set(SOURCES
     src/joint_acceleration_backward_difference.cpp
     src/joint_jerk_backward_difference.cpp
     src/look_at.cpp
+    src/manipulability.cpp
 )
 
 add_library(${PROJECT_NAME} ${SOURCES})

--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -59,4 +59,7 @@
   <class name="exotica/LookAt" type="exotica::LookAt" base_class_type="exotica::TaskMap">
     <description>Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.</description>
   </class>
+  <class name="exotica/Manipulability" type="exotica::Manipulability" base_class_type="exotica::TaskMap">
+    <description>Maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be negative. Derivatives are computed using finite differencing.</description>
+  </class>
 </library>

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -49,7 +49,7 @@ namespace exotica
 ///
 /// Note that
 ///   - the assocaited value for \f$\rho\f$ <b>must</b> be negative in order to maximize the manipulability, and
-///   - derivatives of \f$\Phi\f$ are computed using finite differences. 
+///   - derivatives of \f$\Phi\f$ are computed using finite differences.
 class Manipulability : public TaskMap, public Instantiable<ManipulabilityInitializer>
 {
 public:

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2018, University of Edinburgh
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_CORE_TASK_MAPS_MANIPULABILITY_H_
+#define EXOTICA_CORE_TASK_MAPS_MANIPULABILITY_H_
+
+#include <exotica_core/task_map.h>
+
+#include <exotica_core_task_maps/manipulability_initializer.h>
+
+namespace exotica
+{
+/// \class Manipulability
+///
+/// \ingroup TaskMap
+///
+/// \brief Manipulability measure.
+/// The manipulability measure for a robot at a given joint configuration indicates dexterity, that is, how isotropic the robot's motion is with respect to the task space motion. The measure is high when the manipulator is capable of equal motion in all directions and low when the manipulator is close to a singularity. This task map implements Yoshikawa's manipulability measure that is based on the shape of the velocity ellipsoid and expressed by
+/// \f[
+///   Phi(x) := \sqrt{J(x)J(x)^T}
+/// \f]
+/// where $J(x)$ is the manipulator Jacobian matrix.
+///
+/// Note that
+///   - the assocaited value for \f$\rho\f$ <b>must</b> be negative in order to maximize the manipulability, and
+///   - derivatives of \f$\Phi\f$ are computed using finite differences. 
+class Manipulability : public TaskMap, public Instantiable<ManipulabilityInitializer>
+{
+public:
+    Manipulability();
+    virtual ~Manipulability();
+
+    void Instantiate(ManipulabilityInitializer& init) override;
+    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
+    int TaskSpaceDim() override;
+
+private:
+    int n_end_effs_;  ///< Number of end-effectors.
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_CORE_TASK_MAPS_MANIPULABILITY_H_

--- a/exotations/exotica_core_task_maps/init/manipulability.in
+++ b/exotations/exotica_core_task_maps/init/manipulability.in
@@ -1,0 +1,9 @@
+class Manipulability
+
+extend <exotica_core/task_map>
+
+// inherited from TaskMap:
+// string Link           > name of frame in which point is defined
+// VectorXd LinkOffset   > coordinate of point in Link frame
+// string Base           > name of frame in which line is defined
+// VectorXd BaseOffset   > starting point of line in Base frame

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -43,8 +43,7 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     for (int i = 0; i < n_end_effs_; ++i)
     {
       Eigen::MatrixXd J = kinematics[0].jacobian[i].data;
-      Eigen::MatrixXd JJt = J*J.transpose();
-      phi(i) = std::sqrt(JJt.determinant());
+      phi(i) = std::sqrt((J*J.transpose()).determinant());
     }
 }
 

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -38,18 +38,18 @@ Manipulability::~Manipulability() = default;
 
 void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
-  if (phi.rows() != TaskSpaceDim()) ThrowNamed("Wrong size of phi!");
+    if (phi.rows() != TaskSpaceDim()) ThrowNamed("Wrong size of phi!");
 
     for (int i = 0; i < n_end_effs_; ++i)
     {
-      Eigen::MatrixXd J = kinematics[0].jacobian[i].data;
-      phi(i) = std::sqrt((J*J.transpose()).determinant());
+        Eigen::MatrixXd J = kinematics[0].jacobian[i].data;
+        phi(i) = std::sqrt((J * J.transpose()).determinant());
     }
 }
 
 void Manipulability::Instantiate(ManipulabilityInitializer& init)
 {
-  n_end_effs_ = frames_.size();
+    n_end_effs_ = frames_.size();
 }
 
 int Manipulability::TaskSpaceDim()

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2018, University of Edinburgh
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_core_task_maps/manipulability.h>
+
+REGISTER_TASKMAP_TYPE("Manipulability", exotica::Manipulability);
+
+namespace exotica
+{
+Manipulability::Manipulability() = default;
+Manipulability::~Manipulability() = default;
+
+void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+  if (phi.rows() != TaskSpaceDim()) ThrowNamed("Wrong size of phi!");
+
+    for (int i = 0; i < n_end_effs_; ++i)
+    {
+      Eigen::MatrixXd J = kinematics[0].jacobian[i].data;
+      Eigen::MatrixXd JJt = J*J.transpose();
+      phi(i) = std::sqrt(JJt.determinant());
+    }
+}
+
+void Manipulability::Instantiate(ManipulabilityInitializer& init)
+{
+  n_end_effs_ = frames_.size();
+}
+
+int Manipulability::TaskSpaceDim()
+{
+    return n_end_effs_;
+}
+}

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -73,24 +73,37 @@ void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef Phi, Eigen::M
     if (jacobian.rows() != TaskSpaceDim() && jacobian.cols() != x.rows())
         ThrowNamed("Jacobian dimension mismatch!");
 
-    // Store original x (needs to be reset later).
-    Eigen::VectorXd x_original(x);
-    Update(x_original, Phi);
-
-    // Backward finite differencing.
+    // Set constants
     constexpr double h = 1e-6;
-    Eigen::VectorXd x_tmp;
-    Eigen::VectorXd phi_original(Phi);
-    for (int i = 0; i < TaskSpaceDim(); ++i)
-    {
-        x_tmp = x;
-        x_tmp(i) -= h;
-        Update(x_tmp, Phi);
-        jacobian.row(i) = (1 / h) * (phi_original - Phi);
+    constexpr double hi = 1.0/h;
+    int ntask = TaskSpaceDim();
+    int ndof = jacobian.cols();
+
+    // Compute x/Phi using forward mapping (no jacobain)
+    Update(x, Phi);
+
+    // Backward finite differencing
+    for (int i = 0; i < ndof; ++i) {
+
+      // Setup for gradient estimation
+      Eigen::VectorXd x_down = x;
+      x_down(i) -= h;
+      Eigen::VectorXd phi_down;
+      phi_down.resize(ntask);
+
+      // Set x_down as model state
+      scene_->GetKinematicTree().SetModelState(x_down);
+
+      // Compute phi_down using forward mapping (no jacobian)
+      Update(x_down, phi_down);
+
+      // Compute gradient estimate
+      jacobian.col(i) = hi * (Phi - phi_down);
     }
 
-    // Finally, reset with original value again.
-    Update(x_original, Phi);
+    // Reset model state
+    scene_->GetKinematicTree().SetModelState(x);
+
 }
 
 void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef Phi, Eigen::MatrixXdRef jacobian, HessianRef hessian)

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -75,7 +75,7 @@ void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef Phi, Eigen::M
 
     // Set constants
     constexpr double h = 1e-6;
-    constexpr double hi = 1.0/h;
+    constexpr double hi = 1.0 / h;
     int ntask = TaskSpaceDim();
     int ndof = jacobian.cols();
 
@@ -83,27 +83,26 @@ void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef Phi, Eigen::M
     Update(x, Phi);
 
     // Backward finite differencing
-    for (int i = 0; i < ndof; ++i) {
+    for (int i = 0; i < ndof; ++i)
+    {
+        // Setup for gradient estimation
+        Eigen::VectorXd x_down = x;
+        x_down(i) -= h;
+        Eigen::VectorXd phi_down;
+        phi_down.resize(ntask);
 
-      // Setup for gradient estimation
-      Eigen::VectorXd x_down = x;
-      x_down(i) -= h;
-      Eigen::VectorXd phi_down;
-      phi_down.resize(ntask);
+        // Set x_down as model state
+        scene_->GetKinematicTree().SetModelState(x_down);
 
-      // Set x_down as model state
-      scene_->GetKinematicTree().SetModelState(x_down);
+        // Compute phi_down using forward mapping (no jacobian)
+        Update(x_down, phi_down);
 
-      // Compute phi_down using forward mapping (no jacobian)
-      Update(x_down, phi_down);
-
-      // Compute gradient estimate
-      jacobian.col(i) = hi * (Phi - phi_down);
+        // Compute gradient estimate
+        jacobian.col(i) = hi * (Phi - phi_down);
     }
 
     // Reset model state
     scene_->GetKinematicTree().SetModelState(x);
-
 }
 
 void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef Phi, Eigen::MatrixXdRef jacobian, HessianRef hessian)

--- a/exotica_examples/launch/python_manipulability.launch
+++ b/exotica_examples/launch/python_manipulability.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_manipulability" name="example_ik_node" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/exotica_examples/resources/configs/example_manipulability.xml
+++ b/exotica_examples/resources/configs/example_manipulability.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+
+  <IKSolver Name="MySolver">
+    <MaxIterations>1</MaxIterations>
+  </IKSolver>
+
+  <UnconstrainedEndPoseProblem Name="MyProblem">
+
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+    
+    <Maps>
+      <EffFrame Name="Position">
+        <EndEffector>
+            <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
+        </EndEffector>
+      </EffFrame>
+
+      <Manipulability Name="Manip">
+        <EndEffector>
+            <Frame Link="lwr_arm_6_link"/>
+        </EndEffector>
+      </Manipulability>
+      
+    </Maps>
+
+    <Cost>
+      <Task Task="Position" Rho="1"/>
+      <Task Task="Manip" Rho="-1"/>
+    </Cost>
+
+    <StartState>0 0 0 0 0 0 0</StartState>
+    <NominalState>0 0 0 0 0 0 0</NominalState>
+    <W> 7 6 5 4 3 2 1 </W>
+  </UnconstrainedEndPoseProblem>
+
+</IKSolverDemoConfig>

--- a/exotica_examples/resources/configs/example_manipulability.xml
+++ b/exotica_examples/resources/configs/example_manipulability.xml
@@ -35,7 +35,8 @@
       <Task Task="Manip" Rho="-1"/>
     </Cost>
 
-    <StartState>0 0 0 0 0 0 0</StartState>
+    <StartState>1.147249698638916 -0.22851833701133728 0.5324112772941589 1.2311428785324097 -0.19176392257213593 -0.1434374898672104 0</StartState>
+    <!-- <StartState>0 0 0 0 0 0 0</StartState> -->
     <NominalState>0 0 0 0 0 0 0</NominalState>
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedEndPoseProblem>

--- a/exotica_examples/scripts/example_manipulability
+++ b/exotica_examples/scripts/example_manipulability
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from pyexotica.publish_trajectory import *
+from time import sleep
+import signal
+
+
+def figure_eight(t):
+    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2, 0, 0, 0])
+
+
+exo.Setup.init_ros()
+solver = exo.Setup.load_solver(
+    '{exotica_examples}/resources/configs/example_manipulability.xml')
+problem = solver.get_problem()
+
+dt = 0.002
+t = 0.0
+q = array([0.0] * 7)
+print('Publishing IK')
+signal.signal(signal.SIGINT, sig_int_handler)
+while True:
+    try:
+        problem.set_goal('Position', figure_eight(t))
+        problem.start_state = q
+        q = solver.solve()[0]
+        publish_pose(q, problem)
+        sleep(dt)
+        t = t + dt
+    except KeyboardInterrupt:
+        break

--- a/exotica_examples/scripts/example_manipulability
+++ b/exotica_examples/scripts/example_manipulability
@@ -20,7 +20,7 @@ problem = solver.get_problem()
 
 dt = 0.002
 t = 0.0
-q = array([0.0] * 7)
+q = problem.get_scene().get_model_state()
 print('Publishing IK')
 signal.signal(signal.SIGINT, sig_int_handler)
 while True:
@@ -28,6 +28,7 @@ while True:
         problem.set_goal('Position', figure_eight(t))
         problem.start_state = q
         q = solver.solve()[0]
+        print q
         publish_pose(q, problem)
         sleep(dt)
         t = t + dt


### PR DESCRIPTION
* adds the task map for manipulability using Yoshikawa's formula
* currently requires finite differencing
* added an example to accompany task map

# Checklist

- [x] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory