### PR TITLE
Expose GetNumControlledJoints to python scene

### DIFF
--- a/exotica_core/include/exotica_core/scene.h
+++ b/exotica_core/include/exotica_core/scene.h
@@ -87,6 +87,7 @@ public:
     std::string GetRootJointName();
 
     exotica::KinematicTree& GetKinematicTree();
+    int GetNumberOfControlledJoints() const;
     std::vector<std::string> GetControlledJointNames();
     std::vector<std::string> GetModelJointNames();
     std::vector<std::string> GetControlledLinkNames();

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -428,6 +428,11 @@ exotica::KinematicTree& Scene::GetKinematicTree()
     return kinematica_;
 }
 
+int Scene::GetNumberOfControlledJoints() const
+{
+    return kinematica_.GetNumControlledJoints();
+}
+
 std::vector<std::string> Scene::GetControlledJointNames()
 {
     return kinematica_.GetControlledJointNames();

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1001,6 +1001,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("update", &Scene::Update, py::arg("x"), py::arg("t") = 0.0);
     scene.def("get_controlled_joint_names", (std::vector<std::string>(Scene::*)()) & Scene::GetControlledJointNames);
     scene.def("get_controlled_link_names", &Scene::GetControlledLinkNames);
+    scene.def("get_number_of_controlled_joints", &Scene::GetNumberOfControlledJoints);
     scene.def("get_model_link_names", &Scene::GetModelLinkNames);
     scene.def("get_kinematic_tree", &Scene::GetKinematicTree, py::return_value_policy::reference_internal);
     scene.def("get_collision_scene", &Scene::GetCollisionScene, py::return_value_policy::reference_internal);


### PR DESCRIPTION
Minor addition, exposes `GetNumControlledJoints` in `KinematicTree` to python scene. 

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
