### PR TITLE
split zmq run and build dependency

### DIFF
--- a/exotica_core/package.xml
+++ b/exotica_core/package.xml
@@ -28,8 +28,10 @@
   <depend>eigen_conversions</depend>
   <depend>tf_conversions</depend>
   <depend>tinyxml2</depend>
-  <depend>zeromq3</depend>
   <depend>msgpack</depend>
+
+  <build_depend>libzmq3-dev</build_depend>
+  <exec_depend>zeromq3</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>


### PR DESCRIPTION
After some clarification about the redundant key entries (https://github.com/ros/rosdistro/pull/21958#pullrequestreview-273280571) I think it makes sense to split the ZeroMQ dependency for run and devel cases.