### PR TITLE
AICO clean-up, add world-links-to-exclude to Scene, fix equality constraint checks, OMPL planning time, UML diagrams

### DIFF
--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -54,14 +54,18 @@ void CollisionSceneFCLLatest::Setup()
 
 void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)
 {
-    kinematic_elements_ = MapToVec(objects);
+    kinematic_elements_.clear();
     fcl_cache_.clear();
-    fcl_objects_.resize(objects.size());
+    fcl_objects_.reserve(objects.size());
     long i = 0;
     for (const auto& object : objects)
     {
         // Check whether object is excluded as a world collision object:
-        if (world_links_to_exclude_from_collision_scene.count(object.first) != 0) continue;
+        if (world_links_to_exclude_from_collision_scene.count(object.first) != 0)
+        {
+            HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", object.first << " is excluded, skipping.");
+            continue;
+        }
 
         std::shared_ptr<fcl::CollisionObjectd> new_object;
 
@@ -79,6 +83,7 @@ void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string,
         //     new_object = cache_entry->second;
         // }
         fcl_objects_[i++] = new_object.get();
+        kinematic_elements_.emplace_back(object.second);
     }
 }
 

--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -56,34 +56,38 @@ void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string,
 {
     kinematic_elements_.clear();
     fcl_cache_.clear();
+    fcl_objects_.clear();
     fcl_objects_.reserve(objects.size());
     long i = 0;
     for (const auto& object : objects)
     {
         // Check whether object is excluded as a world collision object:
-        if (world_links_to_exclude_from_collision_scene.count(object.first) != 0)
+        if (world_links_to_exclude_from_collision_scene.count(object.first) > 0)
         {
             HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", object.first << " is excluded, skipping.");
-            continue;
         }
+        else
+        {
+            HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", "Creating " << object.first);
+            std::shared_ptr<fcl::CollisionObjectd> new_object;
 
-        std::shared_ptr<fcl::CollisionObjectd> new_object;
-
-        // const auto& cache_entry = fcl_cache_.find(object.first);
-        // TODO: There is currently a bug with the caching causing proxies not
-        // to update. The correct fix would be to update the user data, for now
-        // disable use of the cache.
-        // if (true)  // (cache_entry == fcl_cache_.end())
-        // {
-        new_object = ConstructFclCollisionObject(i, object.second.lock());
-        fcl_cache_[object.first] = new_object;
-        // }
-        // else
-        // {
-        //     new_object = cache_entry->second;
-        // }
-        fcl_objects_[i++] = new_object.get();
-        kinematic_elements_.emplace_back(object.second);
+            // const auto& cache_entry = fcl_cache_.find(object.first);
+            // TODO: There is currently a bug with the caching causing proxies not
+            // to update. The correct fix would be to update the user data, for now
+            // disable use of the cache.
+            // if (true)  // (cache_entry == fcl_cache_.end())
+            // {
+            new_object = ConstructFclCollisionObject(i, object.second.lock());
+            fcl_cache_[object.first] = new_object;
+            // }
+            // else
+            // {
+            //     new_object = cache_entry->second;
+            // }
+            fcl_objects_.emplace_back(new_object.get());
+            kinematic_elements_.emplace_back(object.second);
+            ++i;
+        }
     }
 }
 

--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -60,6 +60,9 @@ void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string,
     long i = 0;
     for (const auto& object : objects)
     {
+        // Check whether object is excluded as a world collision object:
+        if (world_links_to_exclude_from_collision_scene.count(object.first) != 0) continue;
+
         std::shared_ptr<fcl::CollisionObjectd> new_object;
 
         // const auto& cache_entry = fcl_cache_.find(object.first);

--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -64,11 +64,11 @@ void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string,
         // Check whether object is excluded as a world collision object:
         if (world_links_to_exclude_from_collision_scene.count(object.first) > 0)
         {
-            HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", object.first << " is excluded, skipping.");
+            if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", object.first << " is excluded, skipping.");
         }
         else
         {
-            HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", "Creating " << object.first);
+            if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", "Creating " << object.first);
             std::shared_ptr<fcl::CollisionObjectd> new_object;
 
             // const auto& cache_entry = fcl_cache_.find(object.first);

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
@@ -98,13 +98,13 @@ protected:
 
 private:
     UnconstrainedTimeIndexedProblemPtr prob_;  //!< Shared pointer to the planning problem.
-    double damping;                            //!< Damping
-    double damping_init_;                      //!< Damping
-    double minimum_step_tolerance_;            //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
-    double step_tolerance_;                    //!< Relative step tolerance (termination criterion)
-    double function_tolerance_;                //!< Relative function tolerance/first-order optimality criterion
-    int max_backtrack_iterations_;             //!< Max. number of sweeps without improvement before terminating (= line-search)
-    bool use_bwd_msg_;                         //!< Flag for using backward message initialisation
+    double damping = 0.01;                     //!< Damping
+    double damping_init_ = 0.0;                //!< Damping
+    double minimum_step_tolerance_ = 1e-5;     //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
+    double step_tolerance_ = 1e-5;             //!< Relative step tolerance (termination criterion)
+    double function_tolerance_ = 1e-5;         //!< Relative function tolerance/first-order optimality criterion
+    int max_backtrack_iterations_ = 10;        //!< Max. number of sweeps without improvement before terminating (= line-search)
+    bool use_bwd_msg_ = false;                 //!< Flag for using backward message initialisation
     Eigen::VectorXd bwd_msg_v_;                //!< Backward message initialisation mean
     Eigen::MatrixXd bwd_msg_Vinv_;             //!< Backward message initialisation covariance
     bool sweep_improved_cost_;                 //!< Whether the last sweep improved the cost (for backtrack iterations count)
@@ -140,11 +140,11 @@ private:
     Eigen::VectorXd cost_control_old_;      //!< Control cost for each time step (last most optimal value)
     Eigen::MatrixXd cost_task_old_;         //!< Task cost for each task for each time step (last most optimal value)
 
-    std::vector<Eigen::VectorXd> damping_reference_;  //!< Damping reference point
-    double cost_;                                     //!< cost of MAP trajectory
-    double cost_old_;                                 //!< cost of MAP trajectory (last most optimal value)
-    double cost_prev_;                                //!< previous iteration cost
-    double b_step_;                                   //!< Squared configuration space step
+    std::vector<Eigen::VectorXd> damping_reference_;         //!< Damping reference point
+    double cost_ = 0.0;                                      //!< cost of MAP trajectory
+    double cost_old_ = std::numeric_limits<double>::max();   //!< cost of MAP trajectory (last most optimal value)
+    double cost_prev_ = std::numeric_limits<double>::max();  //!< previous iteration cost
+    double b_step_ = 0.0;                                    //!< Squared configuration space step
     double b_step_old_;
 
     Eigen::MatrixXd W;     //!< Configuration space weight matrix inverse
@@ -152,7 +152,7 @@ private:
 
     int last_T_;  //!< T the last time InitMessages was called.
 
-    int sweep_;  //!< Sweeps so far
+    int sweep_ = 0;  //!< Sweeps so far
     int best_sweep_ = 0;
     int best_sweep_old_ = 0;
     enum SweepMode
@@ -162,8 +162,8 @@ private:
         LOCAL_GAUSS_NEWTON,
         LOCAL_GAUSS_NEWTON_DAMPED
     };
-    int sweep_mode_;  //!< Sweep mode
-    int update_count_;
+    int sweep_mode_ = 0;  //!< Sweep mode
+    int update_count_ = 0;
 
     /// \brief Updates the forward message at time step $t$
     /// @param t Time step

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
@@ -72,18 +72,18 @@ protected:
     void InitTrajectory(const Eigen::VectorXd& q_init);
 
 private:
-    UnconstrainedEndPoseProblemPtr prob_;  //!< Shared pointer to the planning problem.
-    double damping;                        //!< Damping
-    double damping_init_;                  //!< Damping
-    double minimum_step_tolerance_;        //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
-    double step_tolerance_;                //!< Relative step tolerance (termination criterion)
-    double function_tolerance_;            //!< Relative function tolerance/first-order optimality criterion
-    int max_backtrack_iterations_;         //!< Max. number of sweeps without improvement before terminating (= line-search)
-    bool use_bwd_msg_;                     //!< Flag for using backward message initialisation
-    Eigen::VectorXd bwd_msg_v_;            //!< Backward message initialisation mean
-    Eigen::MatrixXd bwd_msg_Vinv_;         //!< Backward message initialisation covariance
-    bool sweep_improved_cost_;             //!< Whether the last sweep improved the cost (for backtrack iterations count)
-    int iteration_count_;                  //!< Iteration counter
+    UnconstrainedEndPoseProblemPtr prob_;   //!< Shared pointer to the planning problem.
+    double damping = 0.01;                  //!< Damping
+    double damping_init_ = 100.0;           //!< Damping
+    double minimum_step_tolerance_ = 1e-5;  //!< Update tolerance to stop update of messages if change of maximum coefficient is less than this tolerance.
+    double step_tolerance_ = 1e-5;          //!< Relative step tolerance (termination criterion)
+    double function_tolerance_ = 1e-5;      //!< Relative function tolerance/first-order optimality criterion
+    int max_backtrack_iterations_ = 10;     //!< Max. number of sweeps without improvement before terminating (= line-search)
+    bool use_bwd_msg_ = false;              //!< Flag for using backward message initialisation
+    Eigen::VectorXd bwd_msg_v_;             //!< Backward message initialisation mean
+    Eigen::MatrixXd bwd_msg_Vinv_;          //!< Backward message initialisation covariance
+    bool sweep_improved_cost_;              //!< Whether the last sweep improved the cost (for backtrack iterations count)
+    int iteration_count_;                   //!< Iteration counter
 
     Eigen::VectorXd s;     //!< Forward message mean
     Eigen::MatrixXd Sinv;  //!< Forward message covariance inverse
@@ -109,17 +109,17 @@ private:
     Eigen::VectorXd q_old;     //!< Configuration space trajectory (last most optimal value)
     Eigen::VectorXd qhat_old;  //!< Point of linearisation (last most optimal value)
 
-    Eigen::VectorXd damping_reference_;  //!< Damping reference point
-    double cost_;                        //!< cost of MAP trajectory
-    double cost_old_;                    //!< cost of MAP trajectory (last most optimal value)
-    double cost_prev_;                   //!< previous iteration cost
-    double b_step_;                      //!< Squared configuration space step
+    Eigen::VectorXd damping_reference_;                      //!< Damping reference point
+    double cost_ = 0.0;                                      //!< cost of MAP trajectory
+    double cost_old_ = std::numeric_limits<double>::max();   //!< cost of MAP trajectory (last most optimal value)
+    double cost_prev_ = std::numeric_limits<double>::max();  //!< previous iteration cost
+    double b_step_ = 0.0;                                    //!< Squared configuration space step
     double b_step_old_;
 
     Eigen::MatrixXd W;     //!< Configuration space weight matrix inverse
     Eigen::MatrixXd Winv;  //!< Configuration space weight matrix inverse
 
-    int sweep_;  //!< Sweeps so far
+    int sweep_ = 0;  //!< Sweeps so far
     int best_sweep_ = 0;
     int best_sweep_old_ = 0;
     enum SweepMode
@@ -129,8 +129,8 @@ private:
         LOCAL_GAUSS_NEWTON,
         LOCAL_GAUSS_NEWTON_DAMPED
     };
-    int sweep_mode_;  //!< Sweep mode
-    int update_count_;
+    int sweep_mode_ = 0;  //!< Sweep mode
+    int update_count_ = 0;
 
     /// \brief Updates the forward message
     /// Updates the mean and covariance of the forward message using:

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/incremental_gaussian.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/incremental_gaussian.h
@@ -36,6 +36,8 @@
 #include <Eigen/Dense>
 #include <vector>
 
+namespace exotica
+{
 class SinglePassMeanCovariance
 {
 private:
@@ -161,5 +163,6 @@ public:
         sig = S / (W - 1.);
     }
 };
+}  // namespace exotica
 
 #endif  // EXOTICA_AICO_SOLVER_INCREMENTAL_GAUSSIAN_H_

--- a/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
@@ -239,18 +239,7 @@ void AICOSolver::InitMessages()
     R.assign(prob_->GetT(), Eigen::MatrixXd::Zero(prob_->N, prob_->N));
     rhat = Eigen::VectorXd::Zero(prob_->GetT());
     qhat.assign(prob_->GetT(), Eigen::VectorXd::Zero(prob_->N));
-    {
-        q = b;
-        if (prob_->W.rows() != prob_->N)
-        {
-            ThrowNamed(prob_->W.rows() << "!=" << prob_->N);
-        }
-    }
-    {
-        // Set constant W,Win,H,Hinv
-        W = prob_->W;
-        Winv = W.inverse();
-    }
+    q = b;
 
     cost_control_.resize(prob_->GetT());
     cost_control_.setZero();
@@ -294,6 +283,16 @@ void AICOSolver::InitTrajectory(const std::vector<Eigen::VectorXd>& q_init)
         // Compute task message reference
         UpdateTaskMessage(t, b[t], 0.0);
     }
+
+    // W is still writable, check dimension
+    if (prob_->W.rows() != prob_->N)
+    {
+        ThrowNamed(prob_->W.rows() << "!=" << prob_->N);
+    }
+
+    // Set constant W,Win,H,Hinv
+    W = prob_->W;
+    Winv = W.inverse();
 
     cost_ = EvaluateTrajectory(b, true);  // The problem will be updated via UpdateTaskMessage, i.e. do not update on this roll-out
     cost_prev_ = cost_;

--- a/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
@@ -65,51 +65,7 @@ void AICOSolver::Instantiate(AICOSolverInitializer& init)
     use_bwd_msg_ = init.UseBackwardMessage;
 }
 
-AICOSolver::AICOSolver()
-    : damping(0.01),
-      minimum_step_tolerance_(1e-5),
-      step_tolerance_(1e-5),
-      function_tolerance_(1e-5),
-      max_backtrack_iterations_(10),
-      use_bwd_msg_(false),
-      bwd_msg_v_(),
-      bwd_msg_Vinv_(),
-      s(),
-      Sinv(),
-      v(),
-      Vinv(),
-      r(),
-      R(),
-      rhat(),
-      b(),
-      Binv(),
-      q(),
-      qhat(),
-      s_old(),
-      Sinv_old(),
-      v_old(),
-      Vinv_old(),
-      r_old(),
-      R_old(),
-      rhat_old(),
-      b_old(),
-      Binv_old(),
-      q_old(),
-      qhat_old(),
-      damping_reference_(),
-      cost_(0.0),
-      cost_old_(0.0),
-      cost_prev_(std::numeric_limits<double>::max()),
-      b_step_(0.0),
-      Winv(),
-      sweep_(0),
-      sweep_mode_(0),
-      W(),
-      update_count_(0),
-      damping_init_(0.0),
-      q_stat_()
-{
-}
+AICOSolver::AICOSolver() = default;
 
 AICOSolver::~AICOSolver() = default;
 

--- a/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
@@ -169,13 +169,6 @@ void BayesianIKSolver::Solve(Eigen::MatrixXd& solution)
 
 void BayesianIKSolver::InitMessages()
 {
-    if (prob_ == nullptr) ThrowNamed("Problem definition is a NULL pointer!");
-
-    if (prob_->N < 1)
-    {
-        ThrowNamed("State dimension is too small: n=" << prob_->N);
-    }
-
     s = Eigen::VectorXd::Zero(prob_->N);
     Sinv = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
     v = Eigen::VectorXd::Zero(prob_->N);
@@ -196,24 +189,11 @@ void BayesianIKSolver::InitMessages()
     b = Eigen::VectorXd::Zero(prob_->N);
     damping_reference_ = Eigen::VectorXd::Zero(prob_->N);
     Binv = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
-    // Binv[0].setIdentity();
-    // Binv[0] = Binv[0] * 1e10;
     r = Eigen::VectorXd::Zero(prob_->N);
     R = Eigen::MatrixXd::Zero(prob_->N, prob_->N);
     rhat = 0;
     qhat = Eigen::VectorXd::Zero(prob_->N);
-    {
-        q = b;
-        if (prob_->W.rows() != prob_->N)
-        {
-            ThrowNamed(prob_->W.rows() << "!=" << prob_->N);
-        }
-    }
-    {
-        // Set constant W,Win,H,Hinv
-        W = prob_->W;
-        Winv = W.inverse();
-    }
+    q = b;
 }
 
 void BayesianIKSolver::InitTrajectory(const Eigen::VectorXd& q_init)
@@ -228,6 +208,16 @@ void BayesianIKSolver::InitTrajectory(const Eigen::VectorXd& q_init)
     Sinv.diagonal().setConstant(damping);
     Vinv.setZero();
     Vinv.diagonal().setConstant(damping);
+
+    // W is still writable, check dimension
+    if (prob_->W.rows() != prob_->N)
+    {
+        ThrowNamed(prob_->W.rows() << "!=" << prob_->N);
+    }
+
+    // Set constant W,Win,H,Hinv
+    W = prob_->W;
+    Winv = W.inverse();
 
     // Compute task message reference
     UpdateTaskMessage(b, 0.0);

--- a/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
@@ -62,52 +62,10 @@ void BayesianIKSolver::Instantiate(BayesianIKSolverInitializer& init)
     use_bwd_msg_ = init.UseBackwardMessage;
 }
 
-BayesianIKSolver::BayesianIKSolver()
-    : damping(0.01),
-      minimum_step_tolerance_(1e-5),
-      step_tolerance_(1e-5),
-      function_tolerance_(1e-5),
-      max_backtrack_iterations_(10),
-      use_bwd_msg_(false),
-      bwd_msg_v_(),
-      bwd_msg_Vinv_(),
-      s(),
-      Sinv(),
-      v(),
-      Vinv(),
-      r(),
-      R(),
-      rhat(),
-      b(),
-      Binv(),
-      q(),
-      qhat(),
-      s_old(),
-      Sinv_old(),
-      v_old(),
-      Vinv_old(),
-      r_old(),
-      R_old(),
-      rhat_old(),
-      b_old(),
-      Binv_old(),
-      q_old(),
-      qhat_old(),
-      damping_reference_(),
-      cost_(0.0),
-      cost_old_(std::numeric_limits<double>::max()),
-      cost_prev_(std::numeric_limits<double>::max()),
-      b_step_(0.0),
-      Winv(),
-      sweep_(0),
-      sweep_mode_(0),
-      W(),
-      update_count_(0),
-      damping_init_(100.0)
-{
-}
+BayesianIKSolver::BayesianIKSolver() = default;
 
-BayesianIKSolver::~BayesianIKSolver() {}
+BayesianIKSolver::~BayesianIKSolver() = default;
+
 void BayesianIKSolver::SpecifyProblem(PlanningProblemPtr problem)
 {
     if (problem->type() != "exotica::UnconstrainedEndPoseProblem")

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -240,10 +240,13 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
     PreSolve();
     ompl::time::point start = ompl::time::now();
     ompl::base::PlannerTerminationCondition ptc = ompl::base::timedPlannerTerminationCondition(init_.Timeout - ompl::time::seconds(ompl::time::now() - start));
+
+    Timer t;
     if (ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION && ompl_simple_setup_->haveSolutionPath())
     {
         GetPath(solution, ptc);
     }
+    planning_time_ = t.GetDuration();
     PostSolve();
 }
 

--- a/exotica/doc/Doxyfile
+++ b/exotica/doc/Doxyfile
@@ -2153,7 +2153,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: YES.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of
@@ -2219,7 +2219,7 @@ GROUP_GRAPHS           = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-UML_LOOK               = NO
+UML_LOOK               = YES
 
 # If the UML_LOOK tag is enabled, the fields and methods are shown inside the
 # class node. If there are many fields or methods and many nodes the graph may

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -260,6 +260,9 @@ public:
 
     bool debug_ = false;
 
+    /// \brief Links to exclude from collision scene - gets set from Scene::UpdateSceneFrames
+    std::set<std::string> world_links_to_exclude_from_collision_scene;
+
 protected:
     /// The allowed collision matrix
     AllowedCollisionMatrix acm_;

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -196,6 +196,8 @@ public:
     /// @param[in]  tf2_end  The end transform for o2.
     /// @return     ContinuousCollisionProxy.
     virtual ContinuousCollisionProxy ContinuousCollisionCheck(const std::string& o1, const KDL::Frame& tf1_beg, const KDL::Frame& tf1_end, const std::string& o2, const KDL::Frame& tf2_beg, const KDL::Frame& tf2_end) { ThrowPretty("Not implemented!"); }
+    /// @brief      Returns the translation of the named collision object.
+    /// @param[in]  name    Name of the collision object to query.
     virtual Eigen::Vector3d GetTranslation(const std::string& name) = 0;
 
     inline void SetACM(const AllowedCollisionMatrix& acm)

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -154,13 +154,13 @@ public:
     bool AlwaysUpdatesCollisionScene() { return force_collision_; }
     /// @brief Returns a map between a model link name and the names of associated collision links.
     /// @return Map between model links and all associated collision links.
-    std::map<std::string, std::vector<std::string>> GetModelLinkToCollisionLinkMap() { return modelLink_to_collisionLink_map_; };
+    std::map<std::string, std::vector<std::string>> GetModelLinkToCollisionLinkMap() { return model_link_to_collision_link_map_; };
     /// @brief Returns a map between a model link name and the KinematicElement of associated collision links.
     /// @return Map between model links and all the KinematicElements of the associated collision links.
-    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> GetModelLinkToCollisionElementMap() { return modelLink_to_collisionElement_map_; };
+    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> GetModelLinkToCollisionElementMap() { return model_link_to_collision_element_map_; };
     /// @brief Returns a map between controlled robot link names and associated collision link names. Here we consider all fixed links between controlled links as belonging to the previous controlled link (as if the collision links had been fused).
     /// @return Map between controlled links and associated collision links.
-    std::map<std::string, std::vector<std::string>> GetControlledLinkToCollisionLinkMap() { return controlledLink_to_collisionLink_map_; };
+    std::map<std::string, std::vector<std::string>> GetControlledLinkToCollisionLinkMap() { return controlled_link_to_collision_link_map_; };
 private:
     void UpdateInternalFrames(bool update_request = true);
 
@@ -203,14 +203,14 @@ private:
     bool force_collision_;
 
     /// \brief Mapping between model link names and collision links.
-    std::map<std::string, std::vector<std::string>> modelLink_to_collisionLink_map_;
-    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> modelLink_to_collisionElement_map_;
+    std::map<std::string, std::vector<std::string>> model_link_to_collision_link_map_;
+    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> model_link_to_collision_element_map_;
 
     /// \brief Mapping between controlled link name and collision links
-    std::map<std::string, std::vector<std::string>> controlledLink_to_collisionLink_map_;
+    std::map<std::string, std::vector<std::string>> controlled_link_to_collision_link_map_;
 
     /// \brief List of robot links to be excluded from the collision scene
-    std::set<std::string> robotLinksToExcludeFromCollisionScene_;
+    std::set<std::string> robot_links_to_exclude_from_collision_scene_;
 
     /// \brief List of world links to be excluded from the collision scene
     std::set<std::string> world_links_to_exclude_from_collision_scene_;

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -161,6 +161,8 @@ public:
     /// @brief Returns a map between controlled robot link names and associated collision link names. Here we consider all fixed links between controlled links as belonging to the previous controlled link (as if the collision links had been fused).
     /// @return Map between controlled links and associated collision links.
     std::map<std::string, std::vector<std::string>> GetControlledLinkToCollisionLinkMap() { return controlled_link_to_collision_link_map_; };
+    /// @brief Returns world links that are to be excluded from collision checking.
+    std::set<std::string> get_world_links_to_exclude_from_collision_scene() { return world_links_to_exclude_from_collision_scene_; }
 private:
     void UpdateInternalFrames(bool update_request = true);
 

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -209,8 +209,11 @@ private:
     /// \brief Mapping between controlled link name and collision links
     std::map<std::string, std::vector<std::string>> controlledLink_to_collisionLink_map_;
 
-    /// \brief List of links to be excluded from the collision scene
+    /// \brief List of robot links to be excluded from the collision scene
     std::set<std::string> robotLinksToExcludeFromCollisionScene_;
+
+    /// \brief List of world links to be excluded from the collision scene
+    std::set<std::string> world_links_to_exclude_from_collision_scene_;
 
     KinematicsRequest kinematic_request_;
     std::shared_ptr<KinematicResponse> kinematic_solution_;

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -117,11 +117,11 @@ public:
     void DetachObject(const std::string& name);
     bool HasAttachedObject(const std::string& name);
 
-    void AddObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool update_collision_scene = true);
+    void AddObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), const bool update_collision_scene = true);
 
-    void AddObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shape_resource_path = "", Eigen::Vector3d scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), bool update_collision_scene = true);
+    void AddObject(const std::string& name, const KDL::Frame& transform = KDL::Frame(), const std::string& parent = "", const std::string& shape_resource_path = "", const Eigen::Vector3d& scale = Eigen::Vector3d::Ones(), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), const bool update_collision_scene = true);
 
-    void AddObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const Eigen::Vector4d& colour = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), const bool& update_collision_scene = true);
+    void AddObjectToEnvironment(const std::string& name, const KDL::Frame& transform = KDL::Frame(), shapes::ShapeConstPtr shape = nullptr, const Eigen::Vector4d& color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), const bool update_collision_scene = true);
 
     void RemoveObject(const std::string& name);
 

--- a/exotica_core/init/scene.in
+++ b/exotica_core/init/scene.in
@@ -24,3 +24,4 @@ Optional std::vector<exotica::Initializer> Links = std::vector<exotica::Initiali
 Optional std::vector<exotica::Initializer> Trajectories = std::vector<exotica::Initializer>();
 Optional std::vector<exotica::Initializer> AttachLinks = std::vector<exotica::Initializer>();
 Optional std::vector<std::string> RobotLinksToExcludeFromCollisionScene = std::vector<std::string>();
+Optional std::vector<std::string> WorldLinksToExcludeFromCollisionScene = std::vector<std::string>();

--- a/exotica_core/src/problems/end_pose_problem.cpp
+++ b/exotica_core/src/problems/end_pose_problem.cpp
@@ -382,9 +382,9 @@ bool EndPoseProblem::IsValid()
     // Check equality constraints
     if (GetEquality().rows() > 0)
     {
-        if (GetEquality().norm() > parameters.EqualityFeasibilityTolerance)
+        if (GetEquality().cwiseAbs().maxCoeff() > parameters.EqualityFeasibilityTolerance)
         {
-            if (debug_) HIGHLIGHT_NAMED("EndPoseProblem::IsValid", "Violated equality constraints: " << GetEquality().norm());
+            if (debug_) HIGHLIGHT_NAMED("EndPoseProblem::IsValid", "Violated equality constraints: " << GetEquality().cwiseAbs().maxCoeff());
             succeeded = false;
         }
     }

--- a/exotica_core/src/problems/time_indexed_problem.cpp
+++ b/exotica_core/src/problems/time_indexed_problem.cpp
@@ -759,9 +759,9 @@ bool TimeIndexedProblem::IsValid()
         // Check equality constraints
         if (GetEquality(t).rows() > 0)
         {
-            if (GetEquality(t).norm() > init_.EqualityFeasibilityTolerance)
+            if (GetEquality(t).cwiseAbs().maxCoeff() > init_.EqualityFeasibilityTolerance)
             {
-                if (debug_) HIGHLIGHT_NAMED("TimeIndexedProblem::IsValid", "Violated equality constraints at timestep " << t << ": " << GetEquality(t).norm());
+                if (debug_) HIGHLIGHT_NAMED("TimeIndexedProblem::IsValid", "Violated equality constraints at timestep " << t << ": " << GetEquality(t).cwiseAbs().maxCoeff());
                 succeeded = false;
             }
         }

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -591,25 +591,21 @@ void Scene::UpdateSceneFrames()
             obj_transform.linear() = object.second->shape_poses_[0].rotation();
             kinematica_.AddEnvironmentElement(object.first, obj_transform);
 
-            // Only add collision objects if not excluded
-            if (world_links_to_exclude_from_collision_scene_.find(object.first) == world_links_to_exclude_from_collision_scene_.end())
+            for (int i = 0; i < object.second->shape_poses_.size(); ++i)
             {
-                for (int i = 0; i < object.second->shape_poses_.size(); ++i)
+                Eigen::Isometry3d shape_transform;
+                shape_transform.translation() = object.second->shape_poses_[i].translation();
+                shape_transform.linear() = object.second->shape_poses_[i].rotation();
+                Eigen::Isometry3d trans = obj_transform.inverse() * shape_transform;
+                if (ps_->hasObjectColor(object.first))
                 {
-                    Eigen::Isometry3d shape_transform;
-                    shape_transform.translation() = object.second->shape_poses_[i].translation();
-                    shape_transform.linear() = object.second->shape_poses_[i].rotation();
-                    Eigen::Isometry3d trans = obj_transform.inverse() * shape_transform;
-                    if (ps_->hasObjectColor(object.first))
-                    {
-                        auto color_msg = ps_->getObjectColor(object.first);
-                        Eigen::Vector4d color = Eigen::Vector4d(color_msg.r, color_msg.g, color_msg.b, color_msg.a);
-                        kinematica_.AddEnvironmentElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i], KDL::RigidBodyInertia::Zero(), color);
-                    }
-                    else
-                    {
-                        kinematica_.AddEnvironmentElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
-                    }
+                    auto color_msg = ps_->getObjectColor(object.first);
+                    Eigen::Vector4d color = Eigen::Vector4d(color_msg.r, color_msg.g, color_msg.b, color_msg.a);
+                    kinematica_.AddEnvironmentElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i], KDL::RigidBodyInertia::Zero(), color);
+                }
+                else
+                {
+                    kinematica_.AddEnvironmentElement(object.first + "_collision_" + std::to_string(i), trans, object.first, object.second->shapes_[i]);
                 }
             }
         }

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -142,6 +142,7 @@ void Scene::Instantiate(SceneInitializer& init)
     collision_scene_->SetWorldLinkScale(init.WorldLinkScale);
     collision_scene_->SetRobotLinkScale(init.RobotLinkScale);
     collision_scene_->replace_cylinders_with_capsules = init.ReplaceCylindersWithCapsules;
+    collision_scene_->world_links_to_exclude_from_collision_scene = world_links_to_exclude_from_collision_scene_;
     UpdateSceneFrames();
     UpdateInternalFrames(false);
 

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -109,7 +109,7 @@ void Scene::Instantiate(SceneInitializer& init)
     for (const exotica::Initializer& linkInit : init.Links)
     {
         LinkInitializer link(linkInit);
-        AddObject(link.Name, GetFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, GetFrame(link.CenterOfMass).p), false);
+        AddObject(link.Name, GetFrame(link.Transform), link.Parent, nullptr, KDL::RigidBodyInertia(link.Mass, GetFrame(link.CenterOfMass).p), Eigen::Vector4d::Zero(), false);
     }
 
     // Check list of links to exclude from CollisionScene
@@ -669,31 +669,31 @@ void Scene::UpdateSceneFrames()
     request_needs_updating_ = true;
 }
 
-void Scene::AddObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, bool update_collision_scene)
+void Scene::AddObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, shapes::ShapeConstPtr shape, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color, bool update_collision_scene)
 {
     if (kinematica_.DoesLinkWithNameExist(name)) ThrowPretty("Link '" << name << "' already exists in the scene!");
     std::string parent_name = (parent == "") ? kinematica_.GetRootFrameName() : parent;
     if (!kinematica_.DoesLinkWithNameExist(parent_name)) ThrowPretty("Can't find parent '" << parent_name << "'!");
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
-    custom_links_.push_back(kinematica_.AddElement(name, pose, parent_name, shape, inertia));
+    custom_links_.push_back(kinematica_.AddElement(name, pose, parent_name, shape, inertia, color));
     if (update_collision_scene) UpdateCollisionObjects();
 }
 
-void Scene::AddObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, const std::string& shape_resource_path, Eigen::Vector3d scale, const KDL::RigidBodyInertia& inertia, bool update_collision_scene)
+void Scene::AddObject(const std::string& name, const KDL::Frame& transform, const std::string& parent, const std::string& shape_resource_path, const Eigen::Vector3d& scale, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color, bool update_collision_scene)
 {
     if (kinematica_.DoesLinkWithNameExist(name)) ThrowPretty("Link '" << name << "' already exists in the scene!");
     std::string parent_name = (parent == "") ? kinematica_.GetRootFrameName() : parent;
     if (!kinematica_.DoesLinkWithNameExist(parent_name)) ThrowPretty("Can't find parent '" << parent_name << "'!");
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
-    custom_links_.push_back(kinematica_.AddElement(name, pose, parent_name, shape_resource_path, scale, inertia));
+    custom_links_.push_back(kinematica_.AddElement(name, pose, parent_name, shape_resource_path, scale, inertia, color));
     UpdateSceneFrames();
     UpdateInternalFrames();
     if (update_collision_scene) UpdateCollisionObjects();
 }
 
-void Scene::AddObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const Eigen::Vector4d& colour, const bool& update_collision_scene)
+void Scene::AddObjectToEnvironment(const std::string& name, const KDL::Frame& transform, shapes::ShapeConstPtr shape, const Eigen::Vector4d& color, const bool update_collision_scene)
 {
     if (kinematica_.HasModelLink(name))
     {
@@ -702,7 +702,7 @@ void Scene::AddObjectToEnvironment(const std::string& name, const KDL::Frame& tr
     Eigen::Isometry3d pose;
     tf::transformKDLToEigen(transform, pose);
     ps_->getWorldNonConst()->addToObject(name, shape, pose);
-    ps_->setObjectColor(name, GetColor(colour));
+    ps_->setObjectColor(name, GetColor(color));
     UpdateSceneFrames();
     if (update_collision_scene) UpdateInternalFrames();
 }

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -117,7 +117,7 @@ void Scene::Instantiate(SceneInitializer& init)
     {
         for (const auto& link : init.RobotLinksToExcludeFromCollisionScene)
         {
-            robotLinksToExcludeFromCollisionScene_.insert(link);
+            robot_links_to_exclude_from_collision_scene_.insert(link);
             if (debug_) HIGHLIGHT_NAMED("RobotLinksToExcludeFromCollisionScene", link);
         }
     }
@@ -625,13 +625,13 @@ void Scene::UpdateSceneFrames()
         ps_->getCollisionRobot()->getRobotModel()->getLinkModelsWithCollisionGeometry();
     int lastControlledJointId = -1;
     std::string lastControlledLinkName;
-    modelLink_to_collisionLink_map_.clear();
-    modelLink_to_collisionElement_map_.clear();
-    controlledLink_to_collisionLink_map_.clear();
+    model_link_to_collision_link_map_.clear();
+    model_link_to_collision_element_map_.clear();
+    controlled_link_to_collision_link_map_.clear();
     for (int i = 0; i < links.size(); ++i)
     {
         // Check whether link is excluded from collision checking
-        if (robotLinksToExcludeFromCollisionScene_.find(links[i]->getName()) != robotLinksToExcludeFromCollisionScene_.end())
+        if (robot_links_to_exclude_from_collision_scene_.find(links[i]->getName()) != robot_links_to_exclude_from_collision_scene_.end())
         {
             continue;
         }
@@ -666,14 +666,14 @@ void Scene::UpdateSceneFrames()
             Eigen::Isometry3d trans = obj_transform.inverse(Eigen::Isometry) * collisionBodyTransform;
 
             std::shared_ptr<KinematicElement> element = kinematica_.AddElement(links[i]->getName() + "_collision_" + std::to_string(j), trans, links[i]->getName(), links[i]->getShapes()[j]);
-            modelLink_to_collisionElement_map_[links[i]->getName()].push_back(element);
+            model_link_to_collision_element_map_[links[i]->getName()].push_back(element);
 
             // Set up mappings
-            modelLink_to_collisionLink_map_[links[i]->getName()].push_back(links[i]->getName() + "_collision_" + std::to_string(j));
+            model_link_to_collision_link_map_[links[i]->getName()].push_back(links[i]->getName() + "_collision_" + std::to_string(j));
 
             if (lastControlledLinkName != "")
             {
-                controlledLink_to_collisionLink_map_[lastControlledLinkName].push_back(links[i]->getName() + "_collision_" + std::to_string(j));
+                controlled_link_to_collision_link_map_[lastControlledLinkName].push_back(links[i]->getName() + "_collision_" + std::to_string(j));
             }
         }
     }

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1048,25 +1048,27 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("get_trajectory", [](Scene* instance, const std::string& link) { return instance->GetTrajectory(link)->ToString(); });
     scene.def("remove_trajectory", &Scene::RemoveTrajectory);
     scene.def("update_scene_frames", &Scene::UpdateSceneFrames);
-    scene.def("add_object", [](Scene* instance, const std::string& name, const KDL::Frame& transform, const std::string& parent, const std::string& shape_resource_path, Eigen::Vector3d scale, bool update_collision_scene) { instance->AddObject(name, transform, parent, shape_resource_path, scale, KDL::RigidBodyInertia::Zero(), update_collision_scene); },
+    scene.def("add_object", [](Scene* instance, const std::string& name, const KDL::Frame& transform, const std::string& parent, const std::string& shape_resource_path, const Eigen::Vector3d scale, const Eigen::Vector4d color, const bool update_collision_scene) { instance->AddObject(name, transform, parent, shape_resource_path, scale, KDL::RigidBodyInertia::Zero(), color, update_collision_scene); },
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("parent") = "",
               py::arg("shape_resource_path"),
               py::arg("scale") = Eigen::Vector3d::Ones(),
+              py::arg("color") = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0),
               py::arg("update_collision_scene") = true);
-    scene.def("add_object", (void (Scene::*)(const std::string&, const KDL::Frame&, const std::string&, shapes::ShapeConstPtr, const KDL::RigidBodyInertia&, bool)) & Scene::AddObject,
+    scene.def("add_object", (void (Scene::*)(const std::string&, const KDL::Frame&, const std::string&, shapes::ShapeConstPtr, const KDL::RigidBodyInertia&, const Eigen::Vector4d&, const bool)) & Scene::AddObject,
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("parent") = std::string(),
               py::arg("shape"),
               py::arg("inertia") = KDL::RigidBodyInertia::Zero(),
+              py::arg("color") = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0),
               py::arg("update_collision_scene") = true);
     scene.def("add_object_to_environment", &Scene::AddObjectToEnvironment,
               py::arg("name"),
               py::arg("transform") = KDL::Frame(),
               py::arg("shape"),
-              py::arg("colour") = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0),
+              py::arg("color") = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0),
               py::arg("update_collision_scene") = true);
     scene.def("remove_object", &Scene::RemoveObject);
     scene.def_property_readonly("model_link_to_collision_link_map", &Scene::GetModelLinkToCollisionLinkMap);


### PR DESCRIPTION
This PR includes a variety of changes from the IROS submission:

- Cleans up AICO (in preparation for dynamic problems)
- Fixes AICO benchmarking problems by making sure state is correctly reset between subsequent optimisations
- Adds support for colors to AddObject (and changes `colour` to `color` - cc: @christian-rauch)
- Allows world objects to be excluded from collision checking (e.g., when only as visual markers)
- Adds planning time to all OMPL solvers (was missing so far)
- Generates UML diagrams for documentation