### PR TITLE
separate vector and scalar task cost

### DIFF
--- a/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
@@ -60,13 +60,6 @@ public:
     Eigen::RowVectorXd GetScalarJacobian() const;
 
     /**
-     * @brief GetTaskError get error vector of objective function
-     * @param task_name valid task
-     * @return error vector
-     */
-    Eigen::VectorXd GetTaskError(const std::string& task_name) const;
-
-    /**
      * @brief GetScalarTaskCost get weighted sum-of-squares of cost vector
      * @param task_name valid task
      * @return scalar cost

--- a/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
@@ -49,16 +49,28 @@ public:
     bool IsValid() override { return true; }
     void SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);
     void SetRho(const std::string& task_name, const double& rho);
-    Eigen::VectorXd GetGoal(const std::string& task_name);
-    double GetRho(const std::string& task_name);
-    Eigen::VectorXd GetNominalPose();
+    Eigen::VectorXd GetGoal(const std::string& task_name) const;
+    double GetRho(const std::string& task_name) const;
+    Eigen::VectorXd GetNominalPose() const;
     void SetNominalPose(Eigen::VectorXdRefConst qNominal_in);
     void PreUpdate() override;
-    int GetTaskId(const std::string& task_name);
+    int GetTaskId(const std::string& task_name) const;
 
     double GetScalarCost() const;
     Eigen::RowVectorXd GetScalarJacobian() const;
 
+    /**
+     * @brief GetTaskError get error vector of objective function
+     * @param task_name valid task
+     * @return error vector
+     */
+    Eigen::VectorXd GetTaskError(const std::string& task_name) const;
+
+    /**
+     * @brief GetScalarTaskCost get weighted sum-of-squares of cost vector
+     * @param task_name valid task
+     * @return scalar cost
+     */
     double GetScalarTaskCost(const std::string& task_name) const;
 
     EndPoseTask cost;

--- a/exotica_core/include/exotica_core/tasks.h
+++ b/exotica_core/include/exotica_core/tasks.h
@@ -110,6 +110,8 @@ struct EndPoseTask : public Task
     void SetRho(const std::string& task_name, const double rho_in);
     double GetRho(const std::string& task_name) const;
 
+    Eigen::VectorXd GetTaskError(const std::string& task_name) const;
+
     Eigen::VectorXd rho;
     TaskSpaceVector y;
     Eigen::VectorXd ydiff;

--- a/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
+++ b/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
@@ -93,21 +93,9 @@ Eigen::RowVectorXd UnconstrainedEndPoseProblem::GetScalarJacobian() const
     return cost.jacobian.transpose() * cost.S * cost.ydiff * 2.0;
 }
 
-Eigen::VectorXd UnconstrainedEndPoseProblem::GetTaskError(const std::string& task_name) const
-{
-    for (int i = 0; i < cost.indexing.size(); ++i)
-    {
-        if (cost.tasks[i]->GetObjectName() == task_name)
-        {
-            return cost.ydiff.segment(cost.indexing[i].start, cost.indexing[i].length);
-        }
-    }
-    ThrowPretty("Cannot get scalar task cost. Task map '" << task_name << "' does not exist.");
-}
-
 double UnconstrainedEndPoseProblem::GetScalarTaskCost(const std::string& task_name) const
 {
-    const Eigen::VectorXd ydiff = GetTaskError(task_name);
+    const Eigen::VectorXd ydiff = cost.GetTaskError(task_name);
     return ydiff.transpose() * GetRho(task_name) * ydiff;
 }
 

--- a/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
+++ b/exotica_core/src/problems/unconstrained_end_pose_problem.cpp
@@ -93,16 +93,22 @@ Eigen::RowVectorXd UnconstrainedEndPoseProblem::GetScalarJacobian() const
     return cost.jacobian.transpose() * cost.S * cost.ydiff * 2.0;
 }
 
-double UnconstrainedEndPoseProblem::GetScalarTaskCost(const std::string& task_name) const
+Eigen::VectorXd UnconstrainedEndPoseProblem::GetTaskError(const std::string& task_name) const
 {
     for (int i = 0; i < cost.indexing.size(); ++i)
     {
         if (cost.tasks[i]->GetObjectName() == task_name)
         {
-            return cost.ydiff.segment(cost.indexing[i].start, cost.indexing[i].length).transpose() * cost.rho(cost.indexing[i].id) * cost.ydiff.segment(cost.indexing[i].start, cost.indexing[i].length);
+            return cost.ydiff.segment(cost.indexing[i].start, cost.indexing[i].length);
         }
     }
     ThrowPretty("Cannot get scalar task cost. Task map '" << task_name << "' does not exist.");
+}
+
+double UnconstrainedEndPoseProblem::GetScalarTaskCost(const std::string& task_name) const
+{
+    const Eigen::VectorXd ydiff = GetTaskError(task_name);
+    return ydiff.transpose() * GetRho(task_name) * ydiff;
 }
 
 void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
@@ -173,7 +179,7 @@ void UnconstrainedEndPoseProblem::SetRho(const std::string& task_name, const dou
     ThrowPretty("Cannot set rho. Task map '" << task_name << "' does not exist.");
 }
 
-Eigen::VectorXd UnconstrainedEndPoseProblem::GetGoal(const std::string& task_name)
+Eigen::VectorXd UnconstrainedEndPoseProblem::GetGoal(const std::string& task_name) const
 {
     for (int i = 0; i < cost.indexing.size(); ++i)
     {
@@ -185,7 +191,7 @@ Eigen::VectorXd UnconstrainedEndPoseProblem::GetGoal(const std::string& task_nam
     ThrowPretty("Cannot get Goal. Task map '" << task_name << "' does not exist.");
 }
 
-double UnconstrainedEndPoseProblem::GetRho(const std::string& task_name)
+double UnconstrainedEndPoseProblem::GetRho(const std::string& task_name) const
 {
     for (int i = 0; i < cost.indexing.size(); ++i)
     {
@@ -197,7 +203,7 @@ double UnconstrainedEndPoseProblem::GetRho(const std::string& task_name)
     ThrowPretty("Cannot get rho. Task map '" << task_name << "' does not exist.");
 }
 
-Eigen::VectorXd UnconstrainedEndPoseProblem::GetNominalPose()
+Eigen::VectorXd UnconstrainedEndPoseProblem::GetNominalPose() const
 {
     return q_nominal;
 }
@@ -211,7 +217,7 @@ void UnconstrainedEndPoseProblem::SetNominalPose(Eigen::VectorXdRefConst qNomina
                     << N << ", received " << qNominal_in.rows() << ").");
 }
 
-int UnconstrainedEndPoseProblem::GetTaskId(const std::string& task_name)
+int UnconstrainedEndPoseProblem::GetTaskId(const std::string& task_name) const
 {
     for (int i = 0; i < cost.indexing.size(); ++i)
     {

--- a/exotica_core/src/tasks.cpp
+++ b/exotica_core/src/tasks.cpp
@@ -150,7 +150,7 @@ void EndPoseTask::Update(const TaskSpaceVector& big_Phi)
 
 void EndPoseTask::SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal)
 {
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -164,7 +164,7 @@ void EndPoseTask::SetGoal(const std::string& task_name, Eigen::VectorXdRefConst 
 
 void EndPoseTask::SetRho(const std::string& task_name, const double rho_in)
 {
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -178,7 +178,7 @@ void EndPoseTask::SetRho(const std::string& task_name, const double rho_in)
 
 Eigen::VectorXd EndPoseTask::GetGoal(const std::string& task_name) const
 {
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -190,7 +190,7 @@ Eigen::VectorXd EndPoseTask::GetGoal(const std::string& task_name) const
 
 double EndPoseTask::GetRho(const std::string& task_name) const
 {
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -278,7 +278,7 @@ inline void TimeIndexedTask::ValidateTimeIndex(int& t_in) const
 void TimeIndexedTask::SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal, int t)
 {
     ValidateTimeIndex(t);
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -293,7 +293,7 @@ void TimeIndexedTask::SetGoal(const std::string& task_name, Eigen::VectorXdRefCo
 Eigen::VectorXd TimeIndexedTask::GetGoal(const std::string& task_name, int t) const
 {
     ValidateTimeIndex(t);
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -306,7 +306,7 @@ Eigen::VectorXd TimeIndexedTask::GetGoal(const std::string& task_name, int t) co
 void TimeIndexedTask::SetRho(const std::string& task_name, const double rho_in, int t)
 {
     ValidateTimeIndex(t);
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {
@@ -321,7 +321,7 @@ void TimeIndexedTask::SetRho(const std::string& task_name, const double rho_in, 
 double TimeIndexedTask::GetRho(const std::string& task_name, int t) const
 {
     ValidateTimeIndex(t);
-    for (int i = 0; i < indexing.size(); ++i)
+    for (size_t i = 0; i < indexing.size(); ++i)
     {
         if (tasks[i]->GetObjectName() == task_name)
         {

--- a/exotica_core/src/tasks.cpp
+++ b/exotica_core/src/tasks.cpp
@@ -200,6 +200,18 @@ double EndPoseTask::GetRho(const std::string& task_name) const
     ThrowPretty("Cannot get rho. Task Map '" << task_name << "' does not exist.");
 }
 
+Eigen::VectorXd EndPoseTask::GetTaskError(const std::string& task_name) const
+{
+    for (size_t i = 0; i < indexing.size(); ++i)
+    {
+        if (tasks[i]->GetObjectName() == task_name)
+        {
+            return ydiff.segment(indexing[i].start, indexing[i].length);
+        }
+    }
+    ThrowPretty("Cannot get task error. Task map '" << task_name << "' does not exist.");
+}
+
 void TimeIndexedTask::Initialize(const std::vector<exotica::Initializer>& inits, PlanningProblemPtr prob, TaskSpaceVector& Phi)
 {
     Task::Initialize(inits, prob, Phi);

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -674,7 +674,8 @@ PYBIND11_MODULE(_pyexotica, module)
         .def_readonly("jacobian", &EndPoseTask::jacobian)
         .def_readonly("S", &EndPoseTask::S)
         .def_readonly("tasks", &EndPoseTask::tasks)
-        .def_readonly("task_maps", &EndPoseTask::task_maps);
+        .def_readonly("task_maps", &EndPoseTask::task_maps)
+        .def("get_task_error", &EndPoseTask::GetTaskError);
 
     py::class_<SamplingTask, std::shared_ptr<SamplingTask>>(module, "SamplingTask")
         .def_readonly("length_Phi", &SamplingTask::length_Phi)
@@ -834,7 +835,6 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrained_end_pose_problem.def_property("q_nominal", &UnconstrainedEndPoseProblem::GetNominalPose, &UnconstrainedEndPoseProblem::SetNominalPose);
     unconstrained_end_pose_problem.def("get_scalar_cost", &UnconstrainedEndPoseProblem::GetScalarCost);
     unconstrained_end_pose_problem.def("get_scalar_jacobian", &UnconstrainedEndPoseProblem::GetScalarJacobian);
-    unconstrained_end_pose_problem.def("get_task_error", &UnconstrainedEndPoseProblem::GetTaskError);
     unconstrained_end_pose_problem.def("get_scalar_task_cost", &UnconstrainedEndPoseProblem::GetScalarTaskCost);
     unconstrained_end_pose_problem.def_readonly("cost", &UnconstrainedEndPoseProblem::cost);
 

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -834,6 +834,7 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrained_end_pose_problem.def_property("q_nominal", &UnconstrainedEndPoseProblem::GetNominalPose, &UnconstrainedEndPoseProblem::SetNominalPose);
     unconstrained_end_pose_problem.def("get_scalar_cost", &UnconstrainedEndPoseProblem::GetScalarCost);
     unconstrained_end_pose_problem.def("get_scalar_jacobian", &UnconstrainedEndPoseProblem::GetScalarJacobian);
+    unconstrained_end_pose_problem.def("get_task_error", &UnconstrainedEndPoseProblem::GetTaskError);
     unconstrained_end_pose_problem.def("get_scalar_task_cost", &UnconstrainedEndPoseProblem::GetScalarTaskCost);
     unconstrained_end_pose_problem.def_readonly("cost", &UnconstrainedEndPoseProblem::cost);
 


### PR DESCRIPTION
This splits the task costs (per task) into its vector and scalar part. I.e. `GetTaskCost` provides the cost vector and `GetScalarTaskCost` provides its sum-of-squares as before.