### PR TITLE
Meshcat visualisation display in Jupyter Notebook

### DIFF
--- a/exotica_python/src/pyexotica/__init__.py
+++ b/exotica_python/src/pyexotica/__init__.py
@@ -4,6 +4,7 @@ from ._pyexotica import *
 from .publish_trajectory import *
 from .tools import *
 from .interactive_cost_tuning import *
+from .jupyter_meshcat import *
 
 # Used for backwards compatibility only, deprecated
 Visualization = VisualizationMoveIt

--- a/exotica_python/src/pyexotica/jupyter_meshcat.py
+++ b/exotica_python/src/pyexotica/jupyter_meshcat.py
@@ -1,0 +1,9 @@
+__all__ = ["show"]
+
+def show(url, height=50):
+    try:
+        import ipywidgets as widgets
+        w=widgets.HTML(value='<iframe style="width:100%; height:'+str(height)+'em;border:0" src="'+url+'"></iframe>')
+        w._ipython_display_()
+    except ImportError:
+        print('Jupyter Meshcat visualisation not supported!')


### PR DESCRIPTION
Adds meshcat visualisation in a jupyter notebook cell:
```
exo.jupyter_meshcat.show('',20)
```

No new dependencies were added. If ipython packages are not installed, display fails gracefully at runtime.