### PR TITLE
KinematicTree: getter for joints

### DIFF
--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -220,6 +220,9 @@ public:
     const std::map<std::string, std::weak_ptr<KinematicElement>>& GetCollisionTreeMap() const { return collision_tree_map_; }
     bool DoesLinkWithNameExist(std::string name) const;  //!< Checks whether a link with this name exists in any of the trees
 
+    const std::vector<std::weak_ptr<KinematicElement>>& GetControlledJoints() const { return controlled_joints_; }
+    const std::map<std::string, std::weak_ptr<KinematicElement>>& GetControlledJointsMap() const { return controlled_joints_map_; }
+    const std::map<std::string, std::weak_ptr<KinematicElement>>& GetModelJointsMap() const { return model_joints_map_; }
     std::map<std::string, shapes::ShapeType> GetCollisionObjectTypes() const;
 
     /// @brief SetSeed sets the seed of the random generator for deterministic joint state sampling

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -175,16 +175,12 @@ void KinematicTree::BuildTree(const KDL::Tree& robot_kinematics)
         model_base_type_ = BaseType::FLOATING;
         model_tree_.resize(7);
         KDL::Joint::JointType types[] = {KDL::Joint::TransX, KDL::Joint::TransY, KDL::Joint::TransZ, KDL::Joint::RotZ, KDL::Joint::RotY, KDL::Joint::RotX};
-        std::vector<std::string> floating_base_variable_names = {
-            root_joint->getName() + "/trans_x",
-            root_joint->getName() + "/trans_y",
-            root_joint->getName() + "/trans_z",
-            root_joint->getName() + "/rot_z",
-            root_joint->getName() + "/rot_y",
-            root_joint->getName() + "/rot_x"};
-        for (int i = 0; i < 6; ++i)
+        const std::vector<std::string> floating_base_suffix = {
+            "/trans_x", "/trans_y", "/trans_z",
+            "/rot_z", "/rot_y", "/rot_x"};
+        for (size_t i = 0; i < 6; ++i)
         {
-            model_tree_[i + 1] = std::make_shared<KinematicElement>(i, model_tree_[i], KDL::Segment(floating_base_variable_names[i], KDL::Joint(floating_base_variable_names[i], types[i])));
+            model_tree_[i + 1] = std::make_shared<KinematicElement>(i, model_tree_[i], KDL::Segment(world_frame_name + floating_base_suffix[i], KDL::Joint(root_joint_name_ + floating_base_suffix[i], types[i])));
             model_tree_[i]->children.push_back(model_tree_[i + 1]);
         }
 
@@ -965,7 +961,7 @@ void KinematicTree::UpdateJointLimits()
 
     // Update random state distributions for generating random controlled states
     random_state_distributions_.clear();
-    for (unsigned int i = 0; i < num_controlled_joints_; ++i)
+    for (int i = 0; i < num_controlled_joints_; ++i)
     {
         random_state_distributions_.push_back(std::uniform_real_distribution<double>(joint_limits_(i, 0), joint_limits_(i, 1)));
     }


### PR DESCRIPTION
This adds getter for the joint elements of the `KinematicTree`.

At the moment, the `KinematicElement`s returned by `GetControlledJointsMap` have empty `parent_name` and the `segment.getName()` returns the joint name instead of the link name, i.e. `segment.getName()` and `segment.getJoint().getName()` both return the same joint name.

From http://docs.ros.org/jade/api/orocos_kdl/html/classKDL_1_1Segment.html:

> This class encapsulates a simple segment, that is a "rigid body" (i.e., a frame and a rigid body inertia) with a joint and with "handles", root and tip to connect to other segments.

I would assume that the `KDL::Segment` always refers to a frame/link and not a joint.

Is this intended?

Edit:
And `closest_robot_link.lock()` is NULL which also appears to be wrong.