### PR TITLE
Updates to Manipulability task map.

### DIFF
--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -63,7 +63,7 @@
     <description>Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.</description>
   </class>
   <class name="exotica/Manipulability" type="exotica::Manipulability" base_class_type="exotica::TaskMap">
-    <description>If used as a cost term, Manipulability maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be negative. When Manipulability is used as an inequality constraint the lower bound must be set using Goal and each term must be negative. Derivatives are computed using finite differencing.</description>
+    <description>If used as a cost term, Manipulability maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be negative and the Goal must not be set to anything other than zeros (as by default). When Manipulability is used as an inequality constraint the lower bound must be set using Goal and each term must be negative. Derivatives are computed using finite differencing.</description>
   </class>
   <class name="exotica/GazeAtConstraint" type="exotica::GazeAtConstraint" base_class_type="exotica::TaskMap">
     <description>Keeps a gaze position within a cone in the end-effector frame defined by a given viewing angle. This task map can only be used as an inequality constraint.</description>

--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -63,7 +63,7 @@
     <description>Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.</description>
   </class>
   <class name="exotica/Manipulability" type="exotica::Manipulability" base_class_type="exotica::TaskMap">
-    <description>Maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be negative. Derivatives are computed using finite differencing.</description>
+    <description>If used as a cost term, Manipulability maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be positive. When Manipulability is used as an inequality constraint the lower bound must be positive. Derivatives are computed using finite differencing.</description>
   </class>
   <class name="exotica/GazeAtConstraint" type="exotica::GazeAtConstraint" base_class_type="exotica::TaskMap">
     <description>Keeps a gaze position within a cone in the end-effector frame defined by a given viewing angle. This task map can only be used as an inequality constraint.</description>

--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -63,7 +63,7 @@
     <description>Looks at a target point by penalizing the vector which defines the orthogonal projection onto a defined line in the end-effector frame.</description>
   </class>
   <class name="exotica/Manipulability" type="exotica::Manipulability" base_class_type="exotica::TaskMap">
-    <description>If used as a cost term, Manipulability maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be positive. When Manipulability is used as an inequality constraint the lower bound must be positive. Derivatives are computed using finite differencing.</description>
+    <description>If used as a cost term, Manipulability maximizes the manipulability measure using Yoshikawa's measure based on the velocity ellipsoid. Note, in-order to maximize manipulability the associated Rho must be negative. When Manipulability is used as an inequality constraint the lower bound must be set using Goal and each term must be negative. Derivatives are computed using finite differencing.</description>
   </class>
   <class name="exotica/GazeAtConstraint" type="exotica::GazeAtConstraint" base_class_type="exotica::TaskMap">
     <description>Keeps a gaze position within a cone in the end-effector frame defined by a given viewing angle. This task map can only be used as an inequality constraint.</description>

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -47,12 +47,13 @@ namespace exotica
 /// \f]
 /// that is based on the shape of the velocity ellipsoid where \f$J(x)\f$ is the manipulator Jacobian matrix.. The task map is expressed by
 /// \f[
-///   Phi(x) := m^- - m(x)
+///   \phi(x) := -m(x).
 /// \f]
-/// where \f$m^-\f$ is a lower bound for \f$m(x)\f$. If the task map is being used in the cost function then \f$m^-\f$ should be set to zero.
+///
+/// To use the task map as an inequality constraint the lower bound for \f$\phi\f$ should be set as a goal and each element should be negative.
 ///
 /// Note that
-///   - the associated value for \f$\rho\f$ <b>must</b> be positivein order to maximize the manipulability, and
+///   - the associated value for \f$\rho\f$ <b>must</b> be negative in order to maximize the manipulability, and
 ///   - derivatives of \f$\Phi\f$ are computed using finite differences.
 ///
 /// Todo
@@ -65,9 +66,8 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    int n_end_effs_;               ///< Number of end-effectors.
-    int n_rows_of_jac_;            ///< Number of rows from the top to extract from full jacobian. Is either 3 (position) or 6 (position and rotation).
-    Eigen::VectorXd lower_bound_;  ///< When task map is a constraint, lower_bound_ is a lower bound for the inequality constraint, i.e. \f$\phi\geqm^-\f$ where \f$m^-\f$ is the lower bound.
+    int n_end_effs_;     ///< Number of end-effectors.
+    int n_rows_of_jac_;  ///< Number of rows from the top to extract from full jacobian. Is either 3 (position) or 6 (position and rotation).
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -60,9 +60,6 @@ namespace exotica
 class Manipulability : public TaskMap, public Instantiable<ManipulabilityInitializer>
 {
 public:
-    Manipulability();
-    virtual ~Manipulability();
-
     void Instantiate(const ManipulabilityInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     int TaskSpaceDim() override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/manipulability.h
@@ -41,14 +41,18 @@ namespace exotica
 /// \ingroup TaskMap
 ///
 /// \brief Manipulability measure.
-/// The manipulability measure for a robot at a given joint configuration indicates dexterity, that is, how isotropic the robot's motion is with respect to the task space motion. The measure is high when the manipulator is capable of equal motion in all directions and low when the manipulator is close to a singularity. This task map implements Yoshikawa's manipulability measure that is based on the shape of the velocity ellipsoid and expressed by
+/// The manipulability measure for a robot at a given joint configuration indicates dexterity, that is, how isotropic the robot's motion is with respect to the task space motion. The measure is high when the manipulator is capable of equal motion in all directions and low when the manipulator is close to a singularity. This task map implements Yoshikawa's manipulability measure
 /// \f[
-///   Phi(x) := \sqrt{J(x)J(x)^T}
+///   m(x) = \sqrt{J(x)J(x)^T}
 /// \f]
-/// where $J(x)$ is the manipulator Jacobian matrix.
+/// that is based on the shape of the velocity ellipsoid where \f$J(x)\f$ is the manipulator Jacobian matrix.. The task map is expressed by
+/// \f[
+///   Phi(x) := m^- - m(x)
+/// \f]
+/// where \f$m^-\f$ is a lower bound for \f$m(x)\f$. If the task map is being used in the cost function then \f$m^-\f$ should be set to zero.
 ///
 /// Note that
-///   - the associated value for \f$\rho\f$ <b>must</b> be negative in order to maximize the manipulability, and
+///   - the associated value for \f$\rho\f$ <b>must</b> be positivein order to maximize the manipulability, and
 ///   - derivatives of \f$\Phi\f$ are computed using finite differences.
 ///
 /// Todo
@@ -64,8 +68,9 @@ public:
     int TaskSpaceDim() override;
 
 private:
-    int n_end_effs_;     ///< Number of end-effectors.
-    int n_rows_of_jac_;  ///< Number of rows from the top to extract from full jacobian. Is either 3 (position) or 6 (position and rotation).
+    int n_end_effs_;               ///< Number of end-effectors.
+    int n_rows_of_jac_;            ///< Number of rows from the top to extract from full jacobian. Is either 3 (position) or 6 (position and rotation).
+    Eigen::VectorXd lower_bound_;  ///< When task map is a constraint, lower_bound_ is a lower bound for the inequality constraint, i.e. \f$\phi\geqm^-\f$ where \f$m^-\f$ is the lower bound.
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/init/manipulability.in
+++ b/exotations/exotica_core_task_maps/init/manipulability.in
@@ -3,7 +3,6 @@ class Manipulability
 extend <exotica_core/task_map>
 
 Optional bool OnlyPosition = false; // If true, only position part of jacobian is used in computation of manipulability. Otherwise, the full jacobian is used.
-Optional Eigen::VectorXd LowerBound = Eigen::VectorXd(); // Lower bound, used when Manipulability is a constraint. If task map is part of the cost terms then LowerBound should be set to zero (this is the default). 
 
 // inherited from TaskMap:
 // string Link           > name of frame in which point is defined

--- a/exotations/exotica_core_task_maps/init/manipulability.in
+++ b/exotations/exotica_core_task_maps/init/manipulability.in
@@ -3,6 +3,7 @@ class Manipulability
 extend <exotica_core/task_map>
 
 Optional bool OnlyPosition = false; // If true, only position part of jacobian is used in computation of manipulability. Otherwise, the full jacobian is used.
+Optional Eigen::VectorXd LowerBound = Eigen::VectorXd(); // Lower bound, used when Manipulability is a constraint. If task map is part of the cost terms then LowerBound should be set to zero (this is the default). 
 
 // inherited from TaskMap:
 // string Link           > name of frame in which point is defined

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -43,13 +43,33 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     for (int i = 0; i < n_end_effs_; ++i)
     {
         const Eigen::MatrixXd& J = kinematics[0].jacobian[i].data.topRows(n_rows_of_jac_);
-        phi(i) = std::sqrt((J * J.transpose()).determinant());
+        phi(i) = lower_bound_(i) - std::sqrt((J * J.transpose()).determinant());
     }
 }
 
 void Manipulability::Instantiate(const ManipulabilityInitializer& init)
 {
+    parameters_ = init;
     n_end_effs_ = frames_.size();
+
+    if (parameters_.LowerBound.rows() == 0)
+    {
+        lower_bound_.setConstant(n_end_effs_, 1, 0.0);
+    }
+    else if (parameters_.LowerBound.rows() == 1)
+    {
+        lower_bound_.setConstant(n_end_effs_, 1, std::abs(static_cast<double>(parameters_.LowerBound(0))));
+    }
+    else if (parameters_.LowerBound.rows() == n_end_effs_)
+    {
+        lower_bound_.resize(n_end_effs_, 1);
+        lower_bound_ = parameters_.LowerBound.cwiseAbs();
+    }
+    else
+    {
+        ThrowNamed("LowerBound vector needs to be either of size 1 or N (N is number of end effectors), but got " << parameters_.LowerBound.rows() << ".");
+    }
+
     if (init.OnlyPosition)
     {
         n_rows_of_jac_ = 3;

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -40,7 +40,7 @@ void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
     for (int i = 0; i < n_end_effs_; ++i)
     {
         const Eigen::MatrixXd& J = kinematics[0].jacobian[i].data.topRows(n_rows_of_jac_);
-        phi(i) = lower_bound_(i) - std::sqrt((J * J.transpose()).determinant());
+        phi(i) = -std::sqrt((J * J.transpose()).determinant());
     }
 }
 
@@ -48,24 +48,6 @@ void Manipulability::Instantiate(const ManipulabilityInitializer& init)
 {
     parameters_ = init;
     n_end_effs_ = frames_.size();
-
-    if (parameters_.LowerBound.rows() == 0)
-    {
-        lower_bound_.setConstant(n_end_effs_, 1, 0.0);
-    }
-    else if (parameters_.LowerBound.rows() == 1)
-    {
-        lower_bound_.setConstant(n_end_effs_, 1, std::abs(static_cast<double>(parameters_.LowerBound(0))));
-    }
-    else if (parameters_.LowerBound.rows() == n_end_effs_)
-    {
-        lower_bound_.resize(n_end_effs_, 1);
-        lower_bound_ = parameters_.LowerBound.cwiseAbs();
-    }
-    else
-    {
-        ThrowNamed("LowerBound vector needs to be either of size 1 or N (N is number of end effectors), but got " << parameters_.LowerBound.rows() << ".");
-    }
 
     if (init.OnlyPosition)
     {

--- a/exotations/exotica_core_task_maps/src/manipulability.cpp
+++ b/exotations/exotica_core_task_maps/src/manipulability.cpp
@@ -33,9 +33,6 @@ REGISTER_TASKMAP_TYPE("Manipulability", exotica::Manipulability);
 
 namespace exotica
 {
-Manipulability::Manipulability() = default;
-Manipulability::~Manipulability() = default;
-
 void Manipulability::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     if (phi.rows() != TaskSpaceDim()) ThrowNamed("Wrong size of phi!");

--- a/exotica_examples/resources/configs/example_manipulability.xml
+++ b/exotica_examples/resources/configs/example_manipulability.xml
@@ -32,7 +32,7 @@
 
     <Cost>
       <Task Task="Position" Rho="1"/>
-      <Task Task="Manip" Rho="-1"/>
+      <Task Task="Manip" Rho="1"/>
     </Cost>
 
     <StartState>1.147249698638916 -0.22851833701133728 0.5324112772941589 1.2311428785324097 -0.19176392257213593 -0.1434374898672104 0</StartState>


### PR DESCRIPTION
[task_maps]
* Changed formulation from phi(x)=manip(x) to phi(x)=low - manip(x) so the task map can be used in both the cost function and as an inequality constraint (with lower bound low here).
* New LowerBound term in initializer.
* Updated documentation.
* Code formatting.

[examples]

* Rho now needs to be positive.

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
