### PR TITLE
load meshes

### DIFF
--- a/exotica_core/include/exotica_core/kinematic_element.h
+++ b/exotica_core/include/exotica_core/kinematic_element.h
@@ -122,7 +122,7 @@ public:
     bool is_trajectory_generated = false;
     std::vector<double> joint_limits;
     shapes::ShapeConstPtr shape = nullptr;
-    std::string shape_resource_path = "";
+    std::string shape_resource_path = std::string();
     Eigen::Vector3d scale = Eigen::Vector3d::Ones();
     bool is_robot_link = false;
     Eigen::Vector4d color = Eigen::Vector4d(0.5, 0.5, 0.5, 1.0);

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -435,7 +435,7 @@ std::shared_ptr<KinematicElement> KinematicTree::AddEnvironmentElement(const std
 std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& name, Eigen::Isometry3d& transform, const std::string& parent, const std::string& shape_resource_path, Eigen::Vector3d scale, const KDL::RigidBodyInertia& inertia, const Eigen::Vector4d& color, const std::vector<VisualElement>& visual, bool is_controlled)
 {
     std::string shape_path(shape_resource_path);
-    if (shape_path == "")
+    if (shape_path.empty())
     {
         ThrowPretty("Shape path cannot be empty!");
     }
@@ -453,10 +453,8 @@ std::shared_ptr<KinematicElement> KinematicTree::AddElement(const std::string& n
         ThrowPretty("Path cannot be resolved.");
     }
 
-    shapes::ShapePtr shape;
-    shape.reset(shapes::createMeshFromResource(shape_path, scale));
-    shapes::ShapeConstPtr tmp_shape(shape);
-    std::shared_ptr<KinematicElement> element = AddElement(name, transform, parent, tmp_shape, inertia, color, visual, is_controlled);
+    shapes::ShapePtr shape = shapes::ShapePtr(shapes::createMeshFromResource(shape_path, scale));
+    std::shared_ptr<KinematicElement> element = AddElement(name, transform, parent, shape, inertia, color, visual, is_controlled);
     element->shape_resource_path = shape_path;
     element->scale = scale;
     return element;

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -335,7 +335,7 @@ void KinematicTree::BuildTree(const KDL::Tree& robot_kinematics)
                         std::shared_ptr<urdf::Mesh> mesh = std::static_pointer_cast<urdf::Mesh>(ToStdPtr(urdf_visual->geometry));
                         visual.shape_resource_path = mesh->filename;
                         visual.scale = Eigen::Vector3d(mesh->scale.x, mesh->scale.y, mesh->scale.z);
-                        visual.shape = std::shared_ptr<shapes::Mesh>(new shapes::Mesh());
+                        visual.shape = std::shared_ptr<shapes::Mesh>(shapes::createMeshFromResource(mesh->filename));
                     }
                     break;
                 }

--- a/exotica_core/src/visualization_meshcat.cpp
+++ b/exotica_core/src/visualization_meshcat.cpp
@@ -195,7 +195,7 @@ void VisualizationMeshcat::DisplayScene(bool use_mesh_materials)
                 break;
                 default:
                 {
-                    if (visual.shape_resource_path != "")
+                    if (!visual.shape_resource_path.empty())
                     {
                         auto mesh = visualization::GeometryMesh(visual.shape_resource_path, file_url_ + visual.shape_resource_path);
                         // If using STL files or if requested specifically, use URDF colours


### PR DESCRIPTION
Load meshes when the `Shape` is instantiated. The method `createMeshFromResource` is also available with an optional `scale` parameter. But I think it would be redundant to scale the mesh when loading and store the scale separately.