### PR TITLE
[exotica_levenberg_marquardt_solver] Turn Eigen 3.3 warning into status

### DIFF
--- a/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED COMPONENTS exotica_core)
 
 find_package(Eigen3 REQUIRED)
 if(NOT TARGET Eigen3::Eigen)
-    message(WARNING "For best performance, the Levenberg-Marquardt solver requires at least Eigen version 3.3. Using an alternative linear solver.")
+    message(STATUS "For best performance, the Levenberg-Marquardt solver requires at least Eigen version 3.3. Using an alternative linear solver.")
 endif()
 
 AddInitializer(levenberg_marquardt_solver)


### PR DESCRIPTION
The buildfarm reports unstable due to warnings on Kinetic and not on Melodic. Turned into a "status" message to avoid.