### PR TITLE
Upgrade clang format from v3.9 to v6.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
 # Checklist
 
-- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i` in the root directory
+- code formatting: run `find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-6.0 -style=file -i` in the root directory
 
 - add unit test(s)
 

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -14,7 +14,7 @@ jobs:
           - {ROS_DISTRO: kinetic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'}
           - {ROS_DISTRO: kinetic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release'}
           - {ROS_DISTRO: kinetic, PRERELEASE: true}
-          - {ROS_DISTRO: kinetic, CLANG_FORMAT_CHECK: file, CLANG_FORMAT_VERSION: 3.9}
+          - {ROS_DISTRO: noetic, CLANG_FORMAT_CHECK: file, CLANG_FORMAT_VERSION: 6.0}
           - {ROS_DISTRO: melodic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'}
           - {ROS_DISTRO: melodic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release'}
           - {ROS_DISTRO: melodic, PRERELEASE: true}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -14,7 +14,7 @@ jobs:
           - {ROS_DISTRO: kinetic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'}
           - {ROS_DISTRO: kinetic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release'}
           - {ROS_DISTRO: kinetic, PRERELEASE: true}
-          - {ROS_DISTRO: noetic, CLANG_FORMAT_CHECK: file, CLANG_FORMAT_VERSION: 6.0}
+          - {ROS_DISTRO: noetic, CLANG_FORMAT_CHECK: file, CLANG_FORMAT_VERSION: "6.0"}
           - {ROS_DISTRO: melodic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'}
           - {ROS_DISTRO: melodic, CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release'}
           - {ROS_DISTRO: melodic, PRERELEASE: true}

--- a/apply_format.sh
+++ b/apply_format.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i
+find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-6.0 -style=file -i
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_distance.h
@@ -49,6 +49,7 @@ public:
     int TaskSpaceDim() override;
 
     std::vector<CollisionProxy> get_collision_proxies() { return closest_proxies_; }
+
 private:
     void Initialize();
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/convex_hull.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/convex_hull.h
@@ -105,6 +105,6 @@ std::list<int> ConvexHull2D(Eigen::MatrixXdRefConst points)
 
     return hull;
 }
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_CONVEXHULL_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/eff_velocity.h
@@ -46,6 +46,6 @@ public:
     void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef jacobian) override;
     int TaskSpaceDim() override;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_EFF_VELOCITY_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/interaction_mesh.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/interaction_mesh.h
@@ -71,6 +71,6 @@ protected:
     ros::Publisher imesh_mark_pub_;
     visualization_msgs::Marker imesh_mark_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_INTERACTION_MESH_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_acceleration_backward_difference.h
@@ -70,6 +70,6 @@ private:
     Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the second time derivative.
     Eigen::MatrixXd I_;                           ///< Identity matrix.
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_JOINT_ACCELERATION_BACKWARD_DIFFERENCE_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_jerk_backward_difference.h
@@ -72,6 +72,6 @@ private:
     Eigen::VectorXd qbd_;                         ///< x+qbd_ is a simplifed estimate of the third time derivative.
     Eigen::MatrixXd I_;                           ///< Identity matrix.
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_JOINT_JERK_BACKWARD_DIFFERENCE_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_limit.h
@@ -60,6 +60,6 @@ private:
     double safe_percentage_;
     int N;
 };
-}  // namespace
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_JOINTLIMIT_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_pose.h
@@ -56,6 +56,6 @@ private:
     Eigen::VectorXd joint_ref_;   ///! Joint reference value
     void Initialize();
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_IDENTITY_H_

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/joint_velocity_backward_difference.h
@@ -67,6 +67,6 @@ private:
     Eigen::VectorXd qbd_;                ///< x+qbd_ is a simplified estimate of the first time derivative.
     Eigen::MatrixXd I_;                  ///< Identity matrix.
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_MAPS_JOINT_VELOCITY_BACKWARD_DIFFERENCE_H_

--- a/exotations/exotica_core_task_maps/src/eff_velocity.cpp
+++ b/exotations/exotica_core_task_maps/src/eff_velocity.cpp
@@ -84,4 +84,4 @@ int EffVelocity::TaskSpaceDim()
 {
     return kinematics[0].Phi.rows();
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/interaction_mesh.cpp
+++ b/exotations/exotica_core_task_maps/src/interaction_mesh.cpp
@@ -339,4 +339,4 @@ void InteractionMesh::SetWeights(const Eigen::MatrixXd& weights)
     }
     weights_ = weights;
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_acceleration_backward_difference.cpp
@@ -102,4 +102,4 @@ int JointAccelerationBackwardDifference::TaskSpaceDim()
 {
     return N_;
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_jerk_backward_difference.cpp
@@ -103,4 +103,4 @@ int JointJerkBackwardDifference::TaskSpaceDim()
 {
     return N_;
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
+++ b/exotations/exotica_core_task_maps/src/joint_velocity_limit.cpp
@@ -111,4 +111,4 @@ void JointVelocityLimit::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef ph
         if (phi(i) == 0.0)
             jacobian(i, i) = 0.0;
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/src/quasi_static.cpp
+++ b/exotations/exotica_core_task_maps/src/quasi_static.cpp
@@ -377,4 +377,4 @@ void QuasiStatic::AssignScene(ScenePtr scene)
     scene_ = scene;
     Initialize();
 }
-}
+}  // namespace exotica

--- a/exotations/exotica_core_task_maps/test/test_maps.cpp
+++ b/exotations/exotica_core_task_maps/test/test_maps.cpp
@@ -53,8 +53,8 @@ enum GTestColor
 };
 #endif
 extern void ColoredPrintf(testing::internal::GTestColor color, const char* fmt, ...);
-}
-}
+}  // namespace internal
+}  // namespace testing
 #define PRINTF(...)                                                                        \
     do                                                                                     \
     {                                                                                      \

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -47,6 +47,7 @@ public:
     const std::vector<Eigen::VectorXd>& get_fs() const { return fs_; };
     const std::vector<Eigen::VectorXd>& get_xs() const { return xs_; };
     const std::vector<Eigen::VectorXd>& get_us() const { return us_; };
+
 protected:
     int NDX_;
     int last_T_ = -1;

--- a/exotations/solvers/exotica_ilqg_solver/src/ilqg_solver.cpp
+++ b/exotations/solvers/exotica_ilqg_solver/src/ilqg_solver.cpp
@@ -124,8 +124,7 @@ void ILQGSolver::BackwardPass()
         S = Q + A.transpose() * S * A + L_gains_[t].transpose() * H * L_gains_[t] + L_gains_[t].transpose() * G + G.transpose() * L_gains_[t];
         s = q + A.transpose() * s + L_gains_[t].transpose() * H * l_gains_[t] +
             L_gains_[t].transpose() * g + G.transpose() * l_gains_[t];
-        s0 = q0 + s0 + (l_gains_[t].transpose() * H * l_gains_[t] / 2.0 +
-                        l_gains_[t].transpose() * g)(0);
+        s0 = q0 + s0 + (l_gains_[t].transpose() * H * l_gains_[t] / 2.0 + l_gains_[t].transpose() * g)(0);
 
         if (parameters_.IncludeNoiseTerms)
         {

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_native_solvers.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_native_solvers.h
@@ -114,6 +114,6 @@ public:
     LBTRRTSolver();
     void Instantiate(const LBTRRTSolverInitializer& init) override;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_OMPL_SOLVER_OMPL_NATIVE_SOLVER_H_

--- a/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
+++ b/exotations/solvers/exotica_ompl_solver/include/exotica_ompl_solver/ompl_solver.h
@@ -73,6 +73,7 @@ public:
     void SetLongestValidSegmentFraction(double segmentFraction) { state_space_->setLongestValidSegmentFraction(segmentFraction); }
     void SetValidSegmentCountFactor(unsigned int factor) { state_space_->setValidSegmentCountFactor(factor); }
     unsigned int GetValidSegmentCountFactor() const { return state_space_->getValidSegmentCountFactor(); }
+
 protected:
     template <typename T>
     static ompl::base::PlannerPtr AllocatePlanner(const ompl::base::SpaceInformationPtr &si, const std::string &new_name)
@@ -96,6 +97,6 @@ protected:
     bool multi_query_ = false;
     std::vector<double> bounds_;  // original bounds for locked state space
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_OMPL_SOLVER_OMPL_SOLVER_H_

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_native_solvers.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_native_solvers.cpp
@@ -240,4 +240,4 @@ void LazyPRMSolver::SetMultiQuery(bool val)
 {
     multi_query_ = val;
 }
-}
+}  // namespace exotica

--- a/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
+++ b/exotations/solvers/exotica_ompl_solver/src/ompl_solver.cpp
@@ -261,4 +261,4 @@ void OMPLSolver<ProblemType>::Solve(Eigen::MatrixXd &solution)
 }
 
 template class OMPLSolver<SamplingProblem>;
-}
+}  // namespace exotica

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
@@ -299,6 +299,6 @@ protected:
 
     bool reverse_check_;
 };
-}
+}  // namespace exotica
 
 #endif  // TIME_INDEXED_RRT_CONNECT_SOLVER_TIME_INDEXED_RRT_CONNECT_H_

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/src/time_indexed_rrt_connect.cpp
@@ -574,4 +574,4 @@ void OMPLTimeIndexedRRTConnect::getPlannerData(base::PlannerData &data) const
     // Add the edge connecting the two trees
     data.addEdge(data.vertexIndex(connectionPoint_.first), data.vertexIndex(connectionPoint_.second));
 }
-}
+}  // namespace exotica

--- a/exotica/doc/Code-Formatting.rst
+++ b/exotica/doc/Code-Formatting.rst
@@ -2,17 +2,17 @@
 Code Formatting
 ***************
 
-We use ``clang-format-3.9`` to automatically format source files and headers *prior* to committing any files. The format is specified in the ``.clang-format`` file provided in the root of the repository.
+We use ``clang-format-6.0`` to automatically format source files and headers *prior* to committing any files. The format is specified in the ``.clang-format`` file provided in the root of the repository.
 
-You can install ``clang-format-3.9`` e.g. via your package managers:
+You can install ``clang-format-6.0`` e.g. via your package managers:
 
 .. code-block:: bash
 
-    sudo apt-get install clang-format-3.9
+    sudo apt-get install clang-format-6.0
 
 In order to format your changes prior to committing, please execute script `apply_format.sh` in the repository root.
 This will run:
 
 .. code-block:: bash
 
-    find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-3.9 -style=file -i
+    find -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | xargs clang-format-6.0 -style=file -i

--- a/exotica_core/include/exotica_core/collision_scene.h
+++ b/exotica_core/include/exotica_core/collision_scene.h
@@ -339,6 +339,6 @@ protected:
 };
 
 typedef std::shared_ptr<CollisionScene> CollisionScenePtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_COLLISION_SCENE_H_

--- a/exotica_core/include/exotica_core/factory.h
+++ b/exotica_core/include/exotica_core/factory.h
@@ -136,6 +136,6 @@ public:
         Factory<BaseClass>::Instance().RegisterType(name, creator);
     }
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_FACTORY_H_

--- a/exotica_core/include/exotica_core/feedback_motion_solver.h
+++ b/exotica_core/include/exotica_core/feedback_motion_solver.h
@@ -40,6 +40,6 @@ public:
     // \brief Returns a control input given the state x and timestep t.
     virtual Eigen::VectorXd GetFeedbackControl(Eigen::VectorXdRefConst x, int t) const = 0;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_MOTION_SOLVER_H_

--- a/exotica_core/include/exotica_core/kinematic_element.h
+++ b/exotica_core/include/exotica_core/kinematic_element.h
@@ -144,6 +144,6 @@ private:
         }
     }
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_KINEMATIC_ELEMENT_H_

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -305,6 +305,6 @@ private:
     visualization_msgs::MarkerArray marker_array_msg_;
     std::string name_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_KINEMATIC_TREE_H_

--- a/exotica_core/include/exotica_core/loaders/xml_loader.h
+++ b/exotica_core/include/exotica_core/loaders/xml_loader.h
@@ -90,6 +90,6 @@ private:
     XMLLoader();
     static std::shared_ptr<XMLLoader> instance_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_XML_LOADER_H_

--- a/exotica_core/include/exotica_core/motion_solver.h
+++ b/exotica_core/include/exotica_core/motion_solver.h
@@ -56,6 +56,7 @@ public:
     }
     int GetNumberOfMaxIterations() { return max_iterations_; }
     double GetPlanningTime() { return planning_time_; }
+
 protected:
     PlanningProblemPtr problem_;
     double planning_time_ = -1;
@@ -63,6 +64,6 @@ protected:
 };
 
 typedef std::shared_ptr<exotica::MotionSolver> MotionSolverPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_MOTION_SOLVER_H_

--- a/exotica_core/include/exotica_core/object.h
+++ b/exotica_core/include/exotica_core/object.h
@@ -85,6 +85,6 @@ public:
     std::string object_name_;
     bool debug_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_OBJECT_H_

--- a/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
@@ -72,6 +72,6 @@ public:
     int num_tasks;
 };
 typedef std::shared_ptr<exotica::BoundedEndPoseProblem> BoundedEndPoseProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_BOUNDED_END_POSE_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
+++ b/exotica_core/include/exotica_core/problems/dynamic_time_indexed_shooting_problem.h
@@ -166,6 +166,7 @@ public:
     void set_loss_type(const ControlCostLossTermType& loss_type_in) { loss_type_ = loss_type_in; }
     double get_control_cost_weight() const { return control_cost_weight_; }
     void set_control_cost_weight(const double control_cost_weight_in) { control_cost_weight_ = control_cost_weight_in; }
+
 protected:
     /// \brief Checks the desired time index for bounds and supports -1 indexing.
     inline void ValidateTimeIndex(int& t_in) const

--- a/exotica_core/include/exotica_core/problems/end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/end_pose_problem.h
@@ -86,6 +86,6 @@ public:
     bool use_bounds;
 };
 typedef std::shared_ptr<exotica::EndPoseProblem> EndPoseProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_END_POSE_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/sampling_problem.h
@@ -81,6 +81,6 @@ private:
 };
 
 typedef std::shared_ptr<exotica::SamplingProblem> SamplingProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_SAMPLING_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_problem.h
@@ -49,6 +49,6 @@ public:
     bool IsValid() override;
 };
 typedef std::shared_ptr<exotica::TimeIndexedProblem> TimeIndexedProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TIME_INDEXED_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
@@ -87,6 +87,6 @@ private:
 };
 
 typedef std::shared_ptr<exotica::TimeIndexedSamplingProblem> TimeIndexedSamplingProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TIME_INDEXED_SAMPLING_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
@@ -79,6 +79,6 @@ public:
     int num_tasks;
 };
 typedef std::shared_ptr<exotica::UnconstrainedEndPoseProblem> UnconstrainedEndPoseProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_UNCONSTRAINED_END_POSE_PROBLEM_H_

--- a/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_time_indexed_problem.h
@@ -96,6 +96,6 @@ private:
     void ReinitializeVariables() override;
 };
 typedef std::shared_ptr<exotica::UnconstrainedTimeIndexedProblem> UnconstrainedTimeIndexedProblemPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_UNCONSTRAINED_TIME_INDEXED_PROBLEM_H_

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -130,6 +130,7 @@ public:
     }
 
     const C& GetParameters() const { return parameters_; }
+
 protected:
     C parameters_;
 };

--- a/exotica_core/include/exotica_core/server.h
+++ b/exotica_core/include/exotica_core/server.h
@@ -50,6 +50,7 @@ public:
     ~RosNode();
     inline ros::NodeHandle &GetNodeHandle() { return *nh_; }
     inline tf::TransformBroadcaster &GetTF() { return tf_; }
+
 protected:
     std::shared_ptr<ros::NodeHandle> nh_;
     ros::AsyncSpinner sp_;
@@ -185,6 +186,6 @@ private:
 };
 
 typedef std::shared_ptr<Server> ServerPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_SERVER_H_

--- a/exotica_core/include/exotica_core/setup.h
+++ b/exotica_core/include/exotica_core/setup.h
@@ -138,6 +138,6 @@ private:
 };
 
 typedef std::shared_ptr<Setup> SetupPtr;
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_SETUP_H_

--- a/exotica_core/include/exotica_core/task_space_vector.h
+++ b/exotica_core/include/exotica_core/task_space_vector.h
@@ -58,6 +58,6 @@ struct TaskSpaceVector
     Eigen::VectorXd data;
     std::vector<TaskVectorEntry> map;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASK_SPACE_VECTOR_H_

--- a/exotica_core/include/exotica_core/tasks.h
+++ b/exotica_core/include/exotica_core/tasks.h
@@ -161,6 +161,6 @@ struct SamplingTask : public Task
     TaskSpaceVector Phi;
     Eigen::MatrixXd S;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TASKS_H_

--- a/exotica_core/include/exotica_core/tools.h
+++ b/exotica_core/include/exotica_core/tools.h
@@ -120,7 +120,7 @@ enum ArgumentPosition
     ARG3 = 3,
     ARG4 = 4
 };
-}
+}  // namespace exotica
 
 namespace
 {
@@ -134,7 +134,7 @@ struct Holder
     Holder(Holder&& other) : p(std::move(other.p)) {}
     void operator()(...) { p.reset(); }
 };
-}
+}  // namespace
 
 template <class T>
 std::shared_ptr<T> ToStdPtr(const boost::shared_ptr<T>& p)

--- a/exotica_core/include/exotica_core/tools/autodiff_scalar.h
+++ b/exotica_core/include/exotica_core/tools/autodiff_scalar.h
@@ -815,7 +815,7 @@ struct NumTraits<AutoDiffScalar<SparseVector<DerType_>>>
         RequireInitialization = 1
     };
 };
-}
+}  // namespace Eigen
 
 namespace std
 {
@@ -830,6 +830,6 @@ class numeric_limits<Eigen::AutoDiffScalar<T&>>
     : public numeric_limits<typename T::Scalar>
 {
 };
-}
+}  // namespace std
 
 #endif  // EIGEN_AUTODIFF_SCALAR_H_

--- a/exotica_core/include/exotica_core/tools/conversions.h
+++ b/exotica_core/include/exotica_core/tools/conversions.h
@@ -180,8 +180,7 @@ inline bool IsVectorContainerType(std::string type)
 }
 
 template <class Key, class Val>
-[[deprecated("Replaced by GetKeysFromMap and GetValuesFromMap")]] std::vector<Val> MapToVec(const std::map<Key, Val>& map)
-{
+[[deprecated("Replaced by GetKeysFromMap and GetValuesFromMap")]] std::vector<Val> MapToVec(const std::map<Key, Val>& map) {
     std::vector<Val> ret;
     for (auto& it : map)
     {
@@ -369,6 +368,6 @@ inline std::vector<bool> ParseBoolList(const std::string value)
     if (ret.empty()) WARNING_NAMED("Parser", "Empty vector!")
     return ret;
 }
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_CONVERSIONS_H_

--- a/exotica_core/include/exotica_core/tools/exception.h
+++ b/exotica_core/include/exotica_core/tools/exception.h
@@ -78,6 +78,6 @@ class SolveException : public Exception
 {
     using Exception::Exception;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_EXCEPTION_H_

--- a/exotica_core/include/exotica_core/tools/finitediff_chain_hessian.h
+++ b/exotica_core/include/exotica_core/tools/finitediff_chain_hessian.h
@@ -133,8 +133,8 @@ public:
     int operator()(const InputJacobianRowType &_jx, ValueType &v, JacobianType &jac, HessianType &hess) const
 #endif
     {
-        using std::sqrt;
         using std::abs;
+        using std::sqrt;
         // Local variables
         FiniteDiffChainJacobian<Functor, mode> autoj(*static_cast<const Functor *>(this), update_, epsfcn_);
         Scalar h;
@@ -225,6 +225,6 @@ public:
         return nfev;
     }
 };
-}
+}  // namespace Eigen
 
 #endif  // EIGEN_FINITEDIFF_CHAIN_HESSIAN_H_

--- a/exotica_core/include/exotica_core/tools/finitediff_chain_jacobian.h
+++ b/exotica_core/include/exotica_core/tools/finitediff_chain_jacobian.h
@@ -118,8 +118,8 @@ public:
     int operator()(const InputJacobianRowType &_jx, ValueType &v, JacobianType &jac) const
 #endif
     {
-        using std::sqrt;
         using std::abs;
+        using std::sqrt;
         // Local variables
         Scalar h;
         int nfev = 0;
@@ -212,6 +212,6 @@ public:
         return nfev;
     }
 };
-}
+}  // namespace Eigen
 
 #endif  // EIGEN_FINITEDIFF_CHAIN_JACOBIAN_H_

--- a/exotica_core/include/exotica_core/tools/functor.h
+++ b/exotica_core/include/exotica_core/tools/functor.h
@@ -47,6 +47,6 @@ struct FunctorBase
 };
 
 typedef FunctorBase<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::Dynamic> Functor;
-}
+}  // namespace exotica
 
 #endif  // EIGEN_AUTODIFF_FUNCTOR_H_

--- a/exotica_core/include/exotica_core/tools/timer.h
+++ b/exotica_core/include/exotica_core/tools/timer.h
@@ -60,6 +60,6 @@ public:
 private:
     std::chrono::time_point<std::chrono::high_resolution_clock> start_time_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TIMER_H_

--- a/exotica_core/include/exotica_core/tools/uncopyable.h
+++ b/exotica_core/include/exotica_core/tools/uncopyable.h
@@ -42,6 +42,6 @@ private:
     Uncopyable(const Uncopyable&);
     Uncopyable& operator=(const Uncopyable&);
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_UNCOPYABLE_H_

--- a/exotica_core/include/exotica_core/trajectory.h
+++ b/exotica_core/include/exotica_core/trajectory.h
@@ -58,6 +58,6 @@ protected:
     Eigen::MatrixXd data_;
     std::shared_ptr<KDL::Trajectory_Composite> trajectory_;
 };
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_TRAJECTORY_H_

--- a/exotica_core/include/exotica_core/version.h
+++ b/exotica_core/include/exotica_core/version.h
@@ -34,6 +34,6 @@ namespace exotica
 {
 extern const char version[];
 extern const char branch[];
-}
+}  // namespace exotica
 
 #endif  // EXOTICA_CORE_VERSION_H_

--- a/exotica_core/src/motion_solver.cpp
+++ b/exotica_core/src/motion_solver.cpp
@@ -57,4 +57,4 @@ std::string MotionSolver::Print(const std::string& prepend) const
     if (problem_) ret += "\n" + problem_->Print(prepend + "    ");
     return ret;
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/problems/sampling_problem.cpp
+++ b/exotica_core/src/problems/sampling_problem.cpp
@@ -281,4 +281,4 @@ bool SamplingProblem::IsCompoundStateSpace()
 {
     return compound_;
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/server.cpp
+++ b/exotica_core/src/server.cpp
@@ -158,4 +158,4 @@ std::string Server::GetName()
 {
     return name_;
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/task_map.cpp
+++ b/exotica_core/src/task_map.cpp
@@ -129,4 +129,4 @@ void TaskMap::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRefConst u, Eigen
     Update(x.head(ndq), phi, dphi_dx.topLeftCorner(TaskSpaceJacobianDim(), ndq), ddphi_ddx);
 }
 
-}  // namespace
+}  // namespace exotica

--- a/exotica_core/src/task_space_vector.cpp
+++ b/exotica_core/src/task_space_vector.cpp
@@ -99,4 +99,4 @@ std::vector<TaskVectorEntry> TaskVectorEntry::reindex(const std::vector<TaskVect
     }
     return ret;
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/tools/conversions.cpp
+++ b/exotica_core/src/tools/conversions.cpp
@@ -45,7 +45,7 @@ Eigen::VectorXd IdentityTransform()
 {
     return VectorTransform();
 }
-}
+}  // namespace Eigen
 
 namespace exotica
 {
@@ -177,4 +177,4 @@ Eigen::VectorXd SetRotation(const KDL::Rotation& data, RotationType type)
             ThrowPretty("Unknown rotation representation type!");
     }
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/tools/exception.cpp
+++ b/exotica_core/src/tools/exception.cpp
@@ -48,4 +48,4 @@ const char *Exception::what() const noexcept
 {
     return msg_.c_str();
 }
-}
+}  // namespace exotica

--- a/exotica_core/src/visualization_moveit.cpp
+++ b/exotica_core/src/visualization_moveit.cpp
@@ -158,4 +158,4 @@ void VisualizationMoveIt::DisplayTrajectory(Eigen::MatrixXdRefConst trajectory)
 
     trajectory_pub_.publish(traj_msg);
 }
-}
+}  // namespace exotica

--- a/exotica_core/test/test_kinematics.cpp
+++ b/exotica_core/test/test_kinematics.cpp
@@ -47,8 +47,8 @@ enum GTestColor
 #endif
 
 extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
-}
-}
+}  // namespace internal
+}  // namespace testing
 #define PRINTF(...)                                                                        \
     do                                                                                     \
     {                                                                                      \

--- a/exotica_examples/test/test_initializers.cpp
+++ b/exotica_examples/test/test_initializers.cpp
@@ -46,8 +46,8 @@ enum GTestColor
 };
 #endif
 extern void ColoredPrintf(testing::internal::GTestColor color, const char* fmt, ...);
-}
-}
+}  // namespace internal
+}  // namespace testing
 #define PRINTF(...)                                                                        \
     do                                                                                     \
     {                                                                                      \

--- a/exotica_examples/test/test_problems.cpp
+++ b/exotica_examples/test/test_problems.cpp
@@ -46,8 +46,8 @@ enum GTestColor
 };
 #endif
 extern void ColoredPrintf(testing::internal::GTestColor color, const char* fmt, ...);
-}
-}
+}  // namespace internal
+}  // namespace testing
 #define PRINTF(...)                                                                        \
     do                                                                                     \
     {                                                                                      \

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -663,8 +663,8 @@ public:
         return hessian_array<Hessian::Scalar::Scalar>(src);
     }
 };
-}
-}  // namespace pybind11::detail
+}  // namespace detail
+}  // namespace pybind11
 
 PYBIND11_MODULE(_pyexotica, module)
 {


### PR DESCRIPTION
3.9 is not available on 20.04. 6.0 is available on both 18.04 and 20.04.

Upgrading to a newer version (e.g. 10) breaks the include order requirement for Pinocchio by reordering includes separated by new lines. This would break compilation.