### PR TITLE
constant initialiser (read-only) for Instantiable

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/center_of_mass.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/center_of_mass.h
@@ -44,7 +44,7 @@ public:
     CenterOfMass();
     virtual ~CenterOfMass();
 
-    void Instantiate(CenterOfMassInitializer& init) override;
+    void Instantiate(const CenterOfMassInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/center_of_mass.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/center_of_mass.h
@@ -44,7 +44,6 @@ public:
     CenterOfMass();
     virtual ~CenterOfMass();
 
-    void Instantiate(const CenterOfMassInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -64,8 +63,6 @@ private:
     visualization_msgs::Marker goal_marker_;
     bool enable_z_;
     int dim_;
-
-    CenterOfMassInitializer init_;
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_check.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_check.h
@@ -42,7 +42,6 @@ public:
     CollisionCheck();
     virtual ~CollisionCheck();
 
-    void Instantiate(const CollisionCheckInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -52,7 +51,6 @@ private:
     void Initialize();
 
     CollisionScenePtr cscene_;
-    CollisionCheckInitializer init_;
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_check.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_check.h
@@ -42,7 +42,7 @@ public:
     CollisionCheck();
     virtual ~CollisionCheck();
 
-    void Instantiate(CollisionCheckInitializer& init) override;
+    void Instantiate(const CollisionCheckInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/distance.h
@@ -42,8 +42,6 @@ public:
     Distance();
     virtual ~Distance();
 
-    void Instantiate(const DistanceInitializer& init) override;
-
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/distance.h
@@ -42,7 +42,7 @@ public:
     Distance();
     virtual ~Distance();
 
-    void Instantiate(DistanceInitializer& init) override;
+    void Instantiate(const DistanceInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_axis_alignment.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_axis_alignment.h
@@ -43,7 +43,6 @@ public:
     EffAxisAlignment();
     virtual ~EffAxisAlignment();
 
-    void Instantiate(const EffAxisAlignmentInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -62,7 +61,6 @@ public:
 private:
     void Initialize();
 
-    EffAxisAlignmentInitializer init_;
     int n_frames_;
 
     Eigen::Matrix3Xd axis_, dir_;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_axis_alignment.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_axis_alignment.h
@@ -43,7 +43,7 @@ public:
     EffAxisAlignment();
     virtual ~EffAxisAlignment();
 
-    void Instantiate(EffAxisAlignmentInitializer& init) override;
+    void Instantiate(const EffAxisAlignmentInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_frame.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_frame.h
@@ -42,7 +42,7 @@ public:
     EffFrame();
     virtual ~EffFrame();
 
-    void Instantiate(EffFrameInitializer& init) override;
+    void Instantiate(const EffFrameInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_orientation.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_orientation.h
@@ -42,7 +42,7 @@ public:
     EffOrientation();
     virtual ~EffOrientation();
 
-    void Instantiate(EffOrientationInitializer& init) override;
+    void Instantiate(const EffOrientationInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_position.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_position.h
@@ -42,7 +42,6 @@ public:
     EffPosition();
     virtual ~EffPosition();
 
-    void Instantiate(const EffPositionInitializer& init) override {}
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_position.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_position.h
@@ -42,7 +42,7 @@ public:
     EffPosition();
     virtual ~EffPosition();
 
-    void Instantiate(EffPositionInitializer& init) override {}
+    void Instantiate(const EffPositionInitializer& init) override {}
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
@@ -42,8 +42,6 @@ public:
     EffVelocity();
     virtual ~EffVelocity();
 
-    void Instantiate(const EffVelocityInitializer& init) override;
-
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
@@ -42,7 +42,7 @@ public:
     EffVelocity();
     virtual ~EffVelocity();
 
-    void Instantiate(EffVelocityInitializer& init) override;
+    void Instantiate(const EffVelocityInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/interaction_mesh.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/interaction_mesh.h
@@ -45,7 +45,7 @@ public:
     InteractionMesh();
     virtual ~InteractionMesh();
 
-    void Instantiate(InteractionMeshInitializer& init) override;
+    void Instantiate(const InteractionMeshInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
@@ -51,7 +51,6 @@ public:
     JointAccelerationBackwardDifference();
     virtual ~JointAccelerationBackwardDifference();
     void AssignScene(ScenePtr scene) override;
-    void Instantiate(const JointAccelerationBackwardDifferenceInitializer& init) override;
 
     /// \brief Logs previous joint state.
     /// SetPreviousJointState must be called after solve is called in a Python/C++ script is called
@@ -67,14 +66,13 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    JointAccelerationBackwardDifferenceInitializer init_;  ///< Task map initializer.
-    ScenePtr scene_;                                       ///< Scene pointer.
-    int N_;                                                ///< Number of dofs for robot.
-    Eigen::Vector2d backward_difference_params_;           ///< Binomial cooeficient parameters.
-    Eigen::MatrixXd q_;                                    ///< Log of previous two joint states.
-    Eigen::VectorXd qbd_;                                  ///< x+qbd_ is a simplifed estimate of the second time derivative.
-    Eigen::MatrixXd I_;                                    ///< Identity matrix.
-    double dt_inv_;                                        ///< Frequency (1/dt)
+    ScenePtr scene_;                              ///< Scene pointer.
+    int N_;                                       ///< Number of dofs for robot.
+    Eigen::Vector2d backward_difference_params_;  ///< Binomial cooeficient parameters.
+    Eigen::MatrixXd q_;                           ///< Log of previous two joint states.
+    Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the second time derivative.
+    Eigen::MatrixXd I_;                           ///< Identity matrix.
+    double dt_inv_;                               ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
@@ -51,7 +51,7 @@ public:
     JointAccelerationBackwardDifference();
     virtual ~JointAccelerationBackwardDifference();
     void AssignScene(ScenePtr scene) override;
-    void Instantiate(JointAccelerationBackwardDifferenceInitializer& init) override;
+    void Instantiate(const JointAccelerationBackwardDifferenceInitializer& init) override;
 
     /// \brief Logs previous joint state.
     /// SetPreviousJointState must be called after solve is called in a Python/C++ script is called

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
@@ -51,7 +51,6 @@ class JointJerkBackwardDifference : public TaskMap, public Instantiable<JointJer
 public:
     JointJerkBackwardDifference();
     virtual ~JointJerkBackwardDifference();
-    void Instantiate(const JointJerkBackwardDifferenceInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.
@@ -67,14 +66,13 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    JointJerkBackwardDifferenceInitializer init_;  ///< Task map initializer.
-    ScenePtr scene_;                               ///< Scene pointer.
-    int N_;                                        ///< Number of dofs for robot.
-    Eigen::Vector3d backward_difference_params_;   ///< Binomial cooeficient parameters.
-    Eigen::MatrixXd q_;                            ///< Log of previous three joint states.
-    Eigen::VectorXd qbd_;                          ///< x+qbd_ is a simplifed estimate of the third time derivative.
-    Eigen::MatrixXd I_;                            ///< Identity matrix.
-    double dt_inv_;                                ///< Frequency (1/dt)
+    ScenePtr scene_;                              ///< Scene pointer.
+    int N_;                                       ///< Number of dofs for robot.
+    Eigen::Vector3d backward_difference_params_;  ///< Binomial cooeficient parameters.
+    Eigen::MatrixXd q_;                           ///< Log of previous three joint states.
+    Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the third time derivative.
+    Eigen::MatrixXd I_;                           ///< Identity matrix.
+    double dt_inv_;                               ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
@@ -51,7 +51,7 @@ class JointJerkBackwardDifference : public TaskMap, public Instantiable<JointJer
 public:
     JointJerkBackwardDifference();
     virtual ~JointJerkBackwardDifference();
-    void Instantiate(JointJerkBackwardDifferenceInitializer& init) override;
+    void Instantiate(const JointJerkBackwardDifferenceInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
@@ -45,7 +45,7 @@ public:
     JointLimit();
     virtual ~JointLimit();
 
-    void Instantiate(JointLimitInitializer& init) override;
+    void Instantiate(const JointLimitInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
@@ -45,7 +45,6 @@ public:
     JointLimit();
     virtual ~JointLimit();
 
-    void Instantiate(const JointLimitInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -56,7 +55,6 @@ private:
     void Initialize();
 
     double safe_percentage_;
-    JointLimitInitializer init_;
     int N;
 };
 }

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
@@ -42,7 +42,7 @@ public:
     JointPose();
     virtual ~JointPose();
 
-    void Instantiate(JointPoseInitializer& init) override;
+    void Instantiate(const JointPoseInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
@@ -42,7 +42,6 @@ public:
     JointPose();
     virtual ~JointPose();
 
-    void Instantiate(const JointPoseInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -56,8 +55,6 @@ public:
 
 private:
     void Initialize();
-
-    JointPoseInitializer init_;
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
@@ -50,7 +50,7 @@ class JointVelocityBackwardDifference : public TaskMap, public Instantiable<Join
 public:
     JointVelocityBackwardDifference();
     virtual ~JointVelocityBackwardDifference();
-    void Instantiate(JointVelocityBackwardDifferenceInitializer& init) override;
+    void Instantiate(const JointVelocityBackwardDifferenceInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
@@ -50,7 +50,6 @@ class JointVelocityBackwardDifference : public TaskMap, public Instantiable<Join
 public:
     JointVelocityBackwardDifference();
     virtual ~JointVelocityBackwardDifference();
-    void Instantiate(const JointVelocityBackwardDifferenceInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.
@@ -64,14 +63,13 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    JointVelocityBackwardDifferenceInitializer init_;  ///< Task map initializer.
-    ScenePtr scene_;                                   ///< Scene pointer.
-    double backward_difference_params_;                ///< Binomial cooeficient parameters.
-    int N_;                                            ///< Number of dofs for robot.
-    Eigen::VectorXd q_;                                ///< Log of previous joint state.
-    Eigen::VectorXd qbd_;                              ///< x+qbd_ is a simplifed estimate of the first time derivative.
-    Eigen::MatrixXd I_;                                ///< Identity matrix.
-    double dt_inv_;                                    ///< Frequency (1/dt)
+    ScenePtr scene_;                     ///< Scene pointer.
+    double backward_difference_params_;  ///< Binomial cooeficient parameters.
+    int N_;                              ///< Number of dofs for robot.
+    Eigen::VectorXd q_;                  ///< Log of previous joint state.
+    Eigen::VectorXd qbd_;                ///< x+qbd_ is a simplifed estimate of the first time derivative.
+    Eigen::MatrixXd I_;                  ///< Identity matrix.
+    double dt_inv_;                      ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_limit.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_limit.h
@@ -44,7 +44,6 @@ public:
     JointVelocityLimit();
     virtual ~JointVelocityLimit();
 
-    void Instantiate(const JointVelocityLimitInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -58,7 +57,6 @@ private:
     double dt_ = 0.1;                                    ///< Timestep between subsequent time-steps (in s)
     Eigen::VectorXd limits_ = Eigen::VectorXd::Zero(1);  ///< Joint velocity limits (absolute, in rads/s)
     Eigen::VectorXd tau_ = Eigen::VectorXd::Zero(1);     ///< Joint velocity limits tolerance
-    JointVelocityLimitInitializer init_;
     int N;
 };
 }  // namespace exotica

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_limit.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_limit.h
@@ -44,7 +44,7 @@ public:
     JointVelocityLimit();
     virtual ~JointVelocityLimit();
 
-    void Instantiate(JointVelocityLimitInitializer& init) override;
+    void Instantiate(const JointVelocityLimitInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
@@ -67,7 +67,7 @@ public:
     LookAt();
     virtual ~LookAt();
 
-    void Instantiate(LookAtInitializer& init) override;
+    void Instantiate(const LookAtInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -59,7 +59,7 @@ public:
     Manipulability();
     virtual ~Manipulability();
 
-    void Instantiate(ManipulabilityInitializer& init) override;
+    void Instantiate(const ManipulabilityInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     int TaskSpaceDim() override;
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/point_to_line.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/point_to_line.h
@@ -43,7 +43,7 @@ public:
     PointToLine();
     virtual ~PointToLine();
 
-    void Instantiate(PointToLineInitializer& init) override;
+    void Instantiate(const PointToLineInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/point_to_plane.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/point_to_plane.h
@@ -44,7 +44,7 @@ public:
     PointToPlane();
     virtual ~PointToPlane();
 
-    void Instantiate(PointToPlaneInitializer &init) override;
+    void Instantiate(const PointToPlaneInitializer &init) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/quasi_static.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/quasi_static.h
@@ -45,7 +45,7 @@ public:
     QuasiStatic();
     virtual ~QuasiStatic();
 
-    void Instantiate(QuasiStaticInitializer& init) override;
+    void Instantiate(const QuasiStaticInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/quasi_static.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/quasi_static.h
@@ -45,7 +45,6 @@ public:
     QuasiStatic();
     virtual ~QuasiStatic();
 
-    void Instantiate(const QuasiStaticInitializer& init) override;
     void AssignScene(ScenePtr scene) override;
 
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
@@ -55,7 +54,6 @@ public:
 private:
     void Initialize();
 
-    QuasiStaticInitializer init_;
     visualization_msgs::MarkerArray debug_msg_;
     ros::Publisher debug_pub_;
 };

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/sphere_collision.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/sphere_collision.h
@@ -45,7 +45,7 @@ public:
     SphereCollision();
     virtual ~SphereCollision();
 
-    void Instantiate(SphereCollisionInitializer& init) override;
+    void Instantiate(const SphereCollisionInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/src/center_of_mass.cpp
+++ b/exotations/exotica_core_task_maps/src/center_of_mass.cpp
@@ -187,7 +187,7 @@ void CenterOfMass::AssignScene(ScenePtr scene)
     Initialize();
 }
 
-void CenterOfMass::Instantiate(CenterOfMassInitializer& init)
+void CenterOfMass::Instantiate(const CenterOfMassInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/center_of_mass.cpp
+++ b/exotations/exotica_core_task_maps/src/center_of_mass.cpp
@@ -148,7 +148,7 @@ int CenterOfMass::TaskSpaceDim()
 
 void CenterOfMass::Initialize()
 {
-    enable_z_ = init_.EnableZ;
+    enable_z_ = parameters_.EnableZ;
     if (enable_z_)
         dim_ = 3;
     else
@@ -185,11 +185,6 @@ void CenterOfMass::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
     Initialize();
-}
-
-void CenterOfMass::Instantiate(const CenterOfMassInitializer &init)
-{
-    init_ = init;
 }
 
 void CenterOfMass::InitializeDebug()

--- a/exotations/exotica_core_task_maps/src/collision_check.cpp
+++ b/exotations/exotica_core_task_maps/src/collision_check.cpp
@@ -40,12 +40,7 @@ void CollisionCheck::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != 1) ThrowNamed("Wrong size of phi!");
     if (!scene_->AlwaysUpdatesCollisionScene()) cscene_->UpdateCollisionObjectTransforms();
-    phi(0) = cscene_->IsStateValid(init_.SelfCollision, init_.SafeDistance) ? 0.0 : 1.0;
-}
-
-void CollisionCheck::Instantiate(const CollisionCheckInitializer &init)
-{
-    init_ = init;
+    phi(0) = cscene_->IsStateValid(parameters_.SelfCollision, parameters_.SafeDistance) ? 0.0 : 1.0;
 }
 
 void CollisionCheck::AssignScene(ScenePtr scene)

--- a/exotations/exotica_core_task_maps/src/collision_check.cpp
+++ b/exotations/exotica_core_task_maps/src/collision_check.cpp
@@ -43,7 +43,7 @@ void CollisionCheck::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     phi(0) = cscene_->IsStateValid(init_.SelfCollision, init_.SafeDistance) ? 0.0 : 1.0;
 }
 
-void CollisionCheck::Instantiate(CollisionCheckInitializer& init)
+void CollisionCheck::Instantiate(const CollisionCheckInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/distance.cpp
+++ b/exotations/exotica_core_task_maps/src/distance.cpp
@@ -59,10 +59,6 @@ void Distance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::
     }
 }
 
-void Distance::Instantiate(const DistanceInitializer &init)
-{
-}
-
 int Distance::TaskSpaceDim()
 {
     return kinematics[0].Phi.rows();

--- a/exotations/exotica_core_task_maps/src/distance.cpp
+++ b/exotations/exotica_core_task_maps/src/distance.cpp
@@ -59,7 +59,7 @@ void Distance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::
     }
 }
 
-void Distance::Instantiate(DistanceInitializer& init)
+void Distance::Instantiate(const DistanceInitializer &init)
 {
 }
 

--- a/exotations/exotica_core_task_maps/src/eff_axis_alignment.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_axis_alignment.cpp
@@ -38,7 +38,7 @@ namespace exotica
 EffAxisAlignment::EffAxisAlignment() = default;
 EffAxisAlignment::~EffAxisAlignment() = default;
 
-void EffAxisAlignment::Instantiate(EffAxisAlignmentInitializer& init)
+void EffAxisAlignment::Instantiate(const EffAxisAlignmentInitializer& init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/eff_axis_alignment.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_axis_alignment.cpp
@@ -38,16 +38,11 @@ namespace exotica
 EffAxisAlignment::EffAxisAlignment() = default;
 EffAxisAlignment::~EffAxisAlignment() = default;
 
-void EffAxisAlignment::Instantiate(const EffAxisAlignmentInitializer& init)
-{
-    init_ = init;
-}
-
 void EffAxisAlignment::Initialize()
 {
     N = scene_->GetKinematicTree().GetNumControlledJoints();
 
-    n_frames_ = init_.EndEffector.size();
+    n_frames_ = parameters_.EndEffector.size();
     if (debug_) HIGHLIGHT_NAMED("EffAxisAlignment", "Number of EndEffectors: " << n_frames_);
     axis_.resize(3, n_frames_);
     dir_.resize(3, n_frames_);
@@ -55,7 +50,7 @@ void EffAxisAlignment::Initialize()
     frames_.resize(2 * n_frames_);
     for (int i = 0; i < n_frames_; ++i)
     {
-        FrameWithAxisAndDirectionInitializer frame(init_.EndEffector[i]);
+        FrameWithAxisAndDirectionInitializer frame(parameters_.EndEffector[i]);
         axis_.col(i) = frame.Axis.normalized();
         dir_.col(i) = frame.Direction.normalized();
 

--- a/exotations/exotica_core_task_maps/src/eff_frame.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_frame.cpp
@@ -36,7 +36,7 @@ namespace exotica
 EffFrame::EffFrame() = default;
 EffFrame::~EffFrame() = default;
 
-void EffFrame::Instantiate(EffFrameInitializer& init)
+void EffFrame::Instantiate(const EffFrameInitializer &init)
 {
     if (init.Type == "Quaternion")
     {

--- a/exotations/exotica_core_task_maps/src/eff_orientation.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_orientation.cpp
@@ -36,7 +36,7 @@ namespace exotica
 EffOrientation::EffOrientation() = default;
 EffOrientation::~EffOrientation() = default;
 
-void EffOrientation::Instantiate(EffOrientationInitializer& init)
+void EffOrientation::Instantiate(const EffOrientationInitializer &init)
 {
     if (init.Type == "Quaternion")
     {

--- a/exotations/exotica_core_task_maps/src/eff_velocity.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_velocity.cpp
@@ -80,10 +80,6 @@ void EffVelocity::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     }
 }
 
-void EffVelocity::Instantiate(const EffVelocityInitializer &init)
-{
-}
-
 int EffVelocity::TaskSpaceDim()
 {
     return kinematics[0].Phi.rows();

--- a/exotations/exotica_core_task_maps/src/eff_velocity.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_velocity.cpp
@@ -80,7 +80,7 @@ void EffVelocity::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     }
 }
 
-void EffVelocity::Instantiate(EffVelocityInitializer& init)
+void EffVelocity::Instantiate(const EffVelocityInitializer &init)
 {
 }
 

--- a/exotations/exotica_core_task_maps/src/interaction_mesh.cpp
+++ b/exotations/exotica_core_task_maps/src/interaction_mesh.cpp
@@ -136,7 +136,7 @@ void InteractionMesh::InitializeDebug(std::string ref)
     if (debug_) HIGHLIGHT("InteractionMesh connectivity is published on ROS topic " << imesh_mark_pub_.getTopic() << ", in reference frame " << ref);
 }
 
-void InteractionMesh::Instantiate(InteractionMeshInitializer& init)
+void InteractionMesh::Instantiate(const InteractionMeshInitializer& init)
 {
     if (debug_)
     {

--- a/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
@@ -47,19 +47,19 @@ void JointAccelerationBackwardDifference::AssignScene(ScenePtr scene)
     backward_difference_params_ << -2, 1;
 
     // Frequency
-    if (init_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / init_.dt;
+    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
+    dt_inv_ = 1 / parameters_.dt;
 
     // Init each col of q_ with start state
     q_.resize(N_, 2);
-    if (init_.StartState.rows() == 0)
+    if (parameters_.StartState.rows() == 0)
     {
         q_.setZero(N_, 2);
     }
-    else if (init_.StartState.rows() == N_)
+    else if (parameters_.StartState.rows() == N_)
     {
         for (int i = 0; i < 2; ++i)
-            q_.col(i) = init_.StartState;
+            q_.col(i) = parameters_.StartState;
     }
     else
     {
@@ -71,11 +71,6 @@ void JointAccelerationBackwardDifference::AssignScene(ScenePtr scene)
 
     // Init identity matrix
     I_ = Eigen::MatrixXd::Identity(N_, N_);
-}
-
-void JointAccelerationBackwardDifference::Instantiate(const JointAccelerationBackwardDifferenceInitializer &init)
-{
-    init_ = init;
 }
 
 void JointAccelerationBackwardDifference::SetPreviousJointState(Eigen::VectorXdRefConst joint_state)

--- a/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
@@ -73,7 +73,7 @@ void JointAccelerationBackwardDifference::AssignScene(ScenePtr scene)
     I_ = Eigen::MatrixXd::Identity(N_, N_);
 }
 
-void JointAccelerationBackwardDifference::Instantiate(JointAccelerationBackwardDifferenceInitializer& init)
+void JointAccelerationBackwardDifference::Instantiate(const JointAccelerationBackwardDifferenceInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
@@ -73,7 +73,7 @@ void JointJerkBackwardDifference::AssignScene(ScenePtr scene)
     I_ = Eigen::MatrixXd::Identity(N_, N_);
 }
 
-void JointJerkBackwardDifference::Instantiate(JointJerkBackwardDifferenceInitializer& init)
+void JointJerkBackwardDifference::Instantiate(const JointJerkBackwardDifferenceInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
@@ -47,19 +47,19 @@ void JointJerkBackwardDifference::AssignScene(ScenePtr scene)
     backward_difference_params_ << -3, 3, -1;
 
     // Frequency
-    if (init_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / init_.dt;
+    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
+    dt_inv_ = 1 / parameters_.dt;
 
     // Initialize q_ with StartState
     q_.resize(N_, 3);
-    if (init_.StartState.rows() == 0)
+    if (parameters_.StartState.rows() == 0)
     {
         q_.setZero(N_, 3);
     }
-    else if (init_.StartState.rows() == N_)
+    else if (parameters_.StartState.rows() == N_)
     {
         for (int i = 0; i < 3; ++i)
-            q_.col(i) = init_.StartState;
+            q_.col(i) = parameters_.StartState;
     }
     else
     {
@@ -71,11 +71,6 @@ void JointJerkBackwardDifference::AssignScene(ScenePtr scene)
 
     // Init identity matrix
     I_ = Eigen::MatrixXd::Identity(N_, N_);
-}
-
-void JointJerkBackwardDifference::Instantiate(const JointJerkBackwardDifferenceInitializer &init)
-{
-    init_ = init;
 }
 
 void JointJerkBackwardDifference::SetPreviousJointState(Eigen::VectorXdRefConst joint_state)

--- a/exotations/exotica_core_task_maps/src/joint_limit.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_limit.cpp
@@ -36,11 +36,6 @@ namespace exotica
 JointLimit::JointLimit() = default;
 JointLimit::~JointLimit() = default;
 
-void JointLimit::Instantiate(const JointLimitInitializer& init)
-{
-    init_ = init;
-}
-
 void JointLimit::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -49,7 +44,7 @@ void JointLimit::AssignScene(ScenePtr scene)
 
 void JointLimit::Initialize()
 {
-    safe_percentage_ = init_.SafePercentage;
+    safe_percentage_ = parameters_.SafePercentage;
 
     N = scene_->GetKinematicTree().GetNumControlledJoints();
 }

--- a/exotations/exotica_core_task_maps/src/joint_limit.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_limit.cpp
@@ -36,7 +36,7 @@ namespace exotica
 JointLimit::JointLimit() = default;
 JointLimit::~JointLimit() = default;
 
-void JointLimit::Instantiate(JointLimitInitializer& init)
+void JointLimit::Instantiate(const JointLimitInitializer& init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_pose.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_pose.cpp
@@ -73,7 +73,7 @@ void JointPose::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen:
 //     }
 // }
 
-void JointPose::Instantiate(JointPoseInitializer& init)
+void JointPose::Instantiate(const JointPoseInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_pose.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_pose.cpp
@@ -73,11 +73,6 @@ void JointPose::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen:
 //     }
 // }
 
-void JointPose::Instantiate(const JointPoseInitializer &init)
-{
-    init_ = init;
-}
-
 void JointPose::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -87,12 +82,12 @@ void JointPose::AssignScene(ScenePtr scene)
 void JointPose::Initialize()
 {
     N_ = scene_->GetKinematicTree().GetNumControlledJoints();
-    if (init_.JointMap.rows() > 0)
+    if (parameters_.JointMap.rows() > 0)
     {
-        joint_map_.resize(init_.JointMap.rows());
-        for (int i = 0; i < init_.JointMap.rows(); ++i)
+        joint_map_.resize(parameters_.JointMap.rows());
+        for (int i = 0; i < parameters_.JointMap.rows(); ++i)
         {
-            joint_map_[i] = init_.JointMap(i);
+            joint_map_[i] = parameters_.JointMap(i);
         }
     }
     else
@@ -104,9 +99,9 @@ void JointPose::Initialize()
         }
     }
 
-    if (init_.JointRef.rows() > 0)
+    if (parameters_.JointRef.rows() > 0)
     {
-        joint_ref_ = init_.JointRef;
+        joint_ref_ = parameters_.JointRef;
         if (joint_ref_.rows() != joint_map_.size()) ThrowNamed("Invalid joint reference size! Expecting " << joint_map_.size() << " but received " << joint_ref_.rows());
     }
     else

--- a/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
@@ -66,7 +66,7 @@ void JointVelocityBackwardDifference::AssignScene(ScenePtr scene)
     I_ = Eigen::MatrixXd::Identity(N_, N_);
 }
 
-void JointVelocityBackwardDifference::Instantiate(JointVelocityBackwardDifferenceInitializer& init)
+void JointVelocityBackwardDifference::Instantiate(const JointVelocityBackwardDifferenceInitializer& init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
@@ -47,15 +47,15 @@ void JointVelocityBackwardDifference::AssignScene(ScenePtr scene)
     backward_difference_params_ = -1.0;
 
     // Frequency
-    if (init_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / init_.dt;
+    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
+    dt_inv_ = 1 / parameters_.dt;
 
     // Init each col of q_ with start state
     q_.resize(N_, 1);
-    if (init_.StartState.rows() == 0)
+    if (parameters_.StartState.rows() == 0)
         q_.setZero(N_);
-    else if (init_.StartState.rows() == N_)
-        q_ = init_.StartState;
+    else if (parameters_.StartState.rows() == N_)
+        q_ = parameters_.StartState;
     else
         ThrowPretty("Wrong size for StartState!");
 
@@ -64,11 +64,6 @@ void JointVelocityBackwardDifference::AssignScene(ScenePtr scene)
 
     // Init identity matrix
     I_ = Eigen::MatrixXd::Identity(N_, N_);
-}
-
-void JointVelocityBackwardDifference::Instantiate(const JointVelocityBackwardDifferenceInitializer& init)
-{
-    init_ = init;
 }
 
 void JointVelocityBackwardDifference::SetPreviousJointState(Eigen::VectorXdRefConst joint_state)

--- a/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
@@ -40,7 +40,7 @@ JointVelocityLimit::JointVelocityLimit()
 
 JointVelocityLimit::~JointVelocityLimit() = default;
 
-void JointVelocityLimit::Instantiate(JointVelocityLimitInitializer& init)
+void JointVelocityLimit::Instantiate(const JointVelocityLimitInitializer &init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
@@ -40,11 +40,6 @@ JointVelocityLimit::JointVelocityLimit()
 
 JointVelocityLimit::~JointVelocityLimit() = default;
 
-void JointVelocityLimit::Instantiate(const JointVelocityLimitInitializer &init)
-{
-    init_ = init;
-}
-
 void JointVelocityLimit::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -53,25 +48,25 @@ void JointVelocityLimit::AssignScene(ScenePtr scene)
 
 void JointVelocityLimit::Initialize()
 {
-    double percent = static_cast<double>(init_.SafePercentage);
+    double percent = static_cast<double>(parameters_.SafePercentage);
 
     N = scene_->GetKinematicTree().GetNumControlledJoints();
-    dt_ = std::abs(init_.dt);
+    dt_ = std::abs(parameters_.dt);
     if (dt_ == 0.0)
         ThrowNamed("Timestep dt needs to be greater than 0");
 
-    if (init_.MaximumJointVelocity.rows() == 1)
+    if (parameters_.MaximumJointVelocity.rows() == 1)
     {
         limits_.setOnes(N);
-        limits_ *= std::abs(static_cast<double>(init_.MaximumJointVelocity(0)));
+        limits_ *= std::abs(static_cast<double>(parameters_.MaximumJointVelocity(0)));
     }
-    else if (init_.MaximumJointVelocity.rows() == N)
+    else if (parameters_.MaximumJointVelocity.rows() == N)
     {
-        limits_ = init_.MaximumJointVelocity.cwiseAbs();
+        limits_ = parameters_.MaximumJointVelocity.cwiseAbs();
     }
     else
     {
-        ThrowNamed("Maximum joint velocity vector needs to be either of size 1 or N, but got " << init_.MaximumJointVelocity.rows());
+        ThrowNamed("Maximum joint velocity vector needs to be either of size 1 or N, but got " << parameters_.MaximumJointVelocity.rows());
     }
 
     tau_ = percent * limits_;

--- a/exotations/exotica_core_task_maps/src/look_at.cpp
+++ b/exotations/exotica_core_task_maps/src/look_at.cpp
@@ -94,7 +94,7 @@ void LookAt::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::Ma
     }
 }
 
-void LookAt::Instantiate(LookAtInitializer& init)
+void LookAt::Instantiate(const LookAtInitializer& init)
 {
     // Error check
     if (frames_.size() % 3 != 0) ThrowNamed("Three frames are required for each end-effector!");

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -47,7 +47,7 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     }
 }
 
-void Manipulability::Instantiate(ManipulabilityInitializer& init)
+void Manipulability::Instantiate(const ManipulabilityInitializer& init)
 {
     n_end_effs_ = frames_.size();
     if (init.OnlyPosition)

--- a/exotations/exotica_core_task_maps/src/point_to_line.cpp
+++ b/exotations/exotica_core_task_maps/src/point_to_line.cpp
@@ -225,7 +225,7 @@ void PointToLine::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
     }
 }
 
-void PointToLine::Instantiate(PointToLineInitializer &init)
+void PointToLine::Instantiate(const PointToLineInitializer &init)
 {
     link_name_ = frames_[0].frame_A_link_name;
     base_name_ = frames_[0].frame_B_link_name;

--- a/exotations/exotica_core_task_maps/src/point_to_plane.cpp
+++ b/exotations/exotica_core_task_maps/src/point_to_plane.cpp
@@ -38,7 +38,7 @@ namespace exotica
 PointToPlane::PointToPlane() = default;
 PointToPlane::~PointToPlane() = default;
 
-void PointToPlane::Instantiate(PointToPlaneInitializer& init)
+void PointToPlane::Instantiate(const PointToPlaneInitializer& init)
 {
     if (debug_ && Server::IsRos())
     {

--- a/exotations/exotica_core_task_maps/src/quasi_static.cpp
+++ b/exotations/exotica_core_task_maps/src/quasi_static.cpp
@@ -206,7 +206,7 @@ void QuasiStatic::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
         }
         else
         {
-            if (!init_.PositiveOnly)
+            if (!parameters_.PositiveOnly)
             {
                 phi(0) = sqrt(-n / pot);
             }
@@ -304,7 +304,7 @@ void QuasiStatic::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eige
         }
         else
         {
-            if (!init_.PositiveOnly)
+            if (!parameters_.PositiveOnly)
             {
                 phi(0) = -sqrt(-n / pot);
                 jacobian.row(0) = potJ * (n / (2 * pot * pot * phi(0)));
@@ -376,10 +376,5 @@ void QuasiStatic::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
     Initialize();
-}
-
-void QuasiStatic::Instantiate(const QuasiStaticInitializer& init)
-{
-    init_ = init;
 }
 }

--- a/exotations/exotica_core_task_maps/src/quasi_static.cpp
+++ b/exotations/exotica_core_task_maps/src/quasi_static.cpp
@@ -378,7 +378,7 @@ void QuasiStatic::AssignScene(ScenePtr scene)
     Initialize();
 }
 
-void QuasiStatic::Instantiate(QuasiStaticInitializer& init)
+void QuasiStatic::Instantiate(const QuasiStaticInitializer& init)
 {
     init_ = init;
 }

--- a/exotations/exotica_core_task_maps/src/sphere_collision.cpp
+++ b/exotations/exotica_core_task_maps/src/sphere_collision.cpp
@@ -37,7 +37,7 @@ namespace exotica
 SphereCollision::SphereCollision() = default;
 SphereCollision::~SphereCollision() = default;
 
-void SphereCollision::Instantiate(SphereCollisionInitializer& init)
+void SphereCollision::Instantiate(const SphereCollisionInitializer& init)
 {
     eps_ = 1.0 / init.Precision;
     for (int i = 0; i < init.EndEffector.size(); ++i)

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
@@ -73,7 +73,7 @@ class AICOSolver : public MotionSolver, public Instantiable<AICOSolverInitialize
 {
 public:
     AICOSolver();
-    void Instantiate(AICOSolverInitializer& init) override;
+    void Instantiate(const AICOSolverInitializer& init) override;
     virtual ~AICOSolver();
 
     ///\brief Solves the problem

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
@@ -48,7 +48,7 @@ class BayesianIKSolver : public MotionSolver, public Instantiable<BayesianIKSolv
 {
 public:
     BayesianIKSolver();
-    void Instantiate(BayesianIKSolverInitializer& init) override;
+    void Instantiate(const BayesianIKSolverInitializer& init) override;
     virtual ~BayesianIKSolver();
 
     /// \brief Solves the problem

--- a/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
@@ -42,7 +42,7 @@ REGISTER_MOTIONSOLVER_TYPE("AICOSolver", exotica::AICOSolver)
 
 namespace exotica
 {
-void AICOSolver::Instantiate(AICOSolverInitializer& init)
+void AICOSolver::Instantiate(const AICOSolverInitializer& init)
 {
     std::string mode = init.SweepMode;
     if (mode == "Forwardly")

--- a/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
@@ -39,7 +39,7 @@ REGISTER_MOTIONSOLVER_TYPE("BayesianIKSolver", exotica::BayesianIKSolver)
 
 namespace exotica
 {
-void BayesianIKSolver::Instantiate(BayesianIKSolverInitializer& init)
+void BayesianIKSolver::Instantiate(const BayesianIKSolverInitializer& init)
 {
     std::string mode = init.SweepMode;
     if (mode == "Forwardly")

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -56,7 +56,7 @@ public:
     IKSolver();
     virtual ~IKSolver();
 
-    void Instantiate(IKSolverInitializer& init) override;
+    void Instantiate(const IKSolverInitializer& init) override;
 
     void Solve(Eigen::MatrixXd& solution) override;
 

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -56,15 +56,11 @@ public:
     IKSolver();
     virtual ~IKSolver();
 
-    void Instantiate(const IKSolverInitializer& init) override;
-
     void Solve(Eigen::MatrixXd& solution) override;
 
     void SpecifyProblem(PlanningProblemPtr pointer) override;
 
 private:
-    IKSolverInitializer parameters_;
-
     void ScaleToStepSize(Eigen::VectorXdRef xd);  //!< \brief Scale the state change vector so that the largest dimension is max. step or smaller.
 
     UnconstrainedEndPoseProblemPtr prob_;  // Shared pointer to the planning problem.

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -37,11 +37,6 @@ IKSolver::IKSolver() = default;
 
 IKSolver::~IKSolver() = default;
 
-void IKSolver::Instantiate(const IKSolverInitializer& init)
-{
-    parameters_ = init;
-}
-
 void IKSolver::SpecifyProblem(PlanningProblemPtr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedEndPoseProblem")

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -37,7 +37,7 @@ IKSolver::IKSolver() = default;
 
 IKSolver::~IKSolver() = default;
 
-void IKSolver::Instantiate(IKSolverInitializer& init)
+void IKSolver::Instantiate(const IKSolverInitializer& init)
 {
     parameters_ = init;
 }

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
@@ -33,7 +33,7 @@ namespace exotica
 class LevenbergMarquardtSolver : public MotionSolver, public Instantiable<LevenbergMarquardtSolverInitializer>
 {
 public:
-    void Instantiate(LevenbergMarquardtSolverInitializer& init) override;
+    void Instantiate(const LevenbergMarquardtSolverInitializer& init) override;
 
     void Solve(Eigen::MatrixXd& solution) override;
 

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/include/exotica_levenberg_marquardt_solver/levenberg_marquardt_solver.h
@@ -33,15 +33,11 @@ namespace exotica
 class LevenbergMarquardtSolver : public MotionSolver, public Instantiable<LevenbergMarquardtSolverInitializer>
 {
 public:
-    void Instantiate(const LevenbergMarquardtSolverInitializer& init) override;
-
     void Solve(Eigen::MatrixXd& solution) override;
 
     void SpecifyProblem(PlanningProblemPtr pointer) override;
 
 private:
-    LevenbergMarquardtSolverInitializer parameters_;
-
     UnconstrainedEndPoseProblemPtr prob_;  ///< Shared pointer to the planning problem.
 
     double lambda_ = 0;  ///< Damping factor

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
@@ -26,7 +26,6 @@ REGISTER_MOTIONSOLVER_TYPE("LevenbergMarquardtSolverSolver", exotica::LevenbergM
 
 namespace exotica
 {
-void LevenbergMarquardtSolver::Instantiate(const LevenbergMarquardtSolverInitializer& init) { parameters_ = init; }
 void LevenbergMarquardtSolver::SpecifyProblem(PlanningProblemPtr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedEndPoseProblem")

--- a/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
+++ b/exotations/solvers/exotica_levenberg_marquardt_solver/src/levenberg_marquardt_solver.cpp
@@ -26,7 +26,7 @@ REGISTER_MOTIONSOLVER_TYPE("LevenbergMarquardtSolverSolver", exotica::LevenbergM
 
 namespace exotica
 {
-void LevenbergMarquardtSolver::Instantiate(LevenbergMarquardtSolverInitializer& init) { parameters_ = init; }
+void LevenbergMarquardtSolver::Instantiate(const LevenbergMarquardtSolverInitializer& init) { parameters_ = init; }
 void LevenbergMarquardtSolver::SpecifyProblem(PlanningProblemPtr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedEndPoseProblem")

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_native_solvers.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_native_solvers.h
@@ -38,14 +38,14 @@ class RRTSolver : public OMPLSolver<SamplingProblem>, Instantiable<RRTSolverInit
 {
 public:
     RRTSolver();
-    void Instantiate(RRTSolverInitializer& init) override;
+    void Instantiate(const RRTSolverInitializer& init) override;
 };
 
 class RRTConnectSolver : public OMPLSolver<SamplingProblem>, Instantiable<RRTConnectSolverInitializer>
 {
 public:
     RRTConnectSolver();
-    void Instantiate(RRTConnectSolverInitializer& init) override;
+    void Instantiate(const RRTConnectSolverInitializer& init) override;
     void SetRange(double range);
     double GetRange();
 };
@@ -54,28 +54,28 @@ class ESTSolver : public OMPLSolver<SamplingProblem>, Instantiable<ESTSolverInit
 {
 public:
     ESTSolver();
-    void Instantiate(ESTSolverInitializer& init) override;
+    void Instantiate(const ESTSolverInitializer& init) override;
 };
 
 class KPIECESolver : public OMPLSolver<SamplingProblem>, Instantiable<KPIECESolverInitializer>
 {
 public:
     KPIECESolver();
-    void Instantiate(KPIECESolverInitializer& init) override;
+    void Instantiate(const KPIECESolverInitializer& init) override;
 };
 
 class BKPIECESolver : public OMPLSolver<SamplingProblem>, Instantiable<BKPIECESolverInitializer>
 {
 public:
     BKPIECESolver();
-    void Instantiate(BKPIECESolverInitializer& init) override;
+    void Instantiate(const BKPIECESolverInitializer& init) override;
 };
 
 class PRMSolver : public OMPLSolver<SamplingProblem>, Instantiable<PRMSolverInitializer>
 {
 public:
     PRMSolver();
-    void Instantiate(PRMSolverInitializer& init) override;
+    void Instantiate(const PRMSolverInitializer& init) override;
     void GrowRoadmap(double t);
     void ExpandRoadmap(double t);
     void Clear();
@@ -91,7 +91,7 @@ class LazyPRMSolver : public OMPLSolver<SamplingProblem>, Instantiable<LazyPRMSo
 {
 public:
     LazyPRMSolver();
-    void Instantiate(LazyPRMSolverInitializer& init) override;
+    void Instantiate(const LazyPRMSolverInitializer& init) override;
     void Clear();
     void ClearQuery();
     void Setup();
@@ -105,14 +105,14 @@ class RRTStarSolver : public OMPLSolver<SamplingProblem>, Instantiable<RRTStarSo
 {
 public:
     RRTStarSolver();
-    void Instantiate(RRTStarSolverInitializer& init) override;
+    void Instantiate(const RRTStarSolverInitializer& init) override;
 };
 
 class LBTRRTSolver : public OMPLSolver<SamplingProblem>, Instantiable<LBTRRTSolverInitializer>
 {
 public:
     LBTRRTSolver();
-    void Instantiate(LBTRRTSolverInitializer& init) override;
+    void Instantiate(const LBTRRTSolverInitializer& init) override;
 };
 }
 

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_native_solvers.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_native_solvers.cpp
@@ -55,36 +55,36 @@ namespace exotica
 {
 RRTStarSolver::RRTStarSolver() = default;
 
-void RRTStarSolver::Instantiate(RRTStarSolverInitializer& init)
+void RRTStarSolver::Instantiate(const RRTStarSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(RRTStarSolverInitializer(init));
     algorithm_ = "Exotica_RRTStar";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::RRTstar>, _1, _2);
 }
 
 LBTRRTSolver::LBTRRTSolver() = default;
 
-void LBTRRTSolver::Instantiate(LBTRRTSolverInitializer& init)
+void LBTRRTSolver::Instantiate(const LBTRRTSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(LBTRRTSolverInitializer(init));
     algorithm_ = "Exotica_LBTRRT";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::LBTRRT>, _1, _2);
 }
 
 RRTSolver::RRTSolver() = default;
 
-void RRTSolver::Instantiate(RRTSolverInitializer& init)
+void RRTSolver::Instantiate(const RRTSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(RRTSolverInitializer(init));
     algorithm_ = "Exotica_RRT";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::RRT>, _1, _2);
 }
 
 RRTConnectSolver::RRTConnectSolver() = default;
 
-void RRTConnectSolver::Instantiate(RRTConnectSolverInitializer& init)
+void RRTConnectSolver::Instantiate(const RRTConnectSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(RRTConnectSolverInitializer(init));
     algorithm_ = "Exotica_RRTConnect";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::RRTConnect>, _1, _2);
 }
@@ -103,36 +103,36 @@ double RRTConnectSolver::GetRange()
 
 ESTSolver::ESTSolver() = default;
 
-void ESTSolver::Instantiate(ESTSolverInitializer& init)
+void ESTSolver::Instantiate(const ESTSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(ESTSolverInitializer(init));
     algorithm_ = "Exotica_EST";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::EST>, _1, _2);
 }
 
 KPIECESolver::KPIECESolver() = default;
 
-void KPIECESolver::Instantiate(KPIECESolverInitializer& init)
+void KPIECESolver::Instantiate(const KPIECESolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(KPIECESolverInitializer(init));
     algorithm_ = "Exotica_KPIECE";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::KPIECE1>, _1, _2);
 }
 
 BKPIECESolver::BKPIECESolver() = default;
 
-void BKPIECESolver::Instantiate(BKPIECESolverInitializer& init)
+void BKPIECESolver::Instantiate(const BKPIECESolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(BKPIECESolverInitializer(init));
     algorithm_ = "Exotica_BKPIECE";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::BKPIECE1>, _1, _2);
 }
 
 PRMSolver::PRMSolver() = default;
 
-void PRMSolver::Instantiate(PRMSolverInitializer& init)
+void PRMSolver::Instantiate(const PRMSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(PRMSolverInitializer(init));
     algorithm_ = "Exotica_PRM";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::PRM>, _1, _2);
     multi_query_ = init.MultiQuery;
@@ -193,9 +193,9 @@ void PRMSolver::SetMultiQuery(bool val)
 
 LazyPRMSolver::LazyPRMSolver() = default;
 
-void LazyPRMSolver::Instantiate(LazyPRMSolverInitializer& init)
+void LazyPRMSolver::Instantiate(const LazyPRMSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = OMPLSolverInitializer(LazyPRMSolverInitializer(init));
     algorithm_ = "Exotica_LazyPRM";
     planner_allocator_ = boost::bind(&AllocatePlanner<ompl::geometric::LazyPRM>, _1, _2);
     multi_query_ = init.MultiQuery;

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
@@ -110,7 +110,7 @@ public:
 
     virtual ~TimeIndexedRRTConnectSolver();
 
-    void Instantiate(TimeIndexedRRTConnectSolverInitializer &init) override;
+    void Instantiate(const TimeIndexedRRTConnectSolverInitializer &init) override;
     void Solve(Eigen::MatrixXd &solution) override;
     void SpecifyProblem(PlanningProblemPtr pointer) override;
     void SetPlannerTerminationCondition(const std::shared_ptr<ompl::base::PlannerTerminationCondition> &ptc);

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
@@ -105,9 +105,9 @@ bool OMPLTimeIndexedStateValidityChecker::isValid(const ompl::base::State *state
 TimeIndexedRRTConnectSolver::TimeIndexedRRTConnectSolver() = default;
 TimeIndexedRRTConnectSolver::~TimeIndexedRRTConnectSolver() = default;
 
-void TimeIndexedRRTConnectSolver::Instantiate(TimeIndexedRRTConnectSolverInitializer &init)
+void TimeIndexedRRTConnectSolver::Instantiate(const TimeIndexedRRTConnectSolverInitializer &init)
 {
-    init_ = static_cast<Initializer>(init);
+    init_ = dynamic_cast<const Initializer &>(init);
     algorithm_ = "Exotica_TimeIndexedRRTConnect";
     planner_allocator_ = boost::bind(&allocatePlanner<OMPLTimeIndexedRRTConnect>, _1, _2);
 

--- a/exotica_core/include/exotica_core/motion_solver.h
+++ b/exotica_core/include/exotica_core/motion_solver.h
@@ -47,7 +47,7 @@ public:
     virtual void SpecifyProblem(PlanningProblemPtr pointer);
     virtual void Solve(Eigen::MatrixXd& solution) = 0;
     PlanningProblemPtr GetProblem() { return problem_; }
-    std::string Print(const std::string& prepend) override;
+    std::string Print(const std::string& prepend) const override;
     void SetNumberOfMaxIterations(int max_iter)
     {
         if (max_iter < 1) ThrowPretty("Number of maximum iterations needs to be greater than 0.");

--- a/exotica_core/include/exotica_core/object.h
+++ b/exotica_core/include/exotica_core/object.h
@@ -58,7 +58,7 @@ public:
 
     /// \brief Type Information wrapper: must be virtual so that it is polymorphic...
     /// @return String containing the type of the object
-    inline virtual std::string type()
+    inline virtual std::string type() const
     {
         return GetTypeName(typeid(*this));
     }
@@ -75,7 +75,7 @@ public:
         debug_ = oinit.Debug;
     }
 
-    virtual std::string Print(const std::string& prepend)
+    virtual std::string Print(const std::string& prepend) const
     {
         return prepend + "  " + object_name_ + " (" + type() + ")";
     }

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -70,7 +70,7 @@ public:
     TaskMapMap& GetTaskMaps();
     TaskMapVec& GetTasks();
     ScenePtr GetScene() const;
-    std::string Print(const std::string& prepend) override;
+    std::string Print(const std::string& prepend) const override;
 
     void SetStartState(Eigen::VectorXdRefConst x);
     Eigen::VectorXd GetStartState() const;

--- a/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
@@ -44,7 +44,7 @@ public:
     BoundedEndPoseProblem();
     virtual ~BoundedEndPoseProblem();
 
-    virtual void Instantiate(BoundedEndPoseProblemInitializer& init);
+    virtual void Instantiate(const BoundedEndPoseProblemInitializer& init);
     void Update(Eigen::VectorXdRefConst x);
 
     void SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);

--- a/exotica_core/include/exotica_core/problems/bounded_time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/bounded_time_indexed_problem.h
@@ -45,7 +45,7 @@ public:
     virtual ~BoundedTimeIndexedProblem() = default;
 
     /// \brief Instantiates the problem from an Initializer
-    void Instantiate(BoundedTimeIndexedProblemInitializer& init) override;
+    void Instantiate(const BoundedTimeIndexedProblemInitializer& init) override;
 
     /// \brief Updates internal variables before solving, e.g., after setting new values for Rho.
     void PreUpdate() override;

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -43,7 +43,7 @@ class DynamicTimeIndexedShootingProblem : public PlanningProblem, public Instant
 public:
     DynamicTimeIndexedShootingProblem();
     virtual ~DynamicTimeIndexedShootingProblem();
-    void Instantiate(DynamicTimeIndexedShootingProblemInitializer& init) override;
+    void Instantiate(const DynamicTimeIndexedShootingProblemInitializer& init) override;
 
     void PreUpdate() override;
     void Update(Eigen::VectorXdRefConst u, int t);

--- a/exotica_core/include/exotica_core/problems/end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/end_pose_problem.h
@@ -44,7 +44,7 @@ public:
     EndPoseProblem();
     virtual ~EndPoseProblem();
 
-    virtual void Instantiate(EndPoseProblemInitializer& init);
+    virtual void Instantiate(const EndPoseProblemInitializer& init);
     void Update(Eigen::VectorXdRefConst x);
     bool IsValid() override;
 

--- a/exotica_core/include/exotica_core/problems/sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/sampling_problem.h
@@ -43,7 +43,7 @@ public:
     SamplingProblem();
     virtual ~SamplingProblem();
 
-    virtual void Instantiate(SamplingProblemInitializer& init);
+    virtual void Instantiate(const SamplingProblemInitializer& init);
 
     void Update(Eigen::VectorXdRefConst x);
     bool IsValid(Eigen::VectorXdRefConst x);  // Not overriding on purpose - this updates and calls IsValid

--- a/exotica_core/include/exotica_core/problems/time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_problem.h
@@ -43,7 +43,7 @@ public:
     virtual ~TimeIndexedProblem() = default;
 
     /// \brief Instantiates the problem from an Initializer
-    void Instantiate(TimeIndexedProblemInitializer& init) override;
+    void Instantiate(const TimeIndexedProblemInitializer& init) override;
 
     /// \brief Evaluates whether the problem is valid, i.e., all bound and general constraints are satisfied.
     bool IsValid() override;

--- a/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
@@ -43,7 +43,7 @@ public:
     TimeIndexedSamplingProblem();
     virtual ~TimeIndexedSamplingProblem();
 
-    virtual void Instantiate(TimeIndexedSamplingProblemInitializer& init);
+    virtual void Instantiate(const TimeIndexedSamplingProblemInitializer& init);
 
     void Update(Eigen::VectorXdRefConst x, const double& t);
     bool IsValid(Eigen::VectorXdRefConst x, const double& t);  // Not overriding on purpose

--- a/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
@@ -43,7 +43,7 @@ public:
     UnconstrainedEndPoseProblem();
     virtual ~UnconstrainedEndPoseProblem();
 
-    virtual void Instantiate(UnconstrainedEndPoseProblemInitializer& init);
+    virtual void Instantiate(const UnconstrainedEndPoseProblemInitializer& init);
     void Update(Eigen::VectorXdRefConst x);
 
     void SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);

--- a/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
@@ -48,7 +48,7 @@ public:
     virtual ~UnconstrainedTimeIndexedProblem() = default;
 
     /// \brief Instantiates the problem from an Initializer
-    void Instantiate(UnconstrainedTimeIndexedProblemInitializer& init) override;
+    void Instantiate(const UnconstrainedTimeIndexedProblemInitializer& init) override;
 
     /// \brief Updates internal variables before solving, e.g., after setting new values for Rho.
     void PreUpdate() override;

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -124,12 +124,18 @@ public:
         return C().GetAllTemplates();
     }
 
-    virtual void Instantiate(const C& init){}
+    virtual void Instantiate(const C& init)
+    {
+        parameters_ = init;
+    }
 
-        [[deprecated]] virtual void Instantiate(C& init)
+    [[deprecated]] virtual void Instantiate(C& init)
     {
         Instantiate(static_cast<const C&>(init));
     }
+
+protected:
+    C parameters_;
 };
 }
 

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -124,7 +124,12 @@ public:
         return C().GetAllTemplates();
     }
 
-    virtual void Instantiate(const C& init) = 0;
+    virtual void Instantiate(const C& init){}
+
+        [[deprecated]] virtual void Instantiate(C& init)
+    {
+        Instantiate(static_cast<const C&>(init));
+    }
 };
 }
 

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -109,7 +109,7 @@ public:
     virtual void InstantiateInternal(const Initializer& init)
     {
         InstantiateBase(init);
-        C tmp(init);
+        const C tmp(init);
         tmp.Check(init);
         Instantiate(tmp);
     }
@@ -124,7 +124,7 @@ public:
         return C().GetAllTemplates();
     }
 
-    virtual void Instantiate(C& init) = 0;
+    virtual void Instantiate(const C& init) = 0;
 };
 }
 

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -102,7 +102,7 @@ public:
     virtual std::vector<Initializer> GetAllTemplates() const = 0;
 };
 
-template <class C>
+template <class C, typename = typename std::enable_if<std::is_base_of<InitializerBase, C>::value, C>::type>
 class Instantiable : public virtual InstantiableBase
 {
 public:

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -66,7 +66,7 @@ public:
     Scene(const std::string& name);
     Scene();
     virtual ~Scene();
-    virtual void Instantiate(SceneInitializer& init);
+    virtual void Instantiate(const SceneInitializer& init);
     void RequestKinematics(KinematicsRequest& request, std::function<void(std::shared_ptr<KinematicResponse>)> callback);
     std::string GetName();
     virtual void Update(Eigen::VectorXdRefConst x, double t = 0);

--- a/exotica_core/include/exotica_core/task_map.h
+++ b/exotica_core/include/exotica_core/task_map.h
@@ -64,7 +64,7 @@ public:
     virtual int TaskSpaceJacobianDim() { return TaskSpaceDim(); }
     virtual void PreUpdate() {}
     virtual std::vector<TaskVectorEntry> GetLieGroupIndices() { return std::vector<TaskVectorEntry>(); }
-    std::string Print(const std::string& prepend) override;
+    std::string Print(const std::string& prepend) const override;
 
     std::vector<KinematicFrameRequest> GetFrames();
 

--- a/exotica_core/src/motion_solver.cpp
+++ b/exotica_core/src/motion_solver.cpp
@@ -50,7 +50,7 @@ void MotionSolver::SpecifyProblem(PlanningProblemPtr pointer)
     problem_ = pointer;
 }
 
-std::string MotionSolver::Print(const std::string& prepend)
+std::string MotionSolver::Print(const std::string& prepend) const
 {
     std::string ret = Object::Print(prepend);
     ret += "\n" + prepend + "  Problem:";

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -43,11 +43,11 @@ namespace exotica
 PlanningProblem::PlanningProblem() = default;
 PlanningProblem::~PlanningProblem() = default;
 
-std::string PlanningProblem::Print(const std::string& prepend)
+std::string PlanningProblem::Print(const std::string& prepend) const
 {
     std::string ret = Object::Print(prepend);
     ret += "\n" + prepend + "  Task definitions:";
-    for (auto& it : task_maps_)
+    for (const auto& it : task_maps_)
         ret += "\n" + it.second->Print(prepend + "    ");
     return ret;
 }

--- a/exotica_core/src/problems/bounded_end_pose_problem.cpp
+++ b/exotica_core/src/problems/bounded_end_pose_problem.cpp
@@ -48,7 +48,7 @@ Eigen::MatrixXd BoundedEndPoseProblem::GetBounds() const
     return scene_->GetKinematicTree().GetJointLimits();
 }
 
-void BoundedEndPoseProblem::Instantiate(BoundedEndPoseProblemInitializer& init)
+void BoundedEndPoseProblem::Instantiate(const BoundedEndPoseProblemInitializer& init)
 {
     num_tasks = tasks_.size();
     length_Phi = 0;

--- a/exotica_core/src/problems/bounded_time_indexed_problem.cpp
+++ b/exotica_core/src/problems/bounded_time_indexed_problem.cpp
@@ -34,7 +34,7 @@ REGISTER_PROBLEM_TYPE("BoundedTimeIndexedProblem", exotica::BoundedTimeIndexedPr
 
 namespace exotica
 {
-void BoundedTimeIndexedProblem::Instantiate(BoundedTimeIndexedProblemInitializer& init)
+void BoundedTimeIndexedProblem::Instantiate(const BoundedTimeIndexedProblemInitializer& init)
 {
     init_ = init;
 

--- a/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
+++ b/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
@@ -39,7 +39,7 @@ DynamicTimeIndexedShootingProblem::DynamicTimeIndexedShootingProblem() = default
 
 DynamicTimeIndexedShootingProblem::~DynamicTimeIndexedShootingProblem() = default;
 
-void DynamicTimeIndexedShootingProblem::Instantiate(DynamicTimeIndexedShootingProblemInitializer& init)
+void DynamicTimeIndexedShootingProblem::Instantiate(const DynamicTimeIndexedShootingProblemInitializer& init)
 {
     init_ = init;
 

--- a/exotica_core/src/problems/end_pose_problem.cpp
+++ b/exotica_core/src/problems/end_pose_problem.cpp
@@ -48,7 +48,7 @@ Eigen::MatrixXd EndPoseProblem::GetBounds() const
     return scene_->GetKinematicTree().GetJointLimits();
 }
 
-void EndPoseProblem::Instantiate(EndPoseProblemInitializer& init)
+void EndPoseProblem::Instantiate(const EndPoseProblemInitializer& init)
 {
     parameters = init;
     num_tasks = tasks_.size();

--- a/exotica_core/src/problems/sampling_problem.cpp
+++ b/exotica_core/src/problems/sampling_problem.cpp
@@ -56,7 +56,7 @@ std::vector<double> SamplingProblem::GetBounds()
     return bounds;
 }
 
-void SamplingProblem::Instantiate(SamplingProblemInitializer& init)
+void SamplingProblem::Instantiate(const SamplingProblemInitializer& init)
 {
     parameters = init;
 

--- a/exotica_core/src/problems/time_indexed_problem.cpp
+++ b/exotica_core/src/problems/time_indexed_problem.cpp
@@ -34,7 +34,7 @@ REGISTER_PROBLEM_TYPE("TimeIndexedProblem", exotica::TimeIndexedProblem)
 
 namespace exotica
 {
-void TimeIndexedProblem::Instantiate(TimeIndexedProblemInitializer& init)
+void TimeIndexedProblem::Instantiate(const TimeIndexedProblemInitializer& init)
 {
     init_ = init;
 

--- a/exotica_core/src/problems/time_indexed_sampling_problem.cpp
+++ b/exotica_core/src/problems/time_indexed_sampling_problem.cpp
@@ -56,7 +56,7 @@ std::vector<double> TimeIndexedSamplingProblem::GetBounds()
     return bounds;
 }
 
-void TimeIndexedSamplingProblem::Instantiate(TimeIndexedSamplingProblemInitializer& init)
+void TimeIndexedSamplingProblem::Instantiate(const TimeIndexedSamplingProblemInitializer& init)
 {
     parameters = init;
 

--- a/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
+++ b/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
@@ -41,7 +41,7 @@ UnconstrainedEndPoseProblem::UnconstrainedEndPoseProblem()
 
 UnconstrainedEndPoseProblem::~UnconstrainedEndPoseProblem() = default;
 
-void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitializer& init)
+void UnconstrainedEndPoseProblem::Instantiate(const UnconstrainedEndPoseProblemInitializer& init)
 {
     num_tasks = tasks_.size();
     length_Phi = 0;

--- a/exotica_core/src/problems/unconstrained_time_indexed_problem.cpp
+++ b/exotica_core/src/problems/unconstrained_time_indexed_problem.cpp
@@ -34,7 +34,7 @@ REGISTER_PROBLEM_TYPE("UnconstrainedTimeIndexedProblem", exotica::UnconstrainedT
 
 namespace exotica
 {
-void UnconstrainedTimeIndexedProblem::Instantiate(UnconstrainedTimeIndexedProblemInitializer& init)
+void UnconstrainedTimeIndexedProblem::Instantiate(const UnconstrainedTimeIndexedProblemInitializer& init)
 {
     init_ = init;
 

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -56,9 +56,9 @@ std::string Scene::GetName()
     return name_;
 }
 
-void Scene::Instantiate(SceneInitializer& init)
+void Scene::Instantiate(const SceneInitializer& init)
 {
-    Object::InstantiateObject(init);
+    Object::InstantiateObject(SceneInitializer(init));
     name_ = object_name_;
     kinematica_.debug = debug_;
     force_collision_ = init.AlwaysUpdateCollisionScene;

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -42,7 +42,7 @@ void TaskMap::AssignScene(ScenePtr scene)
     scene_ = scene;
 }
 
-std::string TaskMap::Print(const std::string& prepend)
+std::string TaskMap::Print(const std::string& prepend) const
 {
     std::string ret = Object::Print(prepend);
     return ret;


### PR DESCRIPTION
The `Initializer` is meant to configure any `Instantiable` object in EXOTica. It is meant to be read-only and this PR declares the `Instantiate` as a method that only reads from the `Initializer`.