### PR TITLE
Review examples for dynamic optimal control; fix iLQR

### DIFF
--- a/exotations/solvers/exotica_ddp_solver/init/abstract_ddp_solver.in
+++ b/exotations/solvers/exotica_ddp_solver/init/abstract_ddp_solver.in
@@ -5,4 +5,5 @@ Optional int FunctionTolerancePatience = 10; // early stopping or patience
 Optional double FunctionTolerance = 1e-3; 
 Optional bool UseSecondOrderDynamics = false;
 Optional double RegularizationRate = 1e-5;
+Optional double MinimumRegularization = 1e-12;  // Minimum regularisation below which it won't be decreased.
 Optional bool ClampControlsInForwardPass = false;

--- a/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
@@ -129,7 +129,7 @@ void AbstractDDPSolver::Solve(Eigen::MatrixXd& solution)
 
         if (debug_)
         {
-            HIGHLIGHT_NAMED("DDPSolver", "Iteration " << iteration << std::setprecision(6) << ":\tBackward pass: " << time_taken_backward_pass_ << " s\tForward pass: " << time_taken_forward_pass_ << " s\tCost: " << cost_ << "\talpha: " << alpha_best_ << "\tRegularization: " << lambda_);
+            HIGHLIGHT_NAMED("DDPSolver", "Iteration " << iteration << std::setprecision(3) << ":\tBackward pass: " << time_taken_backward_pass_ << " s\tForward pass: " << time_taken_forward_pass_ << " s\tCost: " << cost_ << "\talpha: " << alpha_best_ << "\tRegularization: " << lambda_);
         }
 
         //
@@ -184,8 +184,8 @@ void AbstractDDPSolver::Solve(Eigen::MatrixXd& solution)
             }
             else
             {
-                if (debug_) HIGHLIGHT("Cost improved, decrease regularization");
-                DecreaseRegularization();
+                // if (debug_) HIGHLIGHT("Cost improved, decrease regularization");
+                if (lambda_ > 1e-12) DecreaseRegularization();
             }
         }
         else
@@ -193,7 +193,7 @@ void AbstractDDPSolver::Solve(Eigen::MatrixXd& solution)
             cost_ = cost_prev_;
             // Revert by not storing U_try_ as U_ref_ (maintain U_ref_)
 
-            if (debug_) HIGHLIGHT("No improvement - increase regularization");
+            // if (debug_) HIGHLIGHT("No improvement - increase regularization");
             IncreaseRegularization();
         }
 

--- a/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
@@ -185,7 +185,7 @@ void AbstractDDPSolver::Solve(Eigen::MatrixXd& solution)
             else
             {
                 // if (debug_) HIGHLIGHT("Cost improved, decrease regularization");
-                if (lambda_ > 1e-12) DecreaseRegularization();
+                if (lambda_ > base_parameters_.MinimumRegularization) DecreaseRegularization();
             }
         }
         else

--- a/exotations/solvers/exotica_ilqr_solver/src/ilqr_solver.cpp
+++ b/exotations/solvers/exotica_ilqr_solver/src/ilqr_solver.cpp
@@ -42,32 +42,32 @@ void ILQRSolver::SpecifyProblem(PlanningProblemPtr pointer)
     MotionSolver::SpecifyProblem(pointer);
     prob_ = std::static_pointer_cast<DynamicTimeIndexedShootingProblem>(pointer);
     dynamics_solver_ = prob_->GetScene()->GetDynamicsSolver();
-    if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "initialized");
 }
 
 void ILQRSolver::BackwardPass()
 {
-    constexpr double min_clamp_ = -1e10;
-    constexpr double max_clamp_ = 1e10;
+    // constexpr double min_clamp_ = -1e10;
+    // constexpr double max_clamp_ = 1e10;
     const int T = prob_->get_T();
     const double dt = dynamics_solver_->get_dt();
 
-    const Eigen::MatrixXd Qf = prob_->get_Qf(), R = dt * prob_->get_R();
-    const Eigen::MatrixXd X_star = prob_->get_X_star();
+    const Eigen::MatrixXd& Qf = prob_->get_Qf();
+    const Eigen::MatrixXd R = dt * prob_->get_R();
+    const Eigen::MatrixXd& X_star = prob_->get_X_star();
 
     // eq. 18
     vk_gains_[T - 1] = Qf * dynamics_solver_->StateDelta(prob_->get_X(T - 1), X_star.col(T - 1));
-    vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-        return std::min(std::max(x, min_clamp_), max_clamp_);
-    });
+    // vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+    //     return std::min(std::max(x, min_clamp_), max_clamp_);
+    // });
 
     Eigen::MatrixXd Sk = Qf;
-    Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-        return std::min(std::max(x, min_clamp_), max_clamp_);
-    });
-    vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-        return std::min(std::max(x, min_clamp_), max_clamp_);
-    });
+    // Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+    //     return std::min(std::max(x, min_clamp_), max_clamp_);
+    // });
+    // vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+    //     return std::min(std::max(x, min_clamp_), max_clamp_);
+    // });
 
     for (int t = T - 2; t >= 0; t--)
     {
@@ -79,6 +79,7 @@ void ILQRSolver::BackwardPass()
         Ak.noalias() = Ak * dt + Eigen::MatrixXd::Identity(Ak.rows(), Ak.cols());
         Bk.noalias() = Bk * dt;
         // this inverse is common for all factors
+        // TODO: use LLT
         const Eigen::MatrixXd _inv =
             (Eigen::MatrixXd::Identity(R.rows(), R.cols()) * parameters_.RegularizationRate + R + Bk.transpose() * Sk * Bk).inverse();
 
@@ -91,12 +92,12 @@ void ILQRSolver::BackwardPass()
                        (K_gains_[t].transpose() * R * u) + (Q * x);
 
         // fix for large values
-        Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-            return std::min(std::max(x, min_clamp_), max_clamp_);
-        });
-        vk_gains_[t] = vk_gains_[t].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-            return std::min(std::max(x, min_clamp_), max_clamp_);
-        });
+        // Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+        //     return std::min(std::max(x, min_clamp_), max_clamp_);
+        // });
+        // vk_gains_[t] = vk_gains_[t].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+        //     return std::min(std::max(x, min_clamp_), max_clamp_);
+        // });
     }
 }
 
@@ -107,12 +108,13 @@ double ILQRSolver::ForwardPass(const double alpha, Eigen::MatrixXdRefConst ref_x
     const Eigen::MatrixXd control_limits = dynamics_solver_->get_control_limits();
     const double dt = dynamics_solver_->get_dt();
 
+    Eigen::VectorXd delta_uk(dynamics_solver_->get_num_controls()), u(dynamics_solver_->get_num_controls());
     for (int t = 0; t < T - 1; ++t)
     {
-        Eigen::VectorXd u = ref_u.col(t);
+        u = ref_u.col(t);
         // eq. 12
-        Eigen::VectorXd delta_uk = -Ku_gains_[t] * u - Kv_gains_[t] * vk_gains_[t + 1] -
-                                   K_gains_[t] * dynamics_solver_->StateDelta(prob_->get_X(t), ref_x.col(t));
+        delta_uk = -Ku_gains_[t] * u - Kv_gains_[t] * vk_gains_[t + 1] -
+                   K_gains_[t] * dynamics_solver_->StateDelta(prob_->get_X(t), ref_x.col(t));
 
         u.noalias() += alpha * delta_uk;
         // clamp controls
@@ -139,13 +141,17 @@ void ILQRSolver::Solve(Eigen::MatrixXd& solution)
     prob_->ResetCostEvolution(GetNumberOfMaxIterations() + 1);
     prob_->PreUpdate();
 
-    double initial_cost = 0;
+    double cost = 0;
     for (int t = 0; t < T - 1; ++t)
-        initial_cost += dt * (prob_->GetControlCost(t) + prob_->GetStateCost(t));
+    {
+        prob_->Update(prob_->get_U(t), t);
+
+        cost += dt * (prob_->GetControlCost(t) + prob_->GetStateCost(t));
+    }
 
     // add terminal cost
-    initial_cost += prob_->GetStateCost(T - 1);
-    prob_->SetCostEvolution(0, initial_cost);
+    cost += prob_->GetStateCost(T - 1);
+    prob_->SetCostEvolution(0, cost);
 
     // initialize Gain matrices
     K_gains_.assign(T, Eigen::MatrixXd(NU, NX));
@@ -155,14 +161,21 @@ void ILQRSolver::Solve(Eigen::MatrixXd& solution)
 
     // all of the below are not pointers, since we want to copy over
     //  solutions across iterations
-    Eigen::MatrixXd new_U, global_best_U = prob_->get_U();
+    Eigen::MatrixXd new_U = prob_->get_U();
     solution.resize(T - 1, NU);
 
-    if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Running ILQR solver for max " << parameters_.MaxIterations << " iterations");
+    if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Running ILQR solver for max " << GetNumberOfMaxIterations() << " iterations");
 
-    double last_cost = initial_cost, global_best_cost = initial_cost;
+    double cost_prev = cost;
     int last_best_iteration = 0;
 
+    Eigen::VectorXd alpha_space = Eigen::VectorXd::LinSpaced(11, 0.0, -3.0);
+    for (int ai = 0; ai < alpha_space.size(); ++ai)
+    {
+        alpha_space(ai) = std::pow(10.0, alpha_space(ai));
+    }
+
+    double time_taken_backward_pass = 0.0, time_taken_forward_pass = 0.0;
     for (int iteration = 1; iteration <= GetNumberOfMaxIterations(); ++iteration)
     {
         // Check whether user interrupted (Ctrl+C)
@@ -176,70 +189,99 @@ void ILQRSolver::Solve(Eigen::MatrixXd& solution)
         // Backwards pass computes the gains
         backward_pass_timer.Reset();
         BackwardPass();
-        // if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Backward pass complete in " << backward_pass_timer.GetDuration());
-        if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Backward pass complete in " << backward_pass_timer.GetDuration());
+        time_taken_backward_pass = backward_pass_timer.GetDuration();
 
+        // Forward pass to compute new control trajectory
         line_search_timer.Reset();
-        // forward pass to compute new control trajectory
-        // TODO: Configure line-search space from xml
-        // TODO (Wolf): What you are doing is a forward line-search when we may try a
-        //    backtracking line search for a performance improvement later - this just as an aside.
-        const Eigen::VectorXd alpha_space = Eigen::VectorXd::LinSpaced(10, 0.1, 1.0);
-        double current_cost = 0, best_alpha = 0;
 
+        // Make a copy to compare against
         Eigen::MatrixXd ref_x = prob_->get_X(),
                         ref_u = prob_->get_U();
-        // perform a linear search to find the best rate
-        for (int ai = 0; ai < alpha_space.rows(); ++ai)
-        {
-            double alpha = alpha_space(ai);
-            double cost = ForwardPass(alpha, ref_x, ref_u);
 
-            if (ai == 0 || (cost < current_cost && !std::isnan(cost)))
+        // Perform a backtracking line search to find the best rate
+        double best_alpha = 0;
+        for (int ai = 0; ai < alpha_space.size(); ++ai)
+        {
+            const double& alpha = alpha_space(ai);
+            double rollout_cost = ForwardPass(alpha, ref_x, ref_u);
+
+            if (rollout_cost < cost_prev && !std::isnan(rollout_cost))
             {
-                current_cost = cost;
+                cost = rollout_cost;
                 new_U = prob_->get_U();
                 best_alpha = alpha;
+                break;
             }
         }
 
-        // finite checks
-        if (!new_U.allFinite() || !std::isfinite(current_cost))
+        // Finiteness checks
+        if (!new_U.allFinite() || !std::isfinite(cost))
         {
             prob_->termination_criterion = TerminationCriterion::Divergence;
-            WARNING_NAMED("ILQRSolver", "Diverged!");
+            WARNING_NAMED("ILQRSolver", "Diverged: Controls or cost are not finite.");
             return;
         }
 
+        time_taken_forward_pass = line_search_timer.GetDuration();
+
         if (debug_)
         {
-            HIGHLIGHT_NAMED("ILQRSolver", "Forward pass complete in " << line_search_timer.GetDuration() << " with cost: " << current_cost << " and alpha " << best_alpha);
-            HIGHLIGHT_NAMED("ILQRSolver", "Final state: " << prob_->get_X(T - 1).transpose());
+            HIGHLIGHT_NAMED("ILQRSolver", "Iteration " << iteration << std::setprecision(3) << ":\tBackward pass: " << time_taken_backward_pass << " s\tForward pass: " << time_taken_forward_pass << " s\tCost: " << cost << "\talpha: " << best_alpha);
         }
 
-        // copy solutions for next iteration
-        if (global_best_cost > current_cost)
+        //
+        // Stopping criteria checks
+        //
+
+        // Relative function tolerance
+        // (f_t-1 - f_t) <= functionTolerance * max(1, abs(f_t))
+        if ((cost_prev - cost) < parameters_.FunctionTolerance * std::max(1.0, std::abs(cost)))
         {
-            global_best_cost = current_cost;
+            // Function tolerance patience check
+            if (parameters_.FunctionTolerancePatience > 0)
+            {
+                if (iteration - last_best_iteration > parameters_.FunctionTolerancePatience)
+                {
+                    if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Early stopping criterion reached (" << cost << " < " << cost_prev << "). Time: " << planning_timer.GetDuration());
+                    prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
+                    break;
+                }
+            }
+            else
+            {
+                if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Function tolerance reached (" << cost << " < " << cost_prev << "). Time: " << planning_timer.GetDuration());
+                prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
+                break;
+            }
+        }
+        else
+        {
+            // Reset function tolerance patience
             last_best_iteration = iteration;
-            global_best_U = new_U;
+        }
+
+        // If better than previous iteration, copy solutions for next iteration
+        if (cost < cost_prev)
+        {
+            cost_prev = cost;
+            // last_best_iteration = iteration;
             best_ref_x_ = ref_x;
             best_ref_u_ = ref_u;
         }
 
-        if (iteration - last_best_iteration > parameters_.FunctionTolerancePatience)
-        {
-            if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Early stopping criterion reached. Time: " << planning_timer.GetDuration());
-            prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
-            break;
-        }
+        // if (iteration - last_best_iteration > parameters_.FunctionTolerancePatience)
+        // {
+        //     if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Early stopping criterion reached. Time: " << planning_timer.GetDuration());
+        //     prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
+        //     break;
+        // }
 
-        if (last_cost - current_cost < parameters_.FunctionTolerance && last_cost - current_cost > 0)
-        {
-            if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Function tolerance reached. Time: " << planning_timer.GetDuration());
-            prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
-            break;
-        }
+        // if (last_cost - current_cost < parameters_.FunctionTolerance && last_cost - current_cost > 0)
+        // {
+        //     if (debug_) HIGHLIGHT_NAMED("ILQRSolver", "Function tolerance reached. Time: " << planning_timer.GetDuration());
+        //     prob_->termination_criterion = TerminationCriterion::FunctionTolerance;
+        //     break;
+        // }
 
         if (debug_ && iteration == parameters_.MaxIterations)
         {
@@ -247,17 +289,19 @@ void ILQRSolver::Solve(Eigen::MatrixXd& solution)
             prob_->termination_criterion = TerminationCriterion::IterationLimit;
         }
 
-        last_cost = current_cost;
+        // Roll-out
         for (int t = 0; t < T - 1; ++t)
             prob_->Update(new_U.col(t), t);
-        prob_->SetCostEvolution(iteration, current_cost);
+
+        // Set cost evolution
+        prob_->SetCostEvolution(iteration, cost);
     }
 
     // store the best solution found over all iterations
     for (int t = 0; t < T - 1; ++t)
     {
-        solution.row(t) = global_best_U.col(t).transpose();
-        prob_->Update(global_best_U.col(t), t);
+        solution.row(t) = new_U.col(t).transpose();
+        prob_->Update(new_U.col(t), t);
     }
 
     planning_time_ = planning_timer.GetDuration();

--- a/exotations/solvers/exotica_ilqr_solver/src/ilqr_solver.cpp
+++ b/exotations/solvers/exotica_ilqr_solver/src/ilqr_solver.cpp
@@ -46,8 +46,8 @@ void ILQRSolver::SpecifyProblem(PlanningProblemPtr pointer)
 
 void ILQRSolver::BackwardPass()
 {
-    // constexpr double min_clamp_ = -1e10;
-    // constexpr double max_clamp_ = 1e10;
+    constexpr double min_clamp_ = -1e10;
+    constexpr double max_clamp_ = 1e10;
     const int T = prob_->get_T();
     const double dt = dynamics_solver_->get_dt();
 
@@ -57,17 +57,17 @@ void ILQRSolver::BackwardPass()
 
     // eq. 18
     vk_gains_[T - 1] = Qf * dynamics_solver_->StateDelta(prob_->get_X(T - 1), X_star.col(T - 1));
-    // vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-    //     return std::min(std::max(x, min_clamp_), max_clamp_);
-    // });
+    vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+        return std::min(std::max(x, min_clamp_), max_clamp_);
+    });
 
     Eigen::MatrixXd Sk = Qf;
-    // Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-    //     return std::min(std::max(x, min_clamp_), max_clamp_);
-    // });
-    // vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-    //     return std::min(std::max(x, min_clamp_), max_clamp_);
-    // });
+    Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+        return std::min(std::max(x, min_clamp_), max_clamp_);
+    });
+    vk_gains_[T - 1] = vk_gains_[T - 1].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+        return std::min(std::max(x, min_clamp_), max_clamp_);
+    });
 
     for (int t = T - 2; t >= 0; t--)
     {
@@ -92,12 +92,12 @@ void ILQRSolver::BackwardPass()
                        (K_gains_[t].transpose() * R * u) + (Q * x);
 
         // fix for large values
-        // Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-        //     return std::min(std::max(x, min_clamp_), max_clamp_);
-        // });
-        // vk_gains_[t] = vk_gains_[t].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
-        //     return std::min(std::max(x, min_clamp_), max_clamp_);
-        // });
+        Sk = Sk.unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+            return std::min(std::max(x, min_clamp_), max_clamp_);
+        });
+        vk_gains_[t] = vk_gains_[t].unaryExpr([min_clamp_, max_clamp_](double x) -> double {
+            return std::min(std::max(x, min_clamp_), max_clamp_);
+        });
     }
 }
 

--- a/exotica_examples/resources/configs/dynamic_time_indexed/01_ilqr_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/01_ilqr_cartpole.xml
@@ -3,9 +3,7 @@
     <ILQRSolver Name="ilqr">
         <Debug>1</Debug>
         <MaxIterations>200</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>200</FunctionTolerancePatience>
-        <RegularizationRate>0.0001</RegularizationRate>
+        <RegularizationRate>0.01</RegularizationRate>
     </ILQRSolver>
 
     <DynamicTimeIndexedShootingProblem Name="cartpole">

--- a/exotica_examples/resources/configs/dynamic_time_indexed/02_lwr_task_maps.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/02_lwr_task_maps.xml
@@ -2,10 +2,8 @@
 <DynamicTimeIndexedProblemConfig>-->
     <AnalyticDDPSolver Name="ControlLimitedDDPSolver">
         <Debug>1</Debug>
-        <MaxIterations>200</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>200</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
+        <MaxIterations>1000</MaxIterations>
+        <!-- <UseSecondOrderDynamics>1</UseSecondOrderDynamics> -->
         <RegularizationRate>0.1</RegularizationRate>
     </AnalyticDDPSolver>
     

--- a/exotica_examples/resources/configs/dynamic_time_indexed/03_ilqr_valkyrie.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/03_ilqr_valkyrie.xml
@@ -1,27 +1,17 @@
 <?xml version="1.0" ?>
 <DynamicTimeIndexedProblemConfig>
-    <!-- <AnalyticDDPSolver Name="AnalyticDDPSolver">
-        <Debug>1</Debug>
-        <MaxIterations>300</MaxIterations>
-        <FunctionTolerance>1e-3</FunctionTolerance>
-        <FunctionTolerancePatience>300</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
-        <RegularizationRate>1</RegularizationRate>
-    </AnalyticDDPSolver> -->
-    <ControlLimitedDDPSolver Name="ControlLimitedDDPSolver">
+    <!-- 2020-01-08, wxm: This example makes no sense. It has taskmaps when iLQR cannot solve taskmaps. Start and goal state are the same. The Qf is set up incorrectly. As thus, it should do nothing. -->
+
+    <ILQRSolver Name="ILQRSolver">
         <Debug>1</Debug>
         <MaxIterations>10</MaxIterations>
-        <FunctionTolerance>1e-3</FunctionTolerance>
-        <FunctionTolerancePatience>10</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
-        <RegularizationRate>1</RegularizationRate>
-    </ControlLimitedDDPSolver>
+        <!-- <RegularizationRate>1</RegularizationRate> -->
+    </ILQRSolver>
 
     <DynamicTimeIndexedShootingProblem Name="MyProblem">
         <PlanningScene>
         <Scene>
             <JointGroup>whole_body</JointGroup>
-            <Debug>0</Debug>
             <URDF>{exotica_examples}/resources/robots/valkyrie_sim.urdf</URDF>
             <SRDF>{exotica_examples}/resources/robots/valkyrie_sim.srdf</SRDF>
             <SetRobotDescriptionRosParams>1</SetRobotDescriptionRosParams>
@@ -63,7 +53,7 @@
                 </EndEffector>
             </EffPosition>
 
-            <QuasiStatic Name="Stability" PositiveOnly="1" Debug="1">
+            <!-- <QuasiStatic Name="Stability" PositiveOnly="1" Debug="1">
                 <EndEffector>
                     <Frame Link="leftFoot_collision_5"/>
                     <Frame Link="leftFoot_collision_6"/>
@@ -74,7 +64,7 @@
                     <Frame Link="rightFoot_collision_7"/>
                     <Frame Link="rightFoot_collision_8"/>
                 </EndEffector>
-            </QuasiStatic>
+            </QuasiStatic> -->
         </Maps>
 
         <Cost>

--- a/exotica_examples/resources/configs/dynamic_time_indexed/04_analytic_ddp_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/04_analytic_ddp_cartpole.xml
@@ -2,11 +2,9 @@
 <DynamicTimeIndexedProblemConfig>
     <AnalyticDDPSolver Name="AnalyticDDPSolver">
         <Debug>1</Debug>
-        <MaxIterations>300</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>300</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
-        <RegularizationRate>1e-3</RegularizationRate>
+        <!-- Toggle to see the impact of second order dynamics. Regularisation also has an impact. -->
+        <!-- <UseSecondOrderDynamics>1</UseSecondOrderDynamics> -->
+        <RegularizationRate>1e-1</RegularizationRate>
     </AnalyticDDPSolver>
 
     <DynamicTimeIndexedShootingProblem Name="MyProblem">

--- a/exotica_examples/resources/configs/dynamic_time_indexed/05_analytic_ddp_lwr.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/05_analytic_ddp_lwr.xml
@@ -2,10 +2,8 @@
 <DynamicTimeIndexedProblemConfig>
     <AnalyticDDPSolver Name="AnalyticDDPSolver">
         <Debug>1</Debug>
-        <MaxIterations>50</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>50</FunctionTolerancePatience>
         <UseSecondOrderDynamics>1</UseSecondOrderDynamics>
+        <RegularizationRate>1e-3</RegularizationRate>
     </AnalyticDDPSolver>
 
     <DynamicTimeIndexedShootingProblem Name="MyProblem">

--- a/exotica_examples/resources/configs/dynamic_time_indexed/06_analytic_ddp_valkyrie.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/06_analytic_ddp_valkyrie.xml
@@ -2,9 +2,7 @@
 <DynamicTimeIndexedProblemConfig>
     <AnalyticDDPSolver Name="AnalyticDDPSolver">
         <Debug>1</Debug>
-        <MaxIterations>3</MaxIterations>
-        <ConvergenceThreshold>-1</ConvergenceThreshold>
-        <EarlyStopping>3</EarlyStopping>
+        <MaxIterations>10</MaxIterations>
         <UseSecondOrderDynamics>1</UseSecondOrderDynamics>
     </AnalyticDDPSolver>
 
@@ -32,7 +30,7 @@
         <dt>0.02</dt>
         <Q_rate>0</Q_rate>
         <Qf_rate>10</Qf_rate>
-        <R_rate>0.1</R_rate>
+        <R_rate>1e-3</R_rate>
 
         <StartState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 </StartState>
         <GoalState>0.0 0.0 5 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 1.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -0.25 0.0 -1.785398163397 1.571 0.0 0.0 0.0 1.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0 0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 5.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</GoalState>

--- a/exotica_examples/resources/configs/dynamic_time_indexed/07_control_limited_ddp_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/07_control_limited_ddp_cartpole.xml
@@ -2,11 +2,7 @@
 <DynamicTimeIndexedProblemConfig>
     <ControlLimitedDDPSolver Name="ControlLimitedDDPSolver">
         <Debug>1</Debug>
-        <MaxIterations>100</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>100</FunctionTolerancePatience>
         <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
-        <RegularizationRate>1e-3</RegularizationRate>
     </ControlLimitedDDPSolver>
 
     <DynamicTimeIndexedShootingProblem Name="MyProblem">

--- a/exotica_examples/resources/configs/dynamic_time_indexed/08_control_limited_ddp_lwr.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/08_control_limited_ddp_lwr.xml
@@ -3,9 +3,7 @@
     <ControlLimitedDDPSolver Name="ControlLimitedDDPSolver">
         <Debug>1</Debug>
         <MaxIterations>50</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>50</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>1</UseSecondOrderDynamics>
+        <!-- <UseSecondOrderDynamics>1</UseSecondOrderDynamics> -->
     </ControlLimitedDDPSolver>
 
     <DynamicTimeIndexedShootingProblem Name="MyProblem">

--- a/exotica_examples/resources/configs/dynamic_time_indexed/16_kpiece_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/16_kpiece_cartpole.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" ?>
 <DynamicTimeIndexedProblemConfig>
+    <!-- This one does not converge within the 60s iteration time. -->
     <ControlKPIECESolver Name="ControlKPIECESolver">
         <Debug>1</Debug>
         <StateLimits>2 3.14 5 5</StateLimits>
-        <MaxIterationTime>10</MaxIterationTime>
+        <MaxIterationTime>60</MaxIterationTime>
         <ConvergenceTolerance>1e-3</ConvergenceTolerance>
         <ApproximateSolution>1</ApproximateSolution>
         <Seed>1</Seed>

--- a/exotica_examples/resources/configs/dynamic_time_indexed/17_quadrotor_collision_avoidance.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/17_quadrotor_collision_avoidance.xml
@@ -3,10 +3,7 @@
     <AnalyticDDPSolver Name="analytic_ddp">
         <Debug>1</Debug>
         <MaxIterations>1000</MaxIterations>
-        <FunctionTolerance>1e-5</FunctionTolerance>
-        <FunctionTolerancePatience>1000</FunctionTolerancePatience>
-        <UseSecondOrderDynamics>0</UseSecondOrderDynamics>
-        <ClampControlsInForwardPass>0</ClampControlsInForwardPass>
+        <FunctionTolerancePatience>100</FunctionTolerancePatience>
         <RegularizationRate>1e-12</RegularizationRate>
     </AnalyticDDPSolver>
 

--- a/exotica_examples/resources/configs/dynamic_time_indexed/18_ilqr_pendulum.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/18_ilqr_pendulum.xml
@@ -2,9 +2,6 @@
 <DynamicTimeIndexedProblemConfig>
     <ILQRSolver Name="ilqr">
         <Debug>1</Debug>
-        <MaxIterations>100</MaxIterations>
-        <FunctionTolerance>-1</FunctionTolerance>
-        <FunctionTolerancePatience>100</FunctionTolerancePatience>
         <RegularizationRate>0.0001</RegularizationRate>
     </ILQRSolver>
 

--- a/exotica_examples/scripts/example_dynamic_time_indexed
+++ b/exotica_examples/scripts/example_dynamic_time_indexed
@@ -59,6 +59,7 @@ plt.plot(range(len(costs[1])), costs[1])
 plt.xlabel('Iteration')
 plt.ylabel('Cost')
 plt.yscale('log')
+plt.xlim(0, len(costs[1])-1)
 plt.grid()
 plt.show()
 


### PR DESCRIPTION
- Makes iLQR faster by using a backtracking line-search and stopping early (like DDP solvers)
- Updates some of the examples to work again, and faster

Notes:
- The iLQG examples do not work
- The Valkyrie examples do not make sense
- The other dynamic examples do not work as of now