### PR TITLE
Adding new AvoidLookAtSphere task map.

### DIFF
--- a/exotations/exotica_core_task_maps/CMakeLists.txt
+++ b/exotations/exotica_core_task_maps/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 AddInitializer(
+  avoid_look_at_sphere
   center_of_mass
   continuous_joint_pose
   interaction_mesh
@@ -50,6 +51,7 @@ include_directories(
 )
 
 set(SOURCES
+    src/avoid_look_at_sphere.cpp  
     src/center_of_mass.cpp
     src/continuous_joint_pose.cpp
     src/interaction_mesh.cpp

--- a/exotations/exotica_core_task_maps/exotica_plugins.xml
+++ b/exotations/exotica_core_task_maps/exotica_plugins.xml
@@ -71,4 +71,9 @@
   <class name="exotica/GazeAtConstraint" type="exotica::GazeAtConstraint" base_class_type="exotica::TaskMap">
     <description>Keeps a gaze position within a cone in the end-effector frame defined by a given viewing angle. This task map can only be used as an inequality constraint.</description>
   </class>
+  <class name="exotica/AvoidLookAtSphere" type="exotica::AvoidLookAtSphere" base_class_type="exotica::TaskMap">
+    <description>
+      Avoids "looking at" spherical objects. Can be used as either a cost term, or inequality constraint. The task map assumes the positions and radii of each object. 
+    </description>
+  </class>  
 </library>

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/avoid_look_at_sphere.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/avoid_look_at_sphere.h
@@ -62,7 +62,6 @@ namespace exotica
 class AvoidLookAtSphere : public TaskMap, public Instantiable<AvoidLookAtSphereInitializer>
 {
 public:
-
     void Instantiate(const AvoidLookAtSphereInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/avoid_look_at_sphere.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/avoid_look_at_sphere.h
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2019, Christopher E. Mower
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_CORE_TASK_MAPS_AVOID_LOOK_AT_SPHERE_H_
+#define EXOTICA_CORE_TASK_MAPS_AVOID_LOOK_AT_SPHERE_H_
+
+#include <exotica_core/task_map.h>
+
+#include <exotica_core_task_maps/avoid_look_at_sphere_initializer.h>
+
+namespace exotica
+{
+/// \class AvoidLookAtSphere
+///
+/// \ingroup TaskMap
+///
+/// \brief Avoids pointing end-effector at a given spherical object.
+///
+/// This task map avoids pointing the end-effector a number of given spherical objects. AvoidLookAtSphere can be used as either a cost term or an inequality constraint. Each spherical object in the scene is defined by a position \f$o\in\mathbb{R}^3\f$ and radius \f$0<r\in\mathbb{R}\f$. The position and radii of each object must be given.
+///
+/// When using AvoidLookAtSphere as a cost term, the forward mapping defining the task map is expressed by
+/// \f[
+///    \Phi_i(x) := \begin{cases}(1 - \frac{d_i^2}{r_i^2})^2 & d_i<r_i\\0 & \text{otherwise}\end{cases}
+/// \f]
+/// for all \f$i=1{:}N\f$ where \f$N\f$ is the number of objects, \f$d\f$ is the orthogonal distance between the object center and the end-effector approach vector.
+///
+/// When using AvoidLookAtSphere as an inequality constraint, the forward mapping defining the task map is expressed by
+/// \f[
+///    \Phi_i(x) = r_i^2 - d_i^2
+/// \f]
+/// for all \f$i=1{:}N\f$.
+///
+/// \image html taskmap_avoid_look_at_sphere.png "AvoidLookAtSphere task map." width=500px
+///
+///
+class AvoidLookAtSphere : public TaskMap, public Instantiable<AvoidLookAtSphereInitializer>
+{
+public:
+
+    void Instantiate(const AvoidLookAtSphereInitializer& init) override;
+    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi) override;
+    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
+    int TaskSpaceDim() override;
+
+private:
+    void UpdateAsCostWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    void UpdateAsInequalityConstraintWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+    void UpdateAsCostWithJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian);
+    void UpdateAsInequalityConstraintWithJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian);
+
+    void PublishObjectsAsMarkerArray();
+
+    void (AvoidLookAtSphere::*UpdateTaskMapWithoutJacobian)(Eigen::VectorXdRefConst, Eigen::VectorXdRef);
+    void (AvoidLookAtSphere::*UpdateTaskMapWithJacobian)(Eigen::VectorXdRefConst, Eigen::VectorXdRef, Eigen::MatrixXdRef);
+    int n_objects_;                  ///< Number of spherical objects.
+    Eigen::VectorXd diameter_;       ///< The diameter of each object.
+    Eigen::VectorXd radii_squared_;  ///< The square of each object radii.
+    ros::Publisher pub_markers_;     ///< publish marker for RViz
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_CORE_TASK_MAPS_AVOID_LOOK_AT_SPHERE_H_

--- a/exotations/exotica_core_task_maps/init/avoid_look_at_sphere.in
+++ b/exotations/exotica_core_task_maps/init/avoid_look_at_sphere.in
@@ -1,0 +1,11 @@
+class AvoidLookAtSphere
+
+extend <exotica_core/task_map>
+
+// inherited from TaskMap:
+// string Link           > name of frame in which point is defined
+// VectorXd LinkOffset   > coordinate of point in Link frame
+// string Base           > name of frame in which line is defined
+// VectorXd BaseOffset   > starting point of line in Base frame
+
+Optional bool UseAsCost = true; // If true, task map is considered part of the cost function, otherwise the task map is considered as an inequality constraint. 

--- a/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
+++ b/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
@@ -38,21 +38,21 @@ void AvoidLookAtSphere::UpdateAsCostWithoutJacobian(Eigen::VectorXdRefConst x, E
 {
     for (int i = 0; i < n_objects_; ++i)
     {
-        const double frac = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>().squaredNorm() / radii_squared_(i);
+        const double frac = Eigen::Map<Eigen::Vector2d>(kinematics[0].Phi(i).p.data).squaredNorm() / radii_squared_(i);
         if (frac < 1.0) phi(i) = 1.0 - 2.0 * frac + frac * frac;
     }
 }
 
 void AvoidLookAtSphere::UpdateAsInequalityConstraintWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
-    for (int i = 0; i < n_objects_; ++i) phi(i) = radii_squared_(i) - Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>().squaredNorm();
+    for (int i = 0; i < n_objects_; ++i) phi(i) = radii_squared_(i) - Eigen::Map<Eigen::Vector2d>(kinematics[0].Phi(i).p.data).squaredNorm();
 }
 
 void AvoidLookAtSphere::UpdateAsCostWithJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
 {
     for (int i = 0; i < n_objects_; ++i)
     {
-        Eigen::Vector2d o = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>();
+        Eigen::Vector2d o = Eigen::Map<Eigen::Vector2d>(kinematics[0].Phi(i).p.data);
         const double frac = o.squaredNorm() / radii_squared_(i);
         if (frac < 1.0)
         {
@@ -66,7 +66,7 @@ void AvoidLookAtSphere::UpdateAsInequalityConstraintWithJacobian(Eigen::VectorXd
 {
     for (int i = 0; i < n_objects_; ++i)
     {
-        Eigen::Vector2d o = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>();
+        Eigen::Vector2d o = Eigen::Map<Eigen::Vector2d>(kinematics[0].Phi(i).p.data);
         const double d = o.norm();
         phi(i) = radii_squared_(i) - d * d;
         for (int j = 0; j < jacobian.cols(); ++j) jacobian(i, j) = -2.0 * kinematics[0].jacobian[i].data.topRows<2>().col(j).dot(o);

--- a/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
+++ b/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
@@ -34,7 +34,6 @@ REGISTER_TASKMAP_TYPE("AvoidLookAtSphere", exotica::AvoidLookAtSphere);
 
 namespace exotica
 {
-
 void AvoidLookAtSphere::UpdateAsCostWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
 {
     for (int i = 0; i < n_objects_; ++i)

--- a/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
+++ b/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
@@ -39,7 +39,14 @@ void AvoidLookAtSphere::UpdateAsCostWithoutJacobian(Eigen::VectorXdRefConst x, E
     for (int i = 0; i < n_objects_; ++i)
     {
         const double frac = Eigen::Map<Eigen::Vector2d>(kinematics[0].Phi(i).p.data).squaredNorm() / radii_squared_(i);
-        if (frac < 1.0) phi(i) = 1.0 - 2.0 * frac + frac * frac;
+        if (frac < 1.0)
+        {
+            phi(i) = 1.0 - 2.0 * frac + frac * frac;
+        }
+        else
+        {
+            phi(i) = 0.0;
+        }
     }
 }
 
@@ -58,6 +65,11 @@ void AvoidLookAtSphere::UpdateAsCostWithJacobian(Eigen::VectorXdRefConst x, Eige
         {
             phi(i) = 1.0 - 2.0 * frac + frac * frac;
             for (int j = 0; j < jacobian.cols(); ++j) jacobian(i, j) = -4.0 * (1.0 - frac) * kinematics[0].jacobian[i].data.topRows<2>().col(j).dot(o) / radii_squared_(i);
+        }
+        else
+        {
+            phi(i) = 0.0;
+            jacobian.row(i).setZero();
         }
     }
 }
@@ -143,7 +155,7 @@ void AvoidLookAtSphere::Instantiate(const AvoidLookAtSphereInitializer& init)
 
     if (debug_ && Server::IsRos())
     {
-        pub_markers_ = Server::Advertise<visualization_msgs::MarkerArray>("alas_objs", 1, true);
+        pub_markers_ = Server::Advertise<visualization_msgs::MarkerArray>("avoid_look_at_sphere_objects", 1, true);
         visualization_msgs::Marker md;  // delete previous markers
         md.action = visualization_msgs::Marker::DELETEALL;
         visualization_msgs::MarkerArray ma;

--- a/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
+++ b/exotations/exotica_core_task_maps/src/avoid_look_at_sphere.cpp
@@ -1,0 +1,160 @@
+//
+// Copyright (c) 2019, Christopher E. Mower
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_core/server.h>
+#include <exotica_core_task_maps/avoid_look_at_sphere.h>
+
+REGISTER_TASKMAP_TYPE("AvoidLookAtSphere", exotica::AvoidLookAtSphere);
+
+namespace exotica
+{
+
+void AvoidLookAtSphere::UpdateAsCostWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    for (int i = 0; i < n_objects_; ++i)
+    {
+        const double frac = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>().squaredNorm() / radii_squared_(i);
+        if (frac < 1.0) phi(i) = 1.0 - 2.0 * frac + frac * frac;
+    }
+}
+
+void AvoidLookAtSphere::UpdateAsInequalityConstraintWithoutJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    for (int i = 0; i < n_objects_; ++i) phi(i) = radii_squared_(i) - Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>().squaredNorm();
+}
+
+void AvoidLookAtSphere::UpdateAsCostWithJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
+{
+    for (int i = 0; i < n_objects_; ++i)
+    {
+        Eigen::Vector2d o = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>();
+        const double frac = o.squaredNorm() / radii_squared_(i);
+        if (frac < 1.0)
+        {
+            phi(i) = 1.0 - 2.0 * frac + frac * frac;
+            for (int j = 0; j < jacobian.cols(); ++j) jacobian(i, j) = -4.0 * (1.0 - frac) * kinematics[0].jacobian[i].data.topRows<2>().col(j).dot(o) / radii_squared_(i);
+        }
+    }
+}
+
+void AvoidLookAtSphere::UpdateAsInequalityConstraintWithJacobian(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
+{
+    for (int i = 0; i < n_objects_; ++i)
+    {
+        Eigen::Vector2d o = Eigen::Map<Eigen::Vector3d>(kinematics[0].Phi(i).p.data).topRows<2>();
+        const double d = o.norm();
+        phi(i) = radii_squared_(i) - d * d;
+        for (int j = 0; j < jacobian.cols(); ++j) jacobian(i, j) = -2.0 * kinematics[0].jacobian[i].data.topRows<2>().col(j).dot(o);
+    }
+}
+
+void AvoidLookAtSphere::PublishObjectsAsMarkerArray()
+{
+    const ros::Time t = ros::Time::now();
+    visualization_msgs::MarkerArray ma;
+    ma.markers.reserve(n_objects_);
+    for (int i = 0; i < n_objects_; ++i)
+    {
+        visualization_msgs::Marker m;
+        m.header.stamp = t;
+        m.header.frame_id = "exotica/" + frames_[i].frame_B_link_name;
+        m.id = i;
+        m.action = visualization_msgs::Marker::ADD;
+        m.type = visualization_msgs::Marker::SPHERE;
+        m.scale.x = diameter_(i);
+        m.scale.y = diameter_(i);
+        m.scale.z = diameter_(i);
+        Eigen::Vector4d q = GetRotationAsVector(kinematics[0].Phi(i), RotationType::QUATERNION);
+        m.pose.position.x = kinematics[0].Phi(i).p.data[0];
+        m.pose.position.y = kinematics[0].Phi(i).p.data[1];
+        m.pose.position.z = kinematics[0].Phi(i).p.data[2];
+        m.pose.orientation.x = q[0];
+        m.pose.orientation.y = q[1];
+        m.pose.orientation.z = q[2];
+        m.pose.orientation.w = q[3];
+        m.color.r = 1.0;
+        m.color.a = 1.0;
+        ma.markers.emplace_back(m);
+    }
+    pub_markers_.publish(ma);
+}
+
+void AvoidLookAtSphere::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+{
+    (this->*UpdateTaskMapWithoutJacobian)(x, phi);
+    if (debug_ && Server::IsRos()) PublishObjectsAsMarkerArray();
+}
+
+void AvoidLookAtSphere::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
+{
+    (this->*UpdateTaskMapWithJacobian)(x, phi, jacobian);
+    if (debug_ && Server::IsRos()) PublishObjectsAsMarkerArray();
+}
+
+void AvoidLookAtSphere::Instantiate(const AvoidLookAtSphereInitializer& init)
+{
+    parameters_ = init;
+    n_objects_ = frames_.size();
+    diameter_.resize(n_objects_, 1);
+    radii_squared_.resize(n_objects_, 1);
+
+    for (int i = 0; i < n_objects_; ++i)
+    {
+        SphereInitializer sphere(init.EndEffector[i]);
+        diameter_(i) = 2.0 * sphere.Radius;
+        radii_squared_(i) = sphere.Radius * sphere.Radius;
+    }
+
+    if (init.UseAsCost)
+    {
+        UpdateTaskMapWithoutJacobian = &AvoidLookAtSphere::UpdateAsCostWithoutJacobian;
+        UpdateTaskMapWithJacobian = &AvoidLookAtSphere::UpdateAsCostWithJacobian;
+    }
+    else
+    {
+        UpdateTaskMapWithoutJacobian = &AvoidLookAtSphere::UpdateAsInequalityConstraintWithoutJacobian;
+        UpdateTaskMapWithJacobian = &AvoidLookAtSphere::UpdateAsInequalityConstraintWithJacobian;
+    }
+
+    if (debug_ && Server::IsRos())
+    {
+        pub_markers_ = Server::Advertise<visualization_msgs::MarkerArray>("alas_objs", 1, true);
+        visualization_msgs::Marker md;  // delete previous markers
+        md.action = visualization_msgs::Marker::DELETEALL;
+        visualization_msgs::MarkerArray ma;
+        ma.markers.push_back(md);
+        pub_markers_.publish(ma);
+    }
+}
+
+int AvoidLookAtSphere::TaskSpaceDim()
+{
+    return n_objects_;
+}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/test/test_maps.cpp
+++ b/exotations/exotica_core_task_maps/test/test_maps.cpp
@@ -1140,6 +1140,34 @@ TEST(ExoticaTaskMaps, testJointSmoothingBackwardDifference)
     }
 }
 
+TEST(ExoticaTaskMaps, testAvoidLookAtSphere)
+{
+    try
+    {
+        {
+            TEST_COUT << "AvoidLookAtSphere";
+
+            // Custom links
+            std::vector<Initializer> custom_links({Initializer("Link", {{"Name", std::string("AvoidLookAtPosition")},
+                                                                        {"Transform", std::string("1 1 2")}})});
+
+            // Setup taskmap
+            Initializer map("exotica/AvoidLookAtSphere",
+                            {{"Name", std::string("MyTask")},
+                             {"EndEffector", std::vector<Initializer>({Initializer("Frame", {{"Link", std::string("AvoidLookAtPosition")}, {"Base", std::string("")}})})},
+                             {"UseAsCost", std::string("1")},
+                             {"Radii", std::string("0.5")}});
+            UnconstrainedEndPoseProblemPtr problem = setup_problem(map, "", custom_links);
+            EXPECT_TRUE(test_random(problem));
+            EXPECT_TRUE(test_jacobian(problem, 2e-5));
+        }
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Uncaught exception!";
+    }
+}
+
 TEST(ExoticaTaskMaps, testLookAt)
 {
     try

--- a/exotica_examples/launch/python_ik_avoid_look_at_sphere.launch
+++ b/exotica_examples/launch/python_ik_avoid_look_at_sphere.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args python" />
+
+  <param name="robot_description" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.urdf" />
+  <param name="robot_description_semantic" textfile="$(find exotica_examples)/resources/robots/lwr_simplified.srdf" />
+
+  <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_ik_avoid_look_at_sphere" name="example_ik_avoid_look_at_sphere_node" output="screen" />
+
+  <node name="rviz" pkg="rviz" type="rviz" respawn="false" args="-d $(find exotica_examples)/resources/rviz_avoid_look_at_sphere.rviz" />
+</launch>

--- a/exotica_examples/resources/configs/example_ik_avoid_look_at_sphere.xml
+++ b/exotica_examples/resources/configs/example_ik_avoid_look_at_sphere.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<IKSolverDemoConfig>
+
+  <EndPoseProblem Name="My Problem">
+
+    <PlanningScene>
+      <Scene>
+        <JointGroup>arm</JointGroup>
+        <URDF>{exotica_examples}/resources/robots/lwr_simplified.urdf</URDF>
+        <SRDF>{exotica_examples}/resources/robots/lwr_simplified.srdf</SRDF>
+        <Links>
+          <Link Name="LookAtTarget" Transform="-0.5 0 1"/>
+	  <Link Name="AvoidLookAtSpherePosition1" Transform="-1 0 0.5"/>
+	  <Link Name="AvoidLookAtSpherePosition2" Transform="-1 0.4 0.5"/>
+        </Links>
+      </Scene>
+    </PlanningScene>
+    
+    <Maps>
+      <LookAt Name="LookAt">
+        <EndEffector>
+          <Frame Link="LookAtTarget" Base="lwr_arm_6_link"/><!-- EndEffector #1 => Target to look at, in relative frame of EffPoint -->
+        </EndEffector>
+      </LookAt>
+
+      <AvoidLookAtSphere Name="AvoidLookAtSphere" UseAsCost="0" Debug="1">
+	<EndEffector>
+	  <Frame Link="AvoidLookAtSpherePosition1" Radius="0.25" Base="lwr_arm_6_link"/>
+	  <Frame Link="AvoidLookAtSpherePosition2" Radius="0.35" Base="lwr_arm_6_link"/>
+	</EndEffector>
+      </AvoidLookAtSphere>
+      
+    </Maps>
+
+    <Cost>
+      <Task Task="LookAt" Rho="1"/>
+      <!-- <Task Task="AvoidLookAtSphere" Rho="1e2"/> --> <!-- When using as a cost term remember to set UseAsCost="1" above.-->
+    </Cost>
+
+    <Equality>
+    </Equality>
+
+    <Inequality>
+      <Task Task="AvoidLookAtSphere"/>
+    </Inequality>
+
+    <UseBounds>1</UseBounds>
+    
+    <StartState>0 0 0 0 0 0 0</StartState>
+    <NominalState>0 0 0 0 0 0 0</NominalState>
+    <W> 7 6 5 4 3 2 1 </W>
+    
+  </EndPoseProblem>
+  
+</IKSolverDemoConfig>

--- a/exotica_examples/resources/rviz_avoid_look_at_sphere.rviz
+++ b/exotica_examples/resources/rviz_avoid_look_at_sphere.rviz
@@ -1,0 +1,210 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 138
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1
+        - /RobotModel1/Links1
+        - /MarkerArray1
+        - /MarkerArray2
+      Splitter Ratio: 0.5894039869308472
+    Tree Height: 303
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_0_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_1_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_2_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_3_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_4_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_5_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_6_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        lwr_arm_7_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: exotica
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: InteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /target_marker/update
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /exotica/alas_objs
+      Name: MarkerArray
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /environment
+      Name: MarkerArray
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: exotica/world_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 4.485618591308594
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.09661810100078583
+        Y: 0.288012832403183
+        Z: 0.30752062797546387
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.23979726433753967
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 3.440385103225708
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: true
+  Height: 1052
+  Hide Left Dock: true
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001f700000360fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730200000276000000bb000002e20000029ffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003d00000360000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000016300000243fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000006e00000243000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000005cfc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000073d0000036000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1853
+  X: 1435
+  Y: 90

--- a/exotica_examples/resources/rviz_avoid_look_at_sphere.rviz
+++ b/exotica_examples/resources/rviz_avoid_look_at_sphere.rviz
@@ -9,9 +9,9 @@ Panels:
         - /RobotModel1
         - /RobotModel1/Links1
         - /MarkerArray1
-        - /MarkerArray2
+        - /Marker1
       Splitter Ratio: 0.5894039869308472
-    Tree Height: 303
+    Tree Height: 665
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -134,10 +134,10 @@ Visualization Manager:
         "": true
       Queue Size: 100
       Value: true
-    - Class: rviz/MarkerArray
+    - Class: rviz/Marker
       Enabled: true
-      Marker Topic: /environment
-      Name: MarkerArray
+      Marker Topic: /arrow
+      Name: Marker
       Namespaces:
         "": true
       Queue Size: 100
@@ -185,10 +185,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.23979726433753967
+      Pitch: 0.36979714035987854
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 3.440385103225708
+      Yaw: 3.635385751724243
     Saved: ~
 Window Geometry:
   Displays:

--- a/exotica_examples/scripts/example_ik_avoid_look_at_sphere
+++ b/exotica_examples/scripts/example_ik_avoid_look_at_sphere
@@ -5,11 +5,9 @@ import numpy as np
 import signal
 from pyexotica.publish_trajectory import publish_pose, sig_int_handler
 from exotica_examples_py import *
-from visualization_msgs.msg import Marker, MarkerArray
+from visualization_msgs.msg import Marker
 from geometry_msgs.msg import Point
 import exotica_scipy_solver
-
-DT = 1.0 / 100.0 # 100 HZ
 
 class Example(object):
 
@@ -23,8 +21,20 @@ class Example(object):
         self.solver = exotica_scipy_solver.SciPyEndPoseSolver(problem=self.problem, method='SLSQP', debug=False)
 
         # Setup ros marker publisher
-        self.pub = rospy.Publisher('environment', MarkerArray, queue_size=1)
+        self.pub = rospy.Publisher('arrow', Marker, queue_size=1)
         self.target_marker = TargetMarker(pose=self.problem.get_scene().fk('LookAtTarget').get_translation(), marker_shape=2, marker_size=[0.1, 0.1, 0.1])
+
+        # Setup arrow
+        self.arrow = Marker()
+        self.arrow.header.frame_id = 'exotica/lwr_arm_6_link'
+        self.arrow.id = 0
+        self.arrow.type = Marker.ARROW
+        self.arrow.action = Marker.ADD
+        self.arrow.scale.x = 0.02
+        self.arrow.scale.y = 0.05
+        self.arrow.scale.z = 0.05
+        self.arrow.color.b = self.arrow.color.a = 1.0
+        self.arrow.points = [Point(), Point()]
 
     def update(self, event):
         # Set new look at target into world frame
@@ -39,33 +49,17 @@ class Example(object):
         publish_pose(self.q, self.problem)
 
     def update_environment(self, event):
-
-        arrow = Marker()
-        arrow.header.frame_id = 'exotica/lwr_arm_6_link'
-        arrow.id = 0
-        arrow.type = Marker.ARROW
-        arrow.action = Marker.ADD
-        arrow.scale.x = 0.02
-        arrow.scale.y = 0.05
-        arrow.scale.z = 0.05
-        end_pt = Point()
         look_at_position = self.problem.get_scene().fk('LookAtTarget', 'lwr_arm_6_link').get_translation()
-        end_pt.x = look_at_position[0]
-        end_pt.y = look_at_position[1]
-        end_pt.z = look_at_position[2]
-        arrow.points = [Point(), end_pt]
-        arrow.color.b = arrow.color.a = 1.0
-
-        markerarray = MarkerArray()
-        markerarray.markers = [arrow]
-
-        self.pub.publish(markerarray)
+        self.arrow.points[1].x = look_at_position[0]
+        self.arrow.points[1].y = look_at_position[1]
+        self.arrow.points[1].z = look_at_position[2]
+        self.pub.publish(self.arrow)
 
 if __name__=='__main__':
     rospy.init_node('example_ik_avoid_look_at_sphere_node')
     exo.Setup.init_ros()
     signal.signal(signal.SIGINT, sig_int_handler)
     example = Example()
-    rospy.Timer(rospy.Duration(DT), example.update)
+    rospy.Timer(rospy.Duration(1.0/50.0), example.update)
     rospy.Timer(rospy.Duration(1.0/40.0), example.update_environment)
     rospy.spin()

--- a/exotica_examples/scripts/example_ik_avoid_look_at_sphere
+++ b/exotica_examples/scripts/example_ik_avoid_look_at_sphere
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import rospy
+import pyexotica as exo
+import numpy as np
+import signal
+from pyexotica.publish_trajectory import publish_pose, sig_int_handler
+from exotica_examples_py import *
+from visualization_msgs.msg import Marker, MarkerArray
+from geometry_msgs.msg import Point
+import exotica_scipy_solver
+
+DT = 1.0 / 100.0 # 100 HZ
+
+class Example(object):
+
+    def __init__(self):
+
+        # Set init variables
+        self.q = np.array([0.0] * 7)
+
+        # Setup exotica
+        self.problem = exo.Setup.load_problem('{exotica_examples}/resources/configs/example_ik_avoid_look_at_sphere.xml')
+        self.solver = exotica_scipy_solver.SciPyEndPoseSolver(problem=self.problem, method='SLSQP', debug=False)
+
+        # Setup ros marker publisher
+        self.pub = rospy.Publisher('environment', MarkerArray, queue_size=1)
+        self.target_marker = TargetMarker(pose=self.problem.get_scene().fk('LookAtTarget').get_translation(), marker_shape=2, marker_size=[0.1, 0.1, 0.1])
+
+    def update(self, event):
+        # Set new look at target into world frame
+        self.problem.get_scene().attach_object_local('LookAtTarget', '', self.target_marker.position_exo)
+
+        # Set start state
+        qold = self.q.copy()
+        self.problem.start_state = self.q
+
+        # Solve and publish
+        self.q = self.solver.solve()[0]
+        publish_pose(self.q, self.problem)
+
+    def update_environment(self, event):
+
+        arrow = Marker()
+        arrow.header.frame_id = 'exotica/lwr_arm_6_link'
+        arrow.id = 0
+        arrow.type = Marker.ARROW
+        arrow.action = Marker.ADD
+        arrow.scale.x = 0.02
+        arrow.scale.y = 0.05
+        arrow.scale.z = 0.05
+        end_pt = Point()
+        look_at_position = self.problem.get_scene().fk('LookAtTarget', 'lwr_arm_6_link').get_translation()
+        end_pt.x = look_at_position[0]
+        end_pt.y = look_at_position[1]
+        end_pt.z = look_at_position[2]
+        arrow.points = [Point(), end_pt]
+        arrow.color.b = arrow.color.a = 1.0
+
+        markerarray = MarkerArray()
+        markerarray.markers = [arrow]
+
+        self.pub.publish(markerarray)
+
+if __name__=='__main__':
+    rospy.init_node('example_ik_avoid_look_at_sphere_node')
+    exo.Setup.init_ros()
+    signal.signal(signal.SIGINT, sig_int_handler)
+    example = Example()
+    rospy.Timer(rospy.Duration(DT), example.update)
+    rospy.Timer(rospy.Duration(1.0/40.0), example.update_environment)
+    rospy.spin()


### PR DESCRIPTION
* Avoids "looking at" a number of spherical objects.
* Assumes all objects postions/radii are known.
* Can be used as either a cost term or an inequality constraint.
* I was having some strange issues with git on branch for #581 and thought it was easier to make a new branch. 

# Checklist

- [x] code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- [x] add unit test(s)

- [x] ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`


