### PR TITLE
New pseudo-inverse IK solver with faster convergence, better numerical behaviour

### DIFF
--- a/exotations/solvers/exotica_ik_solver/exotica_plugins.xml
+++ b/exotations/solvers/exotica_ik_solver/exotica_plugins.xml
@@ -1,5 +1,5 @@
 <library path="lib/libexotica_ik_solver">
   <class name="exotica/IKSolver" type="exotica::IKSolver" base_class_type="exotica::MotionSolver">
-    <description>Pseudo-inverse inverse kinematics solver</description>
+    <description>Regularized and weighted pseudo-inverse inverse kinematics solver</description>
   </class>
 </library>

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -64,6 +64,13 @@ private:
 
     Eigen::MatrixXd C_;  //!< \brief Regularisation (use values from interval <0, 1))
     Eigen::MatrixXd W_;  //!< \brief Jointspace weighting
+
+    double lambda_;
+    double cost_;
+    double cost_prev_;
+    double stop_;
+    double th_stop_;
+    double steplength_;
 };
 }  // namespace exotica
 

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -38,39 +38,78 @@
 namespace exotica
 {
 ///
-/// \brief	IK position solver
-/// The solver constructs and solves a linear program of the following form:
-/// \f[
-///   (SJW)x=y
-/// \f]
-/// Where S is a diagonal matrix of task scaling factors rho for each task, jacobian is the Jacobian, W is a diagonal matrix
-/// of the joint space weights.
-///
-/// When regularisation term C is used, it gets appended to the Jacobian and distance to the nominal pose is appended
-/// to the y vector. For more details see:
-/// https://github.com/ipab-slmc/exotica/pull/465#issuecomment-449021817
+/// \brief	Weighted and Regularized Pseudo-Inverse Inverse Kinematics Solver
+/// The solver solves a weighted and regularised pseudo-inverse problem. It uses backtracking line-search and adaptive regularization.
 ///
 class IKSolver : public MotionSolver, public Instantiable<IKSolverInitializer>
 {
 public:
     void Solve(Eigen::MatrixXd& solution) override;
-
     void SpecifyProblem(PlanningProblemPtr pointer) override;
 
 private:
-    void ScaleToStepSize(Eigen::VectorXdRef xd);  //!< \brief Scale the state change vector so that the largest dimension is max. step or smaller.
-
     UnconstrainedEndPoseProblemPtr prob_;  // Shared pointer to the planning problem.
 
-    Eigen::MatrixXd C_;  //!< \brief Regularisation (use values from interval <0, 1))
-    Eigen::MatrixXd W_;  //!< \brief Jointspace weighting
+    Eigen::MatrixXd W_inv_;        ///< Joint-space weighting (inverse)
+    Eigen::VectorXd alpha_space_;  ///< Steplengths for backtracking line-search
 
-    double lambda_;
-    double cost_;
-    double cost_prev_;
-    double stop_;
-    double th_stop_;
-    double steplength_;
+    // Pre-allocation of variables used during optimisation
+    double stop_;                                  ///< Stop criterion: Norm of cost Jacobian
+    double step_;                                  ///< Size of step: Sum of squared norm of qd_
+    double lambda_ = 0;                            ///< Damping factor
+    double steplength_;                            ///< Accepted steplength
+    Eigen::VectorXd q_;                            ///< Joint configuration vector, used during optimisation
+    Eigen::VectorXd qd_;                           ///< Change in joint configuration, used during optimisation
+    Eigen::VectorXd yd_;                           ///< Task space difference/error, used during optimisation
+    Eigen::MatrixXd cost_jacobian_;                ///< Jacobian, used during optimisation
+    Eigen::MatrixXd J_pseudo_inverse_;             ///< Jacobian pseudo-inverse, used during optimisation
+    double error_;                                 ///< Error, used during optimisation
+    Eigen::LLT<Eigen::MatrixXd> J_decomposition_;  ///< Cholesky decomposition for the weighted pseudo-inverse
+    Eigen::MatrixXd J_tmp_;                        ///< Temporary variable for inverse computation
+
+    // Convergence thresholds
+    double th_stop_;  ///< Gradient convergence threshold
+
+    // Regularization
+    double regmin_ = 1e-9;      //!< Minimum regularization (will not decrease lower)
+    double regmax_ = 1e9;       //!< Maximum regularization (to exit by divergence)
+    double regfactor_ = 10.;    //!< Factor by which the regularization gets increased/decreased
+    double th_stepdec_ = 0.5;   //!< Step-length threshold used to decrease regularization
+    double th_stepinc_ = 0.01;  //!< Step-length threshold used to increase regularization
+
+    void IncreaseRegularization()
+    {
+        lambda_ *= regfactor_;
+        if (lambda_ > regmax_)
+        {
+            lambda_ = regmax_;
+        }
+    }
+
+    void DecreaseRegularization()
+    {
+        lambda_ /= regfactor_;
+        if (lambda_ < regmin_)
+        {
+            lambda_ = regmin_;
+        }
+    }
+
+    void PrintDebug(const int i)
+    {
+        if (i % 10 == 0 || i == 0)
+        {
+            std::cout << "iter \t cost \t       stop \t    grad \t  reg \t step\n";
+        }
+
+        std::cout << std::setw(4) << i << "  ";
+        std::cout << std::scientific << std::setprecision(5) << error_ << "  ";
+        std::cout << step_ << "  " << stop_ << "  ";
+        std::cout << lambda_ << "  ";
+        std::cout << std::fixed << std::setprecision(4) << steplength_ << '\n';
+    }
+
+    void ScaleToStepSize(Eigen::VectorXdRef xd);  ///< To scale to maximum step size
 };
 }  // namespace exotica
 

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, University of Edinburgh
+// Copyright (c) 2018-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -53,9 +53,6 @@ namespace exotica
 class IKSolver : public MotionSolver, public Instantiable<IKSolverInitializer>
 {
 public:
-    IKSolver();
-    virtual ~IKSolver();
-
     void Solve(Eigen::MatrixXd& solution) override;
 
     void SpecifyProblem(PlanningProblemPtr pointer) override;
@@ -68,6 +65,6 @@ private:
     Eigen::MatrixXd C_;  //!< \brief Regularisation (use values from interval <0, 1))
     Eigen::MatrixXd W_;  //!< \brief Jointspace weighting
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_IK_SOLVER_IK_SOLVER_H_

--- a/exotations/solvers/exotica_ik_solver/init/ik_solver.in
+++ b/exotations/solvers/exotica_ik_solver/init/ik_solver.in
@@ -1,8 +1,14 @@
 class IKSolver
 
 extend <exotica_core/motion_solver>
-Optional double Tolerance = 1e-5;
-Optional double Convergence = 0.0;
-Optional double MaxStep = 0.5;
-Optional double C = 0.0;
-Optional Eigen::VectorXd Alpha = Eigen::VectorXd::Ones(1);
+Optional double Tolerance = 1e-5;  // Absolute cost tolerance
+
+Optional double MaxStep = 0.0; // Only used if MaxIterations == 1, to set the maximum step.
+
+Optional double RegularizationRate = 1e-9;                     // Initial regularization value (C). Will be adapted.
+Optional double MinimumRegularization = 1e-12;                 // Minimum regularization below which it won't be decreased.
+Optional double MaximumRegularization = 1e3;                   // Maximum regularization above which it won't be decreased.
+Optional double ThresholdRegularizationIncrease = 0.01;        // Regularization will be increased if step-length is smaller or equal to this value.
+Optional double ThresholdRegularizationDecrease = 0.5;         // Regularization will be decreased if step-length is greater than this value.
+Optional double GradientToleranceConvergenceThreshold = 1e-9;  // Gradient tolerance.
+Optional double StepToleranceConvergenceThreshold = 1e-5;      // Step tolerance: Squared norm of the change.

--- a/exotations/solvers/exotica_ik_solver/package.xml
+++ b/exotations/solvers/exotica_ik_solver/package.xml
@@ -2,11 +2,10 @@
 <package format="2">
   <name>exotica_ik_solver</name>
   <version>5.1.3</version>
-  <description>Pseudo-inverse unconstrained end-pose solver</description>
+  <description>Regularised and weighted pseudo-inverse unconstrained end-pose solver</description>
 
+  <maintainer email="wolfgang@robots.ox.ac.uk">Wolfgang Merkt</maintainer>
   <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
-  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
-  <author>Michael Camilleri</author>
 
   <license>BSD</license>
 

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, University of Edinburgh
+// Copyright (c) 2018-2020, University of Edinburgh, University of Oxford
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -33,10 +33,6 @@ REGISTER_MOTIONSOLVER_TYPE("IKSolver", exotica::IKSolver)
 
 namespace exotica
 {
-IKSolver::IKSolver() = default;
-
-IKSolver::~IKSolver() = default;
-
 void IKSolver::SpecifyProblem(PlanningProblemPtr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedEndPoseProblem")
@@ -155,4 +151,4 @@ void IKSolver::ScaleToStepSize(Eigen::VectorXdRef xd)
         xd = xd * parameters_.MaxStep / max_vel;
     }
 }
-}
+}  // namespace exotica

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -129,6 +129,27 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
             q -= qd.cwiseProduct(parameters_.Alpha);
         }
 
+        // tmp
+        steplength_ = parameters_.Alpha(0);
+        cost_ = error;
+        lambda_ = C_(0, 0);
+        stop_ = qd.norm();
+
+        // Output
+        if (debug_)
+        {
+            if (i % 10 == 0 || i == 0)
+            {
+                std::cout << "iter \t cost \t       stop \t    grad \t  reg \t step\n";
+            }
+
+            std::cout << std::setw(4) << i << "  ";
+            std::cout << std::scientific << std::setprecision(5) << cost_ << "  ";
+            std::cout << stop_ << "  " << jacobian.sum() << "  ";
+            std::cout << lambda_ << "  ";
+            std::cout << std::fixed << std::setprecision(4) << steplength_ << '\n';
+        }
+
         if (qd.norm() < parameters_.Convergence)
         {
             if (debug_)

--- a/exotica/doc/XML.rst
+++ b/exotica/doc/XML.rst
@@ -12,13 +12,7 @@ file and is shown below:
 
   <?xml version="1.0" ?>
   <IKSolverDemoConfig>
-    <IKSolver Name="MySolver">
-      <MaxIterations>1</MaxIterations>
-      <MaxStep>0.1</MaxStep>
-      <Tolerance>1e-5</Tolerance>
-      <Alpha>1.0</Alpha>
-      <C>1e-3</C>
-    </IKSolver>
+    <IKSolver Name="MySolver" MaxIterations="10"/>
 
     <UnconstrainedEndPoseProblem Name="MyProblem">
       <PlanningScene>
@@ -46,7 +40,7 @@ file and is shown below:
 .. rubric:: CODE EXPLAINED
 
 In the code we see:
-* the initialization of the ``IKSolver`` and its parameters (e.g. ``MaxIterations``,\ ``MaxStep``) set
+* the initialization of the ``IKSolver`` and its parameters (e.g. ``MaxIterations``) set
 * a problem (``UnconstrainedEndPoseProblem``) is specified and  necessary parameters input. 
 - Within the problem, a ``PlanningScene`` and ``Maps`` are initialized in addition to the problem parameters. 
 
@@ -63,10 +57,8 @@ Solver options are then specified:
 .. code-block:: xml
 
       <MaxIterations>1</MaxIterations>
-      <MaxStep>0.1</MaxStep>
       <Tolerance>1e-5</Tolerance>
-      <Alpha>1.0</Alpha>
-      <C>1e-3</C>
+      <RegularizationRate>1e-3</RegularizationRate>
 
 The parameters in this case are optional, but each solver has its own 
 set of initialization parameters, as detailed on the `previous page <initialization.html>`__

--- a/exotica_examples/resources/configs/example_ik.xml
+++ b/exotica_examples/resources/configs/example_ik.xml
@@ -28,7 +28,6 @@
     </Cost>
 
     <StartState>0 0 0 0 0 0 0</StartState>
-    <NominalState>0 0 0 0 0 0 0</NominalState>
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedEndPoseProblem>
 

--- a/exotica_examples/test/resources/test_valkyrie_collisionscene_fcl.xml
+++ b/exotica_examples/test/resources/test_valkyrie_collisionscene_fcl.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
-  <IKSolver Name="DummySolver">
-    <MaxIterations>100</MaxIterations>
-    <MaxStep>0.1</MaxStep>
-    <Tolerance>1e-5</Tolerance>
-    <Alpha>1.0</Alpha>
-    <C>1e-3</C>
-  </IKSolver>
+  <IKSolver Name="DummySolver"/>
   
   <UnconstrainedEndPoseProblem>
     <PlanningScene>
@@ -28,7 +22,6 @@
     <Cost>
       <Task Task="CoM"/>
     </Cost>
-    <NominalState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</NominalState>
     <StartState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</StartState>
   </UnconstrainedEndPoseProblem>
 </ExoticaWholeBodyIKConfig>

--- a/exotica_examples/test/resources/test_valkyrie_collisionscene_fcl_latest.xml
+++ b/exotica_examples/test/resources/test_valkyrie_collisionscene_fcl_latest.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" ?>
 <ExoticaWholeBodyIKConfig>
-  <IKSolver Name="DummySolver">
-    <MaxIterations>100</MaxIterations>
-    <MaxStep>0.1</MaxStep>
-    <Tolerance>1e-5</Tolerance>
-    <Alpha>1.0</Alpha>
-    <C>1e-3</C>
-  </IKSolver>
+  <IKSolver Name="DummySolver"/>
   
   <UnconstrainedEndPoseProblem>
     <PlanningScene>
@@ -28,7 +22,6 @@
     <Cost>
       <Task Task="CoM"/>
     </Cost>
-    <NominalState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</NominalState>
     <StartState>0.0 0.0 1.025 0.0 0.0 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 -0.49 1.205 -0.71 0.0 0.0 0.0 0.0 0.300196631343 -1.25 0.0 -0.785398163397 1.571 0.0 0.0 0.0 0.0 0.0 0.300196631343 1.25 0.0 0.785398163397 1.571 0.0 0.0</StartState>
   </UnconstrainedEndPoseProblem>
 </ExoticaWholeBodyIKConfig>


### PR DESCRIPTION
This PR replaces the linear-system-based IK with a weighted and regularised pseudo-inverse IK with adaptive regularisation and backtracking line-search. It further includes more stopping criteria. These changes result in much better convergence and numerical behaviour/conditioning. The implementation is performance-oriented and uses Cholesky decomposition for the matrix decomposition/inverse.

The solution the new solver returns are also better (read: closer to the original state, within joint limits).

**Changes:**
- It now implements a regularised and weighted Jacobian pseudo-inverse instead of solving a linear system.
- The support for `NominalState` regularisation by appending a nominal state to the error vector was removed.
- Adaptive regularisation and backtracking line-search result in better convergence and numerical behaviour.
- Use of pre-allocation and Cholesky decomposition makes the solver fast :-).
- `MaxStep` for interactive IK is still supported, however, only when `MaxIterations == 1`.
- `example_ik` now converges in 6 iterations, previously 43.
- Turns out the old implementation had a bug when Regularisation was on (C>0.0) - it overwrote the final value of the task error with an erroneously oversized regularisation matrix - this is now also resolved as the old code has been replaced.

Here's a plot of the behaviour on the LWR example (`example_ik`) for the first target - before and after:
![ik_old_vs_new](https://user-images.githubusercontent.com/1664508/79804394-d5c5e400-835b-11ea-994e-1ba135ed9d2b.png)

And corresponding convergence logs:

## Before
```
iter     cost          stop         grad          reg    step
   0  3.22242e+00  2.90930e-01  7.82000e+00  0.00000e+00  1.0000
   1  1.83584e+00  7.36646e-01  1.04546e+01  0.00000e+00  1.0000
   2  2.00144e+00  8.53389e-01  1.11840e+01  0.00000e+00  1.0000
   3  1.60733e+00  3.97460e-01  1.35734e+01  0.00000e+00  1.0000
   4  1.00728e+00  5.74187e-01  1.54258e+01  0.00000e+00  1.0000
   5  6.81838e-01  6.21559e-01  1.82345e+01  0.00000e+00  1.0000
   6  6.56756e-01  6.22272e-01  2.07452e+01  0.00000e+00  1.0000
   7  7.08747e-01  6.26042e-01  2.29382e+01  0.00000e+00  1.0000
   8  7.94282e-01  6.37213e-01  2.47424e+01  0.00000e+00  1.0000
   9  8.70059e-01  6.25281e-01  2.60146e+01  0.00000e+00  1.0000
iter     cost          stop         grad          reg    step
  10  8.00613e-01  1.08680e-01  2.64694e+01  0.00000e+00  1.0000
  11  5.56834e-01  1.28919e-01  2.65169e+01  0.00000e+00  1.0000
  12  3.64317e-01  1.30440e-01  2.66567e+01  0.00000e+00  1.0000
  13  2.35836e-01  1.16878e-01  2.68654e+01  0.00000e+00  1.0000
  14  1.53387e-01  1.02169e-01  2.70985e+01  0.00000e+00  1.0000
  15  1.00689e-01  8.80847e-02  2.73241e+01  0.00000e+00  1.0000
  16  6.68940e-02  7.48868e-02  2.75245e+01  0.00000e+00  1.0000
  17  4.50687e-02  6.28797e-02  2.76925e+01  0.00000e+00  1.0000
  18  3.08148e-02  5.22850e-02  2.78275e+01  0.00000e+00  1.0000
  19  2.13667e-02  4.31689e-02  2.79326e+01  0.00000e+00  1.0000
iter     cost          stop         grad          reg    step
  20  1.49974e-02  3.54708e-02  2.80121e+01  0.00000e+00  1.0000
  21  1.06302e-02  2.90559e-02  2.80706e+01  0.00000e+00  1.0000
  22  7.58925e-03  2.37589e-02  2.81125e+01  0.00000e+00  1.0000
  23  5.44455e-03  1.94113e-02  2.81416e+01  0.00000e+00  1.0000
  24  3.91706e-03  1.58565e-02  2.81610e+01  0.00000e+00  1.0000
  25  2.82167e-03  1.29565e-02  2.81731e+01  0.00000e+00  1.0000
  26  2.03275e-03  1.05932e-02  2.81800e+01  0.00000e+00  1.0000
  27  1.46328e-03  8.66793e-03  2.81833e+01  0.00000e+00  1.0000
  28  1.05193e-03  7.09906e-03  2.81839e+01  0.00000e+00  1.0000
  29  7.54924e-04  5.81987e-03  2.81828e+01  0.00000e+00  1.0000
iter     cost          stop         grad          reg    step
  30  5.40738e-04  4.77599e-03  2.81807e+01  0.00000e+00  1.0000
  31  3.86543e-04  3.92328e-03  2.81780e+01  0.00000e+00  1.0000
  32  2.75757e-04  3.22599e-03  2.81749e+01  0.00000e+00  1.0000
  33  1.96331e-04  2.65515e-03  2.81718e+01  0.00000e+00  1.0000
  34  1.39514e-04  2.18731e-03  2.81687e+01  0.00000e+00  1.0000
  35  9.89587e-05  1.80346e-03  2.81658e+01  0.00000e+00  1.0000
  36  7.00715e-05  1.48818e-03  2.81631e+01  0.00000e+00  1.0000
  37  4.95371e-05  1.22896e-03  2.81606e+01  0.00000e+00  1.0000
  38  3.49679e-05  1.01561e-03  2.81584e+01  0.00000e+00  1.0000
  39  2.46494e-05  8.39858e-04  2.81564e+01  0.00000e+00  1.0000
iter     cost          stop         grad          reg    step
  40  1.73536e-05  6.94949e-04  2.81547e+01  0.00000e+00  1.0000
  41  1.22029e-05  5.75372e-04  2.81532e+01  0.00000e+00  1.0000
[EXOTica]: [IKSolver] Reached tolerance (0.0000 < 0.0000)
Solution found in 0.0003771s [ 2.73987663  0.69071349 -2.75179532  1.28968653 -0.26322913  0.36207069   
0.        ] in 43 iterations
```

## After
```
iter     cost          stop         grad          reg    step
   0  3.22242e+00  8.23631e-01  2.60311e+00  1.00000e-09  1.0000
   1  1.63402e-01  1.51001e+00  2.65507e+00  1.00000e-09  0.4000
   2  1.14527e-01  4.73361e-01  2.62015e+00  1.00000e-09  1.0000
   3  1.11041e-02  1.49634e-01  2.62473e+00  1.00000e-09  1.0000
   4  5.05987e-04  5.23253e-03  2.65237e+00  1.00000e-09  1.0000
   5  1.25895e-06  5.23253e-03  2.65237e+00  1.00000e-09  1.0000
[EXOTica]: [IKSolver] Reached absolute function tolerance (0.0000 < 0.0000)
Solution found in 0.000144965s [-0.40312432 -0.69274757  0.39142517  1.28995832 -0.26320049  0.36257304   
0.        ] in 6 iterations
```