### PR TITLE
Refactor CollisionScene, add faster distance checks, speedup SmoothCollisionDistance

### DIFF
--- a/exotations/exotica_collision_scene_fcl/include/exotica_collision_scene_fcl/collision_scene_fcl.h
+++ b/exotations/exotica_collision_scene_fcl/include/exotica_collision_scene_fcl/collision_scene_fcl.h
@@ -74,10 +74,6 @@ public:
     /// @return     The collision world links.
     std::vector<std::string> GetCollisionWorldLinks() override;
 
-    /// @brief      Gets the KinematicElements associated with the collision world links.
-    /// @return     The KinematicElements associated with the collision world links.
-    std::vector<std::shared_ptr<KinematicElement>> GetCollisionWorldLinkElements() override;
-
     /// @brief      Gets the collision robot links.
     /// @return     The collision robot links.
     std::vector<std::string> GetCollisionRobotLinks() override;

--- a/exotations/exotica_collision_scene_fcl/include/exotica_collision_scene_fcl/collision_scene_fcl.h
+++ b/exotations/exotica_collision_scene_fcl/include/exotica_collision_scene_fcl/collision_scene_fcl.h
@@ -59,9 +59,6 @@ public:
         double safe_distance;
     };
 
-    CollisionSceneFCL();
-    virtual ~CollisionSceneFCL();
-
     void Setup() override;
 
     static bool IsAllowedToCollide(fcl::CollisionObject* o1, fcl::CollisionObject* o2, bool self, CollisionSceneFCL* scene);

--- a/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
+++ b/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
@@ -44,9 +44,6 @@ fcl::Transform3f KDL2fcl(const KDL::Frame& frame)
 
 namespace exotica
 {
-CollisionSceneFCL::CollisionSceneFCL() = default;
-CollisionSceneFCL::~CollisionSceneFCL() = default;
-
 void CollisionSceneFCL::Setup()
 {
     if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCL", "FCL version: " << FCL_VERSION);

--- a/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
+++ b/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
@@ -320,20 +320,6 @@ std::vector<std::string> CollisionSceneFCL::GetCollisionWorldLinks()
     return tmp;
 }
 
-std::vector<std::shared_ptr<KinematicElement>> CollisionSceneFCL::GetCollisionWorldLinkElements()
-{
-    std::vector<std::shared_ptr<KinematicElement>> tmp;
-    for (fcl::CollisionObject* object : fcl_objects_)
-    {
-        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())].lock();
-        if (!element->closest_robot_link.lock())
-        {
-            tmp.push_back(element);
-        }
-    }
-    return tmp;
-}
-
 std::vector<std::string> CollisionSceneFCL::GetCollisionRobotLinks()
 {
     std::vector<std::string> tmp;

--- a/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
+++ b/exotations/exotica_collision_scene_fcl/src/collision_scene_fcl.cpp
@@ -51,7 +51,7 @@ void CollisionSceneFCL::Setup()
 
 void CollisionSceneFCL::UpdateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)
 {
-    kinematic_elements_ = MapToVec(objects);
+    kinematic_elements_ = GetValuesFromMap(objects);
     fcl_cache_.clear();
     fcl_objects_.resize(objects.size());
     long i = 0;

--- a/exotations/exotica_collision_scene_fcl_latest/include/exotica_collision_scene_fcl_latest/collision_scene_fcl_latest.h
+++ b/exotations/exotica_collision_scene_fcl_latest/include/exotica_collision_scene_fcl_latest/collision_scene_fcl_latest.h
@@ -90,6 +90,9 @@ public:
     std::vector<CollisionProxy> GetCollisionDistance(const std::vector<std::string>& objects, const bool& self = true) override;
     std::vector<CollisionProxy> GetCollisionDistance(const std::string& o1, const bool& self = true, const bool& disable_collision_scene_update = false) override;
 
+    std::vector<CollisionProxy> GetRobotToRobotCollisionDistance(double check_margin) override;
+    std::vector<CollisionProxy> GetRobotToWorldCollisionDistance(double check_margin) override;
+
     /// @brief      Performs a continuous collision check between two objects with a linear interpolation between two given
     /// @param[in]  o1       The first collision object, by name.
     /// @param[in]  tf1_beg  The beginning transform for o1.

--- a/exotations/exotica_collision_scene_fcl_latest/include/exotica_collision_scene_fcl_latest/collision_scene_fcl_latest.h
+++ b/exotations/exotica_collision_scene_fcl_latest/include/exotica_collision_scene_fcl_latest/collision_scene_fcl_latest.h
@@ -107,10 +107,6 @@ public:
     /// @return     The collision world links.
     std::vector<std::string> GetCollisionWorldLinks() override;
 
-    /// @brief      Gets the KinematicElements associated with the collision world links.
-    /// @return     The KinematicElements associated with the collision world links.
-    std::vector<std::shared_ptr<KinematicElement>> GetCollisionWorldLinkElements() override;
-
     /// @brief      Gets the collision robot links.
     /// @return     The collision robot links.
     std::vector<std::string> GetCollisionRobotLinks() override;

--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, University of Edinburgh
+// Copyright (c) 2018-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,21 +49,37 @@ inline fcl::Transform3d KDL2fcl(const KDL::Frame& frame)
 
 namespace exotica
 {
-CollisionSceneFCLLatest::CollisionSceneFCLLatest() = default;
-CollisionSceneFCLLatest::~CollisionSceneFCLLatest() = default;
+inline bool IsRobotLink(std::shared_ptr<KinematicElement> e)
+{
+    return e->is_robot_link || e->closest_robot_link.lock();
+}
 
 void CollisionSceneFCLLatest::Setup()
 {
     if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest", "FCL version: " << FCL_VERSION);
+
+    broad_phase_collision_manager_.reset(new fcl::DynamicAABBTreeCollisionManagerd());
 }
 
 void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string, std::weak_ptr<KinematicElement>>& objects)
 {
+    kinematic_elements_map_ = objects;
+
     kinematic_elements_.clear();
+    kinematic_elements_.reserve(objects.size());
+
     fcl_cache_.clear();
+    fcl_cache_.reserve(objects.size());
+
     fcl_objects_.clear();
     fcl_objects_.reserve(objects.size());
+
+    fcl_objects_map_.clear();
+    fcl_robot_objects_map_.clear();
+    fcl_world_objects_map_.clear();
+
     long i = 0;
+
     for (const auto& object : objects)
     {
         // Check whether object is excluded as a world collision object:
@@ -74,32 +90,41 @@ void CollisionSceneFCLLatest::UpdateCollisionObjects(const std::map<std::string,
         else
         {
             if (debug_) HIGHLIGHT_NAMED("CollisionSceneFCLLatest::UpdateCollisionObject", "Creating " << object.first);
-            std::shared_ptr<fcl::CollisionObjectd> new_object;
 
-            // const auto& cache_entry = fcl_cache_.find(object.first);
-            // TODO: There is currently a bug with the caching causing proxies not
-            // to update. The correct fix would be to update the user data, for now
-            // disable use of the cache.
-            // if (true)  // (cache_entry == fcl_cache_.end())
-            // {
-            new_object = ConstructFclCollisionObject(i, object.second.lock());
-            fcl_cache_[object.first] = new_object;
-            // }
-            // else
-            // {
-            //     new_object = cache_entry->second;
-            // }
+            std::shared_ptr<fcl::CollisionObjectd> new_object = ConstructFclCollisionObject(i, object.second.lock());
+
+            fcl_cache_.emplace_back(new_object);
             fcl_objects_.emplace_back(new_object.get());
             kinematic_elements_.emplace_back(object.second);
+
+            fcl_objects_map_[object.first].emplace_back(new_object.get());
+            // Check whether this is a robot or environment link:
+            if (IsRobotLink(object.second.lock()))
+            {
+                fcl_robot_objects_map_[object.first].emplace_back(new_object.get());
+            }
+            else
+            {
+                fcl_world_objects_map_[object.first].emplace_back(new_object.get());
+            }
+
             ++i;
         }
     }
+
+    // Register objects with the BroadPhaseCollisionManager
+    broad_phase_collision_manager_->clear();
+    broad_phase_collision_manager_->registerObjects(fcl_objects_);
 }
 
 void CollisionSceneFCLLatest::UpdateCollisionObjectTransforms()
 {
     for (fcl::CollisionObjectd* collision_object : fcl_objects_)
     {
+        if (!collision_object)
+        {
+            ThrowPretty("Collision object pointer is dead.");
+        }
         std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(collision_object->getUserData())].lock();
         if (!element)
         {
@@ -118,7 +143,7 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::ConstructFclColl
     shapes::ShapePtr shape(element->shape->clone());
 
     // Apply scaling and padding
-    if (element->is_robot_link || element->closest_robot_link.lock())
+    if (IsRobotLink(element))
     {
         if (robot_link_scale_ != 1.0 || robot_link_padding_ > 0.0)
         {
@@ -225,20 +250,11 @@ std::shared_ptr<fcl::CollisionObjectd> CollisionSceneFCLLatest::ConstructFclColl
 
 bool CollisionSceneFCLLatest::IsAllowedToCollide(const std::string& o1, const std::string& o2, const bool& self)
 {
-    std::shared_ptr<KinematicElement> e1, e2;
+    std::shared_ptr<KinematicElement> e1 = GetKinematicElementFromMapByName(o1);
+    std::shared_ptr<KinematicElement> e2 = GetKinematicElementFromMapByName(o2);
 
-    for (auto kinematic_element : kinematic_elements_)
-    {
-        std::shared_ptr<KinematicElement> tmp = kinematic_element.lock();
-        if (tmp->segment.getName() == o1) e1 = tmp;
-        if (tmp->segment.getName() == o2) e2 = tmp;
-    }
-
-    if (!e1) ThrowPretty("o1 is not a valid collision link:" << o1);
-    if (!e2) ThrowPretty("o2 is not a valid collision link:" << o2);
-
-    bool isRobot1 = e1->is_robot_link || e1->closest_robot_link.lock();
-    bool isRobot2 = e2->is_robot_link || e2->closest_robot_link.lock();
+    bool isRobot1 = IsRobotLink(e1);
+    bool isRobot2 = IsRobotLink(e2);
     // Don't check collisions between world objects
     if (!isRobot1 && !isRobot2) return false;
     // Skip self collisions if requested
@@ -262,8 +278,8 @@ bool CollisionSceneFCLLatest::IsAllowedToCollide(fcl::CollisionObjectd* o1, fcl:
     std::shared_ptr<KinematicElement> e1 = scene->kinematic_elements_[reinterpret_cast<long>(o1->getUserData())].lock();
     std::shared_ptr<KinematicElement> e2 = scene->kinematic_elements_[reinterpret_cast<long>(o2->getUserData())].lock();
 
-    bool isRobot1 = e1->is_robot_link || e1->closest_robot_link.lock();
-    bool isRobot2 = e2->is_robot_link || e2->closest_robot_link.lock();
+    bool isRobot1 = IsRobotLink(e1);
+    bool isRobot2 = IsRobotLink(e2);
     // Don't check collisions between world objects
     if (!isRobot1 && !isRobot2) return false;
     // Skip self collisions if requested
@@ -506,12 +522,10 @@ bool CollisionSceneFCLLatest::IsStateValid(bool self, double safe_distance)
 {
     if (!always_externally_updated_collision_scene_) UpdateCollisionObjectTransforms();
 
-    std::shared_ptr<fcl::BroadPhaseCollisionManagerd> manager(new fcl::DynamicAABBTreeCollisionManagerd());
-    manager->registerObjects(fcl_objects_);
     CollisionData data(this);
     data.self = self;
     data.safe_distance = safe_distance;
-    manager->collide(&data, &CollisionSceneFCLLatest::CollisionCallback);
+    broad_phase_collision_manager_->collide(&data, &CollisionSceneFCLLatest::CollisionCallback);
     return !data.result.isCollision();
 }
 
@@ -519,11 +533,14 @@ bool CollisionSceneFCLLatest::IsCollisionFree(const std::string& o1, const std::
 {
     if (!always_externally_updated_collision_scene_) UpdateCollisionObjectTransforms();
 
+    // TODO: Redo this logic using prior built maps
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())].lock();
+
+        // TODO: These following two lines fuzzy the definition of what o1 and o2 are: They can be either the name of the link (e.g., base_link) or the name of the collision object (e.g., base_link_collision_0). We should standardise the API on either!
         if (e->segment.getName() == o1 || e->parent.lock()->segment.getName() == o1) shapes1.push_back(o);
         if (e->segment.getName() == o2 || e->parent.lock()->segment.getName() == o2) shapes2.push_back(o);
     }
@@ -546,11 +563,9 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::GetCollisionDistance(bool s
 {
     if (!always_externally_updated_collision_scene_) UpdateCollisionObjectTransforms();
 
-    std::shared_ptr<fcl::BroadPhaseCollisionManagerd> manager(new fcl::DynamicAABBTreeCollisionManagerd());
-    manager->registerObjects(fcl_objects_);
     DistanceData data(this);
     data.self = self;
-    manager->distance(&data, &CollisionSceneFCLLatest::CollisionCallbackDistance);
+    broad_phase_collision_manager_->distance(&data, &CollisionSceneFCLLatest::CollisionCallbackDistance);
     return data.proxies;
 }
 
@@ -558,11 +573,14 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::GetCollisionDistance(const 
 {
     if (!always_externally_updated_collision_scene_) UpdateCollisionObjectTransforms();
 
+    // TODO: Redo logic with prior built maps.
     std::vector<fcl::CollisionObjectd*> shapes1;
     std::vector<fcl::CollisionObjectd*> shapes2;
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())].lock();
+
+        // TODO: These following two lines fuzzy the definition of what o1 and o2 are: They can be either the name of the link (e.g., base_link) or the name of the collision object (e.g., base_link_collision_0). We should standardise the API on either!
         if (e->segment.getName() == o1 || e->parent.lock()->segment.getName() == o1) shapes1.push_back(o);
         if (e->segment.getName() == o2 || e->parent.lock()->segment.getName() == o2) shapes2.push_back(o);
     }
@@ -599,6 +617,7 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::GetCollisionDistance(
     for (fcl::CollisionObjectd* o : fcl_objects_)
     {
         std::shared_ptr<KinematicElement> e = kinematic_elements_[reinterpret_cast<long>(o->getUserData())].lock();
+        // TODO: These following two lines fuzzy the definition of what o1 and o2 are: They can be either the name of the link (e.g., base_link) or the name of the collision object (e.g., base_link_collision_0). We should standardise the API on either!
         if (e->segment.getName() == o1 || e->parent.lock()->segment.getName() == o1)
             shapes1.push_back(o);
     }
@@ -644,60 +663,34 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::GetCollisionDistance(const 
     return proxies;
 }
 
-Eigen::Vector3d CollisionSceneFCLLatest::GetTranslation(const std::string& name)
 {
-    for (fcl::CollisionObjectd* object : fcl_objects_)
     {
-        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())].lock();
-        if (element->segment.getName() == name)
         {
-            return Eigen::Map<Eigen::Vector3d>(element->frame.p.data);
         }
     }
-    ThrowPretty("Robot not found!");
-    ;
+}
+
+{
+    {
+        {
+        }
+    }
+}
+
+Eigen::Vector3d CollisionSceneFCLLatest::GetTranslation(const std::string& name)
+{
+    auto element = GetKinematicElementFromMapByName(name);
+    return Eigen::Map<Eigen::Vector3d>(element->frame.p.data);
 }
 
 std::vector<std::string> CollisionSceneFCLLatest::GetCollisionWorldLinks()
 {
-    std::vector<std::string> tmp;
-    for (fcl::CollisionObjectd* object : fcl_objects_)
-    {
-        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())].lock();
-        if (!element->closest_robot_link.lock())
-        {
-            tmp.push_back(element->segment.getName());
-        }
-    }
-    return tmp;
-}
-
-std::vector<std::shared_ptr<KinematicElement>> CollisionSceneFCLLatest::GetCollisionWorldLinkElements()
-{
-    std::vector<std::shared_ptr<KinematicElement>> tmp;
-    for (fcl::CollisionObjectd* object : fcl_objects_)
-    {
-        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())].lock();
-        if (!element->closest_robot_link.lock())
-        {
-            tmp.push_back(element);
-        }
-    }
-    return tmp;
+    return GetKeysFromMap(fcl_world_objects_map_);
 }
 
 std::vector<std::string> CollisionSceneFCLLatest::GetCollisionRobotLinks()
 {
-    std::vector<std::string> tmp;
-    for (fcl::CollisionObjectd* object : fcl_objects_)
-    {
-        std::shared_ptr<KinematicElement> element = kinematic_elements_[reinterpret_cast<long>(object->getUserData())].lock();
-        if (element->closest_robot_link.lock())
-        {
-            tmp.push_back(element->segment.getName());
-        }
-    }
-    return tmp;
+    return GetKeysFromMap(fcl_robot_objects_map_);
 }
 
 ContinuousCollisionProxy CollisionSceneFCLLatest::ContinuousCollisionCheck(

--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -663,18 +663,64 @@ std::vector<CollisionProxy> CollisionSceneFCLLatest::GetCollisionDistance(const 
     return proxies;
 }
 
+std::vector<CollisionProxy> CollisionSceneFCLLatest::GetRobotToRobotCollisionDistance(double check_margin)
 {
+    DistanceData data(this);
+    data.self = true;
+
+    // For each robot collision object to each robot collision object
+    for (auto it1 : fcl_robot_objects_map_)
     {
+        for (auto it2 : fcl_robot_objects_map_)
         {
+            if (IsAllowedToCollide(it1.first, it2.first, true))
+            {
+                // Both it1.second and it2.second are vectors of collision objects, so we need to iterate through each:
+                for (auto o1 : it1.second)
+                {
+                    for (auto o2 : it2.second)
+                    {
+                        // Check whether the AABB is less than the check_margin, if so, perform a collision distance call
+                        if (o1->getAABB().distance(o2->getAABB()) < check_margin)
+                        {
+                            ComputeDistance(o1, o2, &data);
+                        }
+                    }
+                }
+            }
         }
     }
+    return data.proxies;
 }
 
+std::vector<CollisionProxy> CollisionSceneFCLLatest::GetRobotToWorldCollisionDistance(double check_margin)
 {
+    DistanceData data(this);
+    data.self = false;
+
+    // For each robot collision object to each robot collision object
+    for (auto it1 : fcl_robot_objects_map_)
     {
+        for (auto it2 : fcl_world_objects_map_)
         {
+            if (IsAllowedToCollide(it1.first, it2.first, false))
+            {
+                // Both it1.second and it2.second are vectors of collision objects, so we need to iterate through each:
+                for (auto o1 : it1.second)
+                {
+                    for (auto o2 : it2.second)
+                    {
+                        // Check whether the AABB is less than the check_margin, if so, perform a collision distance call
+                        if (o1->getAABB().distance(o2->getAABB()) < check_margin)
+                        {
+                            ComputeDistance(o1, o2, &data);
+                        }
+                    }
+                }
+            }
         }
     }
+    return data.proxies;
 }
 
 Eigen::Vector3d CollisionSceneFCLLatest::GetTranslation(const std::string& name)

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/smooth_collision_distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/smooth_collision_distance.h
@@ -52,8 +52,6 @@ public:
 private:
     void Initialize();
 
-    std::vector<std::string> robot_joints_;
-    std::map<std::string, std::vector<std::string>> controlled_joint_to_collision_link_map_;
     double robot_margin_ = 0.0;
     double world_margin_ = 0.0;
     bool linear_ = false;

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, University of Edinburgh
+// Copyright (c) 2018-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -143,9 +143,9 @@ public:
     virtual ~CollisionScene() {}
     /// @brief Setup additional construction that requires initialiser parameter
     virtual void Setup() {}
-    /// @brief Returns whether two links are allowed to collide.
-    /// @param o1
-    /// @param o2
+    /// @brief Returns whether two collision objects/shapes are allowed to collide by name.
+    /// @param o1 Name of the frame of the collision object (e.g., base_link_collision_0)
+    /// @param o2 Name of the frame of the other collision object (e.g., base_link_collision_0)
     /// @return true The two objects are allowed to collide.
     /// @return false The two objects are excluded, e.g., by an ACM.
     virtual bool IsAllowedToCollide(const std::string& o1, const std::string& o2, const bool& self) { ThrowPretty("Not implemented!"); }
@@ -183,6 +183,12 @@ public:
     /// @param[in]  objects    Vector of object names.
     /// @return     Vector of proximity objects.
     virtual std::vector<CollisionProxy> GetCollisionDistance(const std::vector<std::string>& objects, const bool& self) { ThrowPretty("Not implemented!"); }
+    /// @brief      Gets the closest distances between links within the robot that are closer than check_margin
+    /// @param[in]  check_margin    Margin for distance checks - only objects closer than this margin will be checked
+    virtual std::vector<CollisionProxy> GetRobotToRobotCollisionDistance(double check_margin) { ThrowPretty("Not implemented!"); }
+    /// @brief      Gets the closest distances between links of the robot and the environment that are closer than check_margin
+    /// @param[in]  check_margin    Margin for distance checks - only objects closer than this margin will be checked
+    virtual std::vector<CollisionProxy> GetRobotToWorldCollisionDistance(double check_margin) { ThrowPretty("Not implemented!"); }
     /// @brief      Gets the collision world links.
     /// @return     The collision world links.
     virtual std::vector<std::string> GetCollisionWorldLinks() = 0;

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -45,6 +45,8 @@
 #define REGISTER_COLLISION_SCENE_TYPE(TYPE, DERIV) EXOTICA_CORE_REGISTER(exotica::CollisionScene, TYPE, DERIV)
 namespace exotica
 {
+class Scene;
+
 class AllowedCollisionMatrix
 {
 public:
@@ -269,7 +271,16 @@ public:
     /// \brief Links to exclude from collision scene - gets set from Scene::UpdateSceneFrames
     std::set<std::string> world_links_to_exclude_from_collision_scene;
 
+    /// \brief Sets a scene pointer to the CollisionScene for access to methods
+    void AssignScene(std::shared_ptr<Scene> scene)
+    {
+        scene_ = scene;
+    }
+
 protected:
+    /// Stores a pointer to the Scene which owns this CollisionScene
+    std::weak_ptr<Scene> scene_;
+
     /// The allowed collision matrix
     AllowedCollisionMatrix acm_;
 

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -208,51 +208,51 @@ public:
     /// @param[in]  name    Name of the collision object to query.
     virtual Eigen::Vector3d GetTranslation(const std::string& name) = 0;
 
-    inline void SetACM(const AllowedCollisionMatrix& acm)
+    void SetACM(const AllowedCollisionMatrix& acm)
     {
         acm_ = acm;
     }
 
-    inline bool GetAlwaysExternallyUpdatedCollisionScene() { return always_externally_updated_collision_scene_; }
-    inline void SetAlwaysExternallyUpdatedCollisionScene(const bool& value)
+    bool GetAlwaysExternallyUpdatedCollisionScene() const { return always_externally_updated_collision_scene_; }
+    void SetAlwaysExternallyUpdatedCollisionScene(const bool value)
     {
         always_externally_updated_collision_scene_ = value;
     }
 
-    inline double GetRobotLinkScale() { return robot_link_scale_; }
-    inline void SetRobotLinkScale(const double& scale)
+    double GetRobotLinkScale() const { return robot_link_scale_; }
+    void SetRobotLinkScale(const double scale)
     {
         if (scale < 0.0)
             ThrowPretty("Link scaling needs to be greater than or equal to 0");
         robot_link_scale_ = scale;
     }
 
-    inline double GetWorldLinkScale() { return world_link_scale_; }
-    inline void SetWorldLinkScale(const double& scale)
+    double GetWorldLinkScale() const { return world_link_scale_; }
+    void SetWorldLinkScale(const double scale)
     {
         if (scale < 0.0)
             ThrowPretty("Link scaling needs to be greater than or equal to 0");
         world_link_scale_ = scale;
     }
 
-    inline double GetRobotLinkPadding() { return robot_link_padding_; }
-    inline void SetRobotLinkPadding(const double& padding)
+    double GetRobotLinkPadding() const { return robot_link_padding_; }
+    void SetRobotLinkPadding(const double padding)
     {
         if (padding < 0.0)
             HIGHLIGHT_NAMED("SetRobotLinkPadding", "Generally, padding should be positive.");
         robot_link_padding_ = padding;
     }
 
-    inline double GetWorldLinkPadding() { return world_link_padding_; }
-    inline void SetWorldLinkPadding(const double& padding)
+    double GetWorldLinkPadding() const { return world_link_padding_; }
+    void SetWorldLinkPadding(const double padding)
     {
         if (padding < 0.0)
             HIGHLIGHT_NAMED("SetRobotLinkPadding", "Generally, padding should be positive.");
         world_link_padding_ = padding;
     }
 
-    inline bool GetReplacePrimitiveShapesWithMeshes() { return replace_primitive_shapes_with_meshes_; }
-    inline void SetReplacePrimitiveShapesWithMeshes(const bool& value)
+    bool GetReplacePrimitiveShapesWithMeshes() const { return replace_primitive_shapes_with_meshes_; }
+    void SetReplacePrimitiveShapesWithMeshes(const bool value)
     {
         replace_primitive_shapes_with_meshes_ = value;
     }

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -185,10 +185,6 @@ public:
     /// @return     The collision world links.
     virtual std::vector<std::string> GetCollisionWorldLinks() = 0;
 
-    /// @brief      Gets the KineticElements associated with the collision world links.
-    /// @return     The KineticElements associated with the collision world links.
-    virtual std::vector<std::shared_ptr<KinematicElement>> GetCollisionWorldLinkElements() = 0;
-
     /// @brief      Gets the collision robot links.
     /// @return     The collision robot links.
     virtual std::vector<std::string> GetCollisionRobotLinks() = 0;

--- a/exotica_core/include/exotica_core/tools/conversions.h
+++ b/exotica_core/include/exotica_core/tools/conversions.h
@@ -137,12 +137,34 @@ inline bool IsVectorContainerType(std::string type)
 }
 
 template <class Key, class Val>
-std::vector<Val> MapToVec(const std::map<Key, Val>& map)
+[[deprecated("Replaced by GetKeysFromMap and GetValuesFromMap")]] std::vector<Val> MapToVec(const std::map<Key, Val>& map)
 {
     std::vector<Val> ret;
-    for (auto& val : map)
+    for (auto& it : map)
     {
-        ret.push_back(val.second);
+        ret.push_back(it.second);
+    }
+    return ret;
+}
+
+template <class Key, class Val>
+std::vector<Key> GetKeysFromMap(const std::map<Key, Val>& map)
+{
+    std::vector<Key> ret;
+    for (auto& it : map)
+    {
+        ret.push_back(it.first);
+    }
+    return ret;
+}
+
+template <class Key, class Val>
+std::vector<Val> GetValuesFromMap(const std::map<Key, Val>& map)
+{
+    std::vector<Val> ret;
+    for (auto& it : map)
+    {
+        ret.push_back(it.second);
     }
     return ret;
 }

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -138,6 +138,7 @@ void Scene::Instantiate(const SceneInitializer& init)
     collision_scene_ = Setup::CreateCollisionScene(init.CollisionScene);
     collision_scene_->debug_ = this->debug_;
     collision_scene_->Setup();
+    collision_scene_->AssignScene(shared_from_this());
     collision_scene_->SetAlwaysExternallyUpdatedCollisionScene(force_collision_);
     collision_scene_->SetReplacePrimitiveShapesWithMeshes(init.ReplacePrimitiveShapesWithMeshes);
     collision_scene_->SetWorldLinkPadding(init.WorldLinkPadding);

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, University of Edinburgh
+// Copyright (c) 2018-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -1113,6 +1113,8 @@ PYBIND11_MODULE(_pyexotica, module)
     collision_scene.def_property("world_link_padding", &CollisionScene::GetWorldLinkPadding, &CollisionScene::SetWorldLinkPadding);
     collision_scene.def("update_collision_object_transforms", &CollisionScene::UpdateCollisionObjectTransforms);
     collision_scene.def("continuous_collision_check", &CollisionScene::ContinuousCollisionCheck);
+    collision_scene.def("get_robot_to_robot_collision_distance", &CollisionScene::GetRobotToRobotCollisionDistance);
+    collision_scene.def("get_robot_to_world_collision_distance", &CollisionScene::GetRobotToWorldCollisionDistance);
 
     py::class_<VisualizationMoveIt> visualization_moveit(module, "VisualizationMoveIt");
     visualization_moveit.def(py::init<ScenePtr>());


### PR DESCRIPTION
Several orders of magnitude for the distance check itself, less for optimisation problems (e.g. 3x on a recent example while converging to the same local minima)