### PR TITLE
Create scene method

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 - [ ] add unit test(s)
 
-- [ ] ensure tests build and check results: run `catkin run_tests && catkin_test_results`
+- [ ] ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -84,6 +84,7 @@ public:
     Eigen::VectorXd GetControlledState();
     Eigen::VectorXd GetModelState();
     std::map<std::string, double> GetModelStateMap();
+    std::map<std::string, std::weak_ptr<KinematicElement>> GetTreeMap();
     void SetModelState(Eigen::VectorXdRefConst x, double t = 0, bool update_traj = true);
     void SetModelState(std::map<std::string, double> x, double t = 0, bool update_traj = true);
     std::string GetGroupName();

--- a/exotica_core/include/exotica_core/setup.h
+++ b/exotica_core/include/exotica_core/setup.h
@@ -78,12 +78,6 @@ public:
         ret->InstantiateInternal(init);
         return ret;
     }
-    static std::shared_ptr<exotica::TaskMap> CreateMap(const Initializer& init)
-    {
-        std::shared_ptr<exotica::TaskMap> ret = ToStdPtr(Instance()->maps_.createInstance(init.GetName()));
-        ret->InstantiateInternal(init);
-        return ret;
-    }
     static std::shared_ptr<exotica::PlanningProblem> CreateProblem(const Initializer& init)
     {
         std::shared_ptr<exotica::PlanningProblem> ret = Instance()->problems_.CreateInstance(init.GetName());
@@ -108,11 +102,19 @@ public:
     }
 
 private:
+    friend PlanningProblem;
     Setup();
     static std::shared_ptr<Setup> singleton_initialiser_;
     // Make sure the singleton does not get copied
     Setup(Setup const&) = delete;
     void operator=(Setup const&) = delete;
+
+    static std::shared_ptr<exotica::TaskMap> CreateMap(const Initializer& init)
+    {
+        std::shared_ptr<exotica::TaskMap> ret = ToStdPtr(Instance()->maps_.createInstance(init.GetName()));
+        ret->InstantiateInternal(init);
+        return ret;
+    }
 
     pluginlib::ClassLoader<exotica::MotionSolver> solvers_;
     pluginlib::ClassLoader<exotica::TaskMap> maps_;

--- a/exotica_core/include/exotica_core/setup.h
+++ b/exotica_core/include/exotica_core/setup.h
@@ -91,6 +91,22 @@ public:
         return ret;
     }
 
+    ///
+    /// \brief CreateScene instantiate a scene from an initialiser
+    ///     The returned scene is independent of the internal EXOTica solver
+    ///     or problem state. It can only be used to access the parsed information
+    ///     like joint and link names or the kinematics. Changes to the scene
+    ///     will not affect the solver or problem.
+    /// \param init scene initialiser
+    /// \return a shared pointer to the scene
+    ///
+    static exotica::ScenePtr CreateScene(const Initializer& init)
+    {
+        exotica::ScenePtr ret = std::make_shared<exotica::Scene>();
+        ret->InstantiateInternal(init);
+        return ret;
+    }
+
 private:
     Setup();
     static std::shared_ptr<Setup> singleton_initialiser_;

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -429,6 +429,11 @@ std::map<std::string, double> Scene::GetModelStateMap()
     return kinematica_.GetModelStateMap();
 }
 
+std::map<std::string, std::weak_ptr<KinematicElement>> Scene::GetTreeMap()
+{
+    return kinematica_.GetTreeMap();
+}
+
 void Scene::SetModelState(Eigen::VectorXdRefConst x, double t, bool update_traj)
 {
     if (request_needs_updating_ && kinematic_request_callback_)

--- a/exotica_examples/test/test_scene_creation
+++ b/exotica_examples/test/test_scene_creation
@@ -74,6 +74,24 @@ class TestClass(unittest.TestCase):
     def test_clean_FullProblem(self):
         test_scene('FullProblem', True)
 
+    def test_creation(self):
+        scene_conf = {'URDF': "{exotica_examples}/resources/robots/lwr_simplified.urdf",
+                      'SRDF': "{exotica_examples}/resources/robots/lwr_simplified.srdf",
+                      'JointGroup': "arm"}
+
+        # create scene with URDF frames
+        scene1 = exo.Setup.create_scene(('exotica/Scene', scene_conf))
+        scene_links1 = scene1.get_tree_names()
+
+        # add additional frame
+        frame_name = "camera_frame"
+        scene_conf.update({'Links': [('exotica/Link', {'Name': frame_name, 'Transform': [0, 0, 0, 1, 0, 0, 0]})]})
+        scene2 = exo.Setup.create_scene(('exotica/Scene', scene_conf))
+        scene_links2 = scene2.get_tree_names()
+
+        # check
+        self.assertEqual((set(scene_links1) | {frame_name}), set(scene_links2))
+
 
 if __name__ == '__main__':
     import rostest

--- a/exotica_examples/test/test_scene_creation
+++ b/exotica_examples/test/test_scene_creation
@@ -56,9 +56,6 @@ class TestClass(unittest.TestCase):
     def test_clean_MinimalProblem(self):
         test_scene('MinimalProblem', True)
 
-    def test_clean_MinimalProblem(self):
-        test_scene('MinimalProblem', True)
-
     def test_clean_TrajectoryProblem(self):
         test_scene('TrajectoryProblem', True)
 

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -497,7 +497,6 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("create_solver", [](const Initializer& init) { return Setup::CreateSolver(init); }, py::return_value_policy::take_ownership);    // "Creates an instance of the solver identified by name parameter.", py::arg("solverType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_problem", [](const Initializer& init) { return Setup::CreateProblem(init); }, py::return_value_policy::take_ownership);  // "Creates an instance of the problem identified by name parameter.", py::arg("problemType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_scene", [](const Initializer& init) { return Setup::CreateScene(init); }, py::return_value_policy::take_ownership);
-    setup.def_static("create_map", [](const Initializer& init) { return Setup::CreateMap(init); }, py::return_value_policy::take_ownership);          // "Creates an instance of the task map identified by name parameter.", py::arg("taskmapType"), py::arg("prependExoticaNamespace"));
     setup.def_static("print_supported_classes", &Setup::PrintSupportedClasses, "Print a list of available plug-ins sorted by class.");
     setup.def_static("get_initializers", &Setup::GetInitializers, py::return_value_policy::copy, "Returns a list of available initializers with all available parameters/arguments.");
     setup.def_static("get_package_path", &ros::package::getPath, "ROS package path resolution.");

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -496,6 +496,7 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("get_dynamics_solvers", &Setup::GetDynamicsSolvers, "Returns a list of available dynamics solvers plug-ins.");
     setup.def_static("create_solver", [](const Initializer& init) { return Setup::CreateSolver(init); }, py::return_value_policy::take_ownership);    // "Creates an instance of the solver identified by name parameter.", py::arg("solverType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_problem", [](const Initializer& init) { return Setup::CreateProblem(init); }, py::return_value_policy::take_ownership);  // "Creates an instance of the problem identified by name parameter.", py::arg("problemType"), py::arg("prependExoticaNamespace"));
+    setup.def_static("create_scene", [](const Initializer& init) { return Setup::CreateScene(init); }, py::return_value_policy::take_ownership);
     setup.def_static("create_map", [](const Initializer& init) { return Setup::CreateMap(init); }, py::return_value_policy::take_ownership);          // "Creates an instance of the task map identified by name parameter.", py::arg("taskmapType"), py::arg("prependExoticaNamespace"));
     setup.def_static("print_supported_classes", &Setup::PrintSupportedClasses, "Print a list of available plug-ins sorted by class.");
     setup.def_static("get_initializers", &Setup::GetInitializers, py::return_value_policy::copy, "Returns a list of available initializers with all available parameters/arguments.");

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -961,6 +961,14 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("get_model_joint_names", &Scene::GetModelJointNames);
     scene.def("get_model_state", &Scene::GetModelState);
     scene.def("get_model_state_map", &Scene::GetModelStateMap);
+    scene.def("get_tree_names", [](Scene& scene) {
+        std::vector<std::string> frame_names;
+        for (const auto& m : scene.GetTreeMap())
+        {
+            frame_names.push_back(m.first);
+        }
+        return frame_names;
+    });
     scene.def("set_model_state", (void (Scene::*)(Eigen::VectorXdRefConst, double, bool)) & Scene::SetModelState, py::arg("x"), py::arg("t") = 0.0, py::arg("update_trajectory") = false);
     scene.def("set_model_state_map", (void (Scene::*)(std::map<std::string, double>, double, bool)) & Scene::SetModelState, py::arg("x"), py::arg("t") = 0.0, py::arg("update_trajectory") = false);
     scene.def("get_controlled_state", &Scene::GetControlledState);


### PR DESCRIPTION
This adds the `CreateScene` method to instantiate a scene from an Initializer.

It can be used, e.g. for getting the model links before a problem is created:
```Python
model_links = exo.Setup.create_scene(('exotica/Scene', scene)).get_model_link_names()
```