### PR TITLE
Optional def arg

### DIFF
--- a/exotations/exotica_core_task_maps/init/joint_pose.in
+++ b/exotations/exotica_core_task_maps/init/joint_pose.in
@@ -2,5 +2,5 @@ class JointPose
 
 extend <exotica_core/task_map>
 
-Optional Eigen::VectorXd JointRef;
-Optional Eigen::VectorXd JointMap;
+Optional Eigen::VectorXd JointRef = Eigen::VectorXd();
+Optional Eigen::VectorXd JointMap = Eigen::VectorXd();

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -47,7 +47,7 @@ void IKSolver::SpecifyProblem(PlanningProblemPtr pointer)
     prob_ = std::static_pointer_cast<UnconstrainedEndPoseProblem>(pointer);
 
     if (parameters_.C < 0 || parameters_.C >= 1.0)
-        ThrowNamed("C must be from interval <0, 1)!");
+        ThrowNamed("C must be from interval [0, 1)!");
     C_ = Eigen::MatrixXd::Identity(prob_->cost.length_jacobian, prob_->cost.length_jacobian) * parameters_.C;
     W_ = prob_->W;
 

--- a/exotica_core/cmake/generate_initializers.py
+++ b/exotica_core/cmake/generate_initializers.py
@@ -83,8 +83,6 @@ def default_value(data):
 def default_argument_value(data):
     if data['Value'] == None:
         return ""
-    elif data['Value'] == '{}':
-        return " = {}"
     else:
         return " = "+data['Value']
 
@@ -288,14 +286,17 @@ def parse_line(line, line_number, function_name):
     name = ""
     if not required:
         eq = line.find("=")
-        if eq == -1:
-            eq = last
-            value = '{}'
-        else:
+        has_default_arg = not (eq == -1)
+        if has_default_arg:
             value = line[eq + 1:last]
+        else:
+            # we need this to get the parameter name
+            eq = last
         name_start = line[0:eq].strip().rfind(" ")
         name = line[name_start:eq].strip()
         type = line[9:name_start].strip()
+        if not has_default_arg:
+            eprint("Optional parameter '" + name + "' requires a default argument!")
     else:
         name_start = line[0:last].strip().rfind(" ")
         name = line[name_start:last].strip()


### PR DESCRIPTION
As discussed in https://github.com/ipab-slmc/exotica/issues/561, this PR changes the initialiser code generator to require default arguments for `Optional` paramters.

It already triggered for the JointPose task map initiliasier (`Optional parameter 'JointRef' requires a default argument!`) which is a Eigen Matrix type and would load garbage values if not set by the user.

What would be a good default value for these:
https://github.com/ipab-slmc/exotica/blob/79699fc5c94f909329e27b652b36c1b50c086ae4/exotations/exotica_core_task_maps/init/joint_pose.in#L1-L6
or should they be `Required`?

Edit: I already made them `Required` to let the CI pass.