### PR TITLE
[exotica_core/python] Load initializer methods.

### DIFF
--- a/exotica_core/include/exotica_core/loaders/xml_loader.h
+++ b/exotica_core/include/exotica_core/loaders/xml_loader.h
@@ -62,6 +62,20 @@ public:
         return Instance()->LoadXML(file_name, parsePathAsXML);
     }
 
+    static Initializer LoadProblemInitializer(const std::string& file_name)
+    {
+        Initializer solver, problem;
+        XMLLoader::Load(file_name, solver, problem);
+        return problem;
+    }
+
+    static Initializer LoadSolverInitializer(const std::string& file_name)
+    {
+        Initializer solver, problem;
+        XMLLoader::Load(file_name, solver, problem);
+        return solver;
+    }
+
     static std::shared_ptr<exotica::MotionSolver> LoadSolver(const std::string& file_name)
     {
         Initializer solver, problem;

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -515,6 +515,8 @@ PYBIND11_MODULE(_pyexotica, module)
                      },
                      "Initializes an internal ROS node for publishing debug information from Exotica (i.e., activates ROS features). Options are setting the name and whether to spawn an anonymous node.",
                      py::arg("name") = "exotica", py::arg("anonymous") = false);
+    setup.def_static("load_solver_initializer", &XMLLoader::LoadSolverInitializer, "Load only the solver initializer from an XML file containing a solver initializer.", py::arg("filepath"));
+    setup.def_static("load_problem_initializer", &XMLLoader::LoadProblemInitializer, "Load only the problem initializer from an XML file containing a problem initializer.", py::arg("filepath"));
     setup.def_static("load_solver", &XMLLoader::LoadSolver, "Instantiate solver and problem from an XML file containing both a solver and problem initializer.", py::arg("filepath"));
     setup.def_static("load_solver_standalone", &XMLLoader::LoadSolverStandalone, "Instantiate only a solver from an XML file containing solely a solver initializer.", py::arg("filepath"));
     setup.def_static("load_problem", &XMLLoader::LoadProblem, "Instantiate only a problem from an XML file containing solely a problem initializer.", py::arg("filepath"));


### PR DESCRIPTION
* Two new methods to load problem and solver initializer from xml.
* Exposed both methods to Python.
* I have a case where I want to load a base initializer from xml and update on-the-fly, creating a new problem as I go.

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
