### PR TITLE
BoxQP warm-start, check transforms in CollisionScene, warning if plug-in not built

### DIFF
--- a/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
+++ b/exotations/exotica_collision_scene_fcl_latest/src/collision_scene_fcl_latest.cpp
@@ -134,6 +134,13 @@ void CollisionSceneFCLLatest::UpdateCollisionObjectTransforms()
         {
             ThrowPretty("Expired pointer, this should not happen - make sure to call UpdateCollisionObjects() after UpdateSceneFrames()");
         }
+
+        // Check for NaNs
+        if (std::isnan(element->frame.p.data[0]) || std::isnan(element->frame.p.data[1]) || std::isnan(element->frame.p.data[2]))
+        {
+            ThrowPretty("Transform for " << element->segment.getName() << " contains NaNs.");
+        }
+
         collision_object->setTransform(fcl_convert::KDL2fcl(element->frame));
         collision_object->computeAABB();
     }

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -99,6 +99,7 @@ public:
 
     /// \brief Return the difference of two state vectors.
     ///     Used when e.g. angle differences need to be wrapped from [-pi; pi]
+    ///     Returns x_1-x_2
     virtual StateVector StateDelta(const StateVector& x_1, const StateVector& x_2)
     {
         return x_1 - x_2;

--- a/exotica_core/include/exotica_core/planning_problem.h
+++ b/exotica_core/include/exotica_core/planning_problem.h
@@ -56,7 +56,8 @@ enum class TerminationCriterion
     FunctionTolerance,
     GradientTolerance,
     Divergence,
-    UserDefined
+    UserDefined,
+    Convergence
     // Condition,
 };
 

--- a/exotica_core/include/exotica_core/tools/box_qp.h
+++ b/exotica_core/include/exotica_core/tools/box_qp.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019, University of Edinburgh
+// Copyright (c) 2019-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@ namespace exotica
 typedef struct BoxQPSolution
 {
     Eigen::MatrixXd Hff_inv;
-    Eigen::MatrixXd x;
+    Eigen::VectorXd x;
     std::vector<size_t> free_idx;
     std::vector<size_t> clamped_idx;
 } BoxQPSolution;
@@ -53,6 +53,12 @@ inline BoxQPSolution BoxQP(const Eigen::MatrixXd& H, const Eigen::VectorXd& q,
     std::vector<size_t> clamped_idx, free_idx;
     Eigen::VectorXd grad = q + H * x_init;
     Eigen::MatrixXd Hff, Hfc, Hff_inv;
+
+    // Ensure a feasible warm-start
+    for (int i = 0; i < x.size(); ++i)
+    {
+        x(i) = std::max(std::min(x_init(i), b_high(i)), b_low(i));
+    }
 
     Hff_inv = (Eigen::MatrixXd::Identity(H.rows(), H.cols()) * 1e-5 + H).inverse();
 

--- a/exotica_core/src/setup.cpp
+++ b/exotica_core/src/setup.cpp
@@ -106,17 +106,41 @@ std::vector<Initializer> Setup::GetInitializers()
     std::vector<std::string> solvers = Instance()->solvers_.getDeclaredClasses();
     for (const std::string& s : solvers)
     {
-        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateSolver(s, false)), ret);
+        try
+        {
+            AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateSolver(s, false)), ret);
+        }
+        catch (std::exception& e)
+        {
+            WARNING_NAMED("Setup::GetInitializers", "Solver '" << s << "' not built. Won't be able to instantiate.");
+            continue;
+        }
     }
     std::vector<std::string> maps = Instance()->maps_.getDeclaredClasses();
     for (const std::string& s : maps)
     {
-        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateMap(s, false)), ret);
+        try
+        {
+            AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateMap(s, false)), ret);
+        }
+        catch (std::exception& e)
+        {
+            WARNING_NAMED("Setup::GetInitializers", "TaskMap '" << s << "' not built. Won't be able to instantiate.");
+            continue;
+        }
     }
     std::vector<std::string> dynamics_solvers = Instance()->dynamics_solvers_.getDeclaredClasses();
     for (const std::string& s : dynamics_solvers)
     {
-        AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateDynamicsSolver(s, false)), ret);
+        try
+        {
+            AppendInitializer(std::static_pointer_cast<InstantiableBase>(CreateDynamicsSolver(s, false)), ret);
+        }
+        catch (std::exception& e)
+        {
+            WARNING_NAMED("Setup::GetInitializers", "DynamicsSolver '" << s << "' not built. Won't be able to instantiate.");
+            continue;
+        }
     }
     return ret;
 }

--- a/exotica_core/test/test_box_qp.py
+++ b/exotica_core/test/test_box_qp.py
@@ -33,7 +33,7 @@ class TestBoxQP(unittest.TestCase):
                 (b_low[1], b_high[1]),
             ])
 
-            nptest.assert_allclose(sp_sol.x, sol.x.T[0], rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
+            nptest.assert_allclose(sp_sol.x, sol.x, rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
     
     def test_zero_h(self):
         np.random.seed(100)
@@ -57,7 +57,7 @@ class TestBoxQP(unittest.TestCase):
                 (b_low[1], b_high[1]),
             ])
 
-            nptest.assert_allclose(sp_sol.x, sol.x.T[0], rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
+            nptest.assert_allclose(sp_sol.x, sol.x, rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
 
     def test_big_numbers(self):
         np.random.seed(100)
@@ -85,7 +85,7 @@ class TestBoxQP(unittest.TestCase):
                 (b_low[1], b_high[1]),
             ])
 
-            nptest.assert_allclose(sp_sol.x, sol.x.T[0], rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
+            nptest.assert_allclose(sp_sol.x, sol.x, rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
 
     def test_small_numbers(self):
         np.random.seed(100)
@@ -113,7 +113,7 @@ class TestBoxQP(unittest.TestCase):
                 (b_low[1], b_high[1]),
             ])
 
-            nptest.assert_allclose(sp_sol.x, sol.x.T[0], rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
+            nptest.assert_allclose(sp_sol.x, sol.x, rtol=1, atol=1e-4, err_msg="BoxQP and scipy differ!")
 
 if __name__ == '__main__':
     unittest.main()

--- a/exotica_examples/resources/configs/dynamic_time_indexed/05_analytic_ddp_lwr.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/05_analytic_ddp_lwr.xml
@@ -26,7 +26,6 @@
         
         <T>100</T>
         <tau>0.02</tau>
-        <dt>0.02</dt>
         <Q_rate>0</Q_rate>
         <Qf_rate>10</Qf_rate>
         <R_rate>0.1</R_rate>


### PR DESCRIPTION
- Makes sure the BoxQP warm-start is feasible
- Checks if the transform of a CollisionObject contains NaNs and throws if so - this prevents segmentation faults in FCL.
- Print warnings if a plug-in (e.g. a solver) isn't built and degrade gracefully rather than being unable to use [saves a lot of compilation time!]