### PR TITLE
Add JointTorqueMinimizationProxy taskmap and example, fix SciPy solver

### DIFF
--- a/exotations/exotica_core_task_maps/CMakeLists.txt
+++ b/exotations/exotica_core_task_maps/CMakeLists.txt
@@ -19,6 +19,7 @@ AddInitializer(
   eff_velocity
   gaze_at_constraint
   joint_limit
+  joint_torque_minimization_proxy
   joint_velocity_limit
   distance
   point_to_line
@@ -57,6 +58,7 @@ set(SOURCES
     src/eff_velocity.cpp
     src/gaze_at_constraint.cpp
     src/joint_limit.cpp
+    src/joint_torque_minimization_proxy.cpp
     src/joint_velocity_limit.cpp
     src/distance.cpp
     src/point_to_line.cpp

--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -32,6 +32,9 @@
   <class name="exotica/JointPose" type="exotica::JointPose" base_class_type="exotica::TaskMap">
     <description>Joint position reference</description>
   </class>
+  <class name="exotica/JointTorqueMinimizationProxy" type="exotica::JointTorqueMinimizationProxy" base_class_type="exotica::TaskMap">
+    <description>Proxy metric for minimizing joint torque my mapping Cartesian space forces (selectable directions)</description>
+  </class>
   <class name="exotica/InteractionMesh" type="exotica::InteractionMesh" base_class_type="exotica::TaskMap">
     <description>Interaction Mesh</description>
   </class>

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_torque_minimization_proxy.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_torque_minimization_proxy.h
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_CORE_TASK_MAPS_JOINT_TORQUE_MINIMIZATION_PROXY_H_
+#define EXOTICA_CORE_TASK_MAPS_JOINT_TORQUE_MINIMIZATION_PROXY_H_
+
+#include <exotica_core/task_map.h>
+
+#include <exotica_core_task_maps/joint_torque_minimization_proxy_initializer.h>
+
+namespace exotica
+{
+class JointTorqueMinimizationProxy : public TaskMap, public Instantiable<JointTorqueMinimizationProxyInitializer>
+{
+public:
+    void Instantiate(const JointTorqueMinimizationProxyInitializer& init) override;
+
+    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
+    // void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
+    int TaskSpaceDim() override;
+
+private:
+    Eigen::Matrix<double, 6, 1> h_;
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_CORE_TASK_MAPS_JOINT_TORQUE_MINIMIZATION_PROXY_H_

--- a/exotations/exotica_core_task_maps/init/joint_torque_minimization_proxy.in
+++ b/exotations/exotica_core_task_maps/init/joint_torque_minimization_proxy.in
@@ -1,0 +1,5 @@
+class JointTorqueMinimizationProxy
+
+extend <exotica_core/task_map>
+
+Optional Eigen::VectorXd h = Eigen::VectorXd::Ones(6);

--- a/exotations/exotica_core_task_maps/src/joint_torque_minimization_proxy.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_torque_minimization_proxy.cpp
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_core_task_maps/joint_torque_minimization_proxy.h>
+
+REGISTER_TASKMAP_TYPE("JointTorqueMinimizationProxy", exotica::JointTorqueMinimizationProxy);
+
+namespace exotica
+{
+void JointTorqueMinimizationProxy::Instantiate(const JointTorqueMinimizationProxyInitializer &init)
+{
+    parameters_ = init;
+    if (init.h.size() != 6)
+    {
+        ThrowPretty("Size of selection vector h needs to be 6, got " << init.h.size());
+    }
+    h_ = init.h;
+}
+
+void JointTorqueMinimizationProxy::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    if (phi.rows() != frames_.size()) ThrowNamed("Wrong size of Phi!");
+    for (int i = 0; i < kinematics[0].Phi.rows(); ++i)
+    {
+        phi(i) = h_.transpose() * kinematics[0].jacobian[i].data * kinematics[0].jacobian[i].data.transpose() * h_;
+    }
+}
+
+// void JointTorqueMinimizationProxy::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
+// {
+//     if (phi.rows() != frames_.size()) ThrowNamed("Wrong size of Phi!");
+//     for (int i = 0; i < kinematics[0].Phi.rows(); ++i)
+//     {
+//         phi(i) = h_.transpose() * kinematics[0].jacobian[i].data * kinematics[0].jacobian[i].data.transpose() * h_;
+//         Eigen::MatrixXd Jdot = scene_->GetKinematicTree().Jdot(kinematics[0].jacobian[i]);
+//         HIGHLIGHT("Jdot size:" << Jdot.rows() << "x" << Jdot.cols())
+//         HIGHLIGHT("Jacobian size:" << kinematics[0].jacobian[i].data.rows() << "x" << kinematics[0].jacobian[i].data.cols())
+//         HIGHLIGHT("h_ size:" << h_.rows() << "x" << h_.cols())
+//         HIGHLIGHT("jacobian-i size:" << jacobian.row(i).rows() << "x" << jacobian.row(i).cols())
+//         jacobian.row(i) = 2 * (h_.transpose() * Jdot).transpose() * kinematics[0].jacobian[i].data;
+//     }
+// }
+
+int JointTorqueMinimizationProxy::TaskSpaceDim()
+{
+    return frames_.size();
+}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/test/test_maps.cpp
+++ b/exotations/exotica_core_task_maps/test/test_maps.cpp
@@ -496,6 +496,25 @@ TEST(ExoticaTaskMaps, testJointLimit)
     }
 }
 
+TEST(ExoticaTaskMaps, testJointTorqueMinimizationProxy)
+{
+    try
+    {
+        TEST_COUT << "Joint torque minimization proxy test";
+
+        Initializer map("exotica/JointTorqueMinimizationProxy", {{"Name", std::string("MyTask")},
+                                                                 {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("endeff")}})})}});
+        UnconstrainedEndPoseProblemPtr problem = setup_problem(map);
+        EXPECT_TRUE(test_random(problem));
+
+        EXPECT_TRUE(test_jacobian(problem, 1.e-4));
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Uncaught exception!";
+    }
+}
+
 TEST(ExoticaTaskMaps, testJointVelocityLimit)
 {
     try

--- a/exotations/solvers/exotica_scipy_solver/src/exotica_scipy_solver/end_pose_solver.py
+++ b/exotations/solvers/exotica_scipy_solver/src/exotica_scipy_solver/end_pose_solver.py
@@ -27,7 +27,7 @@ class SciPyEndPoseSolver(object):
     
     def eq_constraint_jac(self, x):
         self.problem.update(x)
-        return self.problem.get_equality_jacobian
+        return self.problem.get_equality_jacobian()
     
     def neq_constraint_fun(self, x):
         self.problem.update(x)
@@ -86,4 +86,4 @@ class SciPyEndPoseSolver(object):
         if self.debug:
             print(e-s, res.x)
 
-        return res.x
+        return [res.x]

--- a/exotations/solvers/exotica_scipy_solver/src/exotica_scipy_solver/end_pose_solver.py
+++ b/exotations/solvers/exotica_scipy_solver/src/exotica_scipy_solver/end_pose_solver.py
@@ -17,6 +17,7 @@ class SciPyEndPoseSolver(object):
         self.problem = problem
         self.debug = debug
         self.method = method
+        self.max_iterations = 100
     
     def specifyProblem(self, problem):
         self.problem = problem
@@ -78,10 +79,10 @@ class SciPyEndPoseSolver(object):
                     x0,
                     method=self.method,
                     bounds=bounds,
-                    jac=True, #self.cost_jac,
+                    jac=True,
                     hess=SR1(),
                     constraints=cons,
-                    options={'disp': self.debug, 'initial_tr_radius':1000.})
+                    options={'disp': self.debug, 'initial_tr_radius':1000., 'maxiter': self.max_iterations})
         e = time()
         if self.debug:
             print(e-s, res.x)

--- a/exotations/solvers/exotica_scipy_solver/test/example_scipy_ik_constrained
+++ b/exotations/solvers/exotica_scipy_solver/test/example_scipy_ik_constrained
@@ -24,7 +24,7 @@ while True:
     try:
         problem.start_state = q
         problem.start_time = t
-        q = solver.solve()
+        q = solver.solve()[0]
         publish_pose(q, problem, t)
         sleep(dt)
         t = (t+dt) % 7.0

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -183,6 +183,7 @@ public:
     KDL::Frame FK(const std::string& element_A, const KDL::Frame& offset_a, const std::string& element_B, const KDL::Frame& offset_b) const;
     Eigen::MatrixXd Jacobian(std::shared_ptr<KinematicElement> element_A, const KDL::Frame& offset_a, std::shared_ptr<KinematicElement> element_B, const KDL::Frame& offset_b) const;
     Eigen::MatrixXd Jacobian(const std::string& element_A, const KDL::Frame& offset_a, const std::string& element_B, const KDL::Frame& offset_b) const;
+    Eigen::MatrixXd Jdot(const KDL::Jacobian& jacobian);
 
     void ResetModel();
     std::shared_ptr<KinematicElement> AddElement(const std::string& name, Eigen::Isometry3d& transform, const std::string& parent = "", shapes::ShapeConstPtr shape = shapes::ShapeConstPtr(nullptr), const KDL::RigidBodyInertia& inertia = KDL::RigidBodyInertia::Zero(), const Eigen::Vector4d& color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0), bool is_controlled = false);
@@ -238,7 +239,7 @@ private:
     void UpdateFK();
     void UpdateJ();
     void ComputeJ(KinematicFrame& frame, KDL::Jacobian& jacobian) const;
-    void ComputeJdot(KDL::Jacobian& jacobian, KDL::Jacobian& jacobian_dot) const;
+    void ComputeJdot(const KDL::Jacobian& jacobian, KDL::Jacobian& jacobian_dot) const;
     void UpdateJdot();
 
     // Joint limits

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -721,7 +721,14 @@ Eigen::MatrixXd KinematicTree::Jacobian(const std::string& element_A, const KDL:
     return Jacobian(A->second.lock(), offset_a, B->second.lock(), offset_b);
 }
 
-void KinematicTree::ComputeJdot(KDL::Jacobian& jacobian, KDL::Jacobian& jacobian_dot) const
+Eigen::MatrixXd KinematicTree::Jdot(const KDL::Jacobian& jacobian)
+{
+    KDL::Jacobian Jdot;
+    ComputeJdot(jacobian, Jdot);
+    return Jdot.data;
+}
+
+void KinematicTree::ComputeJdot(const KDL::Jacobian& jacobian, KDL::Jacobian& jacobian_dot) const
 {
     jacobian_dot.data.setZero(jacobian.rows(), jacobian.columns());
     for (int i = 0; i < jacobian.columns(); ++i)

--- a/exotica_examples/launch/python_ik_joint_torque_minimization_proxy.launch
+++ b/exotica_examples/launch/python_ik_joint_torque_minimization_proxy.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_ik_joint_torque_minimization_proxy" name="example_ik_joint_torque_minimization_proxy_node" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />
+</launch>

--- a/exotica_examples/resources/configs/example_ik_joint_torque_minimization_proxy.xml
+++ b/exotica_examples/resources/configs/example_ik_joint_torque_minimization_proxy.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+    <!-- <KnitroEndPoseSolver Name="MySolver" /> -->
+    <!-- <SnoptIKConstrainedSolver Name="MySolver" /> -->
+    <!-- <IfoptEndPoseSolver Name="MySolver" /> -->
+
+    <EndPoseProblem Name="MyProblem">
+        <PlanningScene>
+            <Scene>
+                <JointGroup>arm</JointGroup>
+                <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+                <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+            </Scene>
+        </PlanningScene>
+
+        <Maps>
+            <JointTorqueMinimizationProxy Name="JointTorqueMinimizationProxy">
+                <EndEffector>
+                    <Frame Link="lwr_arm_6_link"/>
+                </EndEffector>
+                <h>1 1 1 0 0 0</h>
+                <!-- <h>0 0 1 0 0 0</h> -->
+            </JointTorqueMinimizationProxy>
+            <JointPose Name="Identity"/>
+            <EffFrame Name="Position">
+                <EndEffector>
+                    <Frame Link="lwr_arm_6_link"/>
+                </EndEffector>
+            </EffFrame>
+        </Maps>
+
+        <Cost>
+            <!-- <Task Task="Identity"/> -->
+            <Task Task="JointTorqueMinimizationProxy"/>
+        </Cost>
+
+        <Equality>
+            <Task Task="Position"/>
+        </Equality>
+
+        <StartState>0 0 0 0 0 0 0</StartState>
+        <W> 7 6 5 4 3 2 1 </W>
+    </EndPoseProblem>
+</IKSolverDemoConfig>

--- a/exotica_examples/resources/configs/example_ik_joint_torque_minimization_proxy.xml
+++ b/exotica_examples/resources/configs/example_ik_joint_torque_minimization_proxy.xml
@@ -22,11 +22,11 @@
                 <!-- <h>0 0 1 0 0 0</h> -->
             </JointTorqueMinimizationProxy>
             <JointPose Name="Identity"/>
-            <EffFrame Name="Position">
+            <EffPosition Name="Position">
                 <EndEffector>
                     <Frame Link="lwr_arm_6_link"/>
                 </EndEffector>
-            </EffFrame>
+            </EffPosition>
         </Maps>
 
         <Cost>
@@ -38,7 +38,7 @@
             <Task Task="Position"/>
         </Equality>
 
-        <StartState>0 0 0 0 0 0 0</StartState>
+        <StartState>0.1 0.1 0.1 0.1 0.1 0.1 0.1</StartState>
         <W> 7 6 5 4 3 2 1 </W>
     </EndPoseProblem>
 </IKSolverDemoConfig>

--- a/exotica_examples/scripts/example_ik_gaze_at_constraint
+++ b/exotica_examples/scripts/example_ik_gaze_at_constraint
@@ -32,7 +32,7 @@ class Example(object):
         self.problem.start_state = self.q
 
         # Solve and publish
-        self.q = self.solver.solve()
+        self.q = self.solver.solve()[0]
         publish_pose(self.q, self.problem)
 
     def update_cone(self, event):

--- a/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
+++ b/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
@@ -2,8 +2,7 @@
 from __future__ import print_function
 
 import pyexotica as exo
-from numpy import array
-from numpy import matrix
+import numpy as np
 import math
 from pyexotica.publish_trajectory import *
 import exotica_scipy_solver
@@ -12,7 +11,7 @@ import signal
 
 
 def figure_eight(t):
-    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2,0,0,0])
+    return np.array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2])
 
 
 use_scipy_solver = True
@@ -23,7 +22,9 @@ problem = None
 solver = None
 if use_scipy_solver:
     problem = exo.Setup.load_problem('{exotica_examples}/resources/configs/example_ik_joint_torque_minimization_proxy.xml')
-    solver = exotica_scipy_solver.SciPyEndPoseSolver(problem, method='SLSQP')
+    solver = exotica_scipy_solver.SciPyEndPoseSolver(problem, method='trust-constr')
+    solver.max_iterations = 10
+    solver.debug = False
 else:
     # Requires to uncomment one of the C++ solvers in the XML
     solver = exo.Setup.load_solver(
@@ -32,7 +33,7 @@ else:
 
 dt = 0.002
 t = 0.0
-q = array([0.0] * 7)
+q = np.array([0.2]*7)
 print('Publishing IK')
 signal.signal(signal.SIGINT, sig_int_handler)
 while True:

--- a/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
+++ b/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from pyexotica.publish_trajectory import *
+import exotica_scipy_solver
+from time import sleep, time
+import signal
+
+
+def figure_eight(t):
+    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2,0,0,0])
+
+
+use_scipy_solver = True
+
+exo.Setup.init_ros()
+
+problem = None
+solver = None
+if use_scipy_solver:
+    problem = exo.Setup.load_problem('{exotica_examples}/resources/configs/example_ik_joint_torque_minimization_proxy.xml')
+    solver = exotica_scipy_solver.SciPyEndPoseSolver(problem, method='SLSQP')
+else:
+    # Requires to uncomment one of the C++ solvers in the XML
+    solver = exo.Setup.load_solver(
+        '{exotica_examples}/resources/configs/example_ik_joint_torque_minimization_proxy.xml')
+    problem = solver.get_problem()
+
+dt = 0.002
+t = 0.0
+q = array([0.0] * 7)
+print('Publishing IK')
+signal.signal(signal.SIGINT, sig_int_handler)
+while True:
+    try:
+        problem.set_goal_eq('Position', figure_eight(t))
+        problem.start_state = q
+        s = time()
+        q = solver.solve()[0]
+        e = time()
+        print("Time taken", e-s)
+        publish_pose(q, problem)
+        sleep(dt)
+        t = t + dt
+    except KeyboardInterrupt:
+        break


### PR DESCRIPTION
cc: @carlotiseo

Adds a new taskmap to minimize 

```
h^T J(q) J(q)^T h
```

and an example showing constrained minimization of this cost subject to achieving a desired frame (can be swapped for position). `h` is a dimension selection vector. This example uses SciPy and solves on the Kuka LWR in ~10ms, with C++ solvers in <1ms.