### PR TITLE
[CI] Try 2 cores for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ env:
   global: # global settings for all jobs
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - ROS_REPO=ros-testing # ros
-    - DOCKER_RUN_OPTS="--cpus=\"2\""
-    # - ROS_PARALLEL_JOBS=-j2 # Don't exhaust virtual memory
-    # - DOCKER_RUN_OPTS='-e TRAVIS_BRANCH -e GITHUBKEY' # Pass CI variables to Docker
     # - UPSTREAM_WORKSPACE=file
     - secure: "hq/S+hFDH44PBWcskCANx2Qli+KE8n8b5a5e+IR5T81j6b/NW8WW9Tx02vQjS8KFHcVNHFd9UcCCiKZrsFqs/GbGjBcRknGTGfslesBzZ2B/eXwR1B6dcG4dnN9xLIZw3j8s+i0JoMn1d3Hx/LJgmXVLdgKp0zrLeYDJCkwJ084nAfe3hgizyqL1JMn9xWIyklpR+qi0KVEeu6aV3w18HpDz87NRG42IRiBtLynTPl39y3H+UQNUKtI9gkIb6fuOQY7e5bK9CcJInQl6RDIWK93BPIzPMrDfzpfej93cP/eyvKbBdmzx6hJRI2qrrEXzY7Aj3gB6W26cQU1A9BoWrRD+pbqC6/EcO8/8LKfyXNj4RWiKkrnUAMMZ48LgLQULVLSEP8PB/KoH0EKB2cm98Tu7DimYUznsyVXfkpMMBj0CDG0Nbi3QiS7j0AcN1ngJkIdn8A64pRHKX/waDLdOPGqnezK5UUqhWrqNwoed8emCxsBvGkbUNL/fsnMtdYThzLvW2b6cMHa1O3brhjVpDLbvieFs/0OBMz02lSlVNE0H6ADJJYiPCF1QHi//D+Dqt1B9ZgwMv3ZfD7xTSdxYFAlcLa1YRKeiDdFMXmz3lxl0IPZLk2Ub4/ScbPzXtidsAnffZoiXZBhGCcHywy/hHLcT/mO3a61hiiwgLujkPcY="
   matrix:
@@ -30,7 +27,7 @@ env:
     - ROS_DISTRO="kinetic" CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Release'
     - ROS_DISTRO="kinetic" PRERELEASE=true
     - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file CLANG_FORMAT_VERSION=3.9
-    - ROS_DISTRO="melodic" CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug'
+    - ROS_DISTRO="melodic" CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug' DOCKER_RUN_OPTS="--cpus=\"1\""
     - ROS_DISTRO="melodic" CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Release'
     - ROS_DISTRO="melodic" PRERELEASE=true
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   global: # global settings for all jobs
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - ROS_REPO=ros-testing # ros
+    - DOCKER_RUN_OPTS="--cpus=\"2\""
     # - ROS_PARALLEL_JOBS=-j2 # Don't exhaust virtual memory
     # - DOCKER_RUN_OPTS='-e TRAVIS_BRANCH -e GITHUBKEY' # Pass CI variables to Docker
     # - UPSTREAM_WORKSPACE=file


### PR DESCRIPTION
The Melodic Release build is timing out on CI because it's exhausting the memory (because of Pinocchio). The new Industrial CI does no longer support setting the maximum number of jobs directlt. This is a workaround trying to limit the CPUs passed to Docker.