### PR TITLE
[exotica_core] Do not force -Werror for dependent projects

### DIFF
--- a/exotica_core/cmake/exotica.cmake
+++ b/exotica_core/cmake/exotica.cmake
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Compiling using c++ 11 (required by EXOTica)")
-add_compile_options(-std=c++11 -Werror -Wfloat-conversion)
+add_compile_options(-std=c++11 -Wfloat-conversion)
+# add_compile_options(-Werror)
 
 # MoveIt Core Robot Model isnt aligned :'(
 #add_definitions(-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_DONT_VECTORIZE)


### PR DESCRIPTION
To resolve #673. We should still introduce some of the warnings for dependent projects as they are often correlated to bugs. They can be hidden with pragmas if unfixable.

<!--
# Checklist

- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory

- add unit test(s)

- ensure tests build and check results: run `catkin run_tests exotica && catkin_test_results`

--!>
