### PR TITLE
[exotica_examples] Remap C++ visualisation topic to display obstacles in examples

### DIFF
--- a/exotica_examples/launch/cpp_ompl.launch
+++ b/exotica_examples/launch/cpp_ompl.launch
@@ -9,6 +9,7 @@
 
   <node launch-prefix="$(arg launch_prefix)" pkg="exotica_examples" type="example_cpp_planner" name="example_cpp_planner_node" output="screen">
     <param name="ConfigurationFile" type="string" value="$(find exotica_examples)/resources/configs/example_ompl.xml" />
+    <remap from="/example_cpp_planner_node/CollisionShapes" to="/exotica/CollisionShapes"/>
   </node>
 
   <node name="rviz" pkg="rviz" type="rviz" respawn="false"	args="-d $(find exotica_examples)/resources/rviz.rviz" />

--- a/exotica_examples/src/planner.cpp
+++ b/exotica_examples/src/planner.cpp
@@ -66,7 +66,7 @@ void run()
             // The rest of the trajectory minimizes the control cost
             problem->SetRho("Frame", 0.0, t);
         }
-        problem->SetRho("Frame", 1e3, 99);
+        problem->SetRho("Frame", 1e3, -1);
     }
 
     // Create the initial configuration
@@ -107,6 +107,6 @@ int main(int argc, char **argv)
     run();
 
     // Clean up
-    // Run this only after all the exoica classes have been disposed of!
+    // Run this only after all the exotica classes have been disposed of!
     Setup::Destroy();
 }


### PR DESCRIPTION
Resolves #710 

cc: @jackey984 This PR resolves the problem you've described by explicitly remapping the topic to the one set in the RViz config.