### PR TITLE
Updated functionality of EffBox task map

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_box.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_box.h
@@ -52,8 +52,8 @@ public:
 
     void PublishObjectsAsMarkerArray();
 
-    Eigen::VectorXd GetLowerLimit() const;
-    Eigen::VectorXd GetUpperLimit() const;
+    Eigen::Vector3d GetLowerLimit(const int eff_id) const;
+    Eigen::Vector3d GetUpperLimit(const int eff_id) const;
 
 private:
     Eigen::VectorXd eff_lower_;   ///< End-effector lower x, y, z limit.

--- a/exotations/exotica_core_task_maps/src/eff_box.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_box.cpp
@@ -71,14 +71,16 @@ void EffBox::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::Ma
     if (debug_ && Server::IsRos()) PublishObjectsAsMarkerArray();
 }
 
-Eigen::VectorXd EffBox::GetLowerLimit() const
+Eigen::Vector3d EffBox::GetLowerLimit(const int eff_id) const
 {
-    return eff_lower_;
+    if (eff_id < 0 || eff_id >= n_effs_) ThrowNamed("Given eff_id (" << eff_id << ") is out of range [0, " << n_effs_ << ")!");
+    return eff_lower_.segment<3>(3 * eff_id);
 }
 
-Eigen::VectorXd EffBox::GetUpperLimit() const
+Eigen::Vector3d EffBox::GetUpperLimit(const int eff_id) const
 {
-    return eff_upper_;
+    if (eff_id < 0 || eff_id >= n_effs_) ThrowNamed("Given eff_id (" << eff_id << ") is out of range [0, " << n_effs_ << ")!");
+    return eff_upper_.segment<3>(3 * eff_id);
 }
 
 void EffBox::PublishObjectsAsMarkerArray()

--- a/exotica_examples/scripts/example_ik_eff_box
+++ b/exotica_examples/scripts/example_ik_eff_box
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import rospy
 import pyexotica as exo
 import math
 import numpy as np
 import signal
+import exotica_core_task_maps_py
 from pyexotica.publish_trajectory import publish_pose, sig_int_handler
 import exotica_scipy_solver
 
@@ -21,6 +23,13 @@ class Example(object):
         self.problem = exo.Setup.load_problem('{exotica_examples}/resources/configs/example_ik_eff_box.xml')
         self.solver = exotica_scipy_solver.SciPyEndPoseSolver(self.problem, method='SLSQP')
         self.t0 = rospy.Time.now().to_sec()
+
+        # Extract and report EffBox limits
+        lower_limits = self.problem.get_task_maps()['EffBox'].get_lower_limit(0)
+        upper_limits = self.problem.get_task_maps()['EffBox'].get_upper_limit(0)
+        print("EffBox Limits:")
+        for i, d in enumerate(['X', 'Y', 'Z']):
+            print("  {}Lim: {}, {}".format(d, lower_limits[i], upper_limits[i]))
 
     def update(self, event):
 


### PR DESCRIPTION
[task_maps] Rather than returning whole vector for lower/upper limits, now user specifies the limits of which end-effector they want to have access to
[examples] Updated example script to show how python interface to EffBox task map is used to get lower/upper limits

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
