### PR TITLE
TimeIndexedProblems: Move from template to abstract base class

### DIFF
--- a/exotica_core/include/exotica_core/problems/bounded_time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/bounded_time_indexed_problem.h
@@ -36,9 +36,12 @@
 namespace exotica
 {
 /// \brief Bound constrained time-indexed problem.
-class BoundedTimeIndexedProblem : public AbstractTimeIndexedProblem<BoundedTimeIndexedProblemInitializer>
+class BoundedTimeIndexedProblem : public AbstractTimeIndexedProblem, public Instantiable<BoundedTimeIndexedProblemInitializer>
 {
 public:
+    BoundedTimeIndexedProblem() = default;
+    ~BoundedTimeIndexedProblem() = default;
+
     /// \brief Instantiates the problem from an Initializer
     void Instantiate(BoundedTimeIndexedProblemInitializer& init) override;
 
@@ -86,6 +89,6 @@ private:
     BoundedTimeIndexedProblemInitializer init_;
 };
 typedef std::shared_ptr<exotica::BoundedTimeIndexedProblem> BoundedTimeIndexedProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_BOUNDED_TIME_INDEXED_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_problem.h
@@ -36,14 +36,20 @@
 namespace exotica
 {
 /// \brief Time-indexed problem with bound, joint velocity, and general equality/inequality constraints.
-class TimeIndexedProblem : public AbstractTimeIndexedProblem<TimeIndexedProblemInitializer>
+class TimeIndexedProblem : public AbstractTimeIndexedProblem, public Instantiable<TimeIndexedProblemInitializer>
 {
 public:
+    TimeIndexedProblem() = default;
+    ~TimeIndexedProblem() = default;
+
     /// \brief Instantiates the problem from an Initializer
     void Instantiate(TimeIndexedProblemInitializer& init) override;
 
     /// \brief Evaluates whether the problem is valid, i.e., all bound and general constraints are satisfied.
     bool IsValid() override;
+
+private:
+    TimeIndexedProblemInitializer init_;
 };
 typedef std::shared_ptr<exotica::TimeIndexedProblem> TimeIndexedProblemPtr;
 }

--- a/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
@@ -39,9 +39,12 @@
 namespace exotica
 {
 /// \brief Unconstrained time-indexed problem.
-class UnconstrainedTimeIndexedProblem : public AbstractTimeIndexedProblem<UnconstrainedTimeIndexedProblemInitializer>
+class UnconstrainedTimeIndexedProblem : public AbstractTimeIndexedProblem, public Instantiable<UnconstrainedTimeIndexedProblemInitializer>
 {
 public:
+    UnconstrainedTimeIndexedProblem() = default;
+    ~UnconstrainedTimeIndexedProblem() = default;
+
     /// \brief Instantiates the problem from an Initializer
     void Instantiate(UnconstrainedTimeIndexedProblemInitializer& init) override;
 

--- a/exotica_core/src/problems/bounded_time_indexed_problem.cpp
+++ b/exotica_core/src/problems/bounded_time_indexed_problem.cpp
@@ -58,6 +58,7 @@ void BoundedTimeIndexedProblem::Instantiate(BoundedTimeIndexedProblemInitializer
     cost.Initialize(init_.Cost, shared_from_this(), cost_Phi);
 
     T_ = init_.T;
+    tau_ = init_.tau;
     ApplyStartState(false);
     ReinitializeVariables();
 }
@@ -145,8 +146,6 @@ void BoundedTimeIndexedProblem::ReinitializeVariables()
 {
     if (debug_) HIGHLIGHT_NAMED("BoundedTimeIndexedProblem", "Initialize problem with T=" << T_);
 
-    SetTau(init_.tau);
-
     num_tasks = tasks_.size();
     length_Phi = 0;
     length_jacobian = 0;
@@ -175,6 +174,11 @@ void BoundedTimeIndexedProblem::ReinitializeVariables()
     initial_trajectory_.resize(T_, scene_->GetControlledState());
 
     cost.ReinitializeVariables(T_, shared_from_this(), cost_Phi);
+
+    // Updates related to tau
+    ct = 1.0 / tau_ / T_;
+    xdiff_max_ = q_dot_max_ * tau_;
+
     PreUpdate();
 }
 

--- a/exotica_core/src/problems/time_indexed_problem.cpp
+++ b/exotica_core/src/problems/time_indexed_problem.cpp
@@ -78,6 +78,7 @@ void TimeIndexedProblem::Instantiate(TimeIndexedProblemInitializer& init)
     equality.Initialize(init_.Equality, shared_from_this(), equality_Phi);
 
     T_ = init_.T;
+    tau_ = init_.tau;
     SetJointVelocityLimits(init_.JointVelocityLimits);
     ApplyStartState(false);
     ReinitializeVariables();

--- a/exotica_core/src/problems/unconstrained_time_indexed_problem.cpp
+++ b/exotica_core/src/problems/unconstrained_time_indexed_problem.cpp
@@ -57,6 +57,7 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
     cost.Initialize(init_.Cost, shared_from_this(), cost_Phi);
 
     T_ = init_.T;
+    tau_ = init_.tau;
     ApplyStartState(false);
     ReinitializeVariables();
 }
@@ -64,8 +65,6 @@ void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProble
 void UnconstrainedTimeIndexedProblem::ReinitializeVariables()
 {
     if (debug_) HIGHLIGHT_NAMED("UnconstrainedTimeIndexedProblem", "Initialize problem with T=" << T_);
-
-    SetTau(init_.tau);
 
     num_tasks = tasks_.size();
     length_Phi = 0;
@@ -95,6 +94,11 @@ void UnconstrainedTimeIndexedProblem::ReinitializeVariables()
     initial_trajectory_.resize(T_, scene_->GetControlledState());
 
     cost.ReinitializeVariables(T_, shared_from_this(), cost_Phi);
+
+    // Updates related to tau
+    ct = 1.0 / tau_ / T_;
+    xdiff_max_ = q_dot_max_ * tau_;
+
     PreUpdate();
 }
 


### PR DESCRIPTION
- Moves SetTau into ReinitializeVariables
- Gets rid of newly introduced warnings regarding used-but-undefined-functions