### PR TITLE
[exotica_core_task_maps] Update to manipulability task map

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -52,7 +52,7 @@ namespace exotica
 ///   - derivatives of \f$\Phi\f$ are computed using finite differences.
 ///
 /// Todo
-///   - Update user options, that is allow user to specify to compute based on translation, rotation, all, yoshikawa, or asada as in Peter Corkes' toolbox.
+///   - Update user options, that is allow user to specify to compute based on translation, rotation, all, yoshikawa, or asada as in Peter Corkes' toolbox (cf. https://github.com/petercorke/robotics-toolbox-matlab/blob/0ca01aac26b4475094845982b9a5e80b02c024fd/%40SerialLink/maniplty.m#L27).
 class Manipulability : public TaskMap, public Instantiable<ManipulabilityInitializer>
 {
 public:

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -61,7 +61,8 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    int n_end_effs_;  ///< Number of end-effectors.
+    int n_end_effs_;     ///< Number of end-effectors.
+    int n_rows_of_jac_;  ///< Number of rows from the top to extract from full jacobian. Is either 3 (position) or 6 (position and rotation).
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -50,6 +50,9 @@ namespace exotica
 /// Note that
 ///   - the associated value for \f$\rho\f$ <b>must</b> be negative in order to maximize the manipulability, and
 ///   - derivatives of \f$\Phi\f$ are computed using finite differences.
+///
+/// Todo
+///   - Update user options, that is allow user to specify to compute based on translation, rotation, all, yoshikawa, or asada as in Peter Corkes' toolbox.
 class Manipulability : public TaskMap, public Instantiable<ManipulabilityInitializer>
 {
 public:

--- a/exotations/exotica_core_task_maps/init/manipulability.in
+++ b/exotations/exotica_core_task_maps/init/manipulability.in
@@ -2,6 +2,8 @@ class Manipulability
 
 extend <exotica_core/task_map>
 
+Optional bool OnlyPosition = false; // If true, only position part of jacobian is used in computation of manipulability. Otherwise, the full jacobian is used.
+
 // inherited from TaskMap:
 // string Link           > name of frame in which point is defined
 // VectorXd LinkOffset   > coordinate of point in Link frame

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -42,7 +42,7 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 
     for (int i = 0; i < n_end_effs_; ++i)
     {
-        const Eigen::MatrixXd& J = kinematics[0].jacobian[i].data;
+        const Eigen::MatrixXd& J = kinematics[0].jacobian[i].data.topRows(n_rows_of_jac_);
         phi(i) = std::sqrt((J * J.transpose()).determinant());
     }
 }
@@ -50,6 +50,14 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 void Manipulability::Instantiate(ManipulabilityInitializer& init)
 {
     n_end_effs_ = frames_.size();
+    if (init.OnlyPosition)
+    {
+        n_rows_of_jac_ = 3;
+    }
+    else
+    {
+        n_rows_of_jac_ = 6;
+    }
 }
 
 int Manipulability::TaskSpaceDim()


### PR DESCRIPTION
* User can now specify to compute manipulability measure based on only position or both position and rotation.
* Documented and applied code formatting.

# Checklist

-  [x] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- [x] add unit test(s)

- [x] ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`


