### PR TITLE
Pinocchio as third-party library

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,8 +1,8 @@
-- git:
-    uri: https://github.com/stack-of-tasks/eigenpy.git
-    version: devel
-    local-name: eigenpy
-- git:
-    uri: https://github.com/wxmerkt/pinocchio.git
-    version: topic/wxm-add-package.xml
-    local-name: pinocchio
+#- git:
+#    uri: https://github.com/stack-of-tasks/eigenpy.git
+#    version: devel
+#    local-name: eigenpy
+#- git:
+#    uri: https://github.com/wxmerkt/pinocchio.git
+#    version: topic/wxm-add-package.xml
+#    local-name: pinocchio

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -3,6 +3,6 @@
 #    version: devel
 #    local-name: eigenpy
 #- git:
-#    uri: https://github.com/wxmerkt/pinocchio.git
-#    version: topic/wxm-add-package.xml
+#    uri: https://github.com/stack-of-tasks/pinocchio.git
+#    version: devel
 #    local-name: pinocchio

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,5 +1,6 @@
 - git:
     uri: https://github.com/stack-of-tasks/eigenpy.git
+    version: devel
     local-name: eigenpy
 - git:
     uri: https://github.com/wxmerkt/pinocchio.git

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,6 +1,7 @@
-#- git:
-#    uri: https://github.com/ipab-slmc/eigenpy_catkin.git
-#    local-name: eigenpy
-#- git:
-#    uri: https://github.com/ipab-slmc/pinocchio_catkin.git
-#    local-name: pinocchio
+- git:
+    uri: https://github.com/stack-of-tasks/eigenpy.git
+    local-name: eigenpy
+- git:
+    uri: https://github.com/wxmerkt/pinocchio.git
+    version: topic/wxm-add-package.xml
+    local-name: pinocchio

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ git:
 env:
   global: # global settings for all jobs
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
-    - ROS_REPO=ros-testing # ros
+    - ROS_REPO=ros
     - ROS_PARALLEL_JOBS=-j2 # Don't exhaust virtual memory
     - DOCKER_RUN_OPTS='-e TRAVIS_BRANCH -e GITHUBKEY' # Pass CI variables to Docker
     - UPSTREAM_WORKSPACE=file

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ git:
 env:
   global: # global settings for all jobs
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
-    - ROS_REPO=ros
+    - ROS_REPO=ros-testing # ros
     - ROS_PARALLEL_JOBS=-j2 # Don't exhaust virtual memory
     - DOCKER_RUN_OPTS='-e TRAVIS_BRANCH -e GITHUBKEY' # Pass CI variables to Docker
     - UPSTREAM_WORKSPACE=file

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp)
-target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated -Wno-variadic-macros -Wno-deprecated-declarations -Wno-comment)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated -Wno-variadic-macros -Wno-deprecated-declarations -Wno-comment -Wno-ignored-attributes)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${PINOCCHIO_CFLAGS_OTHER})
 

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(PINOCCHIO pinocchio>=2.0.0 REQUIRED )
+pkg_check_modules(PINOCCHIO pinocchio REQUIRED)
 
 AddInitializer(pinocchio_dynamics_solver)
 GenInitializers()

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -1,11 +1,13 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(exotica_pinocchio_dynamics_solver)
 
 find_package(catkin REQUIRED COMPONENTS
   exotica_core
   roscpp
-  pinocchio
 )
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PINOCCHIO pinocchio>=2.0.0 REQUIRED )
 
 AddInitializer(pinocchio_dynamics_solver)
 GenInitializers()
@@ -13,17 +15,20 @@ GenInitializers()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS exotica_core pinocchio
+  CATKIN_DEPENDS exotica_core
+  DEPENDS PINOCCHIO
 )
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${PINOCCHIO_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${PINOCCHIO_CFLAGS_OTHER})
 
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp)
-target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated -Wno-variadic-macros -Wno-deprecated-declarations -Wno-comment)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${PINOCCHIO_CFLAGS_OTHER})
 

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
@@ -30,6 +30,11 @@
 #ifndef EXOTICA_PINOCCHIO_DYNAMICS_SOLVER_PINOCCHIO_DYNAMICS_SOLVER_H_
 #define EXOTICA_PINOCCHIO_DYNAMICS_SOLVER_PINOCCHIO_DYNAMICS_SOLVER_H_
 
+/// TODO: remove this pragma once Pinocchio removes neutralConfiguration/
+/// and fixes their deprecation warnings. (Relates to #547)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 /// fwd.hpp needs to be included first (before Boost, which comes with ROS),
 /// else everything breaks for Pinocchio >=2.1.5
 #include <pinocchio/fwd.hpp>
@@ -38,11 +43,6 @@
 #include <exotica_core/scene.h>
 
 #include <exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver_initializer.h>
-
-/// TODO: remove this pragma once Pinocchio removes neutralConfiguration/
-/// and fixes their deprecation warnings. (Relates to #547)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #include <pinocchio/algorithm/aba-derivatives.hpp>
 #include <pinocchio/algorithm/aba.hpp>

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
@@ -30,6 +30,10 @@
 #ifndef EXOTICA_PINOCCHIO_DYNAMICS_SOLVER_PINOCCHIO_DYNAMICS_SOLVER_H_
 #define EXOTICA_PINOCCHIO_DYNAMICS_SOLVER_PINOCCHIO_DYNAMICS_SOLVER_H_
 
+/// fwd.hpp needs to be included first (before Boost, which comes with ROS),
+/// else everything breaks for Pinocchio >=2.1.5
+#include <pinocchio/fwd.hpp>
+
 #include <exotica_core/dynamics_solver.h>
 #include <exotica_core/scene.h>
 


### PR DESCRIPTION
This PR testst whether we can 

(a) upgrade Pinocchio to the latest 2.1.9 (and work around a bug with boost::variant)
(b) use a third-party release mechanism

This will require re-releasing eigenpy and pinocchio via the ROS buildfarm (breaking change). It will make our development a lot easier though and also fix the buildsystem problems we have been seeing with Crocoddyl.