### PR TITLE
JointTorqueMinimizationProxy: Expose h and update/document example

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_torque_minimization_proxy.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_torque_minimization_proxy.h
@@ -45,6 +45,10 @@ public:
     // void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;
 
+    Eigen::Matrix<double, 6, 1> get_h() const;
+
+    void set_h(const Eigen::Matrix<double, 6, 1>& h_in);
+
 private:
     Eigen::Matrix<double, 6, 1> h_;
 };

--- a/exotations/exotica_core_task_maps/src/joint_torque_minimization_proxy.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_torque_minimization_proxy.cpp
@@ -33,7 +33,7 @@ REGISTER_TASKMAP_TYPE("JointTorqueMinimizationProxy", exotica::JointTorqueMinimi
 
 namespace exotica
 {
-void JointTorqueMinimizationProxy::Instantiate(const JointTorqueMinimizationProxyInitializer &init)
+void JointTorqueMinimizationProxy::Instantiate(const JointTorqueMinimizationProxyInitializer& init)
 {
     parameters_ = init;
     if (init.h.size() != 6)
@@ -41,6 +41,18 @@ void JointTorqueMinimizationProxy::Instantiate(const JointTorqueMinimizationProx
         ThrowPretty("Size of selection vector h needs to be 6, got " << init.h.size());
     }
     h_ = init.h;
+}
+
+Eigen::Matrix<double, 6, 1> JointTorqueMinimizationProxy::get_h() const
+{
+    return h_;
+}
+
+void JointTorqueMinimizationProxy::set_h(const Eigen::Matrix<double, 6, 1>& h_in)
+{
+    if (h_in.size() != 6)
+        ThrowPretty("Wrong size!");
+    h_ = h_in;
 }
 
 void JointTorqueMinimizationProxy::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)

--- a/exotations/exotica_core_task_maps/src/task_map_py.cpp
+++ b/exotations/exotica_core_task_maps/src/task_map_py.cpp
@@ -44,6 +44,7 @@
 #include <exotica_core_task_maps/joint_jerk_backward_difference.h>
 #include <exotica_core_task_maps/joint_limit.h>
 #include <exotica_core_task_maps/joint_pose.h>
+#include <exotica_core_task_maps/joint_torque_minimization_proxy.h>
 #include <exotica_core_task_maps/joint_velocity_backward_difference.h>
 #include <exotica_core_task_maps/point_to_line.h>
 #include <exotica_core_task_maps/sphere_collision.h>
@@ -91,6 +92,9 @@ PYBIND11_MODULE(exotica_core_task_maps_py, module)
         .def_readonly("N", &JointPose::N_)
         .def_readonly("joint_map", &JointPose::joint_map_)
         .def_readwrite("joint_ref", &JointPose::joint_ref_);
+
+    py::class_<JointTorqueMinimizationProxy, std::shared_ptr<JointTorqueMinimizationProxy>, TaskMap>(module, "JointTorqueMinimizationProxy")
+        .def_property("h", &JointTorqueMinimizationProxy::get_h, &JointTorqueMinimizationProxy::set_h);
 
     py::class_<InteractionMesh, std::shared_ptr<InteractionMesh>, TaskMap>(module, "InteractionMesh")
         .def_property("W", &InteractionMesh::GetWeights, &InteractionMesh::SetWeights)

--- a/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
+++ b/exotica_examples/scripts/example_ik_joint_torque_minimization_proxy
@@ -5,6 +5,7 @@ import pyexotica as exo
 import numpy as np
 import math
 from pyexotica.publish_trajectory import *
+import exotica_core_task_maps_py
 import exotica_scipy_solver
 from time import sleep, time
 import signal
@@ -31,6 +32,9 @@ else:
         '{exotica_examples}/resources/configs/example_ik_joint_torque_minimization_proxy.xml')
     problem = solver.get_problem()
 
+# Get the task so we can modify the h
+joint_torque_minimization_proxy_task = problem.get_task_maps()["JointTorqueMinimizationProxy"]
+
 dt = 0.002
 t = 0.0
 q = np.array([0.2]*7)
@@ -38,14 +42,38 @@ print('Publishing IK')
 signal.signal(signal.SIGINT, sig_int_handler)
 while True:
     try:
+        start_time = time()
+
+        # Update h
+        joint_torque_minimization_proxy_task.h = np.array([1,1,1,0,0,0])
+
+        # Update goal position for end-effector
         problem.set_goal_eq('Position', figure_eight(t))
+
+        # Set last solution as initialisation for optimisation problem
         problem.start_state = q
+
+        # Solve the problem
         s = time()
         q = solver.solve()[0]
         e = time()
-        print("Time taken", e-s)
+
+        # Extract the positions of the individual links
+        problem.update(q)
+        for i in range(7):
+            name = "lwr_arm_" + str(i) + "_link"
+            position = problem.get_scene().fk(name).get_translation()
+            print(name, position)
+
+        # Publish to RViz (visualisation)
         publish_pose(q, problem)
-        sleep(dt)
+
+        # Sleep if there is remaining time in the control loop
+        end_time = time()
+        if dt > end_time - start_time:
+            sleep(dt - (end_time - start_time))
+
+        print("Optimisation took", e-s, "\tTotal loop time:", end_time - start_time)
         t = t + dt
     except KeyboardInterrupt:
         break


### PR DESCRIPTION
- Expose `h` so it can be set from within Python
- Update example to show use of updating `h` and add documentation
- Also shows how to extract link positions after every solve iteration (verbose)
- I'm hitting **0.6ms** optimisation time right now, with a loop time of ~1ms (including all printing!) - i.e. a 1kHz control loop may be possible

cc: @carlotiseo 