### PR TITLE
Updates to smoothing task maps and corresponding example.

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
@@ -48,8 +48,6 @@ namespace exotica
 class JointAccelerationBackwardDifference : public TaskMap, public Instantiable<JointAccelerationBackwardDifferenceInitializer>
 {
 public:
-    JointAccelerationBackwardDifference();
-    virtual ~JointAccelerationBackwardDifference();
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.
@@ -72,7 +70,6 @@ private:
     Eigen::MatrixXd q_;                           ///< Log of previous two joint states.
     Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the second time derivative.
     Eigen::MatrixXd I_;                           ///< Identity matrix.
-    double dt_inv_;                               ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
@@ -49,8 +49,6 @@ namespace exotica
 class JointJerkBackwardDifference : public TaskMap, public Instantiable<JointJerkBackwardDifferenceInitializer>
 {
 public:
-    JointJerkBackwardDifference();
-    virtual ~JointJerkBackwardDifference();
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.
@@ -72,7 +70,6 @@ private:
     Eigen::MatrixXd q_;                           ///< Log of previous three joint states.
     Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the third time derivative.
     Eigen::MatrixXd I_;                           ///< Identity matrix.
-    double dt_inv_;                               ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
@@ -48,8 +48,6 @@ namespace exotica
 class JointVelocityBackwardDifference : public TaskMap, public Instantiable<JointVelocityBackwardDifferenceInitializer>
 {
 public:
-    JointVelocityBackwardDifference();
-    virtual ~JointVelocityBackwardDifference();
     void AssignScene(ScenePtr scene) override;
 
     /// \brief Logs previous joint state.
@@ -69,7 +67,6 @@ private:
     Eigen::VectorXd q_;                  ///< Log of previous joint state.
     Eigen::VectorXd qbd_;                ///< x+qbd_ is a simplifed estimate of the first time derivative.
     Eigen::MatrixXd I_;                  ///< Identity matrix.
-    double dt_inv_;                      ///< Frequency (1/dt)
 };
 }
 

--- a/exotations/exotica_core_task_maps/init/joint_acceleration_backward_difference.in
+++ b/exotations/exotica_core_task_maps/init/joint_acceleration_backward_difference.in
@@ -8,6 +8,4 @@ extend <exotica_core/task_map>
 // string Base           > name of frame in which line is defined
 // VectorXd BaseOffset   > starting point of line in Base frame
 
-Required double dt;
-
 Optional Eigen::VectorXd StartState = Eigen::VectorXd(); // Starting robot joint configuration.

--- a/exotations/exotica_core_task_maps/init/joint_jerk_backward_difference.in
+++ b/exotations/exotica_core_task_maps/init/joint_jerk_backward_difference.in
@@ -8,6 +8,4 @@ extend <exotica_core/task_map>
 // string Base           > name of frame in which line is defined
 // VectorXd BaseOffset   > starting point of line in Base frame
 
-Required double dt;
-
 Optional Eigen::VectorXd StartState = Eigen::VectorXd(); // Starting robot joint configuration.

--- a/exotations/exotica_core_task_maps/init/joint_velocity_backward_difference.in
+++ b/exotations/exotica_core_task_maps/init/joint_velocity_backward_difference.in
@@ -8,6 +8,4 @@ extend <exotica_core/task_map>
 // string Base           > name of frame in which line is defined
 // VectorXd BaseOffset   > starting point of line in Base frame
 
-Required double dt;
-
 Optional Eigen::VectorXd StartState = Eigen::VectorXd(); // Starting robot joint configuration.

--- a/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
@@ -33,9 +33,6 @@ REGISTER_TASKMAP_TYPE("JointAccelerationBackwardDifference", exotica::JointAccel
 
 namespace exotica
 {
-JointAccelerationBackwardDifference::JointAccelerationBackwardDifference() = default;
-JointAccelerationBackwardDifference::~JointAccelerationBackwardDifference() = default;
-
 void JointAccelerationBackwardDifference::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -45,10 +42,6 @@ void JointAccelerationBackwardDifference::AssignScene(ScenePtr scene)
 
     // Set binomial coefficient parameters
     backward_difference_params_ << -2, 1;
-
-    // Frequency
-    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / parameters_.dt;
 
     // Init each col of q_ with start state
     q_.resize(N_, 2);
@@ -92,18 +85,17 @@ void JointAccelerationBackwardDifference::Update(Eigen::VectorXdRefConst x, Eige
     if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
 
     // Estimate second time derivative
-    phi = dt_inv_ * (x + qbd_);
+    phi = x + qbd_;
 }
 
 void JointAccelerationBackwardDifference::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
 {
     // Input check
-    if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
     if (jacobian.rows() != N_ || jacobian.cols() != N_) ThrowNamed("Wrong size of jacobian! " << N_);
 
     // Estimate second time derivative and set Jacobian to identity matrix
-    phi = dt_inv_ * (x + qbd_);
-    jacobian = dt_inv_ * I_;
+    Update(x, phi);
+    jacobian = I_;
 }
 
 int JointAccelerationBackwardDifference::TaskSpaceDim()

--- a/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
@@ -33,9 +33,6 @@ REGISTER_TASKMAP_TYPE("JointJerkBackwardDifference", exotica::JointJerkBackwardD
 
 namespace exotica
 {
-JointJerkBackwardDifference::JointJerkBackwardDifference() = default;
-JointJerkBackwardDifference::~JointJerkBackwardDifference() = default;
-
 void JointJerkBackwardDifference::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -45,10 +42,6 @@ void JointJerkBackwardDifference::AssignScene(ScenePtr scene)
 
     // Set binomial coefficient parameters.
     backward_difference_params_ << -3, 3, -1;
-
-    // Frequency
-    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / parameters_.dt;
 
     // Initialize q_ with StartState
     q_.resize(N_, 3);
@@ -93,18 +86,17 @@ void JointJerkBackwardDifference::Update(Eigen::VectorXdRefConst x, Eigen::Vecto
     if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
 
     // Estimate third time derivative
-    phi = dt_inv_ * (x + qbd_);
+    phi = x + qbd_;
 }
 
 void JointJerkBackwardDifference::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
 {
     // Input check
-    if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
     if (jacobian.rows() != N_ || jacobian.cols() != N_) ThrowNamed("Wrong size of jacobian! " << N_);
 
     // Estimate third time derivative and set Jacobian to identity matrix
-    phi = dt_inv_ * (x + qbd_);
-    jacobian = dt_inv_ * I_;
+    Update(x, phi);
+    jacobian = I_;
 }
 
 int JointJerkBackwardDifference::TaskSpaceDim()

--- a/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_backward_difference.cpp
@@ -33,9 +33,6 @@ REGISTER_TASKMAP_TYPE("JointVelocityBackwardDifference", exotica::JointVelocityB
 
 namespace exotica
 {
-JointVelocityBackwardDifference::JointVelocityBackwardDifference() = default;
-JointVelocityBackwardDifference::~JointVelocityBackwardDifference() = default;
-
 void JointVelocityBackwardDifference::AssignScene(ScenePtr scene)
 {
     scene_ = scene;
@@ -45,10 +42,6 @@ void JointVelocityBackwardDifference::AssignScene(ScenePtr scene)
 
     // Set binomial coefficient parameters
     backward_difference_params_ = -1.0;
-
-    // Frequency
-    if (parameters_.dt <= 0) ThrowPretty("dt cannot be smaller than or equal to 0.");
-    dt_inv_ = 1 / parameters_.dt;
 
     // Init each col of q_ with start state
     q_.resize(N_, 1);
@@ -84,18 +77,17 @@ void JointVelocityBackwardDifference::Update(Eigen::VectorXdRefConst x, Eigen::V
     if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
 
     // Estimate third time derivative
-    phi = dt_inv_ * (x + qbd_);
+    phi = x + qbd_;
 }
 
 void JointVelocityBackwardDifference::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian)
 {
     // Input check
-    if (phi.rows() != N_) ThrowNamed("Wrong size of phi!");
     if (jacobian.rows() != N_ || jacobian.cols() != N_) ThrowNamed("Wrong size of jacobian! " << N_);
 
     // Estimate third time derivative and set Jacobian to identity matrix
-    phi = dt_inv_ * (x + qbd_);
-    jacobian = dt_inv_ * I_;
+    Update(x, phi);
+    jacobian = I_;
 }
 
 int JointVelocityBackwardDifference::TaskSpaceDim()

--- a/exotica_examples/resources/configs/example_ik_with_jnt_smoothing.xml
+++ b/exotica_examples/resources/configs/example_ik_with_jnt_smoothing.xml
@@ -24,17 +24,14 @@
       </EffFrame>
 
       <JointVelocityBackwardDifference Name="JointVel">
-        <dt>0.01</dt>
         <StartState>1.147249698638916 -0.22851833701133728 0.5324112772941589 1.2311428785324097 -0.19176392257213593 -0.1434374898672104 0</StartState>
       </JointVelocityBackwardDifference>
 
       <JointAccelerationBackwardDifference Name="JointAcc">
-        <dt>0.01</dt>
         <StartState>1.147249698638916 -0.22851833701133728 0.5324112772941589 1.2311428785324097 -0.19176392257213593 -0.1434374898672104 0</StartState>
       </JointAccelerationBackwardDifference>
 
       <JointJerkBackwardDifference Name="JointJerk">
-        <dt>0.01</dt>
         <StartState>1.147249698638916 -0.22851833701133728 0.5324112772941589 1.2311428785324097 -0.19176392257213593 -0.1434374898672104 0</StartState>
       </JointJerkBackwardDifference>
     </Maps>

--- a/exotica_examples/scripts/example_ik_with_jnt_smoothing
+++ b/exotica_examples/scripts/example_ik_with_jnt_smoothing
@@ -16,7 +16,7 @@ import PyKDL as kdl
 DT = 1.0 / 100.0  # 100 HZ
 
 SMOOTHING_TASK_MAPS = ['JointVel', 'JointAcc', 'JointJerk']
-SMOOTHING_RHO = 1e1
+SMOOTHING_RHO = [1e2, 1e1, 1]
 
 def make_box():
     marker = Marker()
@@ -34,9 +34,6 @@ def make_box():
 class Example(object):
 
     def __init__(self):
-
-        # Set init variables
-        self.q = np.array([0.0] * 7)
         
         # Setup interactive marker
         control = InteractiveMarkerControl()
@@ -58,6 +55,10 @@ class Example(object):
         self.task_maps = self.problem.get_task_maps()
         self.smoothing = 1.0
 
+        # Set init variables
+        self.q = self.problem.get_scene().get_model_state()
+
+
     def smoothing_enabled_callback(self, feedback):
         handle = feedback.menu_entry_id
         state = self.menu_handler.getCheckState( handle )
@@ -77,8 +78,8 @@ class Example(object):
 
         # Set start state, rho, and previous joint states
         self.problem.start_state = self.q
-        for name in SMOOTHING_TASK_MAPS:
-            self.problem.set_rho(name, self.smoothing * SMOOTHING_RHO)
+        for i, name in enumerate(SMOOTHING_TASK_MAPS):
+            self.problem.set_rho(name, self.smoothing * SMOOTHING_RHO[i])
             self.task_maps[name].set_previous_joint_state(self.q)
 
         # Solve and publish


### PR DESCRIPTION
* Addressing issue #573. Main difference to note is that I have deprecated the dependency on `dt`. E.g., since `phi = (q + qb)/dt` the `1/dt` is only a scaling factor.
* Other changes that I have made are more to do with maintaining standards. 
* I have checked over the derivation for each smoothing task map and cannot find any errors. I think the issue you are seeing in #573 stems from the choice of `Rho`. This was one of the reasons I wrote the `interactive_cost_tuning` script. 

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
