### PR TITLE
Add FeasibilityDrivenDDPSolver (FDDP)

### DIFF
--- a/exotations/solvers/exotica_ddp_solver/CMakeLists.txt
+++ b/exotations/solvers/exotica_ddp_solver/CMakeLists.txt
@@ -10,6 +10,7 @@ AddInitializer(
   abstract_ddp_solver
   analytic_ddp_solver
   control_limited_ddp_solver
+  feasibility_driven_ddp_solver
 )
 GenInitializers()
 
@@ -30,7 +31,8 @@ add_compile_options(-Wno-ignored-attributes)
 set(SOURCES
   src/abstract_ddp_solver.cpp
   src/analytic_ddp_solver.cpp
-  src/control_limited_ddp_solver.cpp  
+  src/control_limited_ddp_solver.cpp
+  src/feasibility_driven_ddp_solver.cpp
 )
 
 add_library(${PROJECT_NAME} ${SOURCES})

--- a/exotations/solvers/exotica_ddp_solver/exotica_plugins.xml
+++ b/exotations/solvers/exotica_ddp_solver/exotica_plugins.xml
@@ -5,4 +5,7 @@
   <class name="exotica/ControlLimitedDDPSolver" type="exotica::ControlLimitedDDPSolver" base_class_type="exotica::MotionSolver">
     <description>Control-limited DDP Solver (Tassa, Mansard, Todorov, 2014)</description>
   </class>
+  <class name="exotica/FeasibilityDrivenDDPSolver" type="exotica::FeasibilityDrivenDDPSolver" base_class_type="exotica::MotionSolver">
+    <description>Feasibility-driven DDP Solver (Mastalli et al., 2020)</description>
+  </class>
 </library>

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/abstract_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/abstract_ddp_solver.h
@@ -88,6 +88,8 @@ protected:
     int T_;
     int NU_;
     int NX_;
+    int NDX_;
+    int NV_;
     double dt_;
     double cost_;        ///!< Cost during iteration
     double cost_prev_;   ///!< Cost during previous iteration

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -54,7 +54,7 @@ protected:
     void DecreaseRegularization();
     const Eigen::Vector2d& ExpectedImprovement();
     void UpdateExpectedImprovement();
-    bool RaiseIfNaN(const double value)
+    inline bool IsNaN(const double value)
     {
         if (std::isnan(value) || std::isinf(value) || value >= 1e30)
         {

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2019-2020, LAAS-CNRS, University of Edinburgh, University of Oxford
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef EXOTICA_DDP_SOLVER_FEASIBILITY_DRIVEN_DDP_SOLVER_H_
+#define EXOTICA_DDP_SOLVER_FEASIBILITY_DRIVEN_DDP_SOLVER_H_
+
+#include <exotica_ddp_solver/abstract_ddp_solver.h>
+#include <exotica_ddp_solver/feasibility_driven_ddp_solver_initializer.h>
+
+namespace exotica
+{
+// Feasibility-driven DDP solver
+// Based on the implementation in Crocoddyl: https://github.com/loco-3d/crocoddyl.git
+// Cf. https://arxiv.org/abs/1909.04947
+class FeasibilityDrivenDDPSolver : public AbstractDDPSolver, public Instantiable<FeasibilityDrivenDDPSolverInitializer>
+{
+public:
+    void Instantiate(const FeasibilityDrivenDDPSolverInitializer& init) override;
+    void Solve(Eigen::MatrixXd& solution) override;
+
+    const std::vector<Eigen::VectorXd>& get_fs() const { return fs_; };
+    const std::vector<Eigen::VectorXd>& get_xs() const { return xs_; };
+    const std::vector<Eigen::VectorXd>& get_us() const { return us_; };
+protected:
+    int NDX_;
+
+    void IncreaseRegularization();
+    void DecreaseRegularization();
+    const Eigen::Vector2d& ExpectedImprovement();
+    void UpdateExpectedImprovement();
+    bool RaiseIfNaN(const double value)
+    {
+        if (std::isnan(value) || std::isinf(value) || value >= 1e30)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    void SetCandidate(const std::vector<Eigen::VectorXd>& xs_warm, const std::vector<Eigen::VectorXd>& us_warm, const bool is_feasible);
+    double CheckStoppingCriteria();
+
+    double CalcDiff();
+    void ComputeDirection(const bool recalcDiff);
+    void BackwardPass() override;
+    void ComputeGains(const int t);
+    void ForwardPass(const double steplength);
+    double TryStep(const double steplength);
+
+    void AllocateData();
+
+    Eigen::MatrixXd control_limits_;
+
+    double steplength_;           //!< Current applied step-length
+    Eigen::Vector2d d_;           //!< LQ approximation of the expected improvement
+    double dV_;                   //!< Cost reduction obtained by TryStep
+    double dVexp_;                //!< Expected cost reduction
+    double th_acceptstep_ = 0.1;  //!< Threshold used for accepting step
+    double th_stop_ = 1e-9;       //!< Tolerance for stopping the algorithm
+    double stop_;                 //!< Value computed by CheckStoppingCriteria
+
+    double dg_ = 0.;
+    double dq_ = 0.;
+    double dv_ = 0.;
+    double th_acceptnegstep_ = 2.;  //!< Threshold used for accepting step along ascent direction
+    std::vector<Eigen::VectorXd> us_;
+    std::vector<Eigen::VectorXd> xs_;
+    bool is_feasible_ = false;
+    double xreg_ = 1e-9;      //!< State regularization
+    double ureg_ = 1e-9;      //!< Control regularization
+    double regmin_ = 1e-9;    //!< Minimum regularization (will not decrease lower)
+    double regmax_ = 1e9;     //!< Maximum regularization (to exit by divergence)
+    double regfactor_ = 10.;  //!< Factor by which the regularization gets increased/decreased
+
+    double cost_try_;                      //!< Total cost computed by line-search procedure
+    std::vector<Eigen::VectorXd> xs_try_;  //!< State trajectory computed by line-search procedure
+    std::vector<Eigen::VectorXd> us_try_;  //!< Control trajectory computed by line-search procedure
+    std::vector<Eigen::VectorXd> dx_;
+
+    // allocate data
+    std::vector<Eigen::MatrixXd> Vxx_;  //!< Hessian of the Value function
+    std::vector<Eigen::VectorXd> Vx_;   //!< Gradient of the Value function
+    std::vector<Eigen::MatrixXd> Qxx_;  //!< Hessian of the Hamiltonian
+    std::vector<Eigen::MatrixXd> Qxu_;  //!< Hessian of the Hamiltonian
+    std::vector<Eigen::MatrixXd> Quu_;  //!< Hessian of the Hamiltonian
+    std::vector<Eigen::VectorXd> Qx_;   //!< Gradient of the Hamiltonian
+    std::vector<Eigen::VectorXd> Qu_;   //!< Gradient of the Hamiltonian
+    std::vector<Eigen::MatrixXd> K_;    //!< Feedback gains
+    std::vector<Eigen::VectorXd> k_;    //!< Feed-forward terms
+    std::vector<Eigen::VectorXd> fs_;   //!< Gaps/defects between shooting nodes
+
+    Eigen::VectorXd xnext_;
+    Eigen::MatrixXd FxTVxx_p_;
+    std::vector<Eigen::MatrixXd> FuTVxx_p_;
+    Eigen::VectorXd fTVxx_p_;
+    std::vector<Eigen::LLT<Eigen::MatrixXd> > Quu_llt_;
+    std::vector<Eigen::VectorXd> Quuk_;
+    double th_grad_ = 1e-12;     //!< Tolerance of the expected gradient used for testing the step
+    double th_stepdec_ = 0.5;    //!< Step-length threshold used to decrease regularization
+    double th_stepinc_ = 0.01;   //!< Step-length threshold used to increase regularization
+    bool was_feasible_ = false;  //!< Label that indicates in the previous iterate was feasible
+};
+}  // namespace exotica
+
+#endif  // EXOTICA_DDP_SOLVER_FEASIBILITY_DRIVEN_DDP_SOLVER_H_

--- a/exotations/solvers/exotica_ddp_solver/init/feasibility_driven_ddp_solver.in
+++ b/exotations/solvers/exotica_ddp_solver/init/feasibility_driven_ddp_solver.in
@@ -1,0 +1,3 @@
+class FeasibilityDrivenDDPSolver
+
+extend <exotica_ddp_solver/abstract_ddp_solver>

--- a/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/abstract_ddp_solver.cpp
@@ -39,6 +39,8 @@ void AbstractDDPSolver::Solve(Eigen::MatrixXd& solution)
     T_ = prob_->get_T();
     NU_ = prob_->get_num_controls();
     NX_ = prob_->get_num_positions() + prob_->get_num_velocities();
+    NDX_ = 2 * prob_->get_num_velocities();
+    NV_ = prob_->get_num_velocities();
     dt_ = dynamics_solver_->get_dt();
     lambda_ = base_parameters_.RegularizationRate;
     prob_->ResetCostEvolution(GetNumberOfMaxIterations() + 1);

--- a/exotations/solvers/exotica_ddp_solver/src/analytic_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/analytic_ddp_solver.cpp
@@ -57,7 +57,7 @@ void AnalyticDDPSolver::BackwardPass()
         x = prob_->get_X(t);
         u = prob_->get_U(t);
 
-        fx_ = dt_ * dynamics_solver_->fx(x, u) + Eigen::MatrixXd::Identity(NX_, NX_);
+        fx_ = dt_ * dynamics_solver_->fx(x, u) + Eigen::MatrixXd::Identity(NDX_, NDX_);
         fu_ = dt_ * dynamics_solver_->fu(x, u);
 
         //
@@ -78,11 +78,11 @@ void AnalyticDDPSolver::BackwardPass()
         if (parameters_.UseSecondOrderDynamics)
         {
             // clang-format off
-            Vx_tensor = Eigen::TensorMap<Eigen::Tensor<double, 1>>(Vx_.data(), NX_);
+            Vx_tensor = Eigen::TensorMap<Eigen::Tensor<double, 1>>(Vx_.data(), NDX_);
 
             Qxx_ += 
                 Eigen::TensorToMatrix(
-                    (Eigen::Tensor<double, 2>)dynamics_solver_->fxx(x, u).contract(Vx_tensor, dims), NX_, NX_
+                    (Eigen::Tensor<double, 2>)dynamics_solver_->fxx(x, u).contract(Vx_tensor, dims), NDX_, NDX_
                 ) * dt_;
 
             Quu_ += 
@@ -91,7 +91,7 @@ void AnalyticDDPSolver::BackwardPass()
                 ) * dt_;
 
             Qux_ +=
-                Eigen::TensorToMatrix((Eigen::Tensor<double, 2>)dynamics_solver_->fxu(x, u).contract(Vx_tensor, dims), NU_, NX_
+                Eigen::TensorToMatrix((Eigen::Tensor<double, 2>)dynamics_solver_->fxu(x, u).contract(Vx_tensor, dims), NU_, NDX_
                 ) * dt_;
             // clang-format on
         }

--- a/exotations/solvers/exotica_ddp_solver/src/ddp_solver_py.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/ddp_solver_py.cpp
@@ -29,7 +29,10 @@
 
 #include <exotica_ddp_solver/analytic_ddp_solver.h>
 #include <exotica_ddp_solver/control_limited_ddp_solver.h>
+#include <exotica_ddp_solver/feasibility_driven_ddp_solver.h>
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 using namespace exotica;
 namespace py = pybind11;
@@ -43,4 +46,9 @@ PYBIND11_MODULE(exotica_ddp_solver_py, module)
     py::class_<AnalyticDDPSolver, std::shared_ptr<AnalyticDDPSolver>, FeedbackMotionSolver> analytic_ddp_solver(module, "AnalyticDDPSolver");
 
     py::class_<ControlLimitedDDPSolver, std::shared_ptr<ControlLimitedDDPSolver>, FeedbackMotionSolver> control_limited_ddp_solver(module, "ControlLimitedDDPSolver");
+
+    py::class_<FeasibilityDrivenDDPSolver, std::shared_ptr<FeasibilityDrivenDDPSolver>, FeedbackMotionSolver> feasibility_driven_ddp_solver(module, "FeasibilityDrivenDDPSolver");
+    feasibility_driven_ddp_solver.def_property_readonly("fs", &FeasibilityDrivenDDPSolver::get_fs);
+    feasibility_driven_ddp_solver.def_property_readonly("xs", &FeasibilityDrivenDDPSolver::get_xs);
+    feasibility_driven_ddp_solver.def_property_readonly("us", &FeasibilityDrivenDDPSolver::get_us);
 }

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -85,9 +85,9 @@ void FeasibilityDrivenDDPSolver::AllocateData()
         }
         else
         {
-            xs_try_[t] = Eigen::VectorXd::Constant(NX_, NAN);
+            xs_try_[t].setZero(NX_);
         }
-        us_try_[t] = Eigen::VectorXd::Constant(NU_, NAN);
+        us_try_[t].setZero(NU_);
         dx_[t] = Eigen::VectorXd::Zero(NDX_);
 
         FuTVxx_p_[t] = Eigen::MatrixXd::Zero(NU_, NDX_);

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -459,11 +459,11 @@ void FeasibilityDrivenDDPSolver::ForwardPass(const double steplength)
         xnext_ = prob_->get_X(t + 1);
         cost_try_ += dt_ * (prob_->GetStateCost(t) + prob_->GetControlCost(t));
 
-        if (RaiseIfNaN(cost_try_))
+        if (IsNaN(cost_try_))
         {
             throw std::runtime_error("forward_error - NaN in cost_try_ at t=" + std::to_string(t));
         }
-        if (RaiseIfNaN(xnext_.lpNorm<Eigen::Infinity>()))
+        if (IsNaN(xnext_.lpNorm<Eigen::Infinity>()))
         {
             throw std::runtime_error("forward_error - xnext_ isn't finite at t=" + std::to_string(t));
         }
@@ -481,7 +481,7 @@ void FeasibilityDrivenDDPSolver::ForwardPass(const double steplength)
     prob_->UpdateTerminalState(xs_try_.back());
     cost_try_ += prob_->GetStateCost(T_ - 1);
 
-    if (RaiseIfNaN(cost_try_))
+    if (IsNaN(cost_try_))
     {
         throw std::runtime_error("forward_error - cost NaN");
     }
@@ -595,11 +595,11 @@ void FeasibilityDrivenDDPSolver::BackwardPass()
             Vx_[t].noalias() += Vxx_[t] * fs_[t];
         }
 
-        if (RaiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>()))
+        if (IsNaN(Vx_[t].lpNorm<Eigen::Infinity>()))
         {
             ThrowPretty("backward_error (Vx) at t=" << t);
         }
-        if (RaiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>()))
+        if (IsNaN(Vxx_[t].lpNorm<Eigen::Infinity>()))
         {
             ThrowPretty("backward_error (Vxx) at t=" << t);
         }

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -551,7 +551,7 @@ void FeasibilityDrivenDDPSolver::BackwardPass()
         Qx_[t] = dt_ * prob_->GetStateCostJacobian(t);
         Qu_[t] = dt_ * prob_->GetControlCostJacobian(t);
 
-        fx_ = dt_ * dynamics_solver_->fx(xs_[t], us_[t]) + Eigen::MatrixXd::Identity(NX_, NX_);
+        fx_ = dt_ * dynamics_solver_->fx(xs_[t], us_[t]) + Eigen::MatrixXd::Identity(NDX_, NDX_);
         fu_ = dt_ * dynamics_solver_->fu(xs_[t], us_[t]);
 
         FxTVxx_p_.noalias() = fx_.transpose() * Vxx_p;

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -1,0 +1,623 @@
+//
+// Copyright (c) 2019-2020, LAAS-CNRS, University of Edinburgh, University of Oxford
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_ddp_solver/feasibility_driven_ddp_solver.h>
+
+REGISTER_MOTIONSOLVER_TYPE("FeasibilityDrivenDDPSolver", exotica::FeasibilityDrivenDDPSolver)
+
+namespace exotica
+{
+void FeasibilityDrivenDDPSolver::Instantiate(const FeasibilityDrivenDDPSolverInitializer& init)
+{
+    parameters_ = init;
+    base_parameters_ = AbstractDDPSolverInitializer(FeasibilityDrivenDDPSolverInitializer(parameters_));
+}
+
+void FeasibilityDrivenDDPSolver::AllocateData()
+{
+    // TODO: -1 here because of copy-paste and different conventions...
+    // Crocoddyl: T running models + 1 terminal model
+    // Exotica: T models ("T-1 running models")
+    const int T = prob_->get_T() - 1;
+    Vxx_.resize(T + 1);
+    Vx_.resize(T + 1);
+    Qxx_.resize(T);
+    Qxu_.resize(T);
+    Quu_.resize(T);
+    Qx_.resize(T);
+    Qu_.resize(T);
+    K_.resize(T);
+    k_.resize(T);
+    fs_.resize(T + 1);
+
+    xs_.resize(T + 1);
+    us_.resize(T);
+    xs_try_.resize(T + 1);
+    us_try_.resize(T);
+    dx_.resize(T + 1);
+
+    FuTVxx_p_.resize(T);
+    Quu_llt_.resize(T);
+    Quuk_.resize(T);
+
+    for (int t = 0; t < T; ++t)
+    {
+        Vxx_[t] = Eigen::MatrixXd::Zero(NDX_, NDX_);
+        Vx_[t] = Eigen::VectorXd::Zero(NDX_);
+        Qxx_[t] = Eigen::MatrixXd::Zero(NDX_, NDX_);
+        Qxu_[t] = Eigen::MatrixXd::Zero(NDX_, NU_);
+        Quu_[t] = Eigen::MatrixXd::Zero(NU_, NU_);
+        Qx_[t] = Eigen::VectorXd::Zero(NDX_);
+        Qu_[t] = Eigen::VectorXd::Zero(NU_);
+        K_[t] = Eigen::MatrixXd::Zero(NU_, NDX_);
+        k_[t] = Eigen::VectorXd::Zero(NU_);
+        fs_[t] = Eigen::VectorXd::Zero(NDX_);
+
+        if (t == 0)
+        {
+            xs_try_[t] = prob_->get_X(0);
+        }
+        else
+        {
+            xs_try_[t] = Eigen::VectorXd::Constant(NX_, NAN);
+        }
+        us_try_[t] = Eigen::VectorXd::Constant(NU_, NAN);
+        dx_[t] = Eigen::VectorXd::Zero(NDX_);
+
+        FuTVxx_p_[t] = Eigen::MatrixXd::Zero(NU_, NDX_);
+        Quu_llt_[t] = Eigen::LLT<Eigen::MatrixXd>(NU_);
+        Quuk_[t] = Eigen::VectorXd(NU_);
+    }
+    Vxx_.back() = Eigen::MatrixXd::Zero(NDX_, NDX_);
+    Vx_.back() = Eigen::VectorXd::Zero(NDX_);
+    xs_try_.back().setZero(NX_);
+    fs_.back() = Eigen::VectorXd::Zero(NDX_);
+
+    FxTVxx_p_ = Eigen::MatrixXd::Zero(NDX_, NDX_);
+    fTVxx_p_ = Eigen::VectorXd::Zero(NDX_);
+}
+
+void FeasibilityDrivenDDPSolver::Solve(Eigen::MatrixXd& solution)
+{
+    if (!prob_) ThrowNamed("Solver has not been initialized!");
+    Timer planning_timer, backward_pass_timer, line_search_timer;
+
+    T_ = prob_->get_T();
+    NU_ = prob_->get_num_controls();
+    NX_ = prob_->get_num_positions() + prob_->get_num_velocities();  // State vector size
+    NDX_ = 2 * prob_->get_num_velocities();                          // TODO: for now but this is incorrect // Tangent vector size
+    dt_ = dynamics_solver_->get_dt();
+
+    control_limits_ = dynamics_solver_->get_control_limits();
+
+    AllocateData();
+    auto X_warm = prob_->get_X();
+    X_warm.col(0) = prob_->ApplyStartState();  // Apply start state
+    auto U_warm = prob_->get_U();
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        xs_[t] = X_warm.col(t);
+        us_[t] = U_warm.col(t);
+    }
+    xs_.back() = X_warm.col(T_ - 1);
+    is_feasible_ = false;  // We assume the first iteration is always infeasible. TODO: Make this configurable
+
+    prob_->ResetCostEvolution(GetNumberOfMaxIterations() + 1);
+    prob_->PreUpdate();
+    solution.resize(T_ - 1, NU_);
+
+    // Initial roll-out to get initial cost
+    cost_ = 0.0;
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        prob_->Update(xs_[t], us_[t], t);
+        cost_ += dt_ * (prob_->GetStateCost(t) + prob_->GetControlCost(t));
+    }
+    // Reset shooting nodes so we can warm-start from state trajectory
+    prob_->set_X(X_warm);
+    cost_ += prob_->GetStateCost(T_ - 1);
+    prob_->SetCostEvolution(0, cost_);
+
+    xreg_ = std::max(regmin_, parameters_.RegularizationRate);
+    ureg_ = std::max(regmin_, parameters_.RegularizationRate);
+    was_feasible_ = false;
+
+    bool diverged = false;
+    bool converged = false;
+
+    bool recalcDiff = true;
+    int iter;
+    for (iter = 1; iter <= GetNumberOfMaxIterations(); ++iter)
+    {
+        // Check whether user interrupted (Ctrl+C)
+        if (Server::IsRos() && !ros::ok())
+        {
+            if (debug_) HIGHLIGHT("Solving cancelled by user");
+            prob_->termination_criterion = TerminationCriterion::UserDefined;
+            break;
+        }
+
+        backward_pass_timer.Reset();
+        while (true)
+        {
+            try
+            {
+                ComputeDirection(recalcDiff);
+            }
+            catch (std::exception& e)
+            {
+                // HIGHLIGHT("Increase regularization in ComputeDirection and try again." << e.what())
+                recalcDiff = false;
+                IncreaseRegularization();
+                if (xreg_ == regmax_)
+                {
+                    WARNING_NAMED("FeasibilityDrivenDDPSolver::Solve", "State regularization exceeds maximum regularization: " << xreg_ << " > " << regmax_)
+                    diverged = true;
+                    break;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            break;
+        }
+        time_taken_backward_pass_ = backward_pass_timer.GetDuration();
+
+        if (diverged)
+        {
+            WARNING("Terminating: Divergence in ComputeDirection / BackwardPass.");
+            break;
+        }
+
+        UpdateExpectedImprovement();
+
+        // We need to recalculate the derivatives when the step length passes
+        recalcDiff = false;
+        line_search_timer.Reset();
+        for (int ai = 0; ai < alpha_space_.size(); ++ai)
+        {
+            steplength_ = alpha_space_(ai);
+
+            try
+            {
+                dV_ = TryStep(steplength_);
+            }
+            catch (std::exception& e)
+            {
+                // HIGHLIGHT("Error in TryStep: " << e.what())
+                continue;
+            }
+            ExpectedImprovement();
+            dVexp_ = steplength_ * (d_[0] + 0.5 * steplength_ * d_[1]);
+
+            if (dVexp_ >= 0)
+            {  // descend direction
+                if (d_[0] < th_grad_ || dV_ > th_acceptstep_ * dVexp_)
+                {
+                    was_feasible_ = is_feasible_;
+                    SetCandidate(xs_try_, us_try_, (was_feasible_) || (steplength_ == 1));
+                    cost_ = cost_try_;
+                    prob_->SetCostEvolution(iter, cost_);
+                    recalcDiff = true;
+                    break;
+                }
+            }
+            else
+            {  // reducing the gaps by allowing a small increment in the cost value
+                if (dV_ > th_acceptnegstep_ * dVexp_)
+                {
+                    INFO_NAMED("FDDP", "Ascent direction: " << dV_ << " > " << th_acceptnegstep_ * dVexp_)
+                    was_feasible_ = is_feasible_;
+                    SetCandidate(xs_try_, us_try_, (was_feasible_) || (steplength_ == 1));
+                    cost_ = cost_try_;
+                    prob_->SetCostEvolution(iter, cost_);
+                    break;
+                }
+                else
+                {
+                    INFO_NAMED("FDDP", "Ascent direction, but not accepted: " << dV_ << " < " << th_acceptnegstep_ * dVexp_)
+                }
+            }
+
+            prob_->SetCostEvolution(iter, cost_);
+        }
+        time_taken_forward_pass_ = line_search_timer.GetDuration();
+
+        if (debug_)
+        {
+            if (iter % 10 == 0 || iter == 1)
+            {
+                std::cout << "iter \t cost \t      stop \t    grad \t  xreg";
+                std::cout << " \t      ureg \t step \t feas \tdV-exp \t      dV\n";
+            }
+
+            std::cout << std::setw(4) << iter << "  ";
+            std::cout << std::scientific << std::setprecision(5) << cost_ << "  ";
+            std::cout << stop_ << "  " << -d_[1] << "  ";
+            std::cout << xreg_ << "  " << ureg_ << "   ";
+            std::cout << std::fixed << std::setprecision(4) << steplength_ << "     ";
+            std::cout << is_feasible_ << "  ";
+            std::cout << std::scientific << std::setprecision(5) << dVexp_ << "  ";
+            std::cout << dV_ << '\n';
+        }
+
+        // Adapt regularization based on step-length
+        if (steplength_ > th_stepdec_)
+        {
+            DecreaseRegularization();
+        }
+        if (steplength_ <= th_stepinc_)
+        {
+            IncreaseRegularization();
+            if (xreg_ == regmax_)
+            {
+                WARNING_NAMED("FeasibilityDrivenDDPSolver::Solve", "State regularization exceeds maximum regularization: " << xreg_ << " > " << regmax_)
+                diverged = true;
+                break;
+            }
+        }
+        CheckStoppingCriteria();
+
+        if (was_feasible_ && stop_ < th_stop_)
+        {
+            HIGHLIGHT_NAMED("FeasibilityDrivenDDPSolver::Solve", "Convergence: " << stop_ << " < " << th_stop_)
+            converged = true;
+            break;
+        }
+
+        if (diverged)
+        {
+            WARNING_NAMED("FeasibilityDrivenDDPSolver::Solve", "Terminating: Divergence in ForwardPass.");
+            break;
+        }
+    }
+
+    if (diverged) prob_->termination_criterion = TerminationCriterion::Divergence;
+    if (converged) prob_->termination_criterion = TerminationCriterion::Convergence;
+    if (!converged && iter == GetNumberOfMaxIterations()) prob_->termination_criterion = TerminationCriterion::IterationLimit;
+
+    // Store the best solution found over all iterations
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        solution.row(t) = us_[t].transpose();
+        prob_->Update(us_[t], t);
+    }
+
+    planning_time_ = planning_timer.GetDuration();
+}
+
+void FeasibilityDrivenDDPSolver::IncreaseRegularization()
+{
+    xreg_ *= regfactor_;
+    if (xreg_ > regmax_)
+    {
+        xreg_ = regmax_;
+    }
+    ureg_ = xreg_;
+}
+
+void FeasibilityDrivenDDPSolver::DecreaseRegularization()
+{
+    xreg_ /= regfactor_;
+    if (xreg_ < regmin_)
+    {
+        xreg_ = regmin_;
+    }
+    ureg_ = xreg_;
+}
+
+double FeasibilityDrivenDDPSolver::CheckStoppingCriteria()
+{
+    stop_ = 0.;
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        stop_ += Qu_[t].squaredNorm();
+    }
+    return stop_;
+}
+
+const Eigen::Vector2d& FeasibilityDrivenDDPSolver::ExpectedImprovement()
+{
+    dv_ = 0;
+    if (!is_feasible_)
+    {
+        for (int t = 0; t < T_; ++t)
+        {
+            dx_[t] = prob_->GetScene()->GetDynamicsSolver()->StateDelta(xs_[t], xs_try_[t]);
+            fTVxx_p_.noalias() = Vxx_[t] * dx_[t];
+            dv_ -= fs_[t].dot(fTVxx_p_);
+        }
+    }
+    d_[0] = dg_ + dv_;
+    d_[1] = dq_ - 2 * dv_;
+    return d_;
+}
+
+void FeasibilityDrivenDDPSolver::UpdateExpectedImprovement()
+{
+    dg_ = 0;
+    dq_ = 0;
+    if (!is_feasible_)
+    {
+        dg_ -= Vx_.back().dot(fs_.back());
+        fTVxx_p_.noalias() = Vxx_.back() * fs_.back();
+        dq_ += fs_.back().dot(fTVxx_p_);
+    }
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        dg_ += Qu_[t].dot(k_[t]);
+        dq_ -= k_[t].dot(Quuk_[t]);
+        if (!is_feasible_)
+        {
+            dg_ -= Vx_[t].dot(fs_[t]);
+            fTVxx_p_.noalias() = Vxx_[t] * fs_[t];
+            dq_ += fs_[t].dot(fTVxx_p_);
+        }
+    }
+}
+
+void FeasibilityDrivenDDPSolver::SetCandidate(const std::vector<Eigen::VectorXd>& xs_in, const std::vector<Eigen::VectorXd>& us_in, const bool is_feasible)
+{
+    const std::size_t T = static_cast<std::size_t>(prob_->get_T());
+
+    if (xs_in.size() == 0)
+    {
+        for (int t = 0; t < T_; ++t)
+        {
+            xs_[t].setZero(NX_);
+        }
+    }
+    else
+    {
+        if (xs_in.size() != T)
+        {
+            ThrowPretty("Warm start state has wrong dimension, got " << xs_in.size() << " expecting " << (T + 1));
+        }
+        std::copy(xs_in.begin(), xs_in.end(), xs_.begin());
+    }
+
+    if (us_in.size() == 0)
+    {
+        for (int t = 0; t < T_ - 1; ++t)
+        {
+            us_[t].setZero(NU_);
+        }
+    }
+    else
+    {
+        if (us_in.size() != T - 1)
+        {
+            ThrowPretty("Warm start control has wrong dimension, got " << us_in.size() << " expecting " << T);
+        }
+        std::copy(us_in.begin(), us_in.end(), us_.begin());
+    }
+    is_feasible_ = is_feasible;
+}
+
+double FeasibilityDrivenDDPSolver::TryStep(const double steplength)
+{
+    ForwardPass(steplength);
+    return cost_ - cost_try_;
+}
+
+void FeasibilityDrivenDDPSolver::ForwardPass(const double steplength)
+{
+    if (steplength > 1. || steplength < 0.)
+    {
+        ThrowPretty("Invalid argument: invalid step length, value should be between 0. to 1. - got=" << steplength);
+    }
+    cost_try_ = 0.;
+    xnext_ = prob_->get_X(0);
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        // If feasible or the gaps are closed, start the shooting from the previous step.
+        if ((is_feasible_) || (steplength == 1))
+        {
+            xs_try_[t] = xnext_;
+        }
+        else
+        {
+            // We need to obtain a state based on the expected reduction of the gap given the step length (dt=unit time)
+            prob_->GetScene()->GetDynamicsSolver()->Integrate(xnext_, fs_[t] * (steplength - 1), 1., xs_try_[t]);
+        }
+        dx_[t] = prob_->GetScene()->GetDynamicsSolver()->StateDelta(xs_try_[t], xs_[t]);  // NB: StateDelta in Exotica is the other way round than in Pinocchio
+        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];              // This is weird. It works better WITHOUT the feedback ?!
+
+        if (base_parameters_.ClampControlsInForwardPass)
+        {
+            us_try_[t] = us_try_[t].cwiseMax(control_limits_.col(0)).cwiseMin(control_limits_.col(1));
+        }
+
+        prob_->Update(xs_try_[t], us_try_[t], t);  // Performs integration and update of cost
+        xnext_ = prob_->get_X(t + 1);
+        cost_try_ += dt_ * (prob_->GetStateCost(t) + prob_->GetControlCost(t));
+
+        if (RaiseIfNaN(cost_try_))
+        {
+            throw std::runtime_error("forward_error - NaN in cost_try_ at t=" + std::to_string(t));
+        }
+        if (RaiseIfNaN(xnext_.lpNorm<Eigen::Infinity>()))
+        {
+            throw std::runtime_error("forward_error - xnext_ isn't finite at t=" + std::to_string(t));
+        }
+    }
+
+    // Terminal model
+    if ((is_feasible_) || (steplength == 1))
+    {
+        xs_try_.back() = xnext_;
+    }
+    else
+    {
+        prob_->GetScene()->GetDynamicsSolver()->Integrate(xnext_, fs_.back() * (steplength - 1), 1., xs_try_.back());
+    }
+    prob_->UpdateTerminalState(xs_try_.back());
+    cost_try_ += prob_->GetStateCost(T_ - 1);
+
+    if (RaiseIfNaN(cost_try_))
+    {
+        throw std::runtime_error("forward_error - cost NaN");
+    }
+}
+
+void FeasibilityDrivenDDPSolver::ComputeDirection(const bool recalcDiff)
+{
+    if (recalcDiff)
+    {
+        CalcDiff();
+    }
+    BackwardPass();
+}
+
+double FeasibilityDrivenDDPSolver::CalcDiff()
+{
+    cost_ = 0;
+    // Running cost
+    for (int t = 0; t < T_ - 1; ++t)
+    {
+        cost_ += dt_ * (prob_->GetStateCost(t) + prob_->GetControlCost(t));
+    }
+    // Terminal cost
+    cost_ += prob_->GetStateCost(T_ - 1);
+
+    if (!is_feasible_)
+    {
+        // Defects for t=0..T
+        for (int t = 0; t < prob_->get_T(); ++t)
+        {
+            fs_[t] = prob_->GetScene()->GetDynamicsSolver()->StateDelta(prob_->get_X(t), xs_[t]);  // Exotica's convention differs...
+        }
+    }
+    else if (!was_feasible_)
+    {  // closing the gaps
+        for (std::vector<Eigen::VectorXd>::iterator it = fs_.begin(); it != fs_.end(); ++it)
+        {
+            it->setZero();
+        }
+    }
+    return cost_;
+}
+
+void FeasibilityDrivenDDPSolver::BackwardPass()
+{
+    Vxx_.back() = prob_->GetStateCostHessian(T_ - 1);
+    Vx_.back() = prob_->GetStateCostJacobian(T_ - 1);
+
+    if (!std::isnan(xreg_))
+    {
+        Vxx_.back().diagonal().array() += xreg_;
+    }
+
+    if (!is_feasible_)
+    {
+        Vx_.back().noalias() += Vxx_.back() * fs_.back();
+    }
+
+    for (int t = static_cast<int>(prob_->get_T()) - 2; t >= 0; --t)
+    {
+        const Eigen::MatrixXd& Vxx_p = Vxx_[t + 1];
+        const Eigen::VectorXd& Vx_p = Vx_[t + 1];
+
+        Qxx_[t] = dt_ * prob_->GetStateCostHessian(t);
+        Qxu_[t] = dt_ * prob_->GetStateControlCostHessian().transpose();
+        Quu_[t] = dt_ * prob_->GetControlCostHessian();
+        Qx_[t] = dt_ * prob_->GetStateCostJacobian(t);
+        Qu_[t] = dt_ * prob_->GetControlCostJacobian(t);
+
+        fx_ = dt_ * dynamics_solver_->fx(xs_[t], us_[t]) + Eigen::MatrixXd::Identity(NX_, NX_);
+        fu_ = dt_ * dynamics_solver_->fu(xs_[t], us_[t]);
+
+        FxTVxx_p_.noalias() = fx_.transpose() * Vxx_p;
+        FuTVxx_p_[t].noalias() = fu_.transpose() * Vxx_p;
+        Qxx_[t].noalias() += FxTVxx_p_ * fx_;
+        Qxu_[t].noalias() += FxTVxx_p_ * fu_;
+        Quu_[t].noalias() += FuTVxx_p_[t] * fu_;
+        Qx_[t].noalias() += fx_.transpose() * Vx_p;
+        Qu_[t].noalias() += fu_.transpose() * Vx_p;
+
+        if (!std::isnan(ureg_))
+        {
+            Quu_[t].diagonal().array() += ureg_;
+        }
+
+        ComputeGains(t);
+
+        Vx_[t] = Qx_[t];
+        if (std::isnan(ureg_))
+        {
+            Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
+        }
+        else
+        {
+            Quuk_[t].noalias() = Quu_[t] * k_[t];
+            Vx_[t].noalias() += K_[t].transpose() * Quuk_[t];
+            Vx_[t].noalias() -= 2 * (K_[t].transpose() * Qu_[t]);
+        }
+        Vxx_[t] = Qxx_[t];
+        Vxx_[t].noalias() -= Qxu_[t] * K_[t];
+        Vxx_[t] = 0.5 * (Vxx_[t] + Vxx_[t].transpose()).eval();
+
+        if (!std::isnan(xreg_))
+        {
+            Vxx_[t].diagonal().array() += xreg_;
+        }
+
+        // Compute and store the Vx gradient at end of the interval (rollout state)
+        if (!is_feasible_)
+        {
+            Vx_[t].noalias() += Vxx_[t] * fs_[t];
+        }
+
+        if (RaiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>()))
+        {
+            ThrowPretty("backward_error (Vx) at t=" << t);
+        }
+        if (RaiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>()))
+        {
+            ThrowPretty("backward_error (Vxx) at t=" << t);
+        }
+    }
+}
+
+void FeasibilityDrivenDDPSolver::ComputeGains(const int t)
+{
+    Quu_llt_[t].compute(Quu_[t]);
+    const Eigen::ComputationInfo& info = Quu_llt_[t].info();
+    if (info != Eigen::Success)
+    {
+        ThrowPretty("backward_error - error in Cholesky decomposition");
+    }
+    K_[t] = Qxu_[t].transpose();
+    Quu_llt_[t].solveInPlace(K_[t]);
+    k_[t] = Qu_[t];
+    Quu_llt_[t].solveInPlace(k_[t]);
+}
+
+}  // namespace exotica

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -233,7 +233,7 @@ void FeasibilityDrivenDDPSolver::Solve(Eigen::MatrixXd& solution)
             {  // reducing the gaps by allowing a small increment in the cost value
                 if (dV_ > th_acceptnegstep_ * dVexp_)
                 {
-                    INFO_NAMED("FDDP", "Ascent direction: " << dV_ << " > " << th_acceptnegstep_ * dVexp_)
+                    if (debug_) INFO_NAMED("FDDP", "Ascent direction: " << dV_ << " > " << th_acceptnegstep_ * dVexp_)
                     was_feasible_ = is_feasible_;
                     SetCandidate(xs_try_, us_try_, (was_feasible_) || (steplength_ == 1));
                     cost_ = cost_try_;
@@ -242,7 +242,7 @@ void FeasibilityDrivenDDPSolver::Solve(Eigen::MatrixXd& solution)
                 }
                 else
                 {
-                    INFO_NAMED("FDDP", "Ascent direction, but not accepted: " << dV_ << " < " << th_acceptnegstep_ * dVexp_)
+                    if (debug_) INFO_NAMED("FDDP", "Ascent direction, but not accepted: " << dV_ << " < " << th_acceptnegstep_ * dVexp_)
                 }
             }
 

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -140,7 +140,7 @@ public:
     virtual ControlVector InverseDynamics(const StateVector& state);
 
     /// \brief Integrates without performing dynamics.
-    virtual void Integrate(const StateVector& x, const StateVector& dx, StateVector& xout);
+    virtual void Integrate(const StateVector& x, const StateVector& dx, const double dt, StateVector& xout);
 
 private:
     bool control_limits_initialized_ = false;

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -102,6 +102,7 @@ public:
     ///     Returns x_1-x_2
     virtual StateVector StateDelta(const StateVector& x_1, const StateVector& x_2)
     {
+        assert(x_1.size() == x_2.size());
         return x_1 - x_2;
     }
 
@@ -133,10 +134,13 @@ public:
     /// \brief Returns the control limits vector.
     //  returns: Two-column matrix, first column contains low control limits,
     //      second - the high control limits
-    Eigen::MatrixXd get_control_limits();
+    const Eigen::MatrixXd& get_control_limits();
     void set_control_limits(Eigen::VectorXd control_limits_low, Eigen::VectorXd control_limits_high);
 
     virtual ControlVector InverseDynamics(const StateVector& state);
+
+    /// \brief Integrates without performing dynamics.
+    virtual void Integrate(const StateVector& x, const StateVector& dx, StateVector& xout);
 
 private:
     bool control_limits_initialized_ = false;
@@ -156,7 +160,7 @@ protected:
     Eigen::MatrixXd control_limits_;  ///< ControlLimits. Default is empty vector.
 
     /// \brief Integrates the dynamic system from state x with controls u applied for one timestep dt using the selected integrator.
-    inline StateVector Integrate(const StateVector& x, const ControlVector& u);
+    inline StateVector SimulateOneStep(const StateVector& x, const ControlVector& u);
 
     void InitializeSecondOrderDerivatives();
     Eigen::Tensor<T, 3> fxx_default_, fuu_default_, fxu_default_;

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -75,7 +75,7 @@ public:
 
     void SetStartState(Eigen::VectorXdRefConst x);
     Eigen::VectorXd GetStartState() const;
-    Eigen::VectorXd ApplyStartState(bool update_traj = true);
+    virtual Eigen::VectorXd ApplyStartState(bool update_traj = true);
 
     void SetStartTime(double t);
     double GetStartTime() const;

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -48,6 +48,8 @@ public:
 
     void PreUpdate() override;
     void Update(Eigen::VectorXdRefConst u, int t);
+    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRefConst u, int t);
+    void UpdateTerminalState(Eigen::VectorXdRefConst x);  // Updates the terminal state and recomputes the terminal cost - this is required e.g. when considering defects in the dynamics
 
     const int& get_T() const;     ///< Returns the number of timesteps in the state trajectory.
     void set_T(const int& T_in);  ///< Sets the number of timesteps in the state trajectory.

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -46,6 +46,7 @@ public:
 
     void Instantiate(const DynamicTimeIndexedShootingProblemInitializer& init) override;
 
+    Eigen::VectorXd ApplyStartState(bool update_traj = true) override;
     void PreUpdate() override;
     void Update(Eigen::VectorXdRefConst u, int t);
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRefConst u, int t);

--- a/exotica_core/src/dynamics_solver.cpp
+++ b/exotica_core/src/dynamics_solver.cpp
@@ -106,14 +106,14 @@ Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::SimulateOneStep(const
 }
 
 template <typename T, int NX, int NU>
-void AbstractDynamicsSolver<T, NX, NU>::Integrate(const StateVector& x, const StateVector& dx, StateVector& xout)
+void AbstractDynamicsSolver<T, NX, NU>::Integrate(const StateVector& x, const StateVector& dx, const double dt, StateVector& xout)
 {
     switch (integrator_)
     {
         // Forward Euler (RK1) - explicit
         case Integrator::RK1:
         {
-            xout = x + dt_ * dx;
+            xout = x + dt * dx;
         }
         break;
 

--- a/exotica_core/src/dynamics_solver.cpp
+++ b/exotica_core/src/dynamics_solver.cpp
@@ -69,7 +69,7 @@ void AbstractDynamicsSolver<T, NX, NU>::SetDt(double dt_in)
 }
 
 template <typename T, int NX, int NU>
-Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Integrate(const StateVector& x, const ControlVector& u)
+Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::SimulateOneStep(const StateVector& x, const ControlVector& u)
 {
     switch (integrator_)
     {
@@ -77,6 +77,7 @@ Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Integrate(const State
         case Integrator::RK1:
         {
             StateVector xdot = f(x, u);
+            // TODO: This is the explicit RK1. We can switch to semi-implicit.
             return x + dt_ * xdot;
         }
         // Explicit trapezoid rule (RK2)
@@ -105,13 +106,31 @@ Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Integrate(const State
 }
 
 template <typename T, int NX, int NU>
+void AbstractDynamicsSolver<T, NX, NU>::Integrate(const StateVector& x, const StateVector& dx, StateVector& xout)
+{
+    switch (integrator_)
+    {
+        // Forward Euler (RK1) - explicit
+        case Integrator::RK1:
+        {
+            xout = x + dt_ * dx;
+        }
+        break;
+
+        default:
+            ThrowPretty("Not implemented!");
+            // TODO implement the other solvers, but how to get dx updated?!
+    };
+}
+
+template <typename T, int NX, int NU>
 Eigen::Matrix<T, NX, 1> AbstractDynamicsSolver<T, NX, NU>::Simulate(const StateVector& x, const ControlVector& u, T t)
 {
     const int num_timesteps = static_cast<int>(t / dt_);
     StateVector x_t_plus_1 = x;
     for (int i = 0; i < num_timesteps; ++i)
     {
-        x_t_plus_1 = Integrate(x_t_plus_1, u);
+        x_t_plus_1 = SimulateOneStep(x_t_plus_1, u);
     }
     return x_t_plus_1;
 }
@@ -173,7 +192,7 @@ void AbstractDynamicsSolver<T, NX, NU>::SetIntegrator(std::string integrator_in)
 }
 
 template <typename T, int NX, int NU>
-Eigen::MatrixXd AbstractDynamicsSolver<T, NX, NU>::get_control_limits()
+const Eigen::MatrixXd& AbstractDynamicsSolver<T, NX, NU>::get_control_limits()
 {
     if (!control_limits_initialized_)
         set_control_limits(raw_control_limits_low_, raw_control_limits_high_);

--- a/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
+++ b/exotica_core/src/problems/dynamic_time_indexed_shooting_problem.cpp
@@ -319,6 +319,12 @@ void DynamicTimeIndexedShootingProblem::PreUpdate()
     }
 }
 
+Eigen::VectorXd DynamicTimeIndexedShootingProblem::ApplyStartState(bool update_traj)
+{
+    PlanningProblem::ApplyStartState(update_traj);
+    return start_state_;
+}
+
 const Eigen::MatrixXd& DynamicTimeIndexedShootingProblem::get_X() const
 {
     return X_;

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -492,7 +492,6 @@ public:
 
 PYBIND11_MODULE(_pyexotica, module)
 {
-    //Setup::Instance();
     module.doc() = "Exotica Python wrapper";
 
     py::class_<Setup, std::unique_ptr<Setup, py::nodelete>> setup(module, "Setup");
@@ -956,7 +955,8 @@ PYBIND11_MODULE(_pyexotica, module)
     time_indexed_sampling_problem.def("is_valid", (bool (TimeIndexedSamplingProblem::*)(Eigen::VectorXdRefConst, const double&)) & TimeIndexedSamplingProblem::IsValid);
 
     py::class_<DynamicTimeIndexedShootingProblem, std::shared_ptr<DynamicTimeIndexedShootingProblem>, PlanningProblem>(prob, "DynamicTimeIndexedShootingProblem")
-        .def("update", &DynamicTimeIndexedShootingProblem::Update)
+        .def("update", (void (DynamicTimeIndexedShootingProblem::*)(Eigen::VectorXdRefConst, Eigen::VectorXdRefConst, int)) & DynamicTimeIndexedShootingProblem::Update)
+        .def("update", (void (DynamicTimeIndexedShootingProblem::*)(Eigen::VectorXdRefConst, int)) & DynamicTimeIndexedShootingProblem::Update)
         .def_property("X", static_cast<const Eigen::MatrixXd& (DynamicTimeIndexedShootingProblem::*)(void)const>(&DynamicTimeIndexedShootingProblem::get_X), &DynamicTimeIndexedShootingProblem::set_X)
         .def_property("U", static_cast<const Eigen::MatrixXd& (DynamicTimeIndexedShootingProblem::*)(void)const>(&DynamicTimeIndexedShootingProblem::get_U), &DynamicTimeIndexedShootingProblem::set_U)
         .def_property("X_star", &DynamicTimeIndexedShootingProblem::get_X_star, &DynamicTimeIndexedShootingProblem::set_X_star)

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1217,6 +1217,7 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("fu", &DynamicsSolver::fu)
         .def("get_position", &DynamicsSolver::GetPosition)
         .def("simulate", &DynamicsSolver::Simulate)
+        .def("integrate", &DynamicsSolver::Integrate)
         .def_property_readonly("dt", &DynamicsSolver::get_dt, "dt");
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adapts and adds the Crocoddyl implementation of FDDP into Exotica.

The following differences have to be noted:
- Crocoddyl uses `T` running models and a final model after. This leads to differences in `T` lengths and on top of that an additional model. Care needs to be taken to adapt all `T` and iterations
- The `StateDelta` in Pinocchio works _the other way around_ in the argument list.
- ~~I did not yet add an `Integrate` as the Pinocchio integrate assumes unit time, while we usually use `dt_` in the dynamics.~~

This now works well - better on some dynamics systems than on others.

~~**This version currently has numerical issues** - particularly with the state feedback gain matrix `K_`. It works better _without_ in the forward-pass. This could be due~~

~~a) `t`/`T` arguments being wrong in a place,~~
~~b) the differences in the cost computation with `StateDelta` (arguments are swapped) in the `DynamicTimeIndexedShootingProblem`,~~
~~c) the calculation of the defects `fs_` being wrong~~
~~d) or something else.~~

~~The convergence is also poor compared with VanillaDDP.~~