### PR TITLE
New GetNumberOfIterations method in planning problem

### DIFF
--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -83,6 +83,7 @@ public:
     unsigned int GetNumberOfProblemUpdates() const { return number_of_problem_updates_; }
     void ResetNumberOfProblemUpdates() { number_of_problem_updates_ = 0; }
     std::pair<std::vector<double>, std::vector<double>> GetCostEvolution() const;
+    int GetNumberOfIterations() const;
     double GetCostEvolution(int index) const;
     void ResetCostEvolution(size_t size);
     void SetCostEvolution(int index, double value);

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -296,7 +296,7 @@ std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvol
 
 int PlanningProblem::GetNumberOfIterations() const
 {
-    return std::get<0>(GetCostEvolution()).size();
+    return static_cast<int>(std::get<0>(GetCostEvolution())).size();
 }
 
 double PlanningProblem::GetCostEvolution(int index) const

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -294,6 +294,11 @@ std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvol
     return ret;
 }
 
+int PlanningProblem::GetNumberOfIterations() const
+{
+    return std::get<0>(GetCostEvolution()).size();
+}
+
 double PlanningProblem::GetCostEvolution(int index) const
 {
     if (index > -1 && index < cost_evolution_.size())

--- a/exotica_core/src/planning_problem.cpp
+++ b/exotica_core/src/planning_problem.cpp
@@ -296,7 +296,7 @@ std::pair<std::vector<double>, std::vector<double>> PlanningProblem::GetCostEvol
 
 int PlanningProblem::GetNumberOfIterations() const
 {
-    return static_cast<int>(std::get<0>(GetCostEvolution())).size();
+    return static_cast<int>(std::get<0>(GetCostEvolution()).size());
 }
 
 double PlanningProblem::GetCostEvolution(int index) const

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -721,7 +721,7 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("get_number_of_problem_updates", &PlanningProblem::GetNumberOfProblemUpdates)
         .def("reset_number_of_problem_updates", &PlanningProblem::ResetNumberOfProblemUpdates)
         .def("get_cost_evolution", (std::pair<std::vector<double>, std::vector<double>>(PlanningProblem::*)() const) & PlanningProblem::GetCostEvolution)
-        .def("get_num_iterations", &PlanningProblem::GetNumberOfIterations)
+        .def("get_number_of_iterations", &PlanningProblem::GetNumberOfIterations)
         .def("is_valid", &PlanningProblem::IsValid);
 
     // Problem types

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -721,6 +721,7 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("get_number_of_problem_updates", &PlanningProblem::GetNumberOfProblemUpdates)
         .def("reset_number_of_problem_updates", &PlanningProblem::ResetNumberOfProblemUpdates)
         .def("get_cost_evolution", (std::pair<std::vector<double>, std::vector<double>>(PlanningProblem::*)() const) & PlanningProblem::GetCostEvolution)
+        .def("get_num_iterations", &PlanningProblem::GetNumberOfIterations)
         .def("is_valid", &PlanningProblem::IsValid);
 
     // Problem types


### PR DESCRIPTION
New method to get the number of iterations, rather than 
```python
niter = len(problem.get_cost_evolution()[0])
```
now, 
```python
niter = problem.get_number_of_iterations()
```
Not sure why but in `GetNumberOfIterations` implementation I tried to return `cost_evolution_.size()` but this gave incorrect values. An explanation would be interesting to know.

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
