### PR TITLE
Fix analytic derivatives of Pinocchio; fix finite differencing on manifolds; updates to FDDP

### DIFF
--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/include/exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h
@@ -68,6 +68,10 @@ public:
 private:
     pinocchio::Model model_;
     std::unique_ptr<pinocchio::Data> pinocchio_data_;
+
+    Eigen::MatrixXd fx_analytic_;
+    Eigen::MatrixXd fu_analytic_;
+    Eigen::VectorXd xdot_analytic_;
 };
 }  // namespace exotica
 

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver.cpp
@@ -35,19 +35,19 @@ namespace exotica
 {
 void PinocchioDynamicsSolver::AssignScene(ScenePtr scene_in)
 {
-    const bool verbose = false;
+    constexpr bool verbose = false;
     if (scene_in->GetKinematicTree().GetControlledBaseType() == BaseType::FIXED)
     {
         pinocchio::urdf::buildModel(scene_in->GetKinematicTree().GetRobotModel()->getURDF(), model_, verbose);
     }
-    else if (scene_in->GetKinematicTree().GetControlledBaseType() == BaseType::PLANAR)
+    /*else if (scene_in->GetKinematicTree().GetControlledBaseType() == BaseType::PLANAR)
     {
         pinocchio::urdf::buildModel(scene_in->GetKinematicTree().GetRobotModel()->getURDF(), pinocchio::JointModelPlanar(), model_, verbose);
     }
     else if (scene_in->GetKinematicTree().GetControlledBaseType() == BaseType::FLOATING)
     {
         pinocchio::urdf::buildModel(scene_in->GetKinematicTree().GetRobotModel()->getURDF(), pinocchio::JointModelFreeFlyer(), model_, verbose);
-    }
+    }*/
     else
     {
         ThrowPretty("This condition should never happen. Unknown BaseType.");
@@ -58,46 +58,38 @@ void PinocchioDynamicsSolver::AssignScene(ScenePtr scene_in)
     num_controls_ = model_.nv;
 
     pinocchio_data_.reset(new pinocchio::Data(model_));
+
+    // Pre-allocate data for f, fx, fu
+    const int ndx = get_num_state_derivative();
+    xdot_analytic_.setZero(ndx);
+    fx_analytic_.setZero(ndx, ndx);
+    fx_analytic_.topRightCorner(num_velocities_, num_velocities_) = Eigen::MatrixXd::Identity(num_velocities_, num_velocities_);
+    fu_analytic_.setZero(ndx, num_controls_);
 }
 
 Eigen::VectorXd PinocchioDynamicsSolver::f(const StateVector& x, const ControlVector& u)
 {
     // TODO: THIS DOES NOT WORK FOR A FLOATING BASE YET!!
     pinocchio::aba(model_, *pinocchio_data_, x.head(num_positions_).eval(), x.tail(num_velocities_).eval(), u);
-    Eigen::VectorXd x_dot(num_positions_ + num_velocities_);
-    x_dot.head(num_positions_) = x.tail(num_positions_);
-    x_dot.tail(num_velocities_) = pinocchio_data_->ddq;
-    return x_dot;
+    xdot_analytic_.head(num_velocities_) = x.tail(num_velocities_);
+    xdot_analytic_.tail(num_velocities_) = pinocchio_data_->ddq;
+    return xdot_analytic_;
 }
 
 Eigen::MatrixXd PinocchioDynamicsSolver::fx(const StateVector& x, const ControlVector& u)
 {
-    const int NQ = num_positions_;
-    const int NV = num_velocities_;
-    const int NX = NQ + NV;
-
     pinocchio::computeABADerivatives(model_, *pinocchio_data_, x.head(num_positions_).eval(), x.tail(num_velocities_).eval(), u.eval());
+    fx_analytic_.bottomLeftCorner(num_velocities_, num_velocities_) = pinocchio_data_->ddq_dq;
 
-    Eigen::MatrixXd fx_symb = Eigen::MatrixXd::Zero(NX, NX);
-    fx_symb.topRightCorner(NV, NV) = Eigen::MatrixXd::Identity(NV, NV);
-    fx_symb.bottomLeftCorner(NQ, NV) = pinocchio_data_->ddq_dq;
-
-    return fx_symb;
+    return fx_analytic_;
 }
 
 Eigen::MatrixXd PinocchioDynamicsSolver::fu(const StateVector& x, const ControlVector& u)
 {
-    const int NQ = num_positions_;
-    const int NV = num_velocities_;
-    const int NX = NQ + NV;
-    const int NU = num_controls_;
+    pinocchio::computeABADerivatives(model_, *pinocchio_data_, x.head(num_positions_).eval(), x.tail(num_velocities_).eval(), u);
+    fu_analytic_.bottomRightCorner(num_velocities_, num_controls_) = pinocchio_data_->Minv;
 
-    pinocchio::computeABADerivatives(model_, *pinocchio_data_, x.head(num_positions_).eval(), x.tail(num_velocities_).eval(), u.eval());
-
-    Eigen::MatrixXd fu_symb = Eigen::MatrixXd::Zero(NX, NU);
-    fu_symb.bottomRightCorner(NV, NU) = pinocchio_data_->Minv;
-
-    return fu_symb;
+    return fu_analytic_;
 }
 
 Eigen::VectorXd PinocchioDynamicsSolver::InverseDynamics(const StateVector& x)

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -68,8 +68,9 @@ protected:
     double CheckStoppingCriteria();
 
     double CalcDiff();
-    void ComputeDirection(const bool recalcDiff);
-    void BackwardPass() override;
+    bool ComputeDirection(const bool recalcDiff);
+    bool BackwardPassFDDP();
+    void BackwardPass() override { return (void)BackwardPassFDDP(); }
     virtual void ComputeGains(const int t);
     void ForwardPass(const double steplength);
     double TryStep(const double steplength);

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -38,10 +38,9 @@ namespace exotica
 // Feasibility-driven DDP solver
 // Based on the implementation in Crocoddyl: https://github.com/loco-3d/crocoddyl.git
 // Cf. https://arxiv.org/abs/1909.04947
-class FeasibilityDrivenDDPSolver : public AbstractDDPSolver, public Instantiable<FeasibilityDrivenDDPSolverInitializer>
+class AbstractFeasibilityDrivenDDPSolver : public AbstractDDPSolver
 {
 public:
-    void Instantiate(const FeasibilityDrivenDDPSolverInitializer& init) override;
     void Solve(Eigen::MatrixXd& solution) override;
 
     const std::vector<Eigen::VectorXd>& get_fs() const { return fs_; };
@@ -71,13 +70,15 @@ protected:
     double CalcDiff();
     void ComputeDirection(const bool recalcDiff);
     void BackwardPass() override;
-    void ComputeGains(const int t);
+    virtual void ComputeGains(const int t);
     void ForwardPass(const double steplength);
     double TryStep(const double steplength);
 
-    void AllocateData();
+    virtual void AllocateData();
 
     Eigen::MatrixXd control_limits_;
+    double initial_regularization_rate_ = 1e-9;             // Set from parameters on Instantiate
+    bool clamp_to_control_limits_in_forward_pass_ = false;  // Set from parameters on Instantiate
 
     double steplength_;           //!< Current applied step-length
     Eigen::Vector2d d_;           //!< LQ approximation of the expected improvement
@@ -128,6 +129,13 @@ protected:
     double th_stepinc_ = 0.01;   //!< Step-length threshold used to increase regularization
     bool was_feasible_ = false;  //!< Label that indicates in the previous iterate was feasible
 };
+
+class FeasibilityDrivenDDPSolver : public AbstractFeasibilityDrivenDDPSolver, public Instantiable<FeasibilityDrivenDDPSolverInitializer>
+{
+public:
+    void Instantiate(const FeasibilityDrivenDDPSolverInitializer& init) override;
+};
+
 }  // namespace exotica
 
 #endif  // EXOTICA_DDP_SOLVER_FEASIBILITY_DRIVEN_DDP_SOLVER_H_

--- a/exotations/solvers/exotica_ddp_solver/init/control_limited_ddp_solver.in
+++ b/exotations/solvers/exotica_ddp_solver/init/control_limited_ddp_solver.in
@@ -1,3 +1,4 @@
 class ControlLimitedDDPSolver
 
 extend <exotica_ddp_solver/abstract_ddp_solver>
+Optional bool ClampControlsInForwardPass = true;

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -120,7 +120,7 @@ void AbstractFeasibilityDrivenDDPSolver::Solve(Eigen::MatrixXd& solution)
     control_limits_ = dynamics_solver_->get_control_limits();
 
     AllocateData();
-    auto X_warm = prob_->get_X();
+    Eigen::MatrixXd X_warm = prob_->get_X();
     X_warm.col(0) = prob_->ApplyStartState();  // Apply start state
     auto U_warm = prob_->get_U();
     for (int t = 0; t < T_ - 1; ++t)

--- a/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
+++ b/exotations/solvers/exotica_ddp_solver/src/feasibility_driven_ddp_solver.cpp
@@ -199,16 +199,8 @@ void AbstractFeasibilityDrivenDDPSolver::Solve(Eigen::MatrixXd& solution)
         for (int ai = 0; ai < alpha_space_.size(); ++ai)
         {
             steplength_ = alpha_space_(ai);
+            dV_ = TryStep(steplength_);
 
-            try
-            {
-                dV_ = TryStep(steplength_);
-            }
-            catch (std::exception& e)
-            {
-                WARNING_NAMED("NaN in ForwardPass", e.what())
-                continue;
-            }
             ExpectedImprovement();
             dVexp_ = steplength_ * (d_[0] + 0.5 * steplength_ * d_[1]);
 
@@ -456,11 +448,13 @@ void AbstractFeasibilityDrivenDDPSolver::ForwardPass(const double steplength)
 
         if (IsNaN(cost_try_))
         {
-            throw std::runtime_error("forward_error - NaN in cost_try_ at t=" + std::to_string(t));
+            WARNING_NAMED("NaN in ForwardPass", "forward_error - NaN in cost_try_ at t=" << t);
+            return;
         }
         if (IsNaN(xnext_.lpNorm<Eigen::Infinity>()))
         {
-            throw std::runtime_error("forward_error - xnext_ isn't finite at t=" + std::to_string(t));
+            WARNING_NAMED("NaN in ForwardPass", "forward_error - xnext_ isn't finite at t=" << t);
+            return;
         }
     }
 
@@ -478,7 +472,8 @@ void AbstractFeasibilityDrivenDDPSolver::ForwardPass(const double steplength)
 
     if (IsNaN(cost_try_))
     {
-        throw std::runtime_error("forward_error - cost NaN");
+        WARNING_NAMED("NaN in ForwardPass", "forward_error - cost NaN");
+        return;
     }
 }
 

--- a/exotica_core/include/exotica_core/dynamics_solver.h
+++ b/exotica_core/include/exotica_core/dynamics_solver.h
@@ -119,6 +119,12 @@ public:
     /// \brief Returns number of velocities
     int get_num_velocities() const;
 
+    /// \brief Returns size of state space (nx)
+    int get_num_state() const;
+
+    /// \brief Returns size of derivative vector of state space (ndx)
+    int get_num_state_derivative() const;
+
     /// \brief Returns integration timestep dt
     T get_dt() const;
 
@@ -135,7 +141,7 @@ public:
     //  returns: Two-column matrix, first column contains low control limits,
     //      second - the high control limits
     const Eigen::MatrixXd& get_control_limits();
-    void set_control_limits(Eigen::VectorXd control_limits_low, Eigen::VectorXd control_limits_high);
+    void set_control_limits(Eigen::VectorXdRefConst control_limits_low, Eigen::VectorXdRefConst control_limits_high);
 
     virtual ControlVector InverseDynamics(const StateVector& state);
 
@@ -147,9 +153,11 @@ private:
     Eigen::VectorXd raw_control_limits_low_, raw_control_limits_high_;
 
 protected:
-    int num_controls_ = -1;    ///< Number of controls in the dynamic system.
-    int num_positions_ = -1;   ///< Number of positions in the dynamic system.
-    int num_velocities_ = -1;  ///< Number of velocities in the dynamic system.
+    int num_controls_ = -1;          ///< Number of controls in the dynamic system.
+    int num_positions_ = -1;         ///< Number of positions in the dynamic system.
+    int num_velocities_ = -1;        ///< Number of velocities in the dynamic system.
+    int num_state_ = -1;             ///< Size of state space (num_positions + num_velocities)
+    int num_state_derivative_ = -1;  ///< Size of the tangent vector to the state space (2 * num_velocities)
 
     bool second_order_derivatives_initialized_ = false;  ///< Whether fxx, fxu and fuu have been initialized to 0.
 
@@ -160,7 +168,7 @@ protected:
     Eigen::MatrixXd control_limits_;  ///< ControlLimits. Default is empty vector.
 
     /// \brief Integrates the dynamic system from state x with controls u applied for one timestep dt using the selected integrator.
-    inline StateVector SimulateOneStep(const StateVector& x, const ControlVector& u);
+    virtual StateVector SimulateOneStep(const StateVector& x, const ControlVector& u);
 
     void InitializeSecondOrderDerivatives();
     Eigen::Tensor<T, 3> fxx_default_, fuu_default_, fxu_default_;

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -504,6 +504,7 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("create_solver", [](const Initializer& init) { return Setup::CreateSolver(init); }, py::return_value_policy::take_ownership);    // "Creates an instance of the solver identified by name parameter.", py::arg("solverType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_problem", [](const Initializer& init) { return Setup::CreateProblem(init); }, py::return_value_policy::take_ownership);  // "Creates an instance of the problem identified by name parameter.", py::arg("problemType"), py::arg("prependExoticaNamespace"));
     setup.def_static("create_scene", [](const Initializer& init) { return Setup::CreateScene(init); }, py::return_value_policy::take_ownership);
+    setup.def_static("create_dynamics_solver", [](const Initializer& init) { return Setup::CreateDynamicsSolver(init); }, py::return_value_policy::take_ownership);
     setup.def_static("print_supported_classes", &Setup::PrintSupportedClasses, "Print a list of available plug-ins sorted by class.");
     setup.def_static("get_initializers", &Setup::GetInitializers, py::return_value_policy::copy, "Returns a list of available initializers with all available parameters/arguments.");
     setup.def_static("get_package_path", &ros::package::getPath, "ROS package path resolution.");
@@ -1215,9 +1216,19 @@ PYBIND11_MODULE(_pyexotica, module)
         .def("f", &DynamicsSolver::f)
         .def("fx", &DynamicsSolver::fx)
         .def("fu", &DynamicsSolver::fu)
+        .def_property_readonly("nq", &DynamicsSolver::get_num_positions)
+        .def_property_readonly("nv", &DynamicsSolver::get_num_velocities)
+        .def_property_readonly("nx", &DynamicsSolver::get_num_state)
+        .def_property_readonly("ndx", &DynamicsSolver::get_num_state_derivative)
+        .def_property_readonly("nu", &DynamicsSolver::get_num_controls)
         .def("get_position", &DynamicsSolver::GetPosition)
         .def("simulate", &DynamicsSolver::Simulate)
-        .def("integrate", &DynamicsSolver::Integrate)
+        .def("state_delta", &DynamicsSolver::StateDelta)
+        .def("integrate", [](DynamicsSolver* instance, Eigen::VectorXdRefConst x, Eigen::VectorXdRefConst u, const double dt) {
+            Eigen::VectorXd xout(instance->get_num_positions() + instance->get_num_velocities());
+            instance->Integrate(x, u, dt, xout);
+            return xout;
+        })
         .def_property_readonly("dt", &DynamicsSolver::get_dt, "dt");
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR:

1. Fixes various dimensions in dynamic control problems, particular related to the size of the tangent space. It also exposes this variables explicitly (nq, nv, nu, nx, ndx). Further it reduces the number of heap allocations.
2. Fixes the analytic derivative of the `exotica_pinocchio_dynamics_solver` and eliminates allocations during runtime. Part of the partial derivative w.r.t. q was previously omitted.
3. Includes modifications to FDDP to make it (a) abstract and (b) to eliminate try-catch logic as identified in #692 
4. Fixes the default finite differencing in the dynamics solvers to correctly account for manifold operations, e.g., when using quaternions.