### PR TITLE
Fix bugs in BoxQP, TimeIndexedRRTConnect, float conversion

### DIFF
--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -22,6 +22,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}

--- a/exotations/exotica_core_task_maps/init/continuous_joint_pose.in
+++ b/exotations/exotica_core_task_maps/init/continuous_joint_pose.in
@@ -2,4 +2,4 @@ class ContinuousJointPose
 
 extend <exotica_core/task_map>
 
-Optional Eigen::VectorXd JointMap = Eigen::VectorXd();
+Optional Eigen::VectorXi JointMap = Eigen::VectorXi();

--- a/exotations/exotica_core_task_maps/init/joint_pose.in
+++ b/exotations/exotica_core_task_maps/init/joint_pose.in
@@ -3,4 +3,4 @@ class JointPose
 extend <exotica_core/task_map>
 
 Optional Eigen::VectorXd JointRef = Eigen::VectorXd();
-Optional Eigen::VectorXd JointMap = Eigen::VectorXd();
+Optional Eigen::VectorXi JointMap = Eigen::VectorXi();

--- a/exotations/exotica_core_task_maps/src/center_of_mass.cpp
+++ b/exotations/exotica_core_task_maps/src/center_of_mass.cpp
@@ -185,11 +185,11 @@ void CenterOfMass::InitializeDebug()
 {
     com_links_marker_.points.resize(frames_.size());
     com_links_marker_.type = visualization_msgs::Marker::SPHERE_LIST;
-    com_links_marker_.color.a = .7;
-    com_links_marker_.color.r = 0.5;
-    com_links_marker_.color.g = 0;
-    com_links_marker_.color.b = 0;
-    com_links_marker_.scale.x = com_links_marker_.scale.y = com_links_marker_.scale.z = .02;
+    com_links_marker_.color.a = .7f;
+    com_links_marker_.color.r = 0.5f;
+    com_links_marker_.color.g = 0.f;
+    com_links_marker_.color.b = 0.f;
+    com_links_marker_.scale.x = com_links_marker_.scale.y = com_links_marker_.scale.z = .02f;
     com_links_marker_.action = visualization_msgs::Marker::ADD;
 
     com_marker_.type = visualization_msgs::Marker::CYLINDER;

--- a/exotations/exotica_core_task_maps/src/point_to_plane.cpp
+++ b/exotations/exotica_core_task_maps/src/point_to_plane.cpp
@@ -102,13 +102,13 @@ void PointToPlane::PublishDebug()
         plane.type = plane.CUBE;
         plane.action = plane.ADD;
         plane.frame_locked = true;
-        plane.color.g = 1.0;
-        plane.color.a = 0.8;
+        plane.color.g = 1.0f;
+        plane.color.a = 0.8f;
         tf::poseKDLToMsg(frames_[i].frame_B_offset, plane.pose);
 
-        plane.scale.x = 10;
-        plane.scale.y = 10;
-        plane.scale.z = 0.01;
+        plane.scale.x = 10.f;
+        plane.scale.y = 10.f;
+        plane.scale.z = 0.01f;
         plane.pose.position.z -= (plane.scale.z / 2);
 
         msg.markers.push_back(plane);

--- a/exotations/exotica_core_task_maps/src/sphere_collision.cpp
+++ b/exotations/exotica_core_task_maps/src/sphere_collision.cpp
@@ -53,7 +53,7 @@ void SphereCollision::Instantiate(const SphereCollisionInitializer& init)
     for (auto& it : groups_)
     {
         std_msgs::ColorRGBA col = RandomColor();
-        col.a = init.Alpha;
+        col.a = static_cast<float>(init.Alpha);
         for (int i : it.second)
         {
             debug_msg_.markers[i].color = col;

--- a/exotations/exotica_core_task_maps/test/test_maps.cpp
+++ b/exotations/exotica_core_task_maps/test/test_maps.cpp
@@ -612,11 +612,11 @@ TEST(ExoticaTaskMaps, testSphereCollision)
     }
 }
 
-TEST(ExoticaTaskMaps, testIdentity)
+TEST(ExoticaTaskMaps, testJointPose)
 {
     try
     {
-        TEST_COUT << "Identity test";
+        TEST_COUT << "JointPose test";
         Initializer map("exotica/JointPose", {{"Name", std::string("MyTask")}});
         UnconstrainedEndPoseProblemPtr problem = setup_problem(map);
         EXPECT_TRUE(test_random(problem));
@@ -650,7 +650,7 @@ TEST(ExoticaTaskMaps, testIdentity)
         }
         EXPECT_TRUE(test_jacobian(problem));
 
-        TEST_COUT << "Identity test with reference";
+        TEST_COUT << "JointPose test with reference";
         map = Initializer("exotica/JointPose", {{"Name", std::string("MyTask")},
                                                 {"JointRef", std::string("0.5 0.5 0.5")}});
         problem = setup_problem(map);
@@ -685,7 +685,7 @@ TEST(ExoticaTaskMaps, testIdentity)
         }
         EXPECT_TRUE(test_jacobian(problem));
 
-        TEST_COUT << "Identity test with subset of joints";
+        TEST_COUT << "JointPose test with subset of joints";
         map = Initializer("exotica/JointPose", {{"Name", std::string("MyTask")},
                                                 {"JointMap", std::string("0")}});
         problem = setup_problem(map);
@@ -710,9 +710,9 @@ TEST(ExoticaTaskMaps, testIdentity)
         }
         EXPECT_TRUE(test_jacobian(problem));
     }
-    catch (...)
+    catch (std::exception& e)
     {
-        ADD_FAILURE() << "Uncaught exception!";
+        ADD_FAILURE() << "JointPose: Uncaught exception!" << e.what();
     }
 }
 

--- a/exotations/solvers/exotica_ompl_control_solver/init/ompl_control_solver.in
+++ b/exotations/solvers/exotica_ompl_control_solver/init/ompl_control_solver.in
@@ -4,5 +4,5 @@ extend <exotica_core/motion_solver>
 Required Eigen::VectorXd StateLimits;
 Optional double MaxIterationTime = 10.0; // in seconds
 Optional double ConvergenceTolerance = 1e-3;
-Optional double Seed = -1;
+Optional int Seed = -1;
 Optional bool ApproximateSolution = true;

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -229,10 +229,10 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
     if (ompl_simple_setup_->getPlanner()->params().hasParam("GoalBias"))
         ompl_simple_setup_->getPlanner()->params().setParam("GoalBias", init_.GoalBias);
 
-    if (init_.RandomSeed != -1)
+    if (init_.RandomSeed > -1)
     {
         HIGHLIGHT_NAMED(algorithm_, "Setting random seed to " << init_.RandomSeed);
-        ompl::RNG::setSeed(init_.RandomSeed);
+        ompl::RNG::setSeed(static_cast<long unsigned int>(init_.RandomSeed));
     }
 
     SetGoalState(prob_->GetGoalState(), init_.Epsilon);

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
@@ -111,10 +111,10 @@ void TimeIndexedRRTConnectSolver::Instantiate(const TimeIndexedRRTConnectSolverI
     algorithm_ = "Exotica_TimeIndexedRRTConnect";
     planner_allocator_ = boost::bind(&allocatePlanner<OMPLTimeIndexedRRTConnect>, _1, _2);
 
-    if (this->parameters_.RandomSeed != -1)
+    if (this->parameters_.RandomSeed > -1)
     {
         HIGHLIGHT_NAMED(algorithm_, "Setting random seed to " << this->parameters_.RandomSeed);
-        ompl::RNG::setSeed(this->parameters_.RandomSeed);
+        ompl::RNG::setSeed(static_cast<long unsigned int>(this->parameters_.RandomSeed));
     }
 }
 

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
@@ -225,7 +225,7 @@ void TimeIndexedRRTConnectSolver::GetPath(Eigen::MatrixXd &traj, ompl::base::Pla
         Eigen::VectorXd qs, qg;
         state_space_->as<OMPLTimeIndexedRNStateSpace>()->OMPLToExoticaState(pg.getState(0), qs, tstart);
         state_space_->as<OMPLTimeIndexedRNStateSpace>()->OMPLToExoticaState(pg.getState(states.size() - 1), qg, tgoal);
-        length = (tgoal - tstart) * this->parameters_.TrajectoryPointsPerSecond;
+        length = static_cast<int>(std::ceil((tgoal - tstart) * this->parameters_.TrajectoryPointsPerSecond));
     }
     pg.interpolate(length);
 

--- a/exotica_core/CMakeLists.txt
+++ b/exotica_core/CMakeLists.txt
@@ -140,7 +140,7 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_
 # mark all warnings as errors
 target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wextra)
 # enable additional warnings
-target_compile_options(${PROJECT_NAME} PRIVATE -Wdeprecated-declarations -Woverloaded-virtual)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wdeprecated-declarations -Woverloaded-virtual -Wfloat-conversion)
 
 # TODO: if you have time, remove these ignored warnings and fix them
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-unused-parameter -Wno-sign-compare -Wno-unused-variable -Wno-reorder -Wno-unused-but-set-variable)

--- a/exotica_core/cmake/exotica.cmake
+++ b/exotica_core/cmake/exotica.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Compiling using c++ 11 (required by EXOTica)")
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++11 -Werror -Wfloat-conversion)
 
 # MoveIt Core Robot Model isnt aligned :'(
 #add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)

--- a/exotica_core/cmake/generate_initializers.py
+++ b/exotica_core/cmake/generate_initializers.py
@@ -125,6 +125,8 @@ def parser(type):
         parser = "ParseVector<double,3>"
     elif type == 'Eigen::Vector2d':
         parser = 'ParseVector<double,2>'
+    elif type == 'Eigen::VectorXi':
+        parser = "ParseVector<int,Eigen::Dynamic>"
     elif type == 'bool':
         parser = "ParseBool"
     elif type == 'double':

--- a/exotica_core/include/exotica_core/tools.h
+++ b/exotica_core/include/exotica_core/tools.h
@@ -58,20 +58,20 @@ std_msgs::ColorRGBA RandomColor();
 inline std_msgs::ColorRGBA GetColor(double r, double g, double b, double a = 1.0)
 {
     std_msgs::ColorRGBA ret;
-    ret.r = r;
-    ret.g = g;
-    ret.b = b;
-    ret.a = a;
+    ret.r = static_cast<float>(r);
+    ret.g = static_cast<float>(g);
+    ret.b = static_cast<float>(b);
+    ret.a = static_cast<float>(a);
     return ret;
 }
 
 inline std_msgs::ColorRGBA GetColor(const Eigen::Vector4d& rgba)
 {
     std_msgs::ColorRGBA ret;
-    ret.r = rgba(0);
-    ret.g = rgba(1);
-    ret.b = rgba(2);
-    ret.a = rgba(3);
+    ret.r = static_cast<float>(rgba(0));
+    ret.g = static_cast<float>(rgba(1));
+    ret.b = static_cast<float>(rgba(2));
+    ret.a = static_cast<float>(rgba(3));
     return ret;
 }
 

--- a/exotica_core/include/exotica_core/tools/box_qp.h
+++ b/exotica_core/include/exotica_core/tools/box_qp.h
@@ -118,7 +118,7 @@ inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
         Eigen::VectorXd x_new;
         for (int ai = 0; ai < alpha_space.rows(); ++ai)
         {
-            int alpha = alpha_space[ai];
+            const double& alpha = alpha_space[ai];
 
             x_new = x;
             for (int i = 0; i < free_idx.size(); ++i)

--- a/exotica_core/include/exotica_core/tools/box_qp.h
+++ b/exotica_core/include/exotica_core/tools/box_qp.h
@@ -39,8 +39,8 @@ typedef struct BoxQPSolution
 {
     Eigen::MatrixXd Hff_inv;
     Eigen::MatrixXd x;
-    std::vector<int> free_idx;
-    std::vector<int> clamped_idx;
+    std::vector<size_t> free_idx;
+    std::vector<size_t> clamped_idx;
 } BoxQPSolution;
 
 inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
@@ -50,7 +50,7 @@ inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
 {
     int it = 0;
     Eigen::VectorXd delta_xf, x = x_init;
-    std::vector<int> clamped_idx, free_idx;
+    std::vector<size_t> clamped_idx, free_idx;
     Eigen::VectorXd grad = q + H * x_init;
     Eigen::MatrixXd Hff, Hfc, Hff_inv;
 
@@ -84,24 +84,24 @@ inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
             Hff = H;
         else
         {
-            for (int i = 0; i < free_idx.size(); ++i)
-                for (int j = 0; j < free_idx.size(); ++j)
+            for (size_t i = 0; i < free_idx.size(); ++i)
+                for (size_t j = 0; j < free_idx.size(); ++j)
                     Hff(i, j) = H(free_idx[i], free_idx[j]);
 
-            for (int i = 0; i < free_idx.size(); ++i)
-                for (int j = 0; j < clamped_idx.size(); ++j)
+            for (size_t i = 0; i < free_idx.size(); ++i)
+                for (size_t j = 0; j < clamped_idx.size(); ++j)
                     Hfc(i, j) = H(free_idx[i], clamped_idx[j]);
         }
 
         // NOTE: Array indexing not supported in current eigen version
         Eigen::VectorXd q_free(free_idx.size()), x_free(free_idx.size()), x_clamped(clamped_idx.size());
-        for (int i = 0; i < free_idx.size(); ++i)
+        for (size_t i = 0; i < free_idx.size(); ++i)
         {
             q_free(i) = q(free_idx[i]);
             x_free(i) = x(free_idx[i]);
         }
 
-        for (int j = 0; j < clamped_idx.size(); ++j)
+        for (size_t j = 0; j < clamped_idx.size(); ++j)
             x_clamped(j) = x(clamped_idx[j]);
 
         Hff_inv = (Eigen::MatrixXd::Identity(Hff.rows(), Hff.cols()) * lambda + Hff).inverse();
@@ -121,7 +121,7 @@ inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
             const double& alpha = alpha_space[ai];
 
             x_new = x;
-            for (int i = 0; i < free_idx.size(); ++i)
+            for (size_t i = 0; i < free_idx.size(); ++i)
                 x_new(free_idx[i]) = std::max(std::min(
                                                   x(free_idx[i]) + alpha * delta_xf(i), b_high(i)),
                                               b_low(i));

--- a/exotica_core/include/exotica_core/tools/conversions.h
+++ b/exotica_core/include/exotica_core/tools/conversions.h
@@ -30,13 +30,18 @@
 #ifndef EXOTICA_CORE_CONVERSIONS_H_
 #define EXOTICA_CORE_CONVERSIONS_H_
 
-#include <Eigen/Dense>
-#include <kdl/frames.hpp>
-#include <kdl/jacobian.hpp>
 #include <map>
 #include <memory>
-#include <unsupported/Eigen/CXX11/Tensor>
 #include <vector>
+
+#include <kdl/frames.hpp>
+#include <kdl/jacobian.hpp>
+
+#include <Eigen/Dense>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#include <unsupported/Eigen/CXX11/Tensor>
+#pragma GCC diagnostic pop
 
 #include <exotica_core/tools/exception.h>
 #include <exotica_core/tools/printable.h>

--- a/exotica_core/include/exotica_core/tools/conversions.h
+++ b/exotica_core/include/exotica_core/tools/conversions.h
@@ -183,6 +183,12 @@ inline double ToNumber<double>(const std::string& val)
     return std::stod(val);
 }
 
+template <>
+inline int ToNumber<int>(const std::string& val)
+{
+    return std::stoi(val);
+}
+
 template <typename T, const int S>  // Eigen::Vector<S><T>
 inline Eigen::Matrix<T, S, 1> ParseVector(const std::string value)
 {

--- a/exotica_core/include/exotica_core/visualization_meshcat_types.h
+++ b/exotica_core/include/exotica_core/visualization_meshcat_types.h
@@ -286,7 +286,7 @@ struct ArrayFloat
     {
         data.resize(size);
         for (unsigned int i = 0; i < size; ++i)
-            data[i] = data_in[i];
+            data[i] = static_cast<float>(data_in[i]);
 #ifdef MSGPACK_FEATURE_NOT_SUPPORTED
         array = data;
         WARNING("MSGPACK version does not support sending this type of data. Ignoring.");

--- a/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
+++ b/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
@@ -157,7 +157,7 @@ void DynamicTimeIndexedShootingProblem::Instantiate(const DynamicTimeIndexedShoo
     tau_ = this->parameters_.tau;
 
     // For now, without inter-/extra-polation for integrators, assure that tau is a multiple of dt
-    const double fmod_tau_dt = std::fmod(static_cast<long double>(1000. * tau_), static_cast<long double>(1000. * scene_->GetDynamicsSolver()->get_dt()));
+    const long double fmod_tau_dt = std::fmod(static_cast<long double>(1000. * tau_), static_cast<long double>(1000. * scene_->GetDynamicsSolver()->get_dt()));
     if (fmod_tau_dt > 1e-5) ThrowPretty("tau is not a multiple of dt: tau=" << tau_ << ", dt=" << scene_->GetDynamicsSolver()->get_dt() << ", mod(" << fmod_tau_dt << ")");
 
     // Initialize general costs

--- a/exotica_core/src/tools.cpp
+++ b/exotica_core/src/tools.cpp
@@ -48,9 +48,9 @@ std_msgs::ColorRGBA RandomColor()
     std::random_device rd_;
     std::mt19937 gen(rd_());
     std::uniform_real_distribution<> dis(0.0, 1.0);
-    ret.r = dis(gen);
-    ret.g = dis(gen);
-    ret.b = dis(gen);
+    ret.r = static_cast<float>(dis(gen));
+    ret.g = static_cast<float>(dis(gen));
+    ret.b = static_cast<float>(dis(gen));
     return ret;
 }
 


### PR DESCRIPTION
- This PR fixes bugs in BoxQP and TimeIndexedRRTConnect due to implicit conversion from double to float.
- It then enables warnings for these sort of bugs and treats them as errors.
- The existing issues are fixed.
- The warning is exported to all projects depending on Exotica <-- this may be disruptive to some users off, but can save them from bugs.