### PR TITLE
Meshcat visualiser compatibility

### DIFF
--- a/exotica_core/include/exotica_core/visualization_meshcat.h
+++ b/exotica_core/include/exotica_core/visualization_meshcat.h
@@ -41,7 +41,7 @@ namespace exotica
 class VisualizationMeshcat : public Uncopyable
 {
 public:
-    VisualizationMeshcat(ScenePtr scene, const std::string& url, bool use_mesh_materials = true);
+    VisualizationMeshcat(ScenePtr scene, const std::string& url, bool use_mesh_materials = true, const std::string& file_url = "");
     virtual ~VisualizationMeshcat();
 
     void Initialize(bool use_mesh_materials);

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -487,8 +487,8 @@ public:
         return handle(InitializerToTuple(src));
     }
 };
-}
-}
+}  // namespace detail
+}  // namespace pybind11
 
 PYBIND11_MODULE(_pyexotica, module)
 {
@@ -1125,7 +1125,7 @@ PYBIND11_MODULE(_pyexotica, module)
     visualization_moveit.def("display_trajectory", &VisualizationMoveIt::DisplayTrajectory);
 #ifdef MSGPACK_FOUND
     py::class_<VisualizationMeshcat> visualization_meshcat(module, "VisualizationMeshcat");
-    visualization_meshcat.def(py::init<ScenePtr, const std::string&, bool>(), py::arg("scene"), py::arg("url"), py::arg("use_mesh_materials") = true);
+    visualization_meshcat.def(py::init<ScenePtr, const std::string&, bool, const std::string&>(), py::arg("scene"), py::arg("url"), py::arg("use_mesh_materials") = true, py::arg("file_url") = "");
     visualization_meshcat.def("display_scene", &VisualizationMeshcat::DisplayScene, py::arg("use_mesh_materials") = true);
     visualization_meshcat.def("display_state", &VisualizationMeshcat::DisplayState, py::arg("state"), py::arg("t") = 0.0);
     visualization_meshcat.def("display_trajectory", &VisualizationMeshcat::DisplayTrajectory, py::arg("trajectory"), py::arg("dt") = 1.0);


### PR DESCRIPTION
 - Meshcat visualiser now follows mainstream Meshcat release
 - File serving is done vie a separate [server script](https://github.com/VladimirIvan/meshcat_ros_fileserver) that was split from [meshcat-python](https://github.com/rdeits/meshcat-python/pull/47). Install both scripts and start them using:
```
meshcat-server
meshcat-ros-fileserver -f /
```
 - If the file server is running on a different machine/port, you can specify this in the constructor of the `VisualizationMeshcat` class using a new argument `file_url`.
