### PR TITLE
Adds DynamicsSolver plug-in class and DynamicTimeIndexedShootingProblem

### DIFF
--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(exotica_double_integrator_dynamics_solver)
+
+find_package(catkin REQUIRED COMPONENTS
+  exotica_core
+  roscpp
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS exotica_core
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME} src/double_integrator_dynamics_solver.cpp)
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+install(FILES
+  exotica_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/exotica_plugins.xml
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/exotica_plugins.xml
@@ -1,0 +1,5 @@
+<library path="lib/libexotica_double_integrator_dynamics_solver">
+  <class name="exotica/DoubleIntegratorDynamicsSolver" type="exotica::DoubleIntegratorDynamicsSolver" base_class_type="exotica::DynamicsSolver">
+    <description>Linear pseudo dynamics system</description>
+  </class>
+</library>

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/include/exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/include/exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_H_
+#define EXOTICA_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_H_
+
+#include <exotica_core/dynamics_solver.h>
+
+namespace exotica
+{
+class DoubleIntegratorDynamicsSolver : public DynamicsSolver
+{
+public:
+    DoubleIntegratorDynamicsSolver();
+
+    void AssignScene(ScenePtr scene_in) override;
+
+    StateVector f(const StateVector& x, const ControlVector& u) override;
+    StateDerivative fx(const StateVector& x, const ControlVector& u) override;
+    ControlDerivative fu(const StateVector& x, const ControlVector& u) override;
+
+private:
+    Eigen::MatrixXd A_;
+    Eigen::MatrixXd B_;
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_H_

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/package.xml
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>exotica_double_integrator_dynamics_solver</name>
+  <version>0.0.1</version>
+  <description>Double integrator dynamics solver plug-in for Exotica</description>
+
+  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>exotica_core</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_export_depend>exotica_core</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <exec_depend>exotica_core</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+
+  <export>
+    <exotica_core plugin="${prefix}/exotica_plugins.xml" />
+  </export>
+</package>

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/src/double_integrator_dynamics_solver.cpp
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/src/double_integrator_dynamics_solver.cpp
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver.h>
+
+REGISTER_DYNAMICS_SOLVER_TYPE("DoubleIntegratorDynamicsSolver", exotica::DoubleIntegratorDynamicsSolver)
+
+namespace exotica
+{
+DoubleIntegratorDynamicsSolver::DoubleIntegratorDynamicsSolver() = default;
+
+void DoubleIntegratorDynamicsSolver::AssignScene(ScenePtr scene_in)
+{
+    const int num_positions_in = scene_in->GetKinematicTree().GetNumControlledJoints();
+
+    num_positions_ = num_positions_in;
+    num_velocities_ = num_positions_in;
+    num_controls_ = num_positions_in;
+
+    // Cf. https://en.wikipedia.org/wiki/Double_integrator
+    A_ = Eigen::MatrixXd::Zero(num_positions_ + num_velocities_, num_positions_ + num_velocities_);
+    A_.topRightCorner(num_velocities_, num_velocities_) = Eigen::MatrixXd::Identity(num_velocities_, num_velocities_);
+
+    B_ = Eigen::MatrixXd::Zero(num_positions_ + num_velocities_, num_controls_);
+    B_.bottomRightCorner(num_controls_, num_controls_) = Eigen::MatrixXd::Identity(num_controls_, num_controls_);
+}
+
+Eigen::VectorXd DoubleIntegratorDynamicsSolver::f(const StateVector& x, const ControlVector& u)
+{
+    return A_ * x + B_ * u;
+}
+
+Eigen::MatrixXd DoubleIntegratorDynamicsSolver::fx(const StateVector& x, const ControlVector& u)
+{
+    return A_;
+}
+
+Eigen::MatrixXd DoubleIntegratorDynamicsSolver::fu(const StateVector& x, const ControlVector& u)
+{
+    return B_;
+}
+
+}  // namespace exotica

--- a/exotica_core/CMakeLists.txt
+++ b/exotica_core/CMakeLists.txt
@@ -48,6 +48,7 @@ AddInitializer(
   end_pose_problem
   bounded_time_indexed_problem
   bounded_end_pose_problem
+  dynamic_time_indexed_shooting_problem
 )
 GenInitializers()
 
@@ -95,6 +96,7 @@ add_library(${PROJECT_NAME}
   src/problems/bounded_end_pose_problem.cpp
   src/problems/sampling_problem.cpp
   src/problems/time_indexed_sampling_problem.cpp
+  src/problems/dynamic_time_indexed_shooting_problem.cpp
   src/dynamics_solver.cpp
   ${exotica_core_BINARY_DIR}/generated/version.cpp
 )

--- a/exotica_core/CMakeLists.txt
+++ b/exotica_core/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(${PROJECT_NAME}
   src/problems/bounded_end_pose_problem.cpp
   src/problems/sampling_problem.cpp
   src/problems/time_indexed_sampling_problem.cpp
+  src/dynamics_solver.cpp
   ${exotica_core_BINARY_DIR}/generated/version.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML2_LIBRARIES})

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_CORE_DYNAMICS_SOLVER_H_
+#define EXOTICA_CORE_DYNAMICS_SOLVER_H_
+
+#include <exotica_core/factory.h>
+#include <exotica_core/scene.h>
+#include <exotica_core/tools/uncopyable.h>
+
+#define REGISTER_DYNAMICS_SOLVER_TYPE(TYPE, DERIV) EXOTICA_CORE_REGISTER(exotica::DynamicsSolver, TYPE, DERIV)
+
+namespace exotica
+{
+enum Integrator
+{
+    RK1 = 0,  ///< Forward Euler
+    RK2,      ///< Explicit trapezoid rule
+    // RK4,
+    // RK45
+};
+
+template <typename T, int NX, int NU>
+class AbstractDynamicsSolver : public Uncopyable
+{
+public:
+    typedef Eigen::Matrix<T, NX, 1> StateVector;         ///< Convenience definition for a StateVector containing both position and velocity (dimension NX x 1)
+    typedef Eigen::Matrix<T, NU, 1> ControlVector;       ///< Convenience definition for a ControlVector (dimension NU x 1)
+    typedef Eigen::Matrix<T, NX, NX> StateDerivative;    ///< Convenience definition for a StateDerivative
+    typedef Eigen::Matrix<T, NX, NU> ControlDerivative;  ///< Convenience definition for a ControlDerivative
+
+    AbstractDynamicsSolver();
+    virtual ~AbstractDynamicsSolver();
+
+    /// \brief Passes the Scene of the PlanningProblem to the DynamicsSolver
+    ///
+    ///  Called immediately after creation of the DynamicsSolver plug-in using a pointer to the Scene of the PlanningProblem. This can be used to extract required information from the Scene, e.g., URDF, dimensionality, etc.
+    virtual void AssignScene(ScenePtr scene_in);
+
+    /// \brief Sets the timestep dt to be used for integration.
+    virtual void SetDt(double dt_in);
+
+    /// \brief Forward dynamics
+    virtual StateVector f(const StateVector& x, const ControlVector& u) = 0;
+
+    /// \brief Derivative of the forward dynamics w.r.t. the state
+    virtual StateDerivative fx(const StateVector& x, const ControlVector& u) = 0;
+
+    /// \brief Derivative of the forward dynamics w.r.t. the control
+    virtual ControlDerivative fu(const StateVector& x, const ControlVector& u) = 0;
+
+    // TODO: 2nd-order derivatives to be implemented
+    // virtual StateVector fxx(const StateVector& x, const ControlVector& u);
+    // virtual StateVector fuu(const StateVector& x, const ControlVector& u);
+    // virtual StateVector fxu(const StateVector& x, const ControlVector& u);
+
+    /// \brief Simulates the dynamic system from starting state x using control u for t seconds
+    ///
+    /// Simulates the system and steps the simulation by timesteps dt for a total time of t using the specified integration scheme starting from state x and with controls u.
+    StateVector Simulate(const StateVector& x, const ControlVector& u, T t);
+
+    /// \brief Returns number of controls
+    int get_num_controls() const;
+
+    /// \brief Returns number of positions
+    int get_num_positions() const;
+
+    /// \brief Returns number of velocities
+    int get_num_velocities() const;
+
+    /// \brief Returns integration timestep dt
+    T get_dt() const;
+
+    /// \brief Returns used integration scheme
+    Integrator get_integrator() const;
+
+    /// \brief Sets integrator type
+    void set_integrator(Integrator integrator_in);
+
+protected:
+    int num_controls_;    ///< Number of controls in the dynamic system.
+    int num_positions_;   ///< Number of positions in the dynamic system.
+    int num_velocities_;  ///< Number of velocities in the dynamic system.
+
+    T dt_ = 0.01;                              ///< Internal timestep used for integration. Defaults to 10ms.
+    Integrator integrator_ = Integrator::RK1;  ///< Chosen integrator. Defaults to Euler (RK1).
+
+    /// \brief Integrates the dynamic system from state x with controls u applied for one timestep dt using the selected integrator.
+    inline StateVector Integrate(const StateVector& x, const ControlVector& u);
+};
+
+typedef AbstractDynamicsSolver<double, Eigen::Dynamic, Eigen::Dynamic> DynamicsSolver;
+
+typedef std::shared_ptr<exotica::DynamicsSolver> DynamicsSolverPtr;
+}
+
+#endif  // EXOTICA_CORE_DYNAMICS_SOLVER_H_

--- a/exotica_core/include/exotica_core/exotica_core.h
+++ b/exotica_core/include/exotica_core/exotica_core.h
@@ -30,6 +30,7 @@
 #ifndef EXOTICA_CORE_H_
 #define EXOTICA_CORE_H_
 
+#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/loaders/xml_loader.h>
 #include <exotica_core/motion_solver.h>
 #include <exotica_core/planning_problem.h>

--- a/exotica_core/include/exotica_core/exotica_core.h
+++ b/exotica_core/include/exotica_core/exotica_core.h
@@ -36,6 +36,7 @@
 #include <exotica_core/planning_problem.h>
 #include <exotica_core/problems/bounded_end_pose_problem.h>
 #include <exotica_core/problems/bounded_time_indexed_problem.h>
+#include <exotica_core/problems/dynamic_time_indexed_shooting_problem.h>
 #include <exotica_core/problems/end_pose_problem.h>
 #include <exotica_core/problems/sampling_problem.h>
 #include <exotica_core/problems/time_indexed_problem.h>

--- a/exotica_core/include/exotica_core/object.h
+++ b/exotica_core/include/exotica_core/object.h
@@ -68,7 +68,7 @@ public:
         return object_name_;
     }
 
-    void InstatiateObject(const Initializer& init)
+    void InstantiateObject(const Initializer& init)
     {
         ObjectInitializer oinit(init);
         object_name_ = oinit.Name;

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_CORE_DYNAMIC_TIME_INDEXED_SHOOTING_PROBLEM_H_
+#define EXOTICA_CORE_DYNAMIC_TIME_INDEXED_SHOOTING_PROBLEM_H_
+
+#include <exotica_core/dynamics_solver.h>
+#include <exotica_core/planning_problem.h>
+#include <exotica_core/tasks.h>
+
+#include <exotica_core/dynamic_time_indexed_shooting_problem_initializer.h>
+
+namespace exotica
+{
+class DynamicTimeIndexedShootingProblem : public PlanningProblem, public Instantiable<DynamicTimeIndexedShootingProblemInitializer>
+{
+public:
+    DynamicTimeIndexedShootingProblem();
+    virtual ~DynamicTimeIndexedShootingProblem();
+    void Instantiate(DynamicTimeIndexedShootingProblemInitializer& init) override;
+
+    void PreUpdate() override;
+    void Update(Eigen::VectorXdRefConst u, int t);
+
+    int get_T() const;            ///< Returns the number of timesteps in the state trajectory.
+    void set_T(const int& T_in);  ///< Sets the number of timesteps in the state trajectory.
+
+    double get_tau() const;  ///< Returns the discretization timestep tau
+
+    Eigen::MatrixXd get_X() const;             ///< Returns the state trajectory X
+    void set_X(Eigen::MatrixXdRefConst X_in);  ///< Sets the state trajectory X (can be used as the initial guess)
+
+    Eigen::MatrixXd get_U() const;             ///< Returns the control trajectory U
+    void set_U(Eigen::MatrixXdRefConst U_in);  ///< Sets the control trajectory U (can be used as the initial guess)
+
+    Eigen::MatrixXd get_X_star() const;                  ///< Returns the target state trajectory X
+    void set_X_star(Eigen::MatrixXdRefConst X_star_in);  ///< Sets the target state trajectory X
+
+    Eigen::MatrixXd get_Q(int t) const;               ///< Returns the precision matrix at time step t
+    void set_Q(Eigen::MatrixXdRefConst Q_in, int t);  ///< Sets the precision matrix for time step t
+
+    double GetStateCost(int t) const;
+    double GetControlCost(int t) const;
+
+    Eigen::VectorXd GetStateCostJacobian(int t) const;
+    Eigen::VectorXd GetControlCostJacobian(int t) const;
+
+private:
+    void ReinitializeVariables();
+
+    int T_;       ///< Number of time steps
+    double tau_;  ///< Time step duration
+
+    Eigen::MatrixXd X_;       ///< State trajectory (i.e., positions, velocities). Size: num-states x T
+    Eigen::MatrixXd U_;       ///< Control trajectory. Size: num-controls x (T-1)
+    Eigen::MatrixXd X_star_;  ///< Goal state trajectory (i.e., positions, velocities). Size: num-states x T
+
+    std::vector<Eigen::MatrixXd> Q_;  ///< State space penalty matrix (precision matrix), per time index
+    Eigen::MatrixXd R_;               ///< Control space penalty matrix
+
+    DynamicTimeIndexedShootingProblemInitializer init_;  ///< Stores the problem initializer for re-initialization.
+    DynamicsSolverPtr dynamics_solver_;
+
+    std::vector<std::shared_ptr<KinematicResponse>> kinematic_solutions_;
+};
+
+typedef std::shared_ptr<exotica::DynamicTimeIndexedShootingProblem> DynamicTimeIndexedShootingProblemPtr;
+}
+
+#endif  // EXOTICA_CORE_DYNAMIC_TIME_INDEXED_SHOOTING_PROBLEM_H_

--- a/exotica_core/include/exotica_core/setup.h
+++ b/exotica_core/include/exotica_core/setup.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/factory.h>
 #include <exotica_core/motion_solver.h>
 #include <exotica_core/object.h>
@@ -62,11 +63,13 @@ public:
     static std::shared_ptr<exotica::MotionSolver> CreateSolver(const std::string& type, bool prepend = true) { return ToStdPtr(Instance()->solvers_.createInstance((prepend ? "exotica/" : "") + type)); }
     static std::shared_ptr<exotica::TaskMap> CreateMap(const std::string& type, bool prepend = true) { return ToStdPtr(Instance()->maps_.createInstance((prepend ? "exotica/" : "") + type)); }
     static std::shared_ptr<exotica::PlanningProblem> CreateProblem(const std::string& type, bool prepend = true) { return Instance()->problems_.CreateInstance((prepend ? "exotica/" : "") + type); }
-    static std::shared_ptr<exotica::CollisionScene> CreateCollisionScene(const std::string& type, bool prepend = true) { return ToStdPtr(Instance()->scenes_.createInstance((prepend ? "exotica/" : "") + type)); }
+    static std::shared_ptr<exotica::CollisionScene> CreateCollisionScene(const std::string& type, bool prepend = true) { return ToStdPtr(Instance()->collision_scenes_.createInstance((prepend ? "exotica/" : "") + type)); }
+    static std::shared_ptr<exotica::DynamicsSolver> CreateDynamicsSolver(const std::string& type, bool prepend = true) { return ToStdPtr(Instance()->dynamics_solvers_.createInstance((prepend ? "exotica/" : "") + type)); }
     static std::vector<std::string> GetSolvers();
     static std::vector<std::string> GetProblems();
     static std::vector<std::string> GetMaps();
     static std::vector<std::string> GetCollisionScenes();
+    static std::vector<std::string> GetDynamicsSolvers();
     static std::vector<Initializer> GetInitializers();
 
     static std::shared_ptr<exotica::MotionSolver> CreateSolver(const Initializer& init)
@@ -97,7 +100,8 @@ private:
 
     pluginlib::ClassLoader<exotica::MotionSolver> solvers_;
     pluginlib::ClassLoader<exotica::TaskMap> maps_;
-    pluginlib::ClassLoader<exotica::CollisionScene> scenes_;
+    pluginlib::ClassLoader<exotica::CollisionScene> collision_scenes_;
+    pluginlib::ClassLoader<exotica::DynamicsSolver> dynamics_solvers_;
     PlanningProblemFac problems_;
 };
 

--- a/exotica_core/init/dynamic_time_indexed_shooting_problem.in
+++ b/exotica_core/init/dynamic_time_indexed_shooting_problem.in
@@ -1,0 +1,14 @@
+class DynamicTimeIndexedShootingProblem
+
+extend <exotica_core/planning_problem>
+
+Required int T;
+Required double tau;  // Discretisation timestep of the trajectory
+
+Optional std::string DynamicsSolver = "DoubleIntegratorDynamicsSolver";
+Optional double dt = 0.01;  // dt for simulating dynamics
+
+Optional Eigen::VectorXd Q = Eigen::VectorXd();
+Optional Eigen::VectorXd R = Eigen::VectorXd();
+Optional double Q_rate = 1.;
+Optional double R_rate = 1.;

--- a/exotica_core/src/dynamics_solver.cpp
+++ b/exotica_core/src/dynamics_solver.cpp
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_core/dynamics_solver.h>
+
+namespace exotica
+{
+template class AbstractDynamicsSolver<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+template <typename T, int NX, int NU>
+AbstractDynamicsSolver<T, NX, NU>::AbstractDynamicsSolver() = default;
+
+template <typename T, int NX, int NU>
+AbstractDynamicsSolver<T, NX, NU>::~AbstractDynamicsSolver() = default;
+
+template <typename T, int NX, int NU>
+void AbstractDynamicsSolver<T, NX, NU>::AssignScene(ScenePtr scene_in)
+{
+}
+
+template <typename T, int NX, int NU>
+void AbstractDynamicsSolver<T, NX, NU>::SetDt(double dt_in)
+{
+    if (dt_in < 0.0001) ThrowPretty("dt needs to be strictly greater than 0. Provided: " << dt_in);
+    dt_ = dt_in;
+}
+
+template <typename T, int NX, int NU>
+Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Integrate(const StateVector& x, const ControlVector& u)
+{
+    switch (integrator_)
+    {
+        // Forward Euler (RK1)
+        case Integrator::RK1:
+        {
+            StateVector xdot = f(x, u);
+            return x + dt_ * xdot;
+        }
+        // Explicit trapezoid rule (RK2)
+        case Integrator::RK2:
+        {
+            StateVector xdot0 = f(x, u);
+            StateVector x1est = x + dt_ * xdot0;  // explicit Euler step
+            StateVector xdot1 = f(x1est, u);
+
+            // 2nd order result: x = x0 + dt (xd0+xd1)/2.
+            return x + (dt_ / 2.) * (xdot0 + xdot1);
+        }
+    };
+    ThrowPretty("Not implemented!");
+}
+
+template <typename T, int NX, int NU>
+Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Simulate(const StateVector& x, const ControlVector& u, T t)
+{
+    const int num_timesteps = static_cast<int>(t / dt_);
+    StateVector x_t_plus_1 = x;
+    for (int i = 0; i < num_timesteps; ++i)
+    {
+        x_t_plus_1 = Integrate(x_t_plus_1, u);
+    }
+    return x_t_plus_1;
+}
+
+template <typename T, int NX, int NU>
+int AbstractDynamicsSolver<T, NX, NU>::get_num_controls() const
+{
+    return num_controls_;
+}
+
+template <typename T, int NX, int NU>
+int AbstractDynamicsSolver<T, NX, NU>::get_num_positions() const
+{
+    return num_positions_;
+}
+
+template <typename T, int NX, int NU>
+int AbstractDynamicsSolver<T, NX, NU>::get_num_velocities() const
+{
+    return num_velocities_;
+}
+
+template <typename T, int NX, int NU>
+T AbstractDynamicsSolver<T, NX, NU>::get_dt() const
+{
+    return dt_;
+}
+
+template <typename T, int NX, int NU>
+Integrator AbstractDynamicsSolver<T, NX, NU>::get_integrator() const
+{
+    return integrator_;
+}
+
+template <typename T, int NX, int NU>
+void AbstractDynamicsSolver<T, NX, NU>::set_integrator(Integrator integrator_in)
+{
+    integrator_ = integrator_in;
+}
+
+}  // namespace exotica

--- a/exotica_core/src/motion_solver.cpp
+++ b/exotica_core/src/motion_solver.cpp
@@ -37,7 +37,7 @@ namespace exotica
 {
 void MotionSolver::InstantiateBase(const Initializer& init)
 {
-    Object::InstatiateObject(init);
+    Object::InstantiateObject(init);
     SetNumberOfMaxIterations(MotionSolverInitializer(init).MaxIterations);
 }
 

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -105,7 +105,7 @@ double PlanningProblem::GetStartTime()
 
 void PlanningProblem::InstantiateBase(const Initializer& init_)
 {
-    Object::InstatiateObject(init_);
+    Object::InstantiateObject(init_);
     PlanningProblemInitializer init(init_);
 
     task_maps_.clear();

--- a/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
+++ b/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
@@ -74,7 +74,7 @@ void DynamicTimeIndexedShootingProblem::Instantiate(DynamicTimeIndexedShootingPr
         }
         else
         {
-            ThrowNamed("Q dimension mismatch! Expected " << dynamics_solver_->get_num_controls() << ", got " << init_.R.rows());
+            ThrowNamed("R dimension mismatch! Expected " << dynamics_solver_->get_num_controls() << ", got " << init_.R.rows());
         }
     }
 

--- a/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
+++ b/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
@@ -1,0 +1,295 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_core/problems/dynamic_time_indexed_shooting_problem.h>
+#include <exotica_core/setup.h>
+#include <cmath>
+
+REGISTER_PROBLEM_TYPE("DynamicTimeIndexedShootingProblem", exotica::DynamicTimeIndexedShootingProblem)
+
+namespace exotica
+{
+DynamicTimeIndexedShootingProblem::DynamicTimeIndexedShootingProblem() = default;
+
+DynamicTimeIndexedShootingProblem::~DynamicTimeIndexedShootingProblem() = default;
+
+void DynamicTimeIndexedShootingProblem::Instantiate(DynamicTimeIndexedShootingProblemInitializer& init)
+{
+    init_ = init;
+
+    // Create dynamics solver
+    dynamics_solver_ = Setup::CreateDynamicsSolver(init_.DynamicsSolver);
+    dynamics_solver_->AssignScene(scene_);
+    dynamics_solver_->SetDt(init_.dt);
+
+    // TODO: Strictly speaking N here should correspond to the number of controls, which comes from the dynamic solver - to be fixed!
+    N = scene_->GetKinematicTree().GetNumControlledJoints();
+
+    const int NX = dynamics_solver_->get_num_positions() + dynamics_solver_->get_num_velocities();
+    if (init_.Q.rows() > 0)
+    {
+        ThrowPretty("Not supported yet");
+        // if (init_.Q.rows() == NX)
+        // {
+        //     Q_.diagonal() = init_.Q;
+        // }
+        // else
+        // {
+        //     ThrowNamed("Q dimension mismatch! Expected " << NX << ", got " << init_.Q.rows());
+        // }
+    }
+
+    R_ = init_.R_rate * Eigen::MatrixXd::Identity(dynamics_solver_->get_num_controls(), dynamics_solver_->get_num_controls());
+    if (init_.R.rows() > 0)
+    {
+        if (init_.R.rows() == dynamics_solver_->get_num_controls())
+        {
+            R_.diagonal() = init_.R;
+        }
+        else
+        {
+            ThrowNamed("Q dimension mismatch! Expected " << dynamics_solver_->get_num_controls() << ", got " << init_.R.rows());
+        }
+    }
+
+    T_ = init_.T;
+    tau_ = init_.tau;
+
+    // For now, without inter-/extra-polation for integrators, assure that tau is a multiple of dt
+    const double fmod_tau_dt = std::fmod(static_cast<long double>(1000. * tau_), static_cast<long double>(1000. * init_.dt));
+    if (fmod_tau_dt > 1e-5) ThrowPretty("tau is not a multiple of dt: tau=" << tau_ << ", dt=" << init_.dt << ", mod(" << fmod_tau_dt << ")");
+
+    ApplyStartState(false);
+    ReinitializeVariables();
+}
+
+void DynamicTimeIndexedShootingProblem::ReinitializeVariables()
+{
+    if (debug_) HIGHLIGHT_NAMED("DynamicTimeIndexedShootingProblem", "Initialize problem with T=" << T_);
+
+    const int NX = dynamics_solver_->get_num_positions() + dynamics_solver_->get_num_velocities();
+    X_ = Eigen::MatrixXd::Zero(NX, T_);
+    X_star_ = Eigen::MatrixXd::Zero(NX, T_);
+    U_ = Eigen::MatrixXd::Zero(dynamics_solver_->get_num_controls(), T_ - 1);
+
+    Q_.assign(T_, init_.Q_rate * Eigen::MatrixXd::Identity(NX, NX));
+
+    PreUpdate();
+}
+
+int DynamicTimeIndexedShootingProblem::get_T() const
+{
+    return T_;
+}
+
+void DynamicTimeIndexedShootingProblem::set_T(const int& T_in)
+{
+    if (T_in <= 2)
+    {
+        ThrowNamed("Invalid number of timesteps: " << T_in);
+    }
+    T_ = T_in;
+    ReinitializeVariables();
+}
+
+double DynamicTimeIndexedShootingProblem::get_tau() const
+{
+    return tau_;
+}
+
+void DynamicTimeIndexedShootingProblem::PreUpdate()
+{
+    PlanningProblem::PreUpdate();
+    for (int i = 0; i < tasks_.size(); ++i) tasks_[i]->is_used = false;
+
+    // Create a new set of kinematic solutions with the size of the trajectory
+    // based on the lastest KinematicResponse in order to reflect model state
+    // updates etc.
+    kinematic_solutions_.clear();
+    kinematic_solutions_.resize(T_);
+    for (int i = 0; i < T_; ++i) kinematic_solutions_[i] = std::make_shared<KinematicResponse>(*scene_->GetKinematicTree().GetKinematicResponse());
+}
+
+Eigen::MatrixXd DynamicTimeIndexedShootingProblem::get_X() const
+{
+    return X_;
+}
+
+void DynamicTimeIndexedShootingProblem::set_X(Eigen::MatrixXdRefConst X_in)
+{
+    if (X_in.rows() != X_.rows() || X_in.cols() != X_.cols()) ThrowPretty("Sizes don't match!");
+    X_ = X_in;
+}
+
+Eigen::MatrixXd DynamicTimeIndexedShootingProblem::get_U() const
+{
+    return U_;
+}
+
+void DynamicTimeIndexedShootingProblem::set_U(Eigen::MatrixXdRefConst U_in)
+{
+    if (U_in.rows() != U_.rows() || U_in.cols() != U_.cols()) ThrowPretty("Sizes don't match!");
+    U_ = U_in;
+}
+
+Eigen::MatrixXd DynamicTimeIndexedShootingProblem::get_X_star() const
+{
+    return X_star_;
+}
+
+void DynamicTimeIndexedShootingProblem::set_X_star(Eigen::MatrixXdRefConst X_star_in)
+{
+    if (X_star_in.rows() != X_star_.rows() || X_star_in.cols() != X_star_.cols()) ThrowPretty("Sizes don't match!");
+    X_star_ = X_star_in;
+}
+
+Eigen::MatrixXd DynamicTimeIndexedShootingProblem::get_Q(int t) const
+{
+    if (t >= T_ || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 1;
+    }
+    return Q_[t];
+}
+
+void DynamicTimeIndexedShootingProblem::set_Q(Eigen::MatrixXdRefConst Q_in, int t)
+{
+    if (t >= T_ || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 1;
+    }
+    if (Q_in.rows() != Q_[t].rows() || Q_in.cols() != Q_[t].cols()) ThrowPretty("Dimension mismatch!");
+    Q_[t] = Q_in;
+}
+
+void DynamicTimeIndexedShootingProblem::Update(Eigen::VectorXdRefConst u_in, int t)
+{
+    // We can only update t=0, ..., T-1 - the last state will be created from integrating u_{T-1} to get x_T
+    if (t >= (T_ - 1) || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_ - 1);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 2;
+    }
+
+    U_.col(t) = u_in;
+
+    // Set the corresponding KinematicResponse for KinematicTree in order to
+    // have Kinematics elements updated based in x_in.
+    scene_->GetKinematicTree().SetKinematicResponse(kinematic_solutions_[t]);
+
+    // Pass the corresponding number of relevant task kinematics to the TaskMaps
+    // via the PlanningProblem::updateMultipleTaskKinematics method. For now we
+    // support passing _two_ timesteps - this can be easily changed later on.
+    std::vector<std::shared_ptr<KinematicResponse>> kinematics_solutions{kinematic_solutions_[t]};
+
+    // If the current timestep is 0, pass the 0th timestep's response twice.
+    // Otherwise pass the (t-1)th response.
+    kinematics_solutions.emplace_back((t == 0) ? kinematic_solutions_[t] : kinematic_solutions_[t - 1]);
+
+    // Actually update the tasks' kinematics mappings.
+    PlanningProblem::updateMultipleTaskKinematics(kinematics_solutions);
+
+    // Simulate for tau
+    X_.col(t + 1) = dynamics_solver_->Simulate(X_.col(t), U_.col(t), tau_);
+
+    scene_->Update(X_.col(t + 1).topRows(N), static_cast<double>(t) * tau_);
+
+    // TODO: Cost, Equality, Inequality
+
+    ++number_of_problem_updates_;
+}
+
+double DynamicTimeIndexedShootingProblem::GetStateCost(int t) const
+{
+    if (t >= T_ || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 1;
+    }
+    const Eigen::VectorXd x_diff = X_star_.col(t) - X_.col(t);
+    return (x_diff.transpose() * Q_[t] * x_diff);
+}
+
+Eigen::VectorXd DynamicTimeIndexedShootingProblem::GetStateCostJacobian(int t) const
+{
+    if (t >= T_ || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 1;
+    }
+    const Eigen::VectorXd x_diff = X_star_.col(t) - X_.col(t);
+    return x_diff.transpose() * Q_[t] * dynamics_solver_->fu(X_.col(t), U_.col(t)) * -2.0;
+}
+
+double DynamicTimeIndexedShootingProblem::GetControlCost(int t) const
+{
+    if (t >= T_ - 1 || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_ - 1);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 2;
+    }
+    return U_.col(t).transpose() * R_ * U_.col(t);
+}
+
+Eigen::VectorXd DynamicTimeIndexedShootingProblem::GetControlCostJacobian(int t) const
+{
+    if (t >= T_ - 1 || t < -1)
+    {
+        ThrowPretty("Requested t=" << t << " out of range, needs to be 0 =< t < " << T_ - 1);
+    }
+    else if (t == -1)
+    {
+        t = T_ - 2;
+    }
+    return U_.col(t) * R_ * 2.0;
+}
+
+// min (mu-x)^T * Q * (mu-x) + u^T * R * u
+
+}  // namespace exotica

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -58,7 +58,7 @@ std::string Scene::GetName()
 
 void Scene::Instantiate(SceneInitializer& init)
 {
-    Object::InstatiateObject(init);
+    Object::InstantiateObject(init);
     name_ = object_name_;
     kinematica_.debug = debug_;
     force_collision_ = init.AlwaysUpdateCollisionScene;

--- a/exotica_core/src/setup.cpp
+++ b/exotica_core/src/setup.cpp
@@ -65,8 +65,14 @@ void Setup::PrintSupportedClasses()
         HIGHLIGHT(" '" << s << "'");
     }
     HIGHLIGHT("Registered collision scenes:");
-    std::vector<std::string> scenes = Instance()->scenes_.getDeclaredClasses();
+    std::vector<std::string> scenes = Instance()->collision_scenes_.getDeclaredClasses();
     for (std::string s : scenes)
+    {
+        HIGHLIGHT(" '" << s << "'");
+    }
+    HIGHLIGHT("Registered dynamics solvers:");
+    std::vector<std::string> dynamics_solvers = Instance()->dynamics_solvers_.getDeclaredClasses();
+    for (std::string s : dynamics_solvers)
     {
         HIGHLIGHT(" '" << s << "'");
     }
@@ -112,8 +118,13 @@ std::vector<Initializer> Setup::GetInitializers()
 std::vector<std::string> Setup::GetSolvers() { return Instance()->solvers_.getDeclaredClasses(); }
 std::vector<std::string> Setup::GetProblems() { return Instance()->problems_.GetDeclaredClasses(); }
 std::vector<std::string> Setup::GetMaps() { return Instance()->maps_.getDeclaredClasses(); }
-std::vector<std::string> Setup::GetCollisionScenes() { return Instance()->scenes_.getDeclaredClasses(); }
-Setup::Setup() : solvers_("exotica_core", "exotica::MotionSolver"), maps_("exotica_core", "exotica::TaskMap"), problems_(PlanningProblemFac::Instance()), scenes_("exotica_core", "exotica::CollisionScene")
+std::vector<std::string> Setup::GetCollisionScenes() { return Instance()->collision_scenes_.getDeclaredClasses(); }
+std::vector<std::string> Setup::GetDynamicsSolvers() { return Instance()->dynamics_solvers_.getDeclaredClasses(); }
+Setup::Setup() : solvers_("exotica_core", "exotica::MotionSolver"),
+                 maps_("exotica_core", "exotica::TaskMap"),
+                 problems_(PlanningProblemFac::Instance()),
+                 collision_scenes_("exotica_core", "exotica::CollisionScene"),
+                 dynamics_solvers_("exotica_core", "exotica::DynamicsSolver")
 {
 }
 }

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -50,7 +50,7 @@ std::string TaskMap::Print(std::string prepend)
 
 void TaskMap::InstantiateBase(const Initializer& init)
 {
-    Object::InstatiateObject(init);
+    Object::InstantiateObject(init);
     TaskMapInitializer MapInitializer(init);
     is_used = true;
 

--- a/exotica_examples/resources/configs/example_dynamic_time_indexed_problem.xml
+++ b/exotica_examples/resources/configs/example_dynamic_time_indexed_problem.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<PlannerDemoConfig>
+  <DynamicTimeIndexedShootingProblem Name="MyProblem">
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+      </Scene>
+    </PlanningScene>
+   
+    <T>50</T>
+    <tau>0.1</tau>
+    <dt>0.1</dt>
+    <Q_rate>1000</Q_rate>
+    <R_rate>1</R_rate>
+    <!-- <Q>10 10 10 10 10 10 10 1 1 1 1 1 1 1</Q> -->
+  </DynamicTimeIndexedShootingProblem>
+</PlannerDemoConfig>

--- a/exotica_examples/scripts/example_dynamic_time_indexed_problem
+++ b/exotica_examples/scripts/example_dynamic_time_indexed_problem
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+from __future__ import print_function, division
+
+import scipy.optimize as opt
+import matplotlib.pyplot as plt
+import pyexotica as exo
+import numpy as np
+from time import time, sleep
+
+exo.Setup.init_ros()
+sleep(0.2)
+
+prob = exo.Initializers.load_xml(
+    '{exotica_examples}/resources/configs/example_dynamic_time_indexed_problem.xml')
+problem = exo.Setup.create_problem(prob)
+
+print("Constant acceleration to show evolution of system dynamics:")
+s = time()
+for t in xrange(problem.T - 1):
+    u_rand = 0.1 * np.ones((problem.N, 1))
+    problem.update(u_rand, t)
+    problem.get_scene().get_kinematic_tree().publish_frames()
+    sleep(problem.tau)
+e = time()
+print("Time taken to roll-out:", e-s)
+
+'''
+# Visualize: We should see a quadratically increasing position and linear increasing velocity.
+plt.plot(problem.X[:problem.N, :].T)
+plt.title("Positions")
+plt.show()
+
+plt.plot(problem.X[problem.N:, :].T)
+plt.title("Velocities")
+plt.show()
+'''
+
+# Set costs: only penalise states at end of trajectory (Q_f)
+for t in xrange(problem.T - 1):
+    problem.set_Q(0. * problem.get_Q(t), t)
+
+# Set random guess (initial control trajectory)
+problem.U = 0.1 * np.random.rand(problem.U.shape[0], problem.U.shape[1])
+
+# Set target (final state)
+X_star = problem.X_star.copy()
+X_star[0:7, -1] = np.array([0, 0, 0, np.pi/2., 0, -0.5, 0]).T
+problem.X_star = X_star
+
+# Compute cost of roll-out of initial control trajectory
+cost = 0.0
+for t in xrange(problem.T):
+    cost += problem.get_state_cost(t)
+for t in xrange(problem.T - 1):
+    cost += problem.get_control_cost(t)
+print("Initial cost:", cost)
+
+# Set up simple optimization problem
+def cost_function(u):
+    for t in xrange(problem.T - 1):
+        problem.update(u[7 * t: 7 * t + 7], t)
+    cost = 0.0
+    for t in xrange(problem.T):
+        cost += problem.get_state_cost(t)
+    for t in xrange(problem.T - 1):
+        cost += problem.get_control_cost(t)
+    return cost
+
+'''
+# TODO: This needs to use a recursive update (backwards)
+def cost_jacobian(u):
+    for t in xrange(problem.T - 1):
+        problem.update(u[7 * t: 7 * t + 7], t)
+    # Update value function recursively - TODO
+    jac = np.zeros(u.shape[0],)
+    for t in xrange(1, problem.T):
+        # print(t, problem.get_state_cost(t), problem.get_state_cost_jacobian(t))
+        jac[7 * t - 7: 7 * t] += problem.get_state_cost_jacobian(t)
+    # for t in xrange(0, problem.T-1):
+    #    jac[7 * t : 7 * t + 7] += problem.get_control_cost_jacobian(t)
+    return jac
+
+# from scipy.optimize import check_grad
+# print(check_grad(cost_function, cost_jacobian, problem.U.flatten()))
+'''
+
+s = time()
+u_init = problem.U.flatten()
+res = opt.minimize(cost_function, x0=problem.U.flatten(), method='BFGS')
+e = time()
+print("Optimal solution found in", e-s)
+
+for t in xrange(problem.T - 1):
+    problem.update(res.x[problem.N * t:problem.N * t + problem.N], t)
+
+from pyexotica.publish_trajectory import publish_trajectory
+publish_trajectory(problem.X[0:7,:].T, problem.T * problem.tau, problem)
+
+# Visualize final result - the velocity should be smooth
+plt.plot(problem.X[:problem.N, :].T)
+plt.title("Positions")
+plt.show()
+
+plt.plot(problem.X[problem.N:, :].T)
+plt.title("Velocities")
+plt.show()
+
+plt.plot(problem.U.T)
+plt.title("Accelerations")
+plt.show()

--- a/exotica_examples/test/test_core
+++ b/exotica_examples/test/test_core
@@ -20,6 +20,8 @@ def test_getters():
     print(exo.Setup().get_solvers())
     print(exo.Setup().get_problems())
     print(exo.Setup().get_maps())
+    print(exo.Setup().get_collision_scenes())
+    print(exo.Setup().get_dynamics_solvers())
     exo.Setup().get_initializers()
     print(exo.Setup().get_package_path('exotica_python'))
 

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -908,6 +908,21 @@ PYBIND11_MODULE(_pyexotica, module)
     time_indexed_sampling_problem.def("get_goal_neq", &TimeIndexedSamplingProblem::GetGoalNEQ);
     time_indexed_sampling_problem.def("get_rho_neq", &TimeIndexedSamplingProblem::GetRhoNEQ);
 
+    py::class_<DynamicTimeIndexedShootingProblem, std::shared_ptr<DynamicTimeIndexedShootingProblem>, PlanningProblem>(prob, "DynamicTimeIndexedShootingProblem")
+        .def("update", &DynamicTimeIndexedShootingProblem::Update)
+        .def_property("X", &DynamicTimeIndexedShootingProblem::get_X, &DynamicTimeIndexedShootingProblem::set_X)
+        .def_property("U", &DynamicTimeIndexedShootingProblem::get_U, &DynamicTimeIndexedShootingProblem::set_U)
+        .def_property("X_star", &DynamicTimeIndexedShootingProblem::get_X_star, &DynamicTimeIndexedShootingProblem::set_X_star)
+        .def_property_readonly("tau", &DynamicTimeIndexedShootingProblem::get_tau)
+        .def_property("T", &DynamicTimeIndexedShootingProblem::get_T, &DynamicTimeIndexedShootingProblem::set_T)
+        .def_readonly("N", &DynamicTimeIndexedShootingProblem::N)
+        .def("get_Q", &DynamicTimeIndexedShootingProblem::get_Q)
+        .def("set_Q", &DynamicTimeIndexedShootingProblem::set_Q)
+        .def("get_state_cost", &DynamicTimeIndexedShootingProblem::GetStateCost)
+        .def("get_state_cost_jacobian", &DynamicTimeIndexedShootingProblem::GetStateCostJacobian)
+        .def("get_control_cost", &DynamicTimeIndexedShootingProblem::GetControlCost)
+        .def("get_control_cost_jacobian", &DynamicTimeIndexedShootingProblem::GetControlCostJacobian);
+
     py::class_<CollisionProxy, std::shared_ptr<CollisionProxy>> collision_proxy(module, "CollisionProxy");
     collision_proxy.def(py::init());
     collision_proxy.def_readonly("contact_1", &CollisionProxy::contact1);

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -493,6 +493,7 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("get_problems", &Setup::GetProblems, "Returns a list of available problems.");
     setup.def_static("get_maps", &Setup::GetMaps, "Returns a list of available task maps.");
     setup.def_static("get_collision_scenes", &Setup::GetCollisionScenes, "Returns a list of available collision scene plug-ins.");
+    setup.def_static("get_dynamics_solvers", &Setup::GetDynamicsSolvers, "Returns a list of available dynamics solvers plug-ins.");
     setup.def_static("create_solver", [](const Initializer& init) { return Setup::CreateSolver(init); }, py::return_value_policy::take_ownership);    // "Creates an instance of the solver identified by name parameter.", py::arg("solverType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_problem", [](const Initializer& init) { return Setup::CreateProblem(init); }, py::return_value_policy::take_ownership);  // "Creates an instance of the problem identified by name parameter.", py::arg("problemType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_map", [](const Initializer& init) { return Setup::CreateMap(init); }, py::return_value_policy::take_ownership);          // "Creates an instance of the task map identified by name parameter.", py::arg("taskmapType"), py::arg("prependExoticaNamespace"));


### PR DESCRIPTION
This is the first step to adding problems involving dynamics into Exotica. As part of this, this pull request:

1. Introduces a new plug-in class, `DynamicsSolver`, based off the abstract `AbstractDynamicsSolver` class. The dynamics can hereby be either from an implementation of the Articulated Body Algorithm (forward dynamics), or explicit hard-coded dynamics. These are to be implemented in plug-ins. The dynamics solver contains different integration scheme - for now only Euler and explicit trapezoidal (more to be added - RK4, RK45).
2. As a first type of such a plug-in, the canonical double integrator (i.e., `DoubleIntegratorDynamicsSolver`)
3. A first trajectory optimisation problem containing dynamics (indirect optimal control - shooting problem): `DynamicTimeIndexedShootingProblem`.
4. A simple example to run a double integrator dynamics solver on the LWR using Python, and solving an indirect optimal control problem using finite differences (with a scipy solver - the first example for showing the use of an external/Python solver in combination with an Exotica planning problem).

This PR leaves lots of todo items and good starting points.
