### PR TITLE
Add support for Scene creation without SRDF, from robot param server

### DIFF
--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -272,7 +272,7 @@ private:
     std::vector<std::string> controlled_joints_names_;
     std::vector<std::string> model_link_names_;
     std::vector<std::string> controlled_link_names_;
-    std::shared_ptr<KinematicResponse> solution_;
+    std::shared_ptr<KinematicResponse> solution_ = std::make_shared<KinematicResponse>();
     KinematicRequestFlags flags_;
 
     std::vector<tf::StampedTransform> debug_tree_;

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -133,7 +133,7 @@ public:
 class KinematicTree : public Uncopyable
 {
 public:
-    void Instantiate(std::string joint_group, robot_model::RobotModelPtr model, const std::string& name);
+    void Instantiate(const std::string& joint_group, robot_model::RobotModelPtr model, const std::string& name);
     const std::string& GetRootFrameName() const;
     const std::string& GetRootJointName() const;
     robot_model::RobotModelPtr GetRobotModel() const;

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -95,7 +95,7 @@ int KinematicTree::GetNumModelJoints() const
     return num_joints_;
 }
 
-void KinematicTree::Instantiate(std::string joint_group, robot_model::RobotModelPtr model, const std::string& name)
+void KinematicTree::Instantiate(const std::string& joint_group, robot_model::RobotModelPtr model, const std::string& name)
 {
     if (!model) ThrowPretty("No robot model provided!");
     const robot_model::JointModelGroup* group = model->getJointModelGroup(joint_group);

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -142,7 +142,12 @@ void KinematicTree::BuildTree(const KDL::Tree& robot_kinematics)
             world_frame_name = s.parent_frame_;
         }
     }
-    if (world_frame_name == "") ThrowPretty("Can't initialize root joint!");
+    // if (world_frame_name == "") ThrowPretty("Can't initialize root joint!");
+    if (world_frame_name.empty())
+    {
+        world_frame_name = "world_frame";
+        WARNING_NAMED("KinematicTree", "No virtual joint defined. Defaulting world frame to " << world_frame_name)
+    }
 
     // Extract Root Inertial
     double root_mass = 0.0;


### PR DESCRIPTION
This PR adds the required changes to allow creation of a `Scene` e.g. directly from a `robot_description` parameter without an EXOTica-compliant SRDF (which contains virtual joints and joint group). 

After this PR, the following works (assuming `robot_description` has been set):
```python
import pyexotica as exo

exo.Setup.init_ros()
scene = exo.Setup.create_scene(exo.Initializers.SceneInitializer())
kt = scene.get_kinematic_tree()

print("Model Tree:")
for ke in kt.get_model_tree():
    print(ke.id, "link=", ke.get_segment_name(), "parent=", ke.get_parent_name(), "joint=", ke.get_joint_name(),)
```