### PR TITLE
[DO NOT MERGE] Revert "[exotica_python] Support Python2 and Python3"

### DIFF
--- a/exotica_python/CMakeLists.txt
+++ b/exotica_python/CMakeLists.txt
@@ -16,20 +16,11 @@ catkin_package(
   CATKIN_DEPENDS exotica_core pybind11_catkin
 )
 
-include_directories(${catkin_INCLUDE_DIRS} ${pybind11_catkin_INCLUDE_DIRS}/pybind11_catkin)
-
-pybind11_add_module(_pyexotica MODULE src/pyexotica.cpp)
-target_link_libraries(_pyexotica PRIVATE ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
+include_directories(${catkin_INCLUDE_DIRS})
+pybind_add_module(_pyexotica MODULE src/pyexotica.cpp)
+target_link_libraries(_pyexotica PRIVATE ${catkin_LIBRARIES})
 add_dependencies(_pyexotica ${catkin_EXPORTED_TARGETS})
-set_target_properties(_pyexotica PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)
-set(PYTHON_LIB_DIR ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)
-add_custom_command(TARGET _pyexotica
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_LIB_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_pyexotica> ${PYTHON_LIB_DIR}/_pyexotica.so
-    WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
-COMMENT "Copying library files to python directory")
 
 catkin_python_setup()
 
-install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION}/pyexotica)
+install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})

--- a/exotica_python/src/pyexotica/__init__.py
+++ b/exotica_python/src/pyexotica/__init__.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from ._pyexotica import *
-from .publish_trajectory import *
-from .tools import *
-# from .planning_scene_utils import * # pyassimp import currently fails on Kinetic, will fix
+from _pyexotica import *
+import publish_trajectory
+import tools
+# import planning_scene_utils # pyassimp import currently fails on Kinetic, will fix


### PR DESCRIPTION
Somehow Travis is failing (timing out) since merging the Python3 fix PR - even though it passed Continuous Integration. Which is odd - my suspicion is memory use of Pinocchio or another issue. Nonetheless, I'd like to see whether a revert _would_ in theory fix CI.

**Please do not merge. This is for diagnosis only.**

Reverts ipab-slmc/exotica#541