### PR TITLE
Kinematic element visual name duplicate fix

### DIFF
--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -619,7 +619,7 @@ void Scene::UpdateSceneFrames()
                 if (it != visual_map.end())
                 {
                     it->second++;
-                    name = name + std::to_string(it->second);
+                    name = name + "_" + std::to_string(it->second);
                 }
                 else
                 {

--- a/exotica_core/src/scene.cpp
+++ b/exotica_core/src/scene.cpp
@@ -595,6 +595,7 @@ void Scene::UpdateSceneFrames()
     kinematica_.ResetModel();
 
     // Add world objects
+    std::map<std::string, int> visual_map;
     for (const auto& object : *ps_->getWorld())
     {
         if (object.second->shapes_.size())
@@ -612,7 +613,19 @@ void Scene::UpdateSceneFrames()
                 shape_transform.linear() = object.second->shape_poses_[i].rotation();
                 Eigen::Isometry3d trans = obj_transform.inverse() * shape_transform;
                 VisualElement visual;
-                visual.name = object.first;
+                std::string name = object.first;
+                // Check for name duplicates after loading from scene files
+                const auto& it = visual_map.find(name);
+                if (it != visual_map.end())
+                {
+                    it->second++;
+                    name = name + std::to_string(it->second);
+                }
+                else
+                {
+                    visual_map[name] = 0;
+                }
+                visual.name = name;
                 visual.shape = shapes::ShapePtr(object.second->shapes_[i]->clone());
                 tf::transformEigenToKDL(trans, visual.frame);
                 if (ps_->hasObjectColor(object.first))


### PR DESCRIPTION
- Uniquely names visual elements with duplicate names by appending an index: `Shelf` will become `Shelf_0`, `Shelf_1`, ...

This bug was due to the scene loading reusing the object name for all visual elements.
Meshacat visualiser would not display the scene objects correctly because it uses the unique name as an index. Duplicates would cause it to overwrite the object with the same name.