### PR TITLE
[exotica_pinocchio_dynamics_solver] Split derivatives into own compile units

### DIFF
--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/CMakeLists.txt
@@ -26,12 +26,17 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME} src/pinocchio_dynamics_solver.cpp src/pinocchio_gravity_compensation_dynamics_solver.cpp)
+add_library(${PROJECT_NAME}
+  src/pinocchio_dynamics_solver.cpp
+  src/pinocchio_dynamics_solver_derivatives.cpp
+  src/pinocchio_gravity_compensation_dynamics_solver.cpp
+  src/pinocchio_gravity_compensation_dynamics_solver_derivatives.cpp
+)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated -Wno-variadic-macros -Wno-deprecated-declarations -Wno-comment -Wno-ignored-attributes)
 target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers ${catkin_EXPORTED_TARGETS})
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver_derivatives.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver_derivatives.cpp
@@ -32,8 +32,6 @@
 #include <pinocchio/algorithm/aba-derivatives.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
 
-REGISTER_DYNAMICS_SOLVER_TYPE("PinocchioDynamicsSolver", exotica::PinocchioDynamicsSolver)
-
 namespace exotica
 {
 void PinocchioDynamicsSolver::ComputeDerivatives(const StateVector& x, const ControlVector& u)

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver_derivatives.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_dynamics_solver_derivatives.cpp
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2019, Wolfgang Merkt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_pinocchio_dynamics_solver/pinocchio_dynamics_solver.h>
+
+#include <pinocchio/algorithm/aba-derivatives.hpp>
+#include <pinocchio/algorithm/joint-configuration.hpp>
+
+REGISTER_DYNAMICS_SOLVER_TYPE("PinocchioDynamicsSolver", exotica::PinocchioDynamicsSolver)
+
+namespace exotica
+{
+void PinocchioDynamicsSolver::ComputeDerivatives(const StateVector& x, const ControlVector& u)
+{
+    pinocchio::computeABADerivatives(model_, *pinocchio_data_.get(), x.head(num_positions_), x.tail(num_velocities_), u, fx_.block(num_velocities_, 0, num_velocities_, num_velocities_), fx_.block(num_velocities_, num_velocities_, num_velocities_, num_velocities_), fu_.bottomRightCorner(num_velocities_, num_velocities_));
+
+    Eigen::Block<Eigen::MatrixXd> da_dx = fx_.block(num_velocities_, 0, num_velocities_, get_num_state_derivative());
+    Eigen::Block<Eigen::MatrixXd> da_du = fu_.block(num_velocities_, 0, num_velocities_, num_controls_);
+
+    switch (integrator_)
+    {
+        // Forward Euler (RK1)
+        case Integrator::RK1:
+        {
+            Fx_.topRows(num_velocities_).setZero();
+            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
+            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topRows(num_velocities_), pinocchio::ARG1);
+            pinocchio::dIntegrate(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
+            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
+
+            Fu_.topRows(num_velocities_).setZero();
+            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fu_.topRows(num_velocities_), pinocchio::ARG1);
+        }
+        break;
+        // Semi-implicit Euler
+        case Integrator::SymplecticEuler:
+        {
+            Eigen::VectorXd dx_v = dt_ * x.tail(num_velocities_) + dt_ * dt_ * pinocchio_data_->ddq;
+
+            Fx_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_dx;
+            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
+            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fx_.topRows(num_velocities_), pinocchio::ARG1);
+            pinocchio::dIntegrate(model_, x.head(num_positions_), dx_v, Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
+            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
+
+            Fu_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_du;
+            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fu_.topRows(num_velocities_), pinocchio::ARG1);
+        }
+        break;
+        default:
+            ThrowPretty("Not implemented!");
+    };
+}
+
+Eigen::MatrixXd PinocchioDynamicsSolver::fx(const StateVector& x, const ControlVector& u)
+{
+    // Four quadrants should be: 0, Identity, ddq_dq, ddq_dv
+    // 0 and Identity are set during initialisation. Here, we pass references to ddq_dq, ddq_dv to the algorithm.
+    pinocchio::computeABADerivatives(model_, *pinocchio_data_.get(), x.head(num_positions_), x.tail(num_velocities_), u, fx_.block(num_velocities_, 0, num_velocities_, num_velocities_), fx_.block(num_velocities_, num_velocities_, num_velocities_, num_velocities_), fu_.bottomRightCorner(num_velocities_, num_velocities_));
+
+    return fx_;
+}
+
+Eigen::MatrixXd PinocchioDynamicsSolver::fu(const StateVector& x, const ControlVector& u)
+{
+    // NB: ddq_dtau is computed with the same call - i.e., we are duplicating computation.
+    pinocchio::computeABADerivatives(model_, *pinocchio_data_.get(), x.head(num_positions_), x.tail(num_velocities_), u, fx_.block(num_velocities_, 0, num_velocities_, num_velocities_), fx_.block(num_velocities_, num_velocities_, num_velocities_, num_velocities_), fu_.bottomRightCorner(num_velocities_, num_velocities_));
+
+    return fu_;
+}
+
+}  // namespace exotica

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver.cpp
@@ -34,8 +34,6 @@
 #include <pinocchio/algorithm/rnea.hpp>
 #include <pinocchio/parsers/urdf.hpp>
 
-REGISTER_DYNAMICS_SOLVER_TYPE("PinocchioDynamicsSolverWithGravityCompensation", exotica::PinocchioDynamicsSolverWithGravityCompensation)
-
 namespace exotica
 {
 void PinocchioDynamicsSolverWithGravityCompensation::AssignScene(ScenePtr scene_in)

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver.cpp
@@ -29,12 +29,8 @@
 
 #include <exotica_pinocchio_dynamics_solver/pinocchio_gravity_compensation_dynamics_solver.h>
 
-#include <pinocchio/algorithm/aba-derivatives.hpp>
 #include <pinocchio/algorithm/aba.hpp>
-#include <pinocchio/algorithm/cholesky.hpp>
-#include <pinocchio/algorithm/compute-all-terms.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
-#include <pinocchio/algorithm/rnea-derivatives.hpp>
 #include <pinocchio/algorithm/rnea.hpp>
 #include <pinocchio/parsers/urdf.hpp>
 
@@ -87,134 +83,6 @@ Eigen::VectorXd PinocchioDynamicsSolverWithGravityCompensation::f(const StateVec
     xdot_analytic_.head(num_velocities_) = x.tail(num_velocities_);
     xdot_analytic_.tail(num_velocities_) = pinocchio_data_->ddq;
     return xdot_analytic_;
-}
-
-void PinocchioDynamicsSolverWithGravityCompensation::ComputeDerivatives(const StateVector& x, const ControlVector& u)
-{
-    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
-    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
-
-    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
-    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
-
-    // Commanded torque is u_nle_ + u
-    u_command_.noalias() = u_nle_ + u;
-
-    pinocchio_data_->Minv.setZero();
-    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
-    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
-    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), pinocchio_data_->Minv);
-
-    // du_command_dq_
-    a_.noalias() = pinocchio_data_->Minv * u_command_;
-    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
-    du_command_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
-
-    // du_nle_dq_
-    a_.noalias() = pinocchio_data_->Minv * u_nle_;
-    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
-    du_nle_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
-
-    // du_dq_
-    fx_.block(num_velocities_, 0, num_velocities_, num_velocities_).noalias() = du_nle_dq_ - du_command_dq_;
-
-    // Since dtau_du=Identity, the partial derivative of fu is directly Minv.
-    fu_.bottomRightCorner(num_velocities_, num_velocities_) = pinocchio_data_->Minv;
-
-    Eigen::Block<Eigen::MatrixXd> da_dx = fx_.block(num_velocities_, 0, num_velocities_, get_num_state_derivative());
-    Eigen::Block<Eigen::MatrixXd> da_du = fu_.block(num_velocities_, 0, num_velocities_, num_controls_);
-
-    switch (integrator_)
-    {
-        // Forward Euler (RK1)
-        case Integrator::RK1:
-        {
-            Fx_.topRows(num_velocities_).setZero();
-            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
-            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
-            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topRows(num_velocities_), pinocchio::ARG1);
-            pinocchio::dIntegrate(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
-            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
-
-            Fu_.topRows(num_velocities_).setZero();
-            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
-            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fu_.topRows(num_velocities_), pinocchio::ARG1);
-        }
-        break;
-        // Semi-implicit Euler
-        case Integrator::SymplecticEuler:
-        {
-            a_.noalias() = pinocchio_data_->Minv * u_command_;
-            Eigen::VectorXd dx_v = dt_ * x.tail(num_velocities_) + dt_ * dt_ * a_;
-
-            Fx_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_dx;
-            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
-            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
-            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fx_.topRows(num_velocities_), pinocchio::ARG1);
-            pinocchio::dIntegrate(model_, x.head(num_positions_), dx_v, Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
-            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
-
-            Fu_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_du;
-            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
-            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fu_.topRows(num_velocities_), pinocchio::ARG1);
-        }
-        break;
-        default:
-            ThrowPretty("Not implemented!");
-    };
-}
-
-Eigen::MatrixXd PinocchioDynamicsSolverWithGravityCompensation::fx(const StateVector& x, const ControlVector& u)
-{
-    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
-    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
-
-    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
-    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
-
-    // Commanded torque is u_nle_ + u
-    u_command_.noalias() = u_nle_ + u;
-
-    pinocchio_data_->Minv.setZero();
-    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
-    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
-    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), pinocchio_data_->Minv);
-
-    // du_command_dq_
-    a_.noalias() = pinocchio_data_->Minv * u_command_;
-    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
-    du_command_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
-
-    // du_nle_dq_
-    a_.noalias() = pinocchio_data_->Minv * u_nle_;
-    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
-    du_nle_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
-
-    // du_dq_
-    fx_.block(num_velocities_, 0, num_velocities_, num_velocities_).noalias() = du_nle_dq_ - du_command_dq_;
-
-    return fx_;
-}
-
-Eigen::MatrixXd PinocchioDynamicsSolverWithGravityCompensation::fu(const StateVector& x, const ControlVector& u)
-{
-    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
-    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
-
-    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
-    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
-
-    // Commanded torque is u_nle_ + u
-    u_command_.noalias() = u_nle_ + u;
-
-    // Since dtau_du=Identity, the partial derivative of fu is directly Minv.
-    Eigen::Block<Eigen::MatrixXd> Minv = fu_.bottomRightCorner(num_velocities_, num_velocities_);
-
-    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
-    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
-    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), Minv);
-
-    return fu_;
 }
 
 Eigen::VectorXd PinocchioDynamicsSolverWithGravityCompensation::StateDelta(const StateVector& x_1, const StateVector& x_2)

--- a/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver_derivatives.cpp
+++ b/exotations/dynamics_solvers/exotica_pinocchio_dynamics_solver/src/pinocchio_gravity_compensation_dynamics_solver_derivatives.cpp
@@ -1,0 +1,170 @@
+//
+// Copyright (c) 2020, University of Oxford
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of  nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <exotica_pinocchio_dynamics_solver/pinocchio_gravity_compensation_dynamics_solver.h>
+
+#include <pinocchio/algorithm/cholesky.hpp>
+#include <pinocchio/algorithm/compute-all-terms.hpp>
+#include <pinocchio/algorithm/joint-configuration.hpp>
+#include <pinocchio/algorithm/rnea-derivatives.hpp>
+#include <pinocchio/algorithm/rnea.hpp>
+
+REGISTER_DYNAMICS_SOLVER_TYPE("PinocchioDynamicsSolverWithGravityCompensation", exotica::PinocchioDynamicsSolverWithGravityCompensation)
+
+namespace exotica
+{
+void PinocchioDynamicsSolverWithGravityCompensation::ComputeDerivatives(const StateVector& x, const ControlVector& u)
+{
+    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
+    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
+
+    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
+    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
+
+    // Commanded torque is u_nle_ + u
+    u_command_.noalias() = u_nle_ + u;
+
+    pinocchio_data_->Minv.setZero();
+    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
+    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
+    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), pinocchio_data_->Minv);
+
+    // du_command_dq_
+    a_.noalias() = pinocchio_data_->Minv * u_command_;
+    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
+    du_command_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
+
+    // du_nle_dq_
+    a_.noalias() = pinocchio_data_->Minv * u_nle_;
+    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
+    du_nle_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
+
+    // du_dq_
+    fx_.block(num_velocities_, 0, num_velocities_, num_velocities_).noalias() = du_nle_dq_ - du_command_dq_;
+
+    // Since dtau_du=Identity, the partial derivative of fu is directly Minv.
+    fu_.bottomRightCorner(num_velocities_, num_velocities_) = pinocchio_data_->Minv;
+
+    Eigen::Block<Eigen::MatrixXd> da_dx = fx_.block(num_velocities_, 0, num_velocities_, get_num_state_derivative());
+    Eigen::Block<Eigen::MatrixXd> da_du = fu_.block(num_velocities_, 0, num_velocities_, num_controls_);
+
+    switch (integrator_)
+    {
+        // Forward Euler (RK1)
+        case Integrator::RK1:
+        {
+            Fx_.topRows(num_velocities_).setZero();
+            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
+            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topRows(num_velocities_), pinocchio::ARG1);
+            pinocchio::dIntegrate(model_, x.head(num_positions_), x.tail(num_velocities_), Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
+            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
+
+            Fu_.topRows(num_velocities_).setZero();
+            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), x.tail(num_velocities_), Fu_.topRows(num_velocities_), pinocchio::ARG1);
+        }
+        break;
+        // Semi-implicit Euler
+        case Integrator::SymplecticEuler:
+        {
+            a_.noalias() = pinocchio_data_->Minv * u_command_;
+            Eigen::VectorXd dx_v = dt_ * x.tail(num_velocities_) + dt_ * dt_ * a_;
+
+            Fx_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_dx;
+            Fx_.bottomRows(num_velocities_).noalias() = dt_ * da_dx;
+            Fx_.topRightCorner(num_velocities_, num_velocities_).diagonal().array() += dt_;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fx_.topRows(num_velocities_), pinocchio::ARG1);
+            pinocchio::dIntegrate(model_, x.head(num_positions_), dx_v, Fx_.topLeftCorner(num_velocities_, num_velocities_), pinocchio::ARG0, pinocchio::ADDTO);
+            Fx_.bottomRightCorner(num_velocities_, num_velocities_).diagonal().array() += 1.0;
+
+            Fu_.topRows(num_velocities_).noalias() = dt_ * dt_ * da_du;
+            Fu_.bottomRows(num_velocities_).noalias() = dt_ * da_du;
+            pinocchio::dIntegrateTransport(model_, x.head(num_positions_), dx_v, Fu_.topRows(num_velocities_), pinocchio::ARG1);
+        }
+        break;
+        default:
+            ThrowPretty("Not implemented!");
+    };
+}
+
+Eigen::MatrixXd PinocchioDynamicsSolverWithGravityCompensation::fx(const StateVector& x, const ControlVector& u)
+{
+    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
+    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
+
+    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
+    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
+
+    // Commanded torque is u_nle_ + u
+    u_command_.noalias() = u_nle_ + u;
+
+    pinocchio_data_->Minv.setZero();
+    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
+    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
+    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), pinocchio_data_->Minv);
+
+    // du_command_dq_
+    a_.noalias() = pinocchio_data_->Minv * u_command_;
+    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
+    du_command_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
+
+    // du_nle_dq_
+    a_.noalias() = pinocchio_data_->Minv * u_nle_;
+    pinocchio::computeRNEADerivatives(model_, *pinocchio_data_.get(), q, v, a_);
+    du_nle_dq_.noalias() = pinocchio_data_->Minv * pinocchio_data_->dtau_dq;
+
+    // du_dq_
+    fx_.block(num_velocities_, 0, num_velocities_, num_velocities_).noalias() = du_nle_dq_ - du_command_dq_;
+
+    return fx_;
+}
+
+Eigen::MatrixXd PinocchioDynamicsSolverWithGravityCompensation::fu(const StateVector& x, const ControlVector& u)
+{
+    Eigen::VectorBlock<const Eigen::VectorXd> q = x.head(num_positions_);
+    Eigen::VectorBlock<const Eigen::VectorXd> v = x.tail(num_velocities_);
+
+    // Obtain torque to compensate gravity and dynamic effects (Coriolis)
+    u_nle_ = pinocchio::nonLinearEffects(model_, *pinocchio_data_.get(), q, v);
+
+    // Commanded torque is u_nle_ + u
+    u_command_.noalias() = u_nle_ + u;
+
+    // Since dtau_du=Identity, the partial derivative of fu is directly Minv.
+    Eigen::Block<Eigen::MatrixXd> Minv = fu_.bottomRightCorner(num_velocities_, num_velocities_);
+
+    pinocchio::computeAllTerms(model_, *pinocchio_data_.get(), q, v);
+    pinocchio::cholesky::decompose(model_, *pinocchio_data_.get());
+    pinocchio::cholesky::computeMinv(model_, *pinocchio_data_.get(), Minv);
+
+    return fu_;
+}
+
+}  // namespace exotica


### PR DESCRIPTION
Reduced the peak memory use from 7.6 GB to 6.1 GB. We cannot get any lower when using ABA derivatives. Without ABA derivatives, it's 3.8 GB. Hope this helps but might still cause problems on the buildfarm