### PR TITLE
[exotica_pinocchio_dynamics_solver] Turn off deprecated-declarations for Pinocchio

### DIFF
--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
@@ -32,11 +32,18 @@
 
 #include <exotica_core/dynamics_solver.h>
 
+/// TODO: remove this pragma once Pinocchio removes neutralConfiguration/
+/// and fixes their deprecation warnings. (Relates to #547)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include <pinocchio/algorithm/aba-derivatives.hpp>
 #include <pinocchio/algorithm/aba.hpp>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/model.hpp>
 #include <pinocchio/parsers/urdf.hpp>
+
+#pragma GCC diagnostic pop
 
 namespace exotica
 {


### PR DESCRIPTION
Resolves #547 by turning off deprecated-declarations for the Pinocchio includes. Pinocchio deprecated neutralConfigurations but still uses it in the model - i.e., we are seeing warnings leading to unstable builds from things we do not use/control. Should be removed in the future once a new Pinocchio release fully removed those deprecated features.

cc: @christian-rauch 