### PR TITLE
[exotica_python] Support Python2 and Python3

### DIFF
--- a/exotica_python/CMakeLists.txt
+++ b/exotica_python/CMakeLists.txt
@@ -16,11 +16,20 @@ catkin_package(
   CATKIN_DEPENDS exotica_core pybind11_catkin
 )
 
-include_directories(${catkin_INCLUDE_DIRS})
-pybind_add_module(_pyexotica MODULE src/pyexotica.cpp)
-target_link_libraries(_pyexotica PRIVATE ${catkin_LIBRARIES})
+include_directories(${catkin_INCLUDE_DIRS} ${pybind11_catkin_INCLUDE_DIRS}/pybind11_catkin)
+
+pybind11_add_module(_pyexotica MODULE src/pyexotica.cpp)
+target_link_libraries(_pyexotica PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(_pyexotica ${catkin_EXPORTED_TARGETS})
+set_target_properties(_pyexotica PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)
+set(PYTHON_LIB_DIR ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)
+add_custom_command(TARGET _pyexotica
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_LIB_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_pyexotica> ${PYTHON_LIB_DIR}/_pyexotica.so
+    WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
+COMMENT "Copying library files to python directory")
 
 catkin_python_setup()
 
-install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})
+install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)

--- a/exotica_python/src/pyexotica/__init__.py
+++ b/exotica_python/src/pyexotica/__init__.py
@@ -1,4 +1,6 @@
-from _pyexotica import *
-import publish_trajectory
-import tools
-# import planning_scene_utils # pyassimp import currently fails on Kinetic, will fix
+from __future__ import absolute_import
+
+from ._pyexotica import *
+from .publish_trajectory import *
+from .tools import *
+# from .planning_scene_utils import * # pyassimp import currently fails on Kinetic, will fix


### PR DESCRIPTION
Re-enables the use of Exotica with Python 3 as described in [the Python documentation](https://ipab-slmc.github.io/exotica/Python-API.html). This PR makes Python 2 and 3 simultaneously usable with the same code (but different compile/runtime settings).

cc: @Yunaik 