### PR TITLE
[exotica_core] MotionSolver: GetProblem should return non-const

### DIFF
--- a/exotica_core/include/exotica_core/motion_solver.h
+++ b/exotica_core/include/exotica_core/motion_solver.h
@@ -46,7 +46,7 @@ public:
     virtual void InstantiateBase(const Initializer& init);
     virtual void SpecifyProblem(PlanningProblemPtr pointer);
     virtual void Solve(Eigen::MatrixXd& solution) = 0;
-    const PlanningProblemConstPtr GetProblem() const { return problem_; }
+    PlanningProblemPtr GetProblem() const { return problem_; }
     std::string Print(const std::string& prepend) const override;
     void SetNumberOfMaxIterations(int max_iter)
     {


### PR DESCRIPTION
Otherwise SetRho/SetGoal can no longer be called.

Fixes issue introduced in #566. 

cc: @christian-rauch 