### PR TITLE
Chain links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
+<!--
 # Checklist
 
-- [ ] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory
+- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory
 
-- [ ] add unit test(s)
+- add unit test(s)
 
-- [ ] ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`
+- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`
+
+--!>

--- a/apply_format.sh
+++ b/apply_format.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i
+

--- a/exotica/doc/Code-Formatting.rst
+++ b/exotica/doc/Code-Formatting.rst
@@ -10,8 +10,9 @@ You can install ``clang-format-3.9`` e.g. via your package managers:
 
     sudo apt-get install clang-format-3.9
 
-In order to format your changes prior to committing, please run the following from the root of the repository:
+In order to format your changes prior to committing, please execute script `apply_format.sh` in the repository root.
+This will run:
 
 .. code-block:: bash
 
-    find -name '*.cpp' -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i
+    find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -197,7 +197,14 @@ public:
     /// @param begin link name from which the chain starts
     /// @param end link name at which the chain ends
     /// @return list joints between begin and end
-    std::vector<std::string> GetKinematicChain(const std::string& begin, const std::string& end);
+    std::vector<std::string> GetKinematicChain(const std::string& begin, const std::string& end) const;
+
+    /// @brief GetKinematicChainLinks get the links between begin and end of kinematic chain
+    /// @param begin link name from which the chain starts
+    /// @param end link name at which the chain ends
+    /// @return list link between begin and end
+    std::vector<std::string> GetKinematicChainLinks(const std::string& begin, const std::string& end) const;
+
     void SetModelState(Eigen::VectorXdRefConst x);
     void SetModelState(std::map<std::string, double> x);
     Eigen::VectorXd GetControlledState();

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -995,7 +995,7 @@ std::map<std::string, double> KinematicTree::GetModelStateMap()
     return ret;
 }
 
-std::vector<std::string> KinematicTree::GetKinematicChain(const std::string& begin, const std::string& end)
+std::vector<std::string> KinematicTree::GetKinematicChain(const std::string& begin, const std::string& end) const
 {
     // check existence of requested links
     for (const std::string& l : {begin, end})
@@ -1013,6 +1013,33 @@ std::vector<std::string> KinematicTree::GetKinematicChain(const std::string& beg
          l = l.lock()->parent, chain.push_back(l.lock()->segment.getJoint().getName()))
     {
         if (l.lock()->parent.lock() == nullptr)
+        {
+            ThrowPretty("There is no connection between '" + begin + "' and '" + end + "'!");
+        }
+    }
+
+    // return vector in order, begin...end
+    std::reverse(chain.begin(), chain.end());
+    return chain;
+}
+
+std::vector<std::string> KinematicTree::GetKinematicChainLinks(const std::string& begin, const std::string& end) const
+{
+    // check existence of requested links
+    for (const std::string& l : {begin, end})
+    {
+        if (!tree_map_.count(l))
+        {
+            ThrowPretty("Link '" + l + "' does not exist.");
+        }
+    }
+
+    // get chain in reverse order, end...begin
+    std::vector<std::string> chain;
+    for (std::shared_ptr<const KinematicElement> l = tree_map_.at(end).lock(); l->segment.getName() != begin; l = l->parent.lock())
+    {
+        chain.push_back(l->segment.getName());
+        if (l->parent.lock() == nullptr)
         {
             ThrowPretty("There is no connection between '" + begin + "' and '" + end + "'!");
         }

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1099,6 +1099,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematic_tree.def("get_root_frame_name", &KinematicTree::GetRootFrameName);
     kinematic_tree.def("get_root_joint_name", &KinematicTree::GetRootJointName);
     kinematic_tree.def("get_kinematic_chain", &KinematicTree::GetKinematicChain);
+    kinematic_tree.def("get_kinematic_chain_links", &KinematicTree::GetKinematicChainLinks);
     kinematic_tree.def("get_model_base_type", &KinematicTree::GetModelBaseType);
     kinematic_tree.def("get_controlled_base_type", &KinematicTree::GetControlledBaseType);
     kinematic_tree.def("get_controlled_link_mass", &KinematicTree::GetControlledLinkMass);


### PR DESCRIPTION
This PR adds a new method `GetKinematicChainLinks` which behaves similarly to `GetKinematicChain` but returns the link/frame names instead of the joint names.

This PR also:
- adds a script to apply clang-format conveniently (instead of remembering the command)
- reformats the PR checklist as a comment to not appear in the final PR text but only show to the committer when initially creating the PR