### PR TITLE
[task_maps] Updated LookAt.

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
@@ -43,11 +43,6 @@ namespace exotica
 /// \brief Points end-effector to look at a given target.
 /// Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.
 ///
-/// The task map relies on defining three frames for each target to be looked at:
-///  - (0) the EffPoint in the end-effector frame (use in task map)
-///  - (1) the LookAtTarget in the end-effector frame (use in task map)
-///  - (2) the LookAtTarget in the world frame (use by user to easily return target in world coordinates - can be retrieved via get_look_at_target_in_world)
-///
 /// \image html taskmap_lookat.png "LookAt task map." width=500px
 ///
 /// Given the point \f$p\f$ (the point to look at) defined in the end-effector space the task map is expressed by
@@ -71,8 +66,6 @@ public:
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;
-
-    Eigen::Vector3d get_look_at_target_in_world(const int& i);
 
 private:
     int n_end_effs_;  ///< Number of end-effectors.

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/look_at.h
@@ -40,7 +40,7 @@ namespace exotica
 ///
 /// \ingroup TaskMap
 ///
-/// \brief Points end-effector to look at a given target.
+/// \brief Points end-effector to look at a given target by aligning end-effector z-axis with the target.
 /// Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.
 ///
 /// \image html taskmap_lookat.png "LookAt task map." width=500px
@@ -62,14 +62,11 @@ public:
     LookAt();
     virtual ~LookAt();
 
-    void Instantiate(const LookAtInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;
 
 private:
-    int n_end_effs_;  ///< Number of end-effectors.
-    int n_;           ///< Dimension of the task space.
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/init/look_at.in
+++ b/exotations/exotica_core_task_maps/init/look_at.in
@@ -7,8 +7,3 @@ extend <exotica_core/task_map>
 // VectorXd LinkOffset   > coordinate of point in Link frame
 // string Base           > name of frame in which line is defined
 // VectorXd BaseOffset   > starting point of line in Base frame
-
-// Need to specify EndEffector sets of 3, where for each set:
-// 0 - EffPoint | in eff frame
-// 1 - LookAtTarget | in eff frame
-// 2 - LookAtTarget | in world frame

--- a/exotations/exotica_core_task_maps/src/look_at.cpp
+++ b/exotations/exotica_core_task_maps/src/look_at.cpp
@@ -61,4 +61,4 @@ int LookAt::TaskSpaceDim()
 {
     return 2 * frames_.size();
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/look_at.cpp
+++ b/exotations/exotica_core_task_maps/src/look_at.cpp
@@ -59,6 +59,6 @@ void LookAt::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::Ma
 
 int LookAt::TaskSpaceDim()
 {
-    return 3 * frames_.size() - frames_.size();
+    return 2 * frames_.size();
 }
 }

--- a/exotations/exotica_core_task_maps/src/task_map_py.cpp
+++ b/exotations/exotica_core_task_maps/src/task_map_py.cpp
@@ -45,7 +45,6 @@
 #include <exotica_core_task_maps/joint_limit.h>
 #include <exotica_core_task_maps/joint_pose.h>
 #include <exotica_core_task_maps/joint_velocity_backward_difference.h>
-#include <exotica_core_task_maps/look_at.h>
 #include <exotica_core_task_maps/point_to_line.h>
 #include <exotica_core_task_maps/sphere_collision.h>
 
@@ -71,9 +70,6 @@ PYBIND11_MODULE(exotica_core_task_maps_py, module)
         .def("set_axis", &EffAxisAlignment::SetAxis)
         .def("get_direction", &EffAxisAlignment::GetDirection)
         .def("set_direction", &EffAxisAlignment::SetDirection);
-
-    py::class_<LookAt, std::shared_ptr<LookAt>, TaskMap>(module, "LookAt")
-        .def("get_look_at_target_in_world", &LookAt::get_look_at_target_in_world);
 
     py::class_<PointToLine, std::shared_ptr<PointToLine>, TaskMap>(module, "PointToLine")
         .def_property("end_point", &PointToLine::GetEndPoint, &PointToLine::SetEndPoint);

--- a/exotations/exotica_core_task_maps/test/test_maps.cpp
+++ b/exotations/exotica_core_task_maps/test/test_maps.cpp
@@ -1113,17 +1113,12 @@ TEST(ExoticaTaskMaps, testLookAt)
             TEST_COUT << "LookAt";
 
             // Custom links
-            std::vector<Initializer> custom_links({Initializer("Link", {{"Name", std::string("EffPoint")},
-                                                                        {"Parent", std::string("endeff")},
-                                                                        {"Transform", std::string("0 0 1")}}),
-                                                   Initializer("Link", {{"Name", std::string("LookAtTarget")},
+            std::vector<Initializer> custom_links({Initializer("Link", {{"Name", std::string("LookAtTarget")},
                                                                         {"Transform", std::string("1 1 2")}})});
 
             // Setup taskmap
             Initializer map("exotica/LookAt", {{"Name", std::string("MyTask")},
-                                               {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("EffPoint")}, {"Base", std::string("endeff")}}),
-                                                                                         Initializer("Frame", {{"Link", std::string("LookAtTarget")}, {"Base", std::string("endeff")}}),
-                                                                                         Initializer("Frame", {{"Link", std::string("LookAtTarget")}, {"Base", std::string("")}})})}});
+                                               {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("LookAtTarget")}, {"Base", std::string("endeff")}})})}});
             UnconstrainedEndPoseProblemPtr problem = setup_problem(map, "", custom_links);
             EXPECT_TRUE(test_random(problem));
             EXPECT_TRUE(test_jacobian(problem, 2e-5));

--- a/exotica_examples/resources/configs/example_ik_look_at.xml
+++ b/exotica_examples/resources/configs/example_ik_look_at.xml
@@ -11,7 +11,6 @@
         <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
         <Links>
-          <Link Name="EffPoint" Parent="lwr_arm_6_link" Transform="0 0 1"/>
           <Link Name="LookAtTarget" Transform="1 1 2"/>
         </Links>
       </Scene>
@@ -20,9 +19,7 @@
     <Maps>
       <LookAt Name="LookAt">
         <EndEffector>
-          <Frame Link="EffPoint" Base="lwr_arm_6_link"/><!-- EndEffector #0 => Frame on robot to orient -->
           <Frame Link="LookAtTarget" Base="lwr_arm_6_link"/><!-- EndEffector #1 => Target to look at, in relative frame of EffPoint -->
-          <Frame Link="LookAtTarget"/><!-- EndEffector #2 => Target to look at, in world frame (convenience frame) -->
         </EndEffector>
       </LookAt>
     </Maps>


### PR DESCRIPTION
* Now user only required to specify one `LookAtTarget` frame per end-effector (as in example xml).
* Documentation, test script, and example scripts updated accordingly.
* Removed unnecessary function `get_look_at_target_in_world` from `task_map_py`.

# Checklist

- [x] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- [x] updated unit test(s)

- [x] ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`
