### PR TITLE
[exotica_time_indexed_rrt_connect_solver] Fix runtime std::bad_cast exception

### DIFF
--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
@@ -106,10 +106,6 @@ typedef boost::function<ompl::base::PlannerPtr(const ompl::base::SpaceInformatio
 class TimeIndexedRRTConnectSolver : public MotionSolver, Instantiable<TimeIndexedRRTConnectSolverInitializer>
 {
 public:
-    TimeIndexedRRTConnectSolver();
-
-    virtual ~TimeIndexedRRTConnectSolver();
-
     void Instantiate(const TimeIndexedRRTConnectSolverInitializer &init) override;
     void Solve(Eigen::MatrixXd &solution) override;
     void SpecifyProblem(PlanningProblemPtr pointer) override;

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
@@ -102,12 +102,9 @@ bool OMPLTimeIndexedStateValidityChecker::isValid(const ompl::base::State *state
 }
 
 // The solver
-TimeIndexedRRTConnectSolver::TimeIndexedRRTConnectSolver() = default;
-TimeIndexedRRTConnectSolver::~TimeIndexedRRTConnectSolver() = default;
-
 void TimeIndexedRRTConnectSolver::Instantiate(const TimeIndexedRRTConnectSolverInitializer &init)
 {
-    this->parameters_ = dynamic_cast<const Initializer &>(init);
+    this->parameters_ = init;
     algorithm_ = "Exotica_TimeIndexedRRTConnect";
     planner_allocator_ = boost::bind(&allocatePlanner<OMPLTimeIndexedRRTConnect>, _1, _2);
 


### PR DESCRIPTION
Both examples using the `TimeIndexedRRTConnectSolver` currently fail due to a bad dynamic_cast. This fixed them.