### PR TITLE
[examples] Adding forgotten dependency for GazeAtConstraint example.

### DIFF
--- a/exotica_examples/package.xml
+++ b/exotica_examples/package.xml
@@ -19,6 +19,7 @@
   <depend>sensor_msgs</depend>
   <exec_depend>exotica_collision_scene_fcl</exec_depend>
   <exec_depend>exotica_ompl_solver</exec_depend>
+  <exec_depend>exotica_scipy_solver</exec_depend>
   <exec_depend>exotica_time_indexed_rrt_connect_solver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>


### PR DESCRIPTION
* Forgot to add `exotica_scipy_solver` as a dependency after adding `GazeAtConstraint` example.

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
