### PR TITLE
Support full start state (position + velocity) for dynamic problems

### DIFF
--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
+AddInitializer(double_integrator_dynamics_solver)
+GenInitializers()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -18,6 +21,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/double_integrator_dynamics_solver.cpp)
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/include/exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/include/exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver.h
@@ -31,10 +31,13 @@
 #define EXOTICA_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_DOUBLE_INTEGRATOR_DYNAMICS_SOLVER_H_
 
 #include <exotica_core/dynamics_solver.h>
+#include <exotica_core/scene.h>
+
+#include <exotica_double_integrator_dynamics_solver/double_integrator_dynamics_solver_initializer.h>
 
 namespace exotica
 {
-class DoubleIntegratorDynamicsSolver : public DynamicsSolver
+class DoubleIntegratorDynamicsSolver : public DynamicsSolver, public Instantiable<DoubleIntegratorDynamicsSolverInitializer>
 {
 public:
     DoubleIntegratorDynamicsSolver();

--- a/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/init/double_integrator_dynamics_solver.in
+++ b/exotations/dynamics_solvers/exotica_double_integrator_dynamics_solver/init/double_integrator_dynamics_solver.in
@@ -1,0 +1,3 @@
+class DoubleIntegratorDynamicsSolver
+
+extend <exotica_core/dynamics_solver>

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -7,6 +7,9 @@ find_package(catkin REQUIRED COMPONENTS
   pinocchio
 )
 
+AddInitializer(pinocchio_dynamics_solver)
+GenInitializers()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -19,6 +22,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp)
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
@@ -31,6 +31,9 @@
 #define EXOTICA_PINOCCHIO_DYNAMICS_SOLVER_PINOCCHIO_DYNAMICS_SOLVER_H_
 
 #include <exotica_core/dynamics_solver.h>
+#include <exotica_core/scene.h>
+
+#include <exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver_initializer.h>
 
 /// TODO: remove this pragma once Pinocchio removes neutralConfiguration/
 /// and fixes their deprecation warnings. (Relates to #547)
@@ -47,7 +50,7 @@
 
 namespace exotica
 {
-class PinocchioDynamicsSolver : public DynamicsSolver
+class PinocchioDynamicsSolver : public DynamicsSolver, public Instantiable<PinocchioDynamicsSolverInitializer>
 {
 public:
     PinocchioDynamicsSolver();

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/init/pinocchio_dynamics_solver.in
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/init/pinocchio_dynamics_solver.in
@@ -1,0 +1,3 @@
+class PinocchioDynamicsSolver
+
+extend <exotica_core/dynamics_solver>

--- a/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
+AddInitializer(quadrotor_dynamics_solver)
+GenInitializers()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -18,6 +21,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/quadrotor_dynamics_solver.cpp)
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/include/exotica_quadrotor_dynamics_solver/quadrotor_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/include/exotica_quadrotor_dynamics_solver/quadrotor_dynamics_solver.h
@@ -31,6 +31,9 @@
 #define EXOTICA_QUADROTOR_DYNAMICS_SOLVER_QUADROTOR_DYNAMICS_SOLVER_H_
 
 #include <exotica_core/dynamics_solver.h>
+#include <exotica_core/scene.h>
+
+#include <exotica_quadrotor_dynamics_solver/quadrotor_dynamics_solver_initializer.h>
 
 namespace exotica
 {
@@ -41,7 +44,7 @@ namespace exotica
 /// Cf. https://journals.sagepub.com/doi/abs/10.1177/0278364911434236
 ///
 /// StateVector X ∈ R^12 = [x, y, z, r, p, y, xdot, ydot, zdot, omega1, omega2, omega3]
-class QuadrotorDynamicsSolver : public DynamicsSolver
+class QuadrotorDynamicsSolver : public DynamicsSolver, public Instantiable<QuadrotorDynamicsSolverInitializer>
 {
 public:
     QuadrotorDynamicsSolver();

--- a/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/init/quadrotor_dynamics_solver.in
+++ b/exotations/dynamics_solvers/exotica_quadrotor_dynamics_solver/init/quadrotor_dynamics_solver.in
@@ -1,0 +1,3 @@
+class QuadrotorDynamicsSolver
+
+extend <exotica_core/dynamics_solver>

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -45,14 +45,14 @@ void OMPLSolver<ProblemType>::SpecifyProblem(PlanningProblemPtr pointer)
 {
     MotionSolver::SpecifyProblem(pointer);
     prob_ = std::static_pointer_cast<ProblemType>(pointer);
-    if (prob_->GetScene()->GetBaseType() == BaseType::FIXED)
+    if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::FIXED)
         state_space_.reset(new OMPLRNStateSpace(init_));
-    else if (prob_->GetScene()->GetBaseType() == BaseType::PLANAR)
+    else if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::PLANAR)
         state_space_.reset(new OMPLSE2RNStateSpace(init_));
-    else if (prob_->GetScene()->GetBaseType() == BaseType::FLOATING)
+    else if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::FLOATING)
         state_space_.reset(new OMPLSE3RNStateSpace(init_));
     else
-        ThrowNamed("Unsupported base type " << prob_->GetScene()->GetBaseType());
+        ThrowNamed("Unsupported base type " << prob_->GetScene()->GetKinematicTree().GetControlledBaseType());
     ompl_simple_setup_.reset(new ompl::geometric::SimpleSetup(state_space_));
     ompl_simple_setup_->setStateValidityChecker(ompl::base::StateValidityCheckerPtr(new OMPLStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_)));
     ompl_simple_setup_->setPlannerAllocator(boost::bind(planner_allocator_, _1, algorithm_));
@@ -65,11 +65,11 @@ void OMPLSolver<ProblemType>::SpecifyProblem(PlanningProblemPtr pointer)
             project_vars[i] = (int)init_.Projection(i);
             if (project_vars[i] < 0 || project_vars[i] >= prob_->N) ThrowNamed("Invalid projection index! " << project_vars[i]);
         }
-        if (prob_->GetScene()->GetBaseType() == BaseType::FIXED)
+        if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::FIXED)
             ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ompl::base::ProjectionEvaluatorPtr(new OMPLRNProjection(state_space_, project_vars)));
-        else if (prob_->GetScene()->GetBaseType() == BaseType::PLANAR)
+        else if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::PLANAR)
             ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ompl::base::ProjectionEvaluatorPtr(new OMPLSE2RNProjection(state_space_, project_vars)));
-        else if (prob_->GetScene()->GetBaseType() == BaseType::FLOATING)
+        else if (prob_->GetScene()->GetKinematicTree().GetControlledBaseType() == BaseType::FLOATING)
             ompl_simple_setup_->getStateSpace()->registerDefaultProjection(ompl::base::ProjectionEvaluatorPtr(new OMPLSE3RNProjection(state_space_, project_vars)));
     }
 }

--- a/exotica_core/CMakeLists.txt
+++ b/exotica_core/CMakeLists.txt
@@ -49,6 +49,7 @@ AddInitializer(
   bounded_time_indexed_problem
   bounded_end_pose_problem
   dynamic_time_indexed_shooting_problem
+  dynamics_solver
 )
 GenInitializers()
 

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -31,13 +31,17 @@
 #define EXOTICA_CORE_DYNAMICS_SOLVER_H_
 
 #include <exotica_core/factory.h>
-#include <exotica_core/scene.h>
-#include <exotica_core/tools/uncopyable.h>
+#include <exotica_core/object.h>
+#include <exotica_core/property.h>
+
+#include <exotica_core/dynamics_solver_initializer.h>
 
 #define REGISTER_DYNAMICS_SOLVER_TYPE(TYPE, DERIV) EXOTICA_CORE_REGISTER(exotica::DynamicsSolver, TYPE, DERIV)
 
 namespace exotica
 {
+class Scene;
+
 enum Integrator
 {
     RK1 = 0,  ///< Forward Euler
@@ -47,7 +51,7 @@ enum Integrator
 };
 
 template <typename T, int NX, int NU>
-class AbstractDynamicsSolver : public Uncopyable
+class AbstractDynamicsSolver : public Object, Uncopyable, public virtual InstantiableBase
 {
 public:
     typedef Eigen::Matrix<T, NX, 1> StateVector;         ///< Convenience definition for a StateVector containing both position and velocity (dimension NX x 1)
@@ -58,10 +62,13 @@ public:
     AbstractDynamicsSolver();
     virtual ~AbstractDynamicsSolver();
 
+    /// \brief Instantiates the base properties of the DynamicsSolver
+    virtual void InstantiateBase(const Initializer& init);
+
     /// \brief Passes the Scene of the PlanningProblem to the DynamicsSolver
     ///
     ///  Called immediately after creation of the DynamicsSolver plug-in using a pointer to the Scene of the PlanningProblem. This can be used to extract required information from the Scene, e.g., URDF, dimensionality, etc.
-    virtual void AssignScene(ScenePtr scene_in);
+    virtual void AssignScene(std::shared_ptr<Scene> scene_in);
 
     /// \brief Sets the timestep dt to be used for integration.
     virtual void SetDt(double dt_in);

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 
+#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/object.h>
 #include <exotica_core/scene.h>
 #include <exotica_core/task_map.h>

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -35,7 +35,6 @@
 #include <string>
 #include <vector>
 
-#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/object.h>
 #include <exotica_core/scene.h>
 #include <exotica_core/task_map.h>

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -30,7 +30,6 @@
 #ifndef EXOTICA_CORE_DYNAMIC_TIME_INDEXED_SHOOTING_PROBLEM_H_
 #define EXOTICA_CORE_DYNAMIC_TIME_INDEXED_SHOOTING_PROBLEM_H_
 
-#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/planning_problem.h>
 #include <exotica_core/tasks.h>
 
@@ -86,8 +85,6 @@ private:
 
     std::vector<Eigen::MatrixXd> Q_;  ///< State space penalty matrix (precision matrix), per time index
     Eigen::MatrixXd R_;               ///< Control space penalty matrix
-
-    DynamicsSolverPtr dynamics_solver_;
 
     std::vector<std::shared_ptr<KinematicResponse>> kinematic_solutions_;
 };

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -188,7 +188,7 @@ private:
     CollisionScenePtr collision_scene_;
 
     /// The dynamics solver
-    std::shared_ptr<DynamicsSolver> dynamics_solver_;
+    std::shared_ptr<DynamicsSolver> dynamics_solver_ = std::shared_ptr<DynamicsSolver>(nullptr);
 
     /// Internal MoveIt planning scene
     planning_scene::PlanningScenePtr ps_;

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -68,15 +68,15 @@ public:
     virtual ~Scene();
     virtual void Instantiate(const SceneInitializer& init);
     void RequestKinematics(KinematicsRequest& request, std::function<void(std::shared_ptr<KinematicResponse>)> callback);
-    std::string GetName();
-    virtual void Update(Eigen::VectorXdRefConst x, double t = 0);
-    void SetCollisionScene(const moveit_msgs::PlanningScene& scene);
-    CollisionScenePtr& GetCollisionScene();
+    const std::string& GetName() const;  // Deprecated - use GetObjectName
+    void Update(Eigen::VectorXdRefConst x, double t = 0);
+
+    /// \brief Returns a pointer to the CollisionScene
+    const CollisionScenePtr& GetCollisionScene() const;
     std::string GetRootFrameName();
     std::string GetRootJointName();
-    moveit_msgs::PlanningScene GetPlanningSceneMsg();
+
     exotica::KinematicTree& GetKinematicTree();
-    void GetControlledJointNames(std::vector<std::string>& joints);
     std::vector<std::string> GetControlledJointNames();
     std::vector<std::string> GetModelJointNames();
     std::vector<std::string> GetControlledLinkNames();
@@ -87,7 +87,6 @@ public:
     std::map<std::string, std::weak_ptr<KinematicElement>> GetTreeMap();
     void SetModelState(Eigen::VectorXdRefConst x, double t = 0, bool update_traj = true);
     void SetModelState(std::map<std::string, double> x, double t = 0, bool update_traj = true);
-    std::string GetGroupName();
 
     void AddTrajectoryFromFile(const std::string& link, const std::string& traj);
     void AddTrajectory(const std::string& link, const std::string& traj);
@@ -125,18 +124,19 @@ public:
 
     void RemoveObject(const std::string& name);
 
-    /// @brief Update the internal MoveIt planning scene from a
-    /// moveit_msgs::PlanningSceneWorld
+    /// @brief Update the collision scene from a moveit_msgs::PlanningSceneWorld
     /// @param[in] world moveit_msgs::PlanningSceneWorld
-    void UpdateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
+    void UpdatePlanningSceneWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
+
+    /// @brief Update the collision scene from a moveit_msgs::PlanningScene
+    /// @param[in] scene moveit_msgs::PlanningScene
+    void UpdatePlanningScene(const moveit_msgs::PlanningScene& scene);
+
+    /// @brief Returns the current robot configuration and collision environment
+    /// as a moveit_msgs::PlanningScene
+    moveit_msgs::PlanningScene GetPlanningSceneMsg();
 
     void UpdateCollisionObjects();
-
-    BaseType GetBaseType()
-    {
-        return base_type_;
-    }
-
     void UpdateTrajectoryGenerators(double t = 0);
 
     void PublishScene();
@@ -151,18 +151,18 @@ public:
 
     /// @brief Whether the collision scene transforms get updated on every scene update.
     /// @return Whether collision scene transforms are force updated on every scene update.
-    bool AlwaysUpdatesCollisionScene() { return force_collision_; }
+    bool AlwaysUpdatesCollisionScene() const { return force_collision_; }
     /// @brief Returns a map between a model link name and the names of associated collision links.
     /// @return Map between model links and all associated collision links.
-    std::map<std::string, std::vector<std::string>> GetModelLinkToCollisionLinkMap() { return model_link_to_collision_link_map_; };
+    std::map<std::string, std::vector<std::string>> GetModelLinkToCollisionLinkMap() const { return model_link_to_collision_link_map_; };
     /// @brief Returns a map between a model link name and the KinematicElement of associated collision links.
     /// @return Map between model links and all the KinematicElements of the associated collision links.
-    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> GetModelLinkToCollisionElementMap() { return model_link_to_collision_element_map_; };
+    std::map<std::string, std::vector<std::shared_ptr<KinematicElement>>> GetModelLinkToCollisionElementMap() const { return model_link_to_collision_element_map_; };
     /// @brief Returns a map between controlled robot link names and associated collision link names. Here we consider all fixed links between controlled links as belonging to the previous controlled link (as if the collision links had been fused).
     /// @return Map between controlled links and associated collision links.
-    std::map<std::string, std::vector<std::string>> GetControlledLinkToCollisionLinkMap() { return controlled_link_to_collision_link_map_; };
+    std::map<std::string, std::vector<std::string>> GetControlledLinkToCollisionLinkMap() const { return controlled_link_to_collision_link_map_; };
     /// @brief Returns world links that are to be excluded from collision checking.
-    std::set<std::string> get_world_links_to_exclude_from_collision_scene() { return world_links_to_exclude_from_collision_scene_; }
+    std::set<std::string> get_world_links_to_exclude_from_collision_scene() const { return world_links_to_exclude_from_collision_scene_; }
 private:
     void UpdateInternalFrames(bool update_request = true);
 
@@ -171,17 +171,8 @@ private:
 
     void LoadSceneFromStringStream(std::istream& in, const Eigen::Isometry3d& offset, bool update_collision_scene);
 
-    /// The name of the scene
-    std::string name_ = "Unnamed";
-
     /// The kinematica tree
     exotica::KinematicTree kinematica_;
-
-    /// Joint group
-    robot_model::JointModelGroup* group;
-
-    /// Robot base type
-    BaseType base_type_;
 
     /// The collision scene
     CollisionScenePtr collision_scene_;
@@ -224,6 +215,6 @@ private:
 };
 
 typedef std::shared_ptr<Scene> ScenePtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_SCENE_H_

--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -59,8 +59,14 @@ struct AttachedObject
     KDL::Frame pose;
 };
 
+#ifndef EXOTICA_CORE_DYNAMICS_SOLVER_H_
+template <typename T, int NX, int NU>
+class AbstractDynamicsSolver;
+typedef AbstractDynamicsSolver<double, Eigen::Dynamic, Eigen::Dynamic> DynamicsSolver;
+#endif
+
 /// The class of EXOTica Scene
-class Scene : public Object, Uncopyable, public Instantiable<SceneInitializer>
+class Scene : public Object, Uncopyable, public Instantiable<SceneInitializer>, public std::enable_shared_from_this<Scene>
 {
 public:
     Scene(const std::string& name);
@@ -73,6 +79,10 @@ public:
 
     /// \brief Returns a pointer to the CollisionScene
     const CollisionScenePtr& GetCollisionScene() const;
+
+    /// \brief Returns a pointer to the CollisionScene
+    std::shared_ptr<DynamicsSolver> GetDynamicsSolver() const;
+
     std::string GetRootFrameName();
     std::string GetRootJointName();
 
@@ -176,6 +186,9 @@ private:
 
     /// The collision scene
     CollisionScenePtr collision_scene_;
+
+    /// The dynamics solver
+    std::shared_ptr<DynamicsSolver> dynamics_solver_;
 
     /// Internal MoveIt planning scene
     planning_scene::PlanningScenePtr ps_;

--- a/exotica_core/include/exotica_core/server.h
+++ b/exotica_core/include/exotica_core/server.h
@@ -76,12 +76,12 @@ public:
     /// \brief Get robot model
     /// @param path Robot model name
     /// @param model Robot model
-    void GetModel(std::string path, robot_model::RobotModelPtr &model, std::string urdf = "", std::string srdf = "");
+    void GetModel(const std::string &path, robot_model::RobotModelPtr &model, const std::string &urdf = "", const std::string &srdf = "");
 
     /// \brief Get robot model
     /// @param path Robot model name
     /// @return robot model
-    robot_model::RobotModelConstPtr GetModel(std::string path, std::string urdf = "", std::string srdf = "");
+    robot_model::RobotModelConstPtr GetModel(const std::string &path, const std::string &urdf = "", const std::string &srdf = "");
 
     /// \brief Get the name of ther server
     /// @return Server name
@@ -173,7 +173,7 @@ private:
     ///	\brief	Make sure the singleton does not get copied
     Server(Server const &) = delete;
     void operator=(Server const &) = delete;
-    robot_model::RobotModelPtr LoadModel(std::string name, std::string urdf = "", std::string srdf = "");
+    robot_model::RobotModelPtr LoadModel(const std::string &name, const std::string &urdf = "", const std::string &srdf = "");
 
     /// \brief	The name of this server
     std::string name_;

--- a/exotica_core/include/exotica_core/setup.h
+++ b/exotica_core/include/exotica_core/setup.h
@@ -101,6 +101,13 @@ public:
         return ret;
     }
 
+    static std::shared_ptr<exotica::DynamicsSolver> CreateDynamicsSolver(const Initializer& init)
+    {
+        auto ret = ToStdPtr(Instance()->dynamics_solvers_.createInstance(init.GetName()));
+        ret->InstantiateInternal(init);
+        return ret;
+    }
+
 private:
     friend PlanningProblem;
     Setup();

--- a/exotica_core/init/dynamic_time_indexed_shooting_problem.in
+++ b/exotica_core/init/dynamic_time_indexed_shooting_problem.in
@@ -5,10 +5,6 @@ extend <exotica_core/planning_problem>
 Required int T;
 Required double tau;  // Discretisation timestep of the trajectory
 
-Optional std::string DynamicsSolver = "DoubleIntegratorDynamicsSolver";
-Optional double dt = 0.01;  // dt for simulating dynamics
-Optional std::string Integrator = "RK1";
-
 Optional Eigen::VectorXd Q = Eigen::VectorXd();
 Optional Eigen::VectorXd R = Eigen::VectorXd();
 Optional double Q_rate = 1.;

--- a/exotica_core/init/dynamics_solver.in
+++ b/exotica_core/init/dynamics_solver.in
@@ -1,0 +1,6 @@
+class DynamicsSolver
+
+extend <exotica_core/object>
+
+Optional double dt = 0.01;  // dt for simulating dynamics
+Optional std::string Integrator = "RK1";

--- a/exotica_core/init/scene.in
+++ b/exotica_core/init/scene.in
@@ -19,6 +19,9 @@ Optional double RobotLinkScale = 1.0;
 Optional double WorldLinkPadding = 0.0;
 Optional double RobotLinkPadding = 0.0;
 
+// Dynamics solver
+Optional std::vector<exotica::Initializer> DynamicsSolver = std::vector<exotica::Initializer>();
+
 Optional std::string LoadScene = "";  // to load multiple scenes, separate by semi-colon.
 Optional std::vector<exotica::Initializer> Links = std::vector<exotica::Initializer>();
 Optional std::vector<exotica::Initializer> Trajectories = std::vector<exotica::Initializer>();

--- a/exotica_core/src/dynamics_solver.cpp
+++ b/exotica_core/src/dynamics_solver.cpp
@@ -28,6 +28,7 @@
 //
 
 #include <exotica_core/dynamics_solver.h>
+#include <exotica_core/scene.h>
 
 namespace exotica
 {
@@ -40,7 +41,18 @@ template <typename T, int NX, int NU>
 AbstractDynamicsSolver<T, NX, NU>::~AbstractDynamicsSolver() = default;
 
 template <typename T, int NX, int NU>
-void AbstractDynamicsSolver<T, NX, NU>::AssignScene(ScenePtr scene_in)
+void AbstractDynamicsSolver<T, NX, NU>::InstantiateBase(const Initializer& init)
+{
+    Object::InstantiateObject(init);
+    DynamicsSolverInitializer dynamics_solver_initializer = DynamicsSolverInitializer(init);
+    this->SetDt(dynamics_solver_initializer.dt);
+    this->SetIntegrator(dynamics_solver_initializer.Integrator);
+
+    if (debug_) INFO_NAMED(object_name_, "Initialized DynamicsSolver of type " << GetObjectName() << " with dt=" << dynamics_solver_initializer.dt << " and integrator=" << dynamics_solver_initializer.Integrator);
+}
+
+template <typename T, int NX, int NU>
+void AbstractDynamicsSolver<T, NX, NU>::AssignScene(std::shared_ptr<Scene> scene_in)
 {
 }
 

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -100,7 +100,7 @@ KinematicTree::KinematicTree() = default;
 void KinematicTree::Instantiate(std::string joint_group, robot_model::RobotModelPtr model, const std::string& name)
 {
     if (!model) ThrowPretty("No robot model provided!");
-    robot_model::JointModelGroup* group = model->getJointModelGroup(joint_group);
+    const robot_model::JointModelGroup* group = model->getJointModelGroup(joint_group);
     if (!group) ThrowPretty("Joint group '" << joint_group << "' not defined in the robot model!");
     controlled_joints_names_ = group->getVariableNames();
     model_joints_names_ = model->getVariableNames();

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -151,10 +151,20 @@ void PlanningProblem::InstantiateBase(const Initializer& init_in)
 
         if (scene_->GetDynamicsSolver()->get_num_positions() != scene_->GetDynamicsSolver()->get_num_velocities())
         {
-            WARNING_NAMED("PlanningProblem::InstantiateBase",
-                          "Size of tangent vector in DynamicsSolver does not satisfy workaround-assumption (cf. #570):\n"
-                              << "num_positions_=" << num_positions_ << " vs (num_positions_=" << scene_->GetDynamicsSolver()->get_num_positions() << ", num_velocities_=" << scene_->GetDynamicsSolver()->get_num_velocities() << ").");
-            ThrowPretty("SAD.");
+            // If the difference is exactly 1, just add it:
+            // if ((scene_->GetDynamicsSolver()->get_num_positions() - scene_->GetDynamicsSolver()->get_num_velocities()) == 1)
+            // {
+            //     num_velocities_ -= 1;
+            // }
+            if (false)  // Deactivated for now (breaks Quadrotor, cf. #571)
+            // Else, throw for now:
+            else
+            {
+                WARNING_NAMED("PlanningProblem::InstantiateBase",
+                              "Size of tangent vector in DynamicsSolver does not satisfy workaround-assumption (cf. #570):\n"
+                                  << "num_positions_=" << num_positions_ << " vs (num_positions_=" << scene_->GetDynamicsSolver()->get_num_positions() << ", num_velocities_=" << scene_->GetDynamicsSolver()->get_num_velocities() << ").");
+                ThrowPretty("SAD.");
+            }
         }
     }
 

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -149,14 +149,21 @@ void PlanningProblem::InstantiateBase(const Initializer& init_in)
         // dimensions match - otherwise throw.
         num_velocities_ = num_positions_;
 
-        if (scene_->GetDynamicsSolver()->get_num_positions() != scene_->GetDynamicsSolver()->get_num_velocities())
+        if ((scene_->GetDynamicsSolver()->get_num_positions() != scene_->GetDynamicsSolver()->get_num_velocities()) ||
+            (scene_->GetDynamicsSolver()->get_num_positions() != num_positions_))
         {
+            // The quadrotor and other floating-base robots are currently broken (cf. #571)
+            if (scene_->GetDynamicsSolver()->get_num_positions() > num_positions_)
+            {
+                ThrowPretty("Proper floating-base joints in dynamic problems not yet supported. Cf. #571.");
+                // num_positions_ = scene_->GetDynamicsSolver()->get_num_positions();
+                // num_velocities_ = scene_->GetDynamicsSolver()->get_num_velocities();
+            }
             // If the difference is exactly 1, just add it:
-            // if ((scene_->GetDynamicsSolver()->get_num_positions() - scene_->GetDynamicsSolver()->get_num_velocities()) == 1)
-            // {
-            //     num_velocities_ -= 1;
-            // }
-            if (false)  // Deactivated for now (breaks Quadrotor, cf. #571)
+            else if ((scene_->GetDynamicsSolver()->get_num_positions() - scene_->GetDynamicsSolver()->get_num_velocities()) == 1)
+            {
+                num_velocities_ -= 1;
+            }
             // Else, throw for now:
             else
             {

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -139,10 +139,12 @@ void PlanningProblem::InstantiateBase(const Initializer& init_in)
     if (init.StartState.rows() > 0)
         SetStartState(init.StartState);
 
+    // Set the start time
     if (init.StartTime < 0)
         ThrowNamed("Invalid start time " << init.StartTime);
     t_start = init.StartTime;
 
+    // Set the derivative order for Kinematics
     switch (init.DerivativeOrder)
     {
         case 0:

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -138,7 +138,7 @@ void PlanningProblem::InstantiateBase(const Initializer& init_in)
 
     // Check if dynamics solver has been initialised, and if so update problem
     // properties.
-    if (scene_->GetDynamicsSolver())
+    if (scene_->GetDynamicsSolver() != nullptr)
     {
         // TODO: Strictly speaking N here should correspond to the number of controls, which comes from the dynamic solver - to be fixed!
         num_controls_ = scene_->GetDynamicsSolver()->get_num_controls();

--- a/exotica_core/src/problems/sampling_problem.cpp
+++ b/exotica_core/src/problems/sampling_problem.cpp
@@ -71,7 +71,7 @@ void SamplingProblem::Instantiate(const SamplingProblemInitializer& init)
         ThrowNamed("Dimension mismatch: problem N=" << N << ", but goal state has dimension " << init.Goal.size());
     }
 
-    compound_ = scene_->GetBaseType() != exotica::BaseType::FIXED;
+    compound_ = scene_->GetKinematicTree().GetControlledBaseType() != exotica::BaseType::FIXED;
 
     num_tasks = tasks_.size();
     length_Phi = 0;
@@ -92,13 +92,13 @@ void SamplingProblem::Instantiate(const SamplingProblemInitializer& init)
 
     if (compound_ && init.FloatingBaseLowerLimits.rows() > 0 && init.FloatingBaseUpperLimits.rows() > 0)
     {
-        if (scene_->GetBaseType() == exotica::BaseType::FLOATING && init.FloatingBaseLowerLimits.rows() == 6 && init.FloatingBaseUpperLimits.rows() == 6)
+        if (scene_->GetKinematicTree().GetControlledBaseType() == exotica::BaseType::FLOATING && init.FloatingBaseLowerLimits.rows() == 6 && init.FloatingBaseUpperLimits.rows() == 6)
         {
             scene_->GetKinematicTree().SetFloatingBaseLimitsPosXYZEulerZYX(
                 std::vector<double>(init.FloatingBaseLowerLimits.data(), init.FloatingBaseLowerLimits.data() + init.FloatingBaseLowerLimits.size()),
                 std::vector<double>(init.FloatingBaseUpperLimits.data(), init.FloatingBaseUpperLimits.data() + init.FloatingBaseUpperLimits.size()));
         }
-        else if (scene_->GetBaseType() == exotica::BaseType::PLANAR && init.FloatingBaseLowerLimits.rows() == 3 && init.FloatingBaseUpperLimits.rows() == 3)
+        else if (scene_->GetKinematicTree().GetControlledBaseType() == exotica::BaseType::PLANAR && init.FloatingBaseLowerLimits.rows() == 3 && init.FloatingBaseUpperLimits.rows() == 3)
         {
             scene_->GetKinematicTree().SetPlanarBaseLimitsPosXYEulerZ(
                 std::vector<double>(init.FloatingBaseLowerLimits.data(), init.FloatingBaseLowerLimits.data() + init.FloatingBaseLowerLimits.size()),

--- a/exotica_core/src/problems/time_indexed_sampling_problem.cpp
+++ b/exotica_core/src/problems/time_indexed_sampling_problem.cpp
@@ -113,15 +113,15 @@ void TimeIndexedSamplingProblem::Instantiate(const TimeIndexedSamplingProblemIni
 
     ApplyStartState(false);
 
-    if (scene_->GetBaseType() != exotica::BaseType::FIXED && init.FloatingBaseLowerLimits.rows() > 0 && init.FloatingBaseUpperLimits.rows() > 0)
+    if (scene_->GetKinematicTree().GetControlledBaseType() != exotica::BaseType::FIXED && init.FloatingBaseLowerLimits.rows() > 0 && init.FloatingBaseUpperLimits.rows() > 0)
     {
-        if (scene_->GetBaseType() == exotica::BaseType::FLOATING && init.FloatingBaseLowerLimits.rows() == 6 && init.FloatingBaseUpperLimits.rows() == 6)
+        if (scene_->GetKinematicTree().GetControlledBaseType() == exotica::BaseType::FLOATING && init.FloatingBaseLowerLimits.rows() == 6 && init.FloatingBaseUpperLimits.rows() == 6)
         {
             scene_->GetKinematicTree().SetFloatingBaseLimitsPosXYZEulerZYX(
                 std::vector<double>(init.FloatingBaseLowerLimits.data(), init.FloatingBaseLowerLimits.data() + init.FloatingBaseLowerLimits.size()),
                 std::vector<double>(init.FloatingBaseUpperLimits.data(), init.FloatingBaseUpperLimits.data() + init.FloatingBaseUpperLimits.size()));
         }
-        else if (scene_->GetBaseType() == exotica::BaseType::PLANAR && init.FloatingBaseLowerLimits.rows() == 3 && init.FloatingBaseUpperLimits.rows() == 3)
+        else if (scene_->GetKinematicTree().GetControlledBaseType() == exotica::BaseType::PLANAR && init.FloatingBaseLowerLimits.rows() == 3 && init.FloatingBaseUpperLimits.rows() == 3)
         {
             scene_->GetKinematicTree().SetPlanarBaseLimitsPosXYEulerZ(
                 std::vector<double>(init.FloatingBaseLowerLimits.data(), init.FloatingBaseLowerLimits.data() + init.FloatingBaseLowerLimits.size()),

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -203,7 +203,7 @@ void Scene::Instantiate(const SceneInitializer& init)
 
         // Create dynamics solver
         dynamics_solver_ = Setup::CreateDynamicsSolver(init.DynamicsSolver.at(0));
-        dynamics_solver_->AssignScene(std::shared_ptr<Scene>(this));
+        dynamics_solver_->AssignScene(shared_from_this());
         dynamics_solver_->ns_ = ns_ + "/" + dynamics_solver_->GetObjectName();
     }
 

--- a/exotica_core/src/server.cpp
+++ b/exotica_core/src/server.cpp
@@ -77,7 +77,7 @@ robot_model::RobotModelPtr LoadModelImpl(const std::string& urdf, const std::str
     }
 }
 
-robot_model::RobotModelPtr Server::LoadModel(std::string name, std::string urdf, std::string srdf)
+robot_model::RobotModelPtr Server::LoadModel(const std::string& name, const std::string& urdf, const std::string& srdf)
 {
     robot_model::RobotModelPtr model;
     if (HasParam("RobotDescription"))
@@ -120,7 +120,7 @@ robot_model::RobotModelPtr Server::LoadModel(std::string name, std::string urdf,
     return model;
 }
 
-void Server::GetModel(std::string path, robot_model::RobotModelPtr& model, std::string urdf, std::string srdf)
+void Server::GetModel(const std::string& path, robot_model::RobotModelPtr& model, const std::string& urdf, const std::string& srdf)
 {
     if (robot_models_.find(path) != robot_models_.end())
     {
@@ -132,9 +132,9 @@ void Server::GetModel(std::string path, robot_model::RobotModelPtr& model, std::
     }
 }
 
-robot_model::RobotModelConstPtr Server::GetModel(std::string path, std::string urdf, std::string srdf)
+robot_model::RobotModelConstPtr Server::GetModel(const std::string& path, const std::string& urdf, const std::string& srdf)
 {
-    if (robot_models_.find(path) != robot_models_.end())
+    if (robot_models_.count(path))
     {
         return robot_models_[path];
     }

--- a/exotica_core/src/setup.cpp
+++ b/exotica_core/src/setup.cpp
@@ -29,6 +29,7 @@
 
 #include <type_traits>
 
+#include <exotica_core/dynamics_solver.h>
 #include <exotica_core/scene.h>
 #include <exotica_core/server.h>
 #include <exotica_core/setup.h>
@@ -78,7 +79,7 @@ void Setup::PrintSupportedClasses()
     }
 }
 
-void appendInit(std::shared_ptr<InstantiableBase> it, std::vector<Initializer>& ret)
+void AppendInitializer(std::shared_ptr<InstantiableBase> it, std::vector<Initializer>& ret)
 {
     std::vector<Initializer> temps = it->GetAllTemplates();
     for (Initializer& i : temps)
@@ -103,14 +104,19 @@ std::vector<Initializer> Setup::GetInitializers()
 {
     std::vector<Initializer> ret = Scene().GetAllTemplates();
     std::vector<std::string> solvers = Instance()->solvers_.getDeclaredClasses();
-    for (std::string s : solvers)
+    for (const std::string& s : solvers)
     {
-        appendInit(std::static_pointer_cast<InstantiableBase>(CreateSolver(s, false)), ret);
+        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateSolver(s, false)), ret);
     }
     std::vector<std::string> maps = Instance()->maps_.getDeclaredClasses();
-    for (std::string s : maps)
+    for (const std::string& s : maps)
     {
-        appendInit(std::static_pointer_cast<InstantiableBase>(CreateMap(s, false)), ret);
+        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateMap(s, false)), ret);
+    }
+    std::vector<std::string> dynamics_solvers = Instance()->dynamics_solvers_.getDeclaredClasses();
+    for (const std::string& s : dynamics_solvers)
+    {
+        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateDynamicsSolver(s, false)), ret);
     }
     return ret;
 }

--- a/exotica_examples/resources/configs/example_dynamic_time_indexed_problem.xml
+++ b/exotica_examples/resources/configs/example_dynamic_time_indexed_problem.xml
@@ -7,11 +7,13 @@
         <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
         <SetRobotDescriptionRosParams>1</SetRobotDescriptionRosParams>
+        <DynamicsSolver>
+          <PinocchioDynamicsSolver Name="PinocchioDynamicsSolver" Integrator="RK4"/>
+          <!-- <DoubleIntegratorDynamicsSolver Name="PinocchioDynamicsSolver" Integrator="RK4"/> -->
+        </DynamicsSolver>
       </Scene>
     </PlanningScene>
    
-    <DynamicsSolver>PinocchioDynamicsSolver</DynamicsSolver>
-    <Integrator>RK4</Integrator>
     <T>100</T>
     <tau>0.01</tau>
     <dt>0.01</dt>

--- a/exotica_examples/resources/configs/example_dynamic_time_indexed_problem_quadrotor.xml
+++ b/exotica_examples/resources/configs/example_dynamic_time_indexed_problem_quadrotor.xml
@@ -7,11 +7,12 @@
         <URDF>{exotica_examples}/resources/robots/quadrotor.urdf</URDF>
         <SRDF>{exotica_examples}/resources/robots/quadrotor.srdf</SRDF>
         <SetRobotDescriptionRosParams>1</SetRobotDescriptionRosParams>
+        <DynamicsSolver>
+          <QuadrotorDynamicsSolver dt="0.05" Integrator="RK4"/>
+        </DynamicsSolver>
       </Scene>
     </PlanningScene>
    
-    <DynamicsSolver>QuadrotorDynamicsSolver</DynamicsSolver>
-    <Integrator>RK4</Integrator>
     <T>50</T>
     <tau>0.05</tau>
     <dt>0.05</dt>

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -966,8 +966,6 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<Scene, std::shared_ptr<Scene>, Object> scene(module, "Scene");
     scene.def("update", &Scene::Update, py::arg("x"), py::arg("t") = 0.0);
-    scene.def("get_base_type", &Scene::GetBaseType);
-    scene.def("get_group_name", &Scene::GetGroupName);
     scene.def("get_controlled_joint_names", (std::vector<std::string>(Scene::*)()) & Scene::GetControlledJointNames);
     scene.def("get_controlled_link_names", &Scene::GetControlledLinkNames);
     scene.def("get_model_link_names", &Scene::GetModelLinkNames);
@@ -989,7 +987,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("get_controlled_state", &Scene::GetControlledState);
     scene.def("publish_scene", &Scene::PublishScene);
     scene.def("publish_proxies", &Scene::PublishProxies);
-    scene.def("set_collision_scene", &Scene::SetCollisionScene);
+    scene.def("update_planning_scene", &Scene::UpdatePlanningScene);
     scene.def("load_scene",
               (void (Scene::*)(const std::string&, const KDL::Frame&, bool)) & Scene::LoadScene,
               py::arg("scene_string"),
@@ -1021,7 +1019,7 @@ PYBIND11_MODULE(_pyexotica, module)
               [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
                   moveit_msgs::PlanningSceneWorldConstPtr my_ptr(
                       new moveit_msgs::PlanningSceneWorld(world));
-                  instance->UpdateWorld(my_ptr);
+                  instance->UpdatePlanningSceneWorld(my_ptr);
               });
     scene.def("update_collision_objects", &Scene::UpdateCollisionObjects);
     scene.def("get_collision_robot_links", [](Scene* instance) { return instance->GetCollisionScene()->GetCollisionRobotLinks(); });


### PR DESCRIPTION
Required quite a few changes:

- `DynamicsSolver` is now instantiable and owned by the `Scene`, not the problem.
- Deactivated quadrotor and floating-base dynamic problems as we aren't treating floating bases properly (#570, #571)

cc: @include4eto 