### PR TITLE
fix CMake warnings

### DIFF
--- a/exotations/solvers/exotica_ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_ompl_solver/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME} ${OMPL_LIBRARIES}
   CATKIN_DEPENDS exotica_core
-  DEPENDS ompl
+  DEPENDS OMPL
 )
 
 AddInitializer(

--- a/exotica_core/CMakeLists.txt
+++ b/exotica_core/CMakeLists.txt
@@ -58,7 +58,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp moveit_core moveit_ros_planning tf kdl_parser pluginlib tf_conversions eigen_conversions geometry_msgs moveit_msgs std_msgs
   CFG_EXTRAS exotica.cmake add_initializer.cmake
-  DEPENDS TinyXML2 Eigen3 Boost
+  DEPENDS TinyXML2 EIGEN3 Boost
 )
 
 ## Build ##


### PR DESCRIPTION
Fixes the recent CI [Kdev warnings](http://build.ros.org/job/Kdev__exotica__ubuntu_xenial_amd64/40/warnings2Result/new/):

> catkin_package() DEPENDS on 'Eigen3' but neither 'Eigen3_INCLUDE_DIRS' nor  'Eigen3_LIBRARIES' is defined.
> 
> catkin_package() DEPENDS on 'ompl' but neither 'ompl_INCLUDE_DIRS' nor  'ompl_LIBRARIES' is defined.

(See: https://answers.ros.org/question/253588/ros-kinetic-eigen/?answer=253596#post-id-253596)