### PR TITLE
New AttachObjectLocal overloaded

### DIFF
--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -119,6 +119,7 @@ public:
     /// \param pose Relative pose of the attached object in the new parent's local frame.
     ///
     void AttachObjectLocal(const std::string& name, const std::string& parent, const KDL::Frame& pose);
+    void AttachObjectLocal(const std::string& name, const std::string& parent, const Eigen::VectorXd& pose);
     ///
     /// \brief Detaches an object and leaves it a at its current world location. This effectively attaches the object to the world frame.
     /// \param name Name of the object to detach.

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -763,6 +763,11 @@ void Scene::AttachObjectLocal(const std::string& name, const std::string& parent
     attached_objects_[name] = AttachedObject(parent, pose);
 }
 
+void Scene::AttachObjectLocal(const std::string& name, const std::string& parent, const Eigen::VectorXd& pose)
+{
+    AttachObjectLocal(name, parent, GetFrame(pose));
+}
+
 void Scene::DetachObject(const std::string& name)
 {
     if (!HasAttachedObject(name)) ThrowPretty("'" << name << "' is not attached to the robot!");

--- a/exotica_examples/scripts/example_ik_look_at
+++ b/exotica_examples/scripts/example_ik_look_at
@@ -26,7 +26,7 @@ class Example(object):
 
     def update(self, event):
         # Set new look at target into world frame
-        self.problem.get_scene().attach_object_local('LookAtTarget', '', self.target_marker.position_exo)
+        self.problem.get_scene().attach_object_local('LookAtTarget', '', self.target_marker.position_exo.get_translation_and_quaternion())
 
         # Set start state
         self.problem.start_state = self.q

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1038,7 +1038,8 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("get_root_frame_name", &Scene::GetRootFrameName);
     scene.def("get_root_joint_name", &Scene::GetRootJointName);
     scene.def("attach_object", &Scene::AttachObject);
-    scene.def("attach_object_local", &Scene::AttachObjectLocal);
+    scene.def("attach_object_local", (void (Scene::*)(const std::string& name, const std::string& parent, const KDL::Frame& pose)) & Scene::AttachObjectLocal);
+    scene.def("attach_object_local", (void (Scene::*)(const std::string& name, const std::string& parent, const Eigen::VectorXd& pose)) & Scene::AttachObjectLocal);
     scene.def("detach_object", &Scene::DetachObject);
     scene.def("has_attached_object", &Scene::HasAttachedObject);
     scene.def("fk", [](Scene* instance, const std::string& e1, const KDL::Frame& o1, const std::string& e2, const KDL::Frame& o2) { return instance->GetKinematicTree().FK(e1, o1, e2, o2); });


### PR DESCRIPTION
* New overloaded function accepts `Eigen::VectorXd` rather than `KDL::Frame`.
* Use of this is as follows

Before
```python
new_trans = np.array([0, 0, 1])
scene.attach_object_local('MyFrame', '', exo.KDLFrame(new_trans))
```
After
```python
new_trans = np.array([0, 0, 1])
scene.attach_object_local('MyFrame', '', new_trans)
```

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
