### PR TITLE
Fix start state for dynamic problems, validity check for sampling problems, update PlanningProblem methods

### DIFF
--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -49,7 +49,7 @@ CollisionSceneFCLLatest::~CollisionSceneFCLLatest() = default;
 
 void CollisionSceneFCLLatest::Setup()
 {
-    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);
+    if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
 }
 
 void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)

--- a/exotica_core/include/exotica_core/motion_solver.h
+++ b/exotica_core/include/exotica_core/motion_solver.h
@@ -47,7 +47,7 @@ public:
     virtual void SpecifyProblem(PlanningProblemPtr pointer);
     virtual void Solve(Eigen::MatrixXd& solution) = 0;
     PlanningProblemPtr GetProblem() { return problem_; }
-    virtual std::string Print(std::string prepend);
+    std::string Print(const std::string& prepend) override;
     void SetNumberOfMaxIterations(int max_iter)
     {
         if (max_iter < 1) ThrowPretty("Number of maximum iterations needs to be greater than 0.");

--- a/exotica_core/include/exotica_core/object.h
+++ b/exotica_core/include/exotica_core/object.h
@@ -75,7 +75,7 @@ public:
         debug_ = oinit.Debug;
     }
 
-    virtual std::string Print(std::string prepend)
+    virtual std::string Print(const std::string& prepend)
     {
         return prepend + "  " + object_name_ + " (" + type() + ")";
     }

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -64,25 +64,29 @@ class PlanningProblem : public Object, Uncopyable, public virtual InstantiableBa
 {
 public:
     PlanningProblem();
-    virtual ~PlanningProblem() = default;
+    virtual ~PlanningProblem();
+
     void InstantiateBase(const Initializer& init) override;
     TaskMapMap& GetTaskMaps();
     TaskMapVec& GetTasks();
-    ScenePtr GetScene();
+    ScenePtr GetScene() const;
     std::string Print(const std::string& prepend) override;
+
     void SetStartState(Eigen::VectorXdRefConst x);
-    void SetStartTime(double t);
-    Eigen::VectorXd GetStartState();
-    double GetStartTime();
+    Eigen::VectorXd GetStartState() const;
     Eigen::VectorXd ApplyStartState(bool update_traj = true);
+
+    void SetStartTime(double t);
+    double GetStartTime() const;
+
     virtual void PreUpdate();
-    unsigned int GetNumberOfProblemUpdates() { return number_of_problem_updates_; }
+    unsigned int GetNumberOfProblemUpdates() const { return number_of_problem_updates_; }
     void ResetNumberOfProblemUpdates() { number_of_problem_updates_ = 0; }
-    std::pair<std::vector<double>, std::vector<double>> GetCostEvolution();
-    double GetCostEvolution(int index);
+    std::pair<std::vector<double>, std::vector<double>> GetCostEvolution() const;
+    double GetCostEvolution(int index) const;
     void ResetCostEvolution(size_t size);
     void SetCostEvolution(int index, double value);
-    KinematicRequestFlags GetFlags() { return flags_; }
+    KinematicRequestFlags GetFlags() const { return flags_; }
     /// \brief Evaluates whether the problem is valid.
     virtual bool IsValid() { ThrowNamed("Not implemented"); };
     double t_start;
@@ -104,7 +108,7 @@ protected:
     ScenePtr scene_;
     TaskMapMap task_maps_;
     TaskMapVec tasks_;
-    KinematicRequestFlags flags_;
+    KinematicRequestFlags flags_ = KinematicRequestFlags::KIN_FK;
     Eigen::VectorXd start_state_;
     unsigned int number_of_problem_updates_ = 0;  // Stores number of times the problem has been updated
     std::vector<std::pair<std::chrono::high_resolution_clock::time_point, double>> cost_evolution_;
@@ -112,6 +116,6 @@ protected:
 
 typedef Factory<PlanningProblem> PlanningProblemFac;
 typedef std::shared_ptr<PlanningProblem> PlanningProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_PLANNING_PROBLEM_H_

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -69,7 +69,7 @@ public:
     TaskMapMap& GetTaskMaps();
     TaskMapVec& GetTasks();
     ScenePtr GetScene();
-    std::string Print(std::string prepend) override;
+    std::string Print(const std::string& prepend) override;
     void SetStartState(Eigen::VectorXdRefConst x);
     void SetStartTime(double t);
     Eigen::VectorXd GetStartState();

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -85,13 +85,21 @@ public:
     KinematicRequestFlags GetFlags() { return flags_; }
     /// \brief Evaluates whether the problem is valid.
     virtual bool IsValid() { ThrowNamed("Not implemented"); };
-    int N;
     double t_start;
     TerminationCriterion termination_criterion;
+
+    int N = 0;  ///! Dimension of planning problem. TODO: Update from positions/velocities/controls and make private.
+    int get_num_positions() const;
+    int get_num_velocities() const;
+    int get_num_controls() const;
 
 protected:
     void UpdateTaskKinematics(std::shared_ptr<KinematicResponse> response);
     void UpdateMultipleTaskKinematics(std::vector<std::shared_ptr<KinematicResponse>> responses);
+
+    int num_positions_ = 0;
+    int num_velocities_ = 0;
+    int num_controls_ = 0;
 
     ScenePtr scene_;
     TaskMapMap task_maps_;

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -65,8 +65,6 @@ public:
     Eigen::MatrixXd get_Q(int t) const;               ///< Returns the precision matrix at time step t
     void set_Q(Eigen::MatrixXdRefConst Q_in, int t);  ///< Sets the precision matrix for time step t
 
-    int get_num_controls() const;  ///< Returns size of control vector
-
     double GetStateCost(int t) const;
     double GetControlCost(int t) const;
 

--- a/exotica_core/include/exotica_core/problems/sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/sampling_problem.h
@@ -46,7 +46,8 @@ public:
     virtual void Instantiate(SamplingProblemInitializer& init);
 
     void Update(Eigen::VectorXdRefConst x);
-    bool IsValid(Eigen::VectorXdRefConst x);  // Not overriding on purpose
+    bool IsValid(Eigen::VectorXdRefConst x);  // Not overriding on purpose - this updates and calls IsValid
+    bool IsValid() override;
     void PreUpdate() override;
 
     int GetSpaceDim();

--- a/exotica_core/include/exotica_core/task_map.h
+++ b/exotica_core/include/exotica_core/task_map.h
@@ -64,7 +64,7 @@ public:
     virtual int TaskSpaceJacobianDim() { return TaskSpaceDim(); }
     virtual void PreUpdate() {}
     virtual std::vector<TaskVectorEntry> GetLieGroupIndices() { return std::vector<TaskVectorEntry>(); }
-    virtual std::string Print(std::string prepend);
+    std::string Print(const std::string& prepend) override;
 
     std::vector<KinematicFrameRequest> GetFrames();
 

--- a/exotica_core/src/motion_solver.cpp
+++ b/exotica_core/src/motion_solver.cpp
@@ -50,7 +50,7 @@ void MotionSolver::SpecifyProblem(PlanningProblemPtr pointer)
     problem_ = pointer;
 }
 
-std::string MotionSolver::Print(std::string prepend)
+std::string MotionSolver::Print(const std::string& prepend)
 {
     std::string ret = Object::Print(prepend);
     ret += "\n" + prepend + "  Problem:";

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -40,9 +40,8 @@
 
 namespace exotica
 {
-PlanningProblem::PlanningProblem() : flags_(KIN_FK), N(0)
-{
-}
+PlanningProblem::PlanningProblem() = default;
+PlanningProblem::~PlanningProblem() = default;
 
 std::string PlanningProblem::Print(const std::string& prepend)
 {
@@ -104,7 +103,7 @@ void PlanningProblem::SetStartState(Eigen::VectorXdRefConst x)
     }
 }
 
-Eigen::VectorXd PlanningProblem::GetStartState()
+Eigen::VectorXd PlanningProblem::GetStartState() const
 {
     return start_state_;
 }
@@ -114,7 +113,7 @@ void PlanningProblem::SetStartTime(double t)
     t_start = t;
 }
 
-double PlanningProblem::GetStartTime()
+double PlanningProblem::GetStartTime() const
 {
     return t_start;
 }
@@ -223,6 +222,7 @@ void PlanningProblem::UpdateMultipleTaskKinematics(std::vector<std::shared_ptr<K
         }
     }
 }
+
 TaskMapMap& PlanningProblem::GetTaskMaps()
 {
     return task_maps_;
@@ -233,12 +233,12 @@ TaskMapVec& PlanningProblem::GetTasks()
     return tasks_;
 }
 
-ScenePtr PlanningProblem::GetScene()
+ScenePtr PlanningProblem::GetScene() const
 {
     return scene_;
 }
 
-std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvolution()
+std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvolution() const
 {
     std::pair<std::vector<double>, std::vector<double>> ret;
     for (size_t position = 0; position < cost_evolution_.size(); ++position)
@@ -251,7 +251,7 @@ std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvol
     return ret;
 }
 
-double PlanningProblem::GetCostEvolution(int index)
+double PlanningProblem::GetCostEvolution(int index) const
 {
     if (index > -1 && index < cost_evolution_.size())
     {
@@ -290,4 +290,4 @@ void PlanningProblem::SetCostEvolution(int index, double value)
         ThrowPretty("Out of range: " << index << " where length=" << cost_evolution_.size());
     }
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -44,7 +44,7 @@ PlanningProblem::PlanningProblem() : flags_(KIN_FK), N(0)
 {
 }
 
-std::string PlanningProblem::Print(std::string prepend)
+std::string PlanningProblem::Print(const std::string& prepend)
 {
     std::string ret = Object::Print(prepend);
     ret += "\n" + prepend + "  Task definitions:";

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -42,7 +42,7 @@ void TaskMap::AssignScene(ScenePtr scene)
     scene_ = scene;
 }
 
-std::string TaskMap::Print(std::string prepend)
+std::string TaskMap::Print(const std::string& prepend)
 {
     std::string ret = Object::Print(prepend);
     return ret;

--- a/exotica_examples/scripts/example_dynamic_time_indexed_problem_quadrotor
+++ b/exotica_examples/scripts/example_dynamic_time_indexed_problem_quadrotor
@@ -18,7 +18,7 @@ print("Constant force to hover:")
 s = time()
 F_hover = 0.5 * 9.81 / 4.
 for t in xrange(problem.T - 1):
-    u_rand = F_hover * np.ones((problem.NU, 1))
+    u_rand = F_hover * np.ones((problem.num_controls, 1))
     problem.update(u_rand, t)
     problem.get_scene().get_kinematic_tree().publish_frames()
     sleep(problem.tau)
@@ -57,7 +57,7 @@ print("Initial cost:", cost)
 # Set up simple optimization problem
 def cost_function(u):
     for t in xrange(problem.T - 1):
-        problem.update(u[problem.NU * t: problem.NU * t + problem.NU], t)
+        problem.update(u[problem.num_controls * t: problem.num_controls * t + problem.num_controls], t)
     cost = 0.0
     for t in xrange(problem.T):
         cost += problem.get_state_cost(t)

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -709,6 +709,10 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("get_task_maps", &PlanningProblem::GetTaskMaps, py::return_value_policy::reference_internal)
         .def("get_scene", &PlanningProblem::GetScene, py::return_value_policy::reference_internal)
         .def("__repr__", &PlanningProblem::Print, "String representation of the object", py::arg("prepend") = std::string(""))
+        .def_readonly("N", &PlanningProblem::N)
+        .def_property_readonly("num_positions", &PlanningProblem::get_num_positions)
+        .def_property_readonly("num_velocities", &PlanningProblem::get_num_velocities)
+        .def_property_readonly("num_controls", &PlanningProblem::get_num_controls)
         .def_property("start_state", &PlanningProblem::GetStartState, &PlanningProblem::SetStartState)
         .def_property("start_time", &PlanningProblem::GetStartTime, &PlanningProblem::SetStartTime)
         .def("get_number_of_problem_updates", &PlanningProblem::GetNumberOfProblemUpdates)
@@ -733,7 +737,6 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrained_time_indexed_problem.def_property("T", &UnconstrainedTimeIndexedProblem::GetT, &UnconstrainedTimeIndexedProblem::SetT);
     unconstrained_time_indexed_problem.def_readonly("length_Phi", &UnconstrainedTimeIndexedProblem::length_Phi);
     unconstrained_time_indexed_problem.def_readonly("length_jacobian", &UnconstrainedTimeIndexedProblem::length_jacobian);
-    unconstrained_time_indexed_problem.def_readonly("N", &UnconstrainedTimeIndexedProblem::N);
     unconstrained_time_indexed_problem.def_readonly("num_tasks", &UnconstrainedTimeIndexedProblem::num_tasks);
     unconstrained_time_indexed_problem.def_readonly("Phi", &UnconstrainedTimeIndexedProblem::Phi);
     unconstrained_time_indexed_problem.def_readonly("jacobian", &UnconstrainedTimeIndexedProblem::jacobian);
@@ -767,7 +770,6 @@ PYBIND11_MODULE(_pyexotica, module)
     time_indexed_problem.def_property("T", &TimeIndexedProblem::GetT, &TimeIndexedProblem::SetT);
     time_indexed_problem.def_readonly("length_Phi", &TimeIndexedProblem::length_Phi);
     time_indexed_problem.def_readonly("length_jacobian", &TimeIndexedProblem::length_jacobian);
-    time_indexed_problem.def_readonly("N", &TimeIndexedProblem::N);
     time_indexed_problem.def_readonly("num_tasks", &TimeIndexedProblem::num_tasks);
     time_indexed_problem.def_readonly("Phi", &TimeIndexedProblem::Phi);
     time_indexed_problem.def_readonly("jacobian", &TimeIndexedProblem::jacobian);
@@ -804,7 +806,6 @@ PYBIND11_MODULE(_pyexotica, module)
     bounded_time_indexed_problem.def_property("T", &BoundedTimeIndexedProblem::GetT, &BoundedTimeIndexedProblem::SetT);
     bounded_time_indexed_problem.def_readonly("length_Phi", &BoundedTimeIndexedProblem::length_Phi);
     bounded_time_indexed_problem.def_readonly("length_jacobian", &BoundedTimeIndexedProblem::length_jacobian);
-    bounded_time_indexed_problem.def_readonly("N", &BoundedTimeIndexedProblem::N);
     bounded_time_indexed_problem.def_readonly("num_tasks", &BoundedTimeIndexedProblem::num_tasks);
     bounded_time_indexed_problem.def_readonly("Phi", &BoundedTimeIndexedProblem::Phi);
     bounded_time_indexed_problem.def_readonly("jacobian", &BoundedTimeIndexedProblem::jacobian);
@@ -824,7 +825,6 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrained_end_pose_problem.def_readwrite("W", &UnconstrainedEndPoseProblem::W);
     unconstrained_end_pose_problem.def_readonly("length_Phi", &UnconstrainedEndPoseProblem::length_Phi);
     unconstrained_end_pose_problem.def_readonly("length_jacobian", &UnconstrainedEndPoseProblem::length_jacobian);
-    unconstrained_end_pose_problem.def_readonly("N", &UnconstrainedEndPoseProblem::N);
     unconstrained_end_pose_problem.def_readonly("num_tasks", &UnconstrainedEndPoseProblem::num_tasks);
     unconstrained_end_pose_problem.def_readonly("Phi", &UnconstrainedEndPoseProblem::Phi);
     unconstrained_end_pose_problem.def_readonly("jacobian", &UnconstrainedEndPoseProblem::jacobian);
@@ -854,7 +854,6 @@ PYBIND11_MODULE(_pyexotica, module)
     end_pose_problem.def_readwrite("use_bounds", &EndPoseProblem::use_bounds);
     end_pose_problem.def_readonly("length_Phi", &EndPoseProblem::length_Phi);
     end_pose_problem.def_readonly("length_jacobian", &EndPoseProblem::length_jacobian);
-    end_pose_problem.def_readonly("N", &EndPoseProblem::N);
     end_pose_problem.def_readonly("num_tasks", &EndPoseProblem::num_tasks);
     end_pose_problem.def_readonly("Phi", &EndPoseProblem::Phi);
     end_pose_problem.def_readonly("jacobian", &EndPoseProblem::jacobian);
@@ -879,7 +878,6 @@ PYBIND11_MODULE(_pyexotica, module)
     bounded_end_pose_problem.def_readwrite("W", &BoundedEndPoseProblem::W);
     bounded_end_pose_problem.def_readonly("length_Phi", &BoundedEndPoseProblem::length_Phi);
     bounded_end_pose_problem.def_readonly("length_jacobian", &BoundedEndPoseProblem::length_jacobian);
-    bounded_end_pose_problem.def_readonly("N", &BoundedEndPoseProblem::N);
     bounded_end_pose_problem.def_readonly("num_tasks", &BoundedEndPoseProblem::num_tasks);
     bounded_end_pose_problem.def_readonly("Phi", &BoundedEndPoseProblem::Phi);
     bounded_end_pose_problem.def_readonly("jacobian", &BoundedEndPoseProblem::jacobian);
@@ -894,7 +892,6 @@ PYBIND11_MODULE(_pyexotica, module)
     sampling_problem.def_property("goal_state", &SamplingProblem::GetGoalState, &SamplingProblem::SetGoalState);
     sampling_problem.def("get_space_dim", &SamplingProblem::GetSpaceDim);
     sampling_problem.def("get_bounds", &SamplingProblem::GetBounds);
-    sampling_problem.def_readonly("N", &SamplingProblem::N);
     sampling_problem.def_readonly("num_tasks", &SamplingProblem::num_tasks);
     sampling_problem.def_readonly("Phi", &SamplingProblem::Phi);
     sampling_problem.def_readonly("inequality", &SamplingProblem::inequality);
@@ -914,7 +911,6 @@ PYBIND11_MODULE(_pyexotica, module)
     time_indexed_sampling_problem.def("get_bounds", &TimeIndexedSamplingProblem::GetBounds);
     time_indexed_sampling_problem.def_property("goal_state", &TimeIndexedSamplingProblem::GetGoalState, &TimeIndexedSamplingProblem::SetGoalState);
     time_indexed_sampling_problem.def_property("goal_time", &TimeIndexedSamplingProblem::GetGoalTime, &TimeIndexedSamplingProblem::SetGoalTime);
-    time_indexed_sampling_problem.def_readonly("N", &TimeIndexedSamplingProblem::N);
     time_indexed_sampling_problem.def_readonly("num_tasks", &TimeIndexedSamplingProblem::num_tasks);
     time_indexed_sampling_problem.def_readonly("Phi", &TimeIndexedSamplingProblem::Phi);
     time_indexed_sampling_problem.def_readonly("inequality", &TimeIndexedSamplingProblem::inequality);
@@ -935,8 +931,6 @@ PYBIND11_MODULE(_pyexotica, module)
         .def_property("X_star", &DynamicTimeIndexedShootingProblem::get_X_star, &DynamicTimeIndexedShootingProblem::set_X_star)
         .def_property_readonly("tau", &DynamicTimeIndexedShootingProblem::get_tau)
         .def_property("T", &DynamicTimeIndexedShootingProblem::get_T, &DynamicTimeIndexedShootingProblem::set_T)
-        .def_readonly("N", &DynamicTimeIndexedShootingProblem::N)
-        .def_property_readonly("NU", &DynamicTimeIndexedShootingProblem::get_num_controls)
         .def("dynamics", &DynamicTimeIndexedShootingProblem::Dynamics)
         .def("simulate", &DynamicTimeIndexedShootingProblem::Simulate)
         .def("get_Q", &DynamicTimeIndexedShootingProblem::get_Q)

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -717,7 +717,7 @@ PYBIND11_MODULE(_pyexotica, module)
         .def_property("start_time", &PlanningProblem::GetStartTime, &PlanningProblem::SetStartTime)
         .def("get_number_of_problem_updates", &PlanningProblem::GetNumberOfProblemUpdates)
         .def("reset_number_of_problem_updates", &PlanningProblem::ResetNumberOfProblemUpdates)
-        .def("get_cost_evolution", (std::pair<std::vector<double>, std::vector<double>>(PlanningProblem::*)()) & PlanningProblem::GetCostEvolution)
+        .def("get_cost_evolution", (std::pair<std::vector<double>, std::vector<double>>(PlanningProblem::*)() const) & PlanningProblem::GetCostEvolution)
         .def("is_valid", &PlanningProblem::IsValid);
 
     // Problem types


### PR DESCRIPTION
Some changes to `PlanningProblem` to get dimensions of position, velocity, control vectors - and to properly support start states for dynamic problems. Also adds a generic validity check to `SamplingProblem`.

Changes in detail:
- [exotica_collision_scene_fcl_latest] Minor typo
- [exotica_core] Print method now takes const-ref prepend
- [exotica_core] PlanningProblem now contains num_positions, num_velocities, num_controls
  - Also applied to dynamic problems which set velocity and control vector dimension (otherwise zero)
  - Start states can now contain velocities for dynamic problems
  - Correctly expose all dimensions to Python for all problems
- [exotica_core] PlanningProblem const correctness clean-up 
- [exotica_core] SamplingProblem: Adds dedicated IsValid and Update
  - Split Update/IsValid
  - IsValid() now behaves the same way as for all other problems
  - IsValid(x) behaves as before: first calls Update(x), then IsValid()

cc: @include4eto - this relates to our discussion this morning and fixes the start-state issue.