### PR TITLE
Fix mesh object visualisation + color

### DIFF
--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -620,20 +620,7 @@ void KinematicTree::PublishFrames()
             marker_array_msg_.markers.clear();
             for (int i = 0; i < tree_.size(); ++i)
             {
-                if (tree_[i].lock()->shape && (!tree_[i].lock()->closest_robot_link.lock() || !tree_[i].lock()->closest_robot_link.lock()->is_robot_link))
-                {
-                    visualization_msgs::Marker mrk;
-                    shapes::constructMarkerFromShape(tree_[i].lock()->shape.get(), mrk);
-                    mrk.action = visualization_msgs::Marker::ADD;
-                    mrk.frame_locked = true;
-                    mrk.id = i;
-                    mrk.ns = "CollisionObjects";
-                    mrk.color = GetColor(tree_[i].lock()->color);
-                    mrk.header.frame_id = "exotica/" + tree_[i].lock()->segment.getName();
-                    mrk.pose.orientation.w = 1.0;
-                    marker_array_msg_.markers.push_back(mrk);
-                }
-                else if (tree_[i].lock()->shape_resource_path != "")
+                if (tree_[i].lock()->shape_resource_path != "")
                 {
                     visualization_msgs::Marker mrk;
                     mrk.action = visualization_msgs::Marker::ADD;
@@ -649,6 +636,19 @@ void KinematicTree::PublishFrames()
                     mrk.scale.x = tree_[i].lock()->scale(0);
                     mrk.scale.y = tree_[i].lock()->scale(1);
                     mrk.scale.z = tree_[i].lock()->scale(2);
+                    marker_array_msg_.markers.push_back(mrk);
+                }
+                else if (tree_[i].lock()->shape && (!tree_[i].lock()->closest_robot_link.lock() || !tree_[i].lock()->closest_robot_link.lock()->is_robot_link))
+                {
+                    visualization_msgs::Marker mrk;
+                    shapes::constructMarkerFromShape(tree_[i].lock()->shape.get(), mrk);
+                    mrk.action = visualization_msgs::Marker::ADD;
+                    mrk.frame_locked = true;
+                    mrk.id = i;
+                    mrk.ns = "CollisionObjects";
+                    mrk.color = GetColor(tree_[i].lock()->color);
+                    mrk.header.frame_id = "exotica/" + tree_[i].lock()->segment.getName();
+                    mrk.pose.orientation.w = 1.0;
                     marker_array_msg_.markers.push_back(mrk);
                 }
             }

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -547,7 +547,7 @@ void Scene::UpdateInternalFrames(bool update_request)
         tf::transformKDLToEigen(it->segment.getFrameToTip(), pose);
         std::string shape_resource_path = it->shape_resource_path;
         Eigen::Vector3d scale = it->scale;
-        it = kinematica_.AddElement(it->segment.getName(), pose, it->parent_name, it->shape, it->segment.getInertia(), Eigen::Vector4d::Zero(), it->is_controlled);
+        it = kinematica_.AddElement(it->segment.getName(), pose, it->parent_name, it->shape, it->segment.getInertia(), it->color, it->is_controlled);
         it->shape_resource_path = shape_resource_path;
         it->scale = scale;
     }


### PR DESCRIPTION
Visualisation of scene mesh objects was broken some time ago: It now sent meshes in a message using vertices and faces rather than the path to the mesh - this was super slow and also broke the shapes in many cases. This PR fixes this and also preserves color when calling `UpdateInternalFrames`. The result: faster and more beautiful visualisations in RViz.