### PR TITLE
Fix convergence in IK solver - resolve issue #712

### DIFF
--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -64,6 +64,7 @@ private:
     Eigen::MatrixXd cost_jacobian_;                ///< Jacobian, used during optimisation
     Eigen::MatrixXd J_pseudo_inverse_;             ///< Jacobian pseudo-inverse, used during optimisation
     double error_;                                 ///< Error, used during optimisation
+    double error_prev_;                            ///< Error at previous iteration, used during optimisation
     Eigen::LLT<Eigen::MatrixXd> J_decomposition_;  ///< Cholesky decomposition for the weighted pseudo-inverse
     Eigen::MatrixXd J_tmp_;                        ///< Temporary variable for inverse computation
 

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -75,7 +75,7 @@ private:
     double regmax_ = 1e9;       //!< Maximum regularization (to exit by divergence)
     double regfactor_ = 10.;    //!< Factor by which the regularization gets increased/decreased
     double th_stepdec_ = 0.5;   //!< Step-length threshold used to decrease regularization
-    double th_stepinc_ = 0.01;  //!< Step-length threshold used to increase regularization
+    double th_stepinc_ = 0.1;   //!< Step-length threshold used to increase regularization
 
     void IncreaseRegularization()
     {

--- a/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
+++ b/exotations/solvers/exotica_ik_solver/include/exotica_ik_solver/ik_solver.h
@@ -71,11 +71,11 @@ private:
     double th_stop_;  ///< Gradient convergence threshold
 
     // Regularization
-    double regmin_ = 1e-9;      //!< Minimum regularization (will not decrease lower)
-    double regmax_ = 1e9;       //!< Maximum regularization (to exit by divergence)
-    double regfactor_ = 10.;    //!< Factor by which the regularization gets increased/decreased
-    double th_stepdec_ = 0.5;   //!< Step-length threshold used to decrease regularization
-    double th_stepinc_ = 0.1;   //!< Step-length threshold used to increase regularization
+    double regmin_ = 1e-9;     //!< Minimum regularization (will not decrease lower)
+    double regmax_ = 1e9;      //!< Maximum regularization (to exit by divergence)
+    double regfactor_ = 10.;   //!< Factor by which the regularization gets increased/decreased
+    double th_stepdec_ = 0.5;  //!< Step-length threshold used to decrease regularization
+    double th_stepinc_ = 0.1;  //!< Step-length threshold used to increase regularization
 
     void IncreaseRegularization()
     {

--- a/exotations/solvers/exotica_ik_solver/init/ik_solver.in
+++ b/exotations/solvers/exotica_ik_solver/init/ik_solver.in
@@ -8,7 +8,7 @@ Optional double MaxStep = 0.0; // Only used if MaxIterations == 1, to set the ma
 Optional double RegularizationRate = 1e-9;                     // Initial regularization value (C). Will be adapted.
 Optional double MinimumRegularization = 1e-12;                 // Minimum regularization below which it won't be decreased.
 Optional double MaximumRegularization = 1e3;                   // Maximum regularization above which it won't be decreased.
-Optional double ThresholdRegularizationIncrease = 0.01;        // Regularization will be increased if step-length is smaller or equal to this value.
+Optional double ThresholdRegularizationIncrease = 0.1;         // Regularization will be increased if step-length is smaller or equal to this value.
 Optional double ThresholdRegularizationDecrease = 0.5;         // Regularization will be decreased if step-length is greater than this value.
 Optional double GradientToleranceConvergenceThreshold = 1e-9;  // Gradient tolerance.
 Optional double StepToleranceConvergenceThreshold = 1e-5;      // Step tolerance: Squared norm of the change.

--- a/exotations/solvers/exotica_ik_solver/init/ik_solver.in
+++ b/exotations/solvers/exotica_ik_solver/init/ik_solver.in
@@ -7,7 +7,7 @@ Optional double MaxStep = 0.0; // Only used if MaxIterations == 1, to set the ma
 
 Optional double RegularizationRate = 1e-9;                     // Initial regularization value (C). Will be adapted.
 Optional double MinimumRegularization = 1e-12;                 // Minimum regularization below which it won't be decreased.
-Optional double MaximumRegularization = 1e3;                   // Maximum regularization above which it won't be decreased.
+Optional double MaximumRegularization = 1e9;                   // Maximum regularization above which it won't be decreased.
 Optional double ThresholdRegularizationIncrease = 0.1;         // Regularization will be increased if step-length is smaller or equal to this value.
 Optional double ThresholdRegularizationDecrease = 0.5;         // Regularization will be decreased if step-length is greater than this value.
 Optional double GradientToleranceConvergenceThreshold = 1e-9;  // Gradient tolerance.

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -184,11 +184,11 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
         if (steplength_ <= th_stepinc_)
         {
             IncreaseRegularization();
-            if (lambda_ == regmax_)
-            {
-                prob_->termination_criterion = TerminationCriterion::Divergence;
-                break;
-            }
+            // if (lambda_ == regmax_)
+            // {
+            //     prob_->termination_criterion = TerminationCriterion::Divergence;
+            //     break;
+            // }
         }
     }
 

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -91,6 +91,7 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
         prob_->Update(q_);
         error_ = prob_->GetScalarCost();
         prob_->SetCostEvolution(i, error_);
+        error_prev_ = error_;
 
         // Absolute function tolerance check
         if (error_ < parameters_.Tolerance)
@@ -103,7 +104,7 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
         cost_jacobian_.noalias() = prob_->cost.S * prob_->cost.jacobian;
 
         // Weighted Regularized Pseudo-Inverse
-        //   J_pseudo_inverse_ = W_inv_ * cost_jacobian_.transpose() * ( cost_jacobian_ * W_inv_ * cost_jacobian_.transpose() + C_ ).inverse();
+        //   J_pseudo_inverse_ = W_inv_ * cost_jacobian_.transpose() * ( cost_jacobian_ * W_inv_ * cost_jacobian_.transpose() + lambda_ * I ).inverse();
 
         bool decomposition_ok = false;
         while (!decomposition_ok)

--- a/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
+++ b/exotations/solvers/exotica_ik_solver/src/ik_solver.cpp
@@ -155,7 +155,7 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
         }
 
         // Check gradient tolerance (convergence)
-        if (step_ < parameters_.GradientToleranceConvergenceThreshold)
+        if (stop_ < parameters_.GradientToleranceConvergenceThreshold)
         {
             prob_->termination_criterion = TerminationCriterion::GradientTolerance;
             break;
@@ -178,7 +178,7 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
     }
 
     // Check if we ran out of iterations
-    if (i == GetNumberOfMaxIterations() - 1)
+    if (i == GetNumberOfMaxIterations())
     {
         prob_->termination_criterion = TerminationCriterion::IterationLimit;
     }
@@ -192,13 +192,13 @@ void IKSolver::Solve(Eigen::MatrixXd& solution)
         switch (prob_->termination_criterion)
         {
             case TerminationCriterion::GradientTolerance:
-                HIGHLIGHT_NAMED("IKSolver", "Reached convergence (" << stop_ << " < " << parameters_.GradientToleranceConvergenceThreshold << ")");
+                HIGHLIGHT_NAMED("IKSolver", "Reached convergence (" << std::scientific << stop_ << " < " << parameters_.GradientToleranceConvergenceThreshold << ")");
                 break;
             case TerminationCriterion::FunctionTolerance:
-                HIGHLIGHT_NAMED("IKSolver", "Reached absolute function tolerance (" << error_ << " < " << parameters_.Tolerance << ")");
+                HIGHLIGHT_NAMED("IKSolver", "Reached absolute function tolerance (" << std::scientific << error_ << " < " << parameters_.Tolerance << ")");
                 break;
             case TerminationCriterion::StepTolerance:
-                HIGHLIGHT_NAMED("IKSolver", "Reached step tolerance (" << step_ << " < " << parameters_.StepToleranceConvergenceThreshold << ")");
+                HIGHLIGHT_NAMED("IKSolver", "Reached step tolerance (" << std::scientific << step_ << " < " << parameters_.StepToleranceConvergenceThreshold << ")");
                 break;
             case TerminationCriterion::Divergence:
                 WARNING_NAMED("IKSolver", "Regularization exceeds maximum regularization: " << lambda_ << " > " << regmax_);

--- a/exotica_examples/resources/configs/example_manipulate_ik.xml
+++ b/exotica_examples/resources/configs/example_manipulate_ik.xml
@@ -13,27 +13,28 @@
   </PlanningScene>
   <Maps>
     <EffFrame Name="Position1">
-      <Type>RPY</Type>
       <EndEffector>
           <Frame Link="lwr_arm_6_link" BaseOffset="0.6 -0.3 0.5 0 0 0 1" LinkOffset="0 0 0.2 0.7071067811865476 0  0.7071067811865475 0"/>
       </EndEffector>
     </EffFrame>
     <EffFrame Name="Position2">
-      <Type>RPY</Type>
       <EndEffector>
           <Frame Link="lwr_arm_6_link" BaseOffset="0.6 0.3 0.5 0 0 0 1" LinkOffset="0 0 0.2 0.7071067811865476 0  0.7071067811865475 0"/>
       </EndEffector>
     </EffFrame>
+    <JointLimit Name="JointLimit"/>
+    <JointPose Name="JointPose"/>
   </Maps>
 
   <Cost>
+    <Task Task="JointLimit"/>
+    <Task Task="JointPose"/>
     <Task Task="Position1"/>
     <Task Task="Position2"/>
   </Cost>
 
   <W> 7 6 5 4 3 2 1 </W>
   <StartState>0 0 0 0 0 0 0</StartState>
-  <NominalState>0 0 0 0 0 0 0</NominalState>
 </UnconstrainedEndPoseProblem>
 
 </ExampleConfig>

--- a/exotica_examples/scripts/example_attach
+++ b/exotica_examples/scripts/example_attach
@@ -27,11 +27,11 @@ ompl = exo.Setup.load_solver(
     '{exotica_examples}/resources/configs/example_manipulate_ompl.xml')
 
 # Plan 3 end poses
-ik.get_problem().set_rho('Position1', 1e3)
+ik.get_problem().set_rho('Position1', 1e2)
 ik.get_problem().set_rho('Position2', 0)
 goal_pose = [ik.solve()[0].tolist()]
 ik.get_problem().set_rho('Position1', 0)
-ik.get_problem().set_rho('Position2', 1e3)
+ik.get_problem().set_rho('Position2', 1e2)
 goal_pose.append(ik.solve()[0].tolist())
 goal_pose.append([0]*len(goal_pose[0]))
 start_pose = [[0]*len(goal_pose[0]), goal_pose[0], goal_pose[1]]


### PR DESCRIPTION
- Upstreams some changes to IK solver that fix exit criteria, damping adaptation, and thus convergence
- Updates example config to remove deprecated nominal state and replace with JointPose, adds JointLimit

And most crucially:
- Reduce scaling of cost from 1e3 to 1e2. This is what resolved the issue.

@the-raspberry-pi-guy please try this - it should work