### PR TITLE
[exotica_core] Implement velocity & acceleration joint limit exposure

### DIFF
--- a/exotica_core/include/exotica_core/kinematic_element.h
+++ b/exotica_core/include/exotica_core/kinematic_element.h
@@ -121,8 +121,8 @@ public:
     KDL::Frame generated_offset = KDL::Frame::Identity();
     bool is_trajectory_generated = false;
     std::vector<double> joint_limits;
-    double velocity_limit;
-    double acceleration_limit;
+    double velocity_limit = std::numeric_limits<double>::quiet_NaN();
+    double acceleration_limit = std::numeric_limits<double>::quiet_NaN();
     shapes::ShapeConstPtr shape = nullptr;
     std::string shape_resource_path = std::string();
     Eigen::Vector3d scale = Eigen::Vector3d::Ones();

--- a/exotica_core/include/exotica_core/kinematic_element.h
+++ b/exotica_core/include/exotica_core/kinematic_element.h
@@ -121,6 +121,8 @@ public:
     KDL::Frame generated_offset = KDL::Frame::Identity();
     bool is_trajectory_generated = false;
     std::vector<double> joint_limits;
+    std::vector<double> velocity_limit;
+    std::vector<double> acceleration_limit;
     shapes::ShapeConstPtr shape = nullptr;
     std::string shape_resource_path = std::string();
     Eigen::Vector3d scale = Eigen::Vector3d::Ones();

--- a/exotica_core/include/exotica_core/kinematic_element.h
+++ b/exotica_core/include/exotica_core/kinematic_element.h
@@ -121,8 +121,8 @@ public:
     KDL::Frame generated_offset = KDL::Frame::Identity();
     bool is_trajectory_generated = false;
     std::vector<double> joint_limits;
-    std::vector<double> velocity_limit;
-    std::vector<double> acceleration_limit;
+    double velocity_limit;
+    double acceleration_limit;
     shapes::ShapeConstPtr shape = nullptr;
     std::string shape_resource_path = std::string();
     Eigen::Vector3d scale = Eigen::Vector3d::Ones();

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -156,12 +156,12 @@ public:
     void SetJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
     void SetJointVelocityLimits(Eigen::VectorXdRefConst velocity_in);
     void SetJointAccelerationLimits(Eigen::VectorXdRefConst acceleration_in);
-    void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
-    void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
+    void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper);
+    void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     std::map<std::string, std::vector<double>> GetUsedJointLimits() const;
-    bool HasAccelerationLimits() const { return has_acceleration_limit; }
+    const bool& HasAccelerationLimits() const { return has_acceleration_limit_; }
     const Eigen::VectorXd& GetAccelerationLimits() const { return acceleration_limits_; }
     const Eigen::VectorXd& GetVelocityLimits() const { return velocity_limits_; }
     int GetNumControlledJoints() const;
@@ -263,7 +263,7 @@ private:
     Eigen::MatrixXd joint_limits_;
     Eigen::VectorXd velocity_limits_;
     Eigen::VectorXd acceleration_limits_;
-    bool has_acceleration_limit = false;
+    bool has_acceleration_limit_ = false;
     void UpdateJointLimits();
 
     // Random state generation

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -154,16 +154,16 @@ public:
     const Eigen::MatrixXd& GetJointLimits() const { return joint_limits_; }
     void SetJointLimitsLower(Eigen::VectorXdRefConst lower_in);
     void SetJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
-    void SetJointLimitsVelocity(Eigen::VectorXdRefConst velocity_in);
-    void SetJointLimitsAcceleration(Eigen::VectorXdRefConst acceleration_in);
+    void SetJointVelocityLimits(Eigen::VectorXdRefConst velocity_in);
+    void SetJointAccelerationLimits(Eigen::VectorXdRefConst acceleration_in);
     void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> GetUsedJointLimits() const;
-    bool GetHasAccelerationLimit() const { return has_acceleration_limit; }
-    const Eigen::VectorXd& GetAccelerationLimit() const { return acceleration_limit_; }
-    const Eigen::VectorXd& GetVelocityLimit() const { return velocity_limit_; }
+    bool HasAccelerationLimits() const { return has_acceleration_limit; }
+    const Eigen::VectorXd& GetAccelerationLimits() const { return acceleration_limits_; }
+    const Eigen::VectorXd& GetVelocityLimits() const { return velocity_limits_; }
     int GetNumControlledJoints() const;
     int GetNumModelJoints() const;
     void PublishFrames();
@@ -261,8 +261,8 @@ private:
     // Joint limits
     // TODO: Add effort limits
     Eigen::MatrixXd joint_limits_;
-    Eigen::VectorXd velocity_limit_;
-    Eigen::VectorXd acceleration_limit_;
+    Eigen::VectorXd velocity_limits_;
+    Eigen::VectorXd acceleration_limits_;
     bool has_acceleration_limit = false;
     void UpdateJointLimits();
 

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -61,6 +61,17 @@ enum KinematicRequestFlags
     KIN_J_DOT = 8
 };
 
+enum JointLimitType
+{
+    LIMIT_POSITION_LOWER = 0,
+    LIMIT_POSITION_UPPER = 1,
+    LIMIT_VELOCITY = 2,
+    LIMIT_ACCELERATION = 3
+};
+
+constexpr double inf = std::numeric_limits<double>::infinity();
+constexpr double pi = std::atan(1) * 4;
+
 inline KinematicRequestFlags operator|(KinematicRequestFlags a, KinematicRequestFlags b)
 {
     return static_cast<KinematicRequestFlags>(static_cast<int>(a) | static_cast<int>(b));
@@ -145,6 +156,10 @@ public:
     const Eigen::MatrixXd& GetJointLimits() const { return joint_limits_; }
     void SetJointLimitsLower(Eigen::VectorXdRefConst lower_in);
     void SetJointLimitsUpper(Eigen::VectorXdRefConst upper_in);
+    void SetJointLimitsVelocity(Eigen::VectorXdRefConst velocity_in);
+    void SetJointLimitsAcceleration(Eigen::VectorXdRefConst acceleration_in);
+    void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
+    void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration);
     void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> GetUsedJointLimits() const;

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -64,9 +64,7 @@ enum KinematicRequestFlags
 enum JointLimitType
 {
     LIMIT_POSITION_LOWER = 0,
-    LIMIT_POSITION_UPPER = 1,
-    LIMIT_VELOCITY = 2,
-    LIMIT_ACCELERATION = 3
+    LIMIT_POSITION_UPPER = 1
 };
 
 constexpr double inf = std::numeric_limits<double>::infinity();
@@ -163,6 +161,9 @@ public:
     void SetFloatingBaseLimitsPosXYZEulerZYX(const std::vector<double>& lower, const std::vector<double>& upper);
     void SetPlanarBaseLimitsPosXYEulerZ(const std::vector<double>& lower, const std::vector<double>& upper);
     std::map<std::string, std::vector<double>> GetUsedJointLimits() const;
+    bool GetHasAccelerationLimit() const { return has_acceleration_limit; }
+    const Eigen::VectorXd& GetAccelerationLimit() const { return acceleration_limit_; }
+    const Eigen::VectorXd& GetVelocityLimit() const { return velocity_limit_; }
     int GetNumControlledJoints() const;
     int GetNumModelJoints() const;
     void PublishFrames();
@@ -258,7 +259,11 @@ private:
     void UpdateJdot();
 
     // Joint limits
+    // TODO: Add effort limits
     Eigen::MatrixXd joint_limits_;
+    Eigen::VectorXd velocity_limit_;
+    Eigen::VectorXd acceleration_limit_;
+    bool has_acceleration_limit = false;
     void UpdateJointLimits();
 
     // Random state generation

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -1053,7 +1053,7 @@ void KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX(
 }
 
 void KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX(
-    const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity = {}, const std::vector<double>& acceleration = {})
+    const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration)
 {
     if (controlled_base_type_ != BaseType::FLOATING)
     {
@@ -1101,7 +1101,7 @@ void KinematicTree::SetPlanarBaseLimitsPosXYEulerZ(
 }
 
 void KinematicTree::SetPlanarBaseLimitsPosXYEulerZ(
-    const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity = {}, const std::vector<double>& acceleration = {})
+    const std::vector<double>& lower, const std::vector<double>& upper, const std::vector<double>& velocity, const std::vector<double>& acceleration)
 {
     if (controlled_base_type_ != BaseType::PLANAR)
     {
@@ -1143,7 +1143,7 @@ void KinematicTree::ResetJointLimits()
             // TODO: use urdf::Model instead
 
             // Check for bounds, else set limits to inf
-            if (model_->getVariableBounds(vars[i]).position_bounded_ == true)
+            if (model_->getVariableBounds(vars[i]).position_bounded_)
             {
                 controlled_joints_[index].lock()->joint_limits = {model_->getVariableBounds(vars[i]).min_position_, model_->getVariableBounds(vars[i]).max_position_};
             }
@@ -1151,7 +1151,7 @@ void KinematicTree::ResetJointLimits()
             {
                 controlled_joints_[index].lock()->joint_limits = {-inf, inf};
             }
-            if (model_->getVariableBounds(vars[i]).velocity_bounded_ == true)
+            if (model_->getVariableBounds(vars[i]).velocity_bounded_)
             {
                 controlled_joints_[index].lock()->velocity_limit = {model_->getVariableBounds(vars[i]).max_velocity_};
             }
@@ -1159,7 +1159,7 @@ void KinematicTree::ResetJointLimits()
             {
                 controlled_joints_[index].lock()->velocity_limit = {inf};
             }
-            if (model_->getVariableBounds(vars[i]).acceleration_bounded_ == true)
+            if (model_->getVariableBounds(vars[i]).acceleration_bounded_)
             {
                 controlled_joints_[index].lock()->acceleration_limit = {model_->getVariableBounds(vars[i]).max_acceleration_};
             }

--- a/exotica_core/src/kinematic_tree.cpp
+++ b/exotica_core/src/kinematic_tree.cpp
@@ -1116,7 +1116,11 @@ void KinematicTree::ResetJointLimits()
         {
             auto& ControlledJoint = controlled_joints_map_.at(vars[i]);
             int index = ControlledJoint.lock()->control_id;
-            controlled_joints_[index].lock()->joint_limits = {model_->getVariableBounds(vars[i]).min_position_, model_->getVariableBounds(vars[i]).max_position_, model_->getVariableBounds(vars[i]).max_velocity_, model_->getVariableBounds(vars[i]).max_acceleration_};
+
+            // Last element should be model_->getVariableBounds(vars[i]).max_acceleration_, but the URDF-parser
+            // in ros_control seems to skip over parsing acceleration limits (https://github.com/ros-controls/ros_control/issues/350#issuecomment-411670354)
+            // Set to infinity as a work around
+            controlled_joints_[index].lock()->joint_limits = {model_->getVariableBounds(vars[i]).min_position_, model_->getVariableBounds(vars[i]).max_position_, model_->getVariableBounds(vars[i]).max_velocity_, inf};
         }
     }
 

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1203,15 +1203,15 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematic_tree.def("reset_joint_limits", &KinematicTree::ResetJointLimits);
     kinematic_tree.def("set_joint_limits_lower", &KinematicTree::SetJointLimitsLower);
     kinematic_tree.def("set_joint_limits_upper", &KinematicTree::SetJointLimitsUpper);
-    kinematic_tree.def("set_joint_limits_velocity", &KinematicTree::SetJointLimitsVelocity);
-    kinematic_tree.def("set_joint_limits_acceleration", &KinematicTree::SetJointLimitsAcceleration);
-    kinematic_tree.def("get_velocity_limit", &KinematicTree::GetVelocityLimit);
-    kinematic_tree.def("get_has_acceleration_limit", &KinematicTree::GetHasAccelerationLimit);
-    kinematic_tree.def("get_acceleration_limit", &KinematicTree::GetAccelerationLimit);
-    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
-    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
-    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
-    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
+    kinematic_tree.def("set_joint_velocity_limits", &KinematicTree::SetJointVelocityLimits);
+    kinematic_tree.def("set_joint_acceleration_limits", &KinematicTree::SetJointAccelerationLimits);
+    kinematic_tree.def("get_velocity_limits", &KinematicTree::GetVelocityLimits);
+    kinematic_tree.def("has_acceleration_limits", &KinematicTree::HasAccelerationLimits);
+    kinematic_tree.def("get_acceleration_limits", &KinematicTree::GetAccelerationLimits);
+    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) & KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
+    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) & KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
+    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) & KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
+    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) & KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
     kinematic_tree.def("get_used_joint_limits", &KinematicTree::GetUsedJointLimits);
 
     // Get full tree

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1203,8 +1203,12 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematic_tree.def("reset_joint_limits", &KinematicTree::ResetJointLimits);
     kinematic_tree.def("set_joint_limits_lower", &KinematicTree::SetJointLimitsLower);
     kinematic_tree.def("set_joint_limits_upper", &KinematicTree::SetJointLimitsUpper);
-    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
-    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
+    kinematic_tree.def("set_joint_limits_velocity", &KinematicTree::SetJointLimitsVelocity);
+    kinematic_tree.def("set_joint_limits_acceleration", &KinematicTree::SetJointLimitsAcceleration);
+    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
+    kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
+    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
+    kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);
     kinematic_tree.def("get_used_joint_limits", &KinematicTree::GetUsedJointLimits);
 
     // Get full tree

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -1205,6 +1205,9 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematic_tree.def("set_joint_limits_upper", &KinematicTree::SetJointLimitsUpper);
     kinematic_tree.def("set_joint_limits_velocity", &KinematicTree::SetJointLimitsVelocity);
     kinematic_tree.def("set_joint_limits_acceleration", &KinematicTree::SetJointLimitsAcceleration);
+    kinematic_tree.def("get_velocity_limit", &KinematicTree::GetVelocityLimit);
+    kinematic_tree.def("get_has_acceleration_limit", &KinematicTree::GetHasAccelerationLimit);
+    kinematic_tree.def("get_acceleration_limit", &KinematicTree::GetAccelerationLimit);
     kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
     kinematic_tree.def("set_floating_base_limits_pos_xyz_euler_zyx", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetFloatingBaseLimitsPosXYZEulerZYX);
     kinematic_tree.def("set_planar_base_limits_pos_xy_euler_z", (void (KinematicTree::*)(const std::vector<double>&, const std::vector<double>&)) &KinematicTree::SetPlanarBaseLimitsPosXYEulerZ);


### PR DESCRIPTION
This PR addresses the fact that there is no way to get velocity/acceleration limits from a URDF using EXOTica. The edits here add this functionality. In detail, the changes I have made are:
- kinematic_tree.h
    - Add an enum JointLimitType for use in the joint_limits vector. Easier to remember and read better.
    - Moved the constexpr for inf and pi to the start of this file, and in global scope. Previously they were defined locally inside ResetJointLimits in kinematic_tree.cpp - they are useful outside of this function.
    - Add function headers for the SetJointLimitsVelocity, SetJointLimitsAcceleration and overloaded SetFloatingBaseLimitsPosXYZEulerZYX and SetPlanarBaseLimitsPosXYEulerZ
- kinematic_tree.cpp
    - Changed the joint_limits vector to have dimension=4 to store upper, lower, velocity, acceleration limits
    - Added setters/getters for joint limit velocity/acceleration
    - Overloaded SetFloatingBaseLimitsPosXYZEulerZYX and SetPlanarBaseLimitsPosXYEulerZ to also have the option to specify velocity and acceleration limits (without breaking old API). Default the 2 arg version to set velocity and acceleration to inf.
    - In ResetJointLimits, set the acceleration limit to inf as workaround as Vlad suggested due to the issue I uncovered in ros_control: it doesn't parse acceleration limits from the URDF by default for some reason, described [here](https://github.com/ros-controls/ros_control/issues/350#issuecomment-411670354).
- Pyexotica
    - Add bindings for these additions, including overloaded bindings (done by [following this example](https://github.com/ros-controls/ros_control/issues/350#issuecomment-411670354))