### PR TITLE
allow parsing empty vectors

### DIFF
--- a/exotica_core/include/exotica_core/tools/conversions.h
+++ b/exotica_core/include/exotica_core/tools/conversions.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include <exotica_core/tools/exception.h>
+#include <exotica_core/tools/printable.h>
 
 namespace Eigen
 {
@@ -198,7 +199,7 @@ inline Eigen::Matrix<T, S, 1> ParseVector(const std::string value)
             ret[i - 1] = std::numeric_limits<T>::quiet_NaN();
         }
     }
-    if (i == 0) ThrowPretty("Empty vector!");
+    if (i == 0) WARNING_NAMED("Parser", "Empty vector!")
     if (S != Eigen::Dynamic && S != i)
     {
         ThrowPretty("Wrong vector size! Requested: " + std::to_string(S) + ", Provided: " + std::to_string(i));
@@ -249,7 +250,7 @@ inline std::vector<std::string> ParseList(const std::string& value, char token =
     {
         ret.push_back(Trim(item));
     }
-    if (ret.size() == 0) ThrowPretty("Empty vector!");
+    if (ret.size() == 0) WARNING_NAMED("Parser", "Empty vector!")
     return ret;
 }
 
@@ -269,7 +270,7 @@ inline std::vector<int> ParseIntList(const std::string value)
         }
         ret.push_back(tmp);
     }
-    if (ret.size() == 0) ThrowPretty("Empty vector!");
+    if (ret.size() == 0) WARNING_NAMED("Parser", "Empty vector!")
     return ret;
 }
 
@@ -289,7 +290,7 @@ inline std::vector<bool> ParseBoolList(const std::string value)
         }
         ret.push_back(tmp);
     }
-    if (ret.empty()) ThrowPretty("Empty vector!");
+    if (ret.empty()) WARNING_NAMED("Parser", "Empty vector!")
     return ret;
 }
 }


### PR DESCRIPTION
This removes the exceptions when an empty vector (Eigen or STL) is parsed.

When a vector is used as an optional parameter, it often makes sense to have an empty default argument, e.g.:
```C++
Optional std::vector<std::string> Tasks = std::vector<std::string>();
```
or 
```C++
Optional Eigen::VectorXd Convergence = Eigen::VectorXd();
```
The parameter can then be ignored by testing the the vector insite the task map.