### PR TITLE
Clang support and bug fixes

### DIFF
--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/collision_distance.h
@@ -63,7 +63,7 @@ private:
     int dim_;
     CollisionScenePtr cscene_;
 
-    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
+    void UpdateInternal(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/smooth_collision_distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/smooth_collision_distance.h
@@ -60,7 +60,7 @@ private:
     const unsigned int dim_ = 1;
     CollisionScenePtr cscene_;
 
-    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
+    void UpdateInternal(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/include/exotica_core_task_maps/variable_size_collision_distance.h
+++ b/exotations/exotica_core_task_maps/include/exotica_core_task_maps/variable_size_collision_distance.h
@@ -55,7 +55,7 @@ private:
     std::size_t dim_;
     CollisionScenePtr cscene_;
 
-    void Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
+    void UpdateInternal(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian = true);
 };
 }  // namespace exotica
 

--- a/exotations/exotica_core_task_maps/src/collision_distance.cpp
+++ b/exotations/exotica_core_task_maps/src/collision_distance.cpp
@@ -38,7 +38,7 @@ void CollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi
     if (phi.rows() != dim_) ThrowNamed("Wrong size of phi!");
     phi.setZero();
     Eigen::MatrixXd J(dim_, dim_);
-    Update(x, phi, J, false);
+    UpdateInternal(x, phi, J, false);
 }
 
 void CollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
@@ -46,10 +46,10 @@ void CollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi
     if (phi.rows() != dim_) ThrowNamed("Wrong size of phi!");
     phi.setZero();
     J.setZero();
-    Update(x, phi, J, true);
+    UpdateInternal(x, phi, J, true);
 }
 
-void CollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian)
+void CollisionDistance::UpdateInternal(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian)
 {
     if (!scene_->AlwaysUpdatesCollisionScene())
         cscene_->UpdateCollisionObjectTransforms();

--- a/exotations/exotica_core_task_maps/src/smooth_collision_distance.cpp
+++ b/exotations/exotica_core_task_maps/src/smooth_collision_distance.cpp
@@ -39,7 +39,7 @@ void SmoothCollisionDistance::Update(Eigen::VectorXdRefConst x,
     if (phi.rows() != dim_) ThrowNamed("Wrong size of phi!");
     phi.setZero();
     Eigen::MatrixXd J(dim_, x.size());
-    Update(x, phi, J, false);
+    UpdateInternal(x, phi, J, false);
 }
 
 void SmoothCollisionDistance::Update(Eigen::VectorXdRefConst x,
@@ -49,13 +49,13 @@ void SmoothCollisionDistance::Update(Eigen::VectorXdRefConst x,
     if (phi.rows() != dim_) ThrowNamed("Wrong size of phi!");
     phi.setZero();
     J.setZero();
-    Update(x, phi, J, true);
+    UpdateInternal(x, phi, J, true);
 }
 
-void SmoothCollisionDistance::Update(Eigen::VectorXdRefConst x,
-                                     Eigen::VectorXdRef phi,
-                                     Eigen::MatrixXdRef J,
-                                     bool updateJacobian)
+void SmoothCollisionDistance::UpdateInternal(Eigen::VectorXdRefConst x,
+                                             Eigen::VectorXdRef phi,
+                                             Eigen::MatrixXdRef J,
+                                             bool updateJacobian)
 {
     if (!scene_->AlwaysUpdatesCollisionScene())
         cscene_->UpdateCollisionObjectTransforms();

--- a/exotations/exotica_core_task_maps/src/variable_size_collision_distance.cpp
+++ b/exotations/exotica_core_task_maps/src/variable_size_collision_distance.cpp
@@ -37,17 +37,17 @@ void VariableSizeCollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::Vec
 {
     if (phi.rows() != static_cast<int>(dim_)) ThrowNamed("Wrong size of phi!");
     Eigen::MatrixXd J;
-    Update(x, phi, J, false);
+    UpdateInternal(x, phi, J, false);
 }
 
 void VariableSizeCollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
 {
     if (phi.rows() != static_cast<int>(dim_)) ThrowNamed("Wrong size of phi!");
     if (J.rows() != static_cast<int>(dim_) || J.cols() != scene_->GetKinematicTree().GetNumControlledJoints()) ThrowNamed("Wrong size of Jacobian!");
-    Update(x, phi, J, true);
+    UpdateInternal(x, phi, J, true);
 }
 
-void VariableSizeCollisionDistance::Update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian)
+void VariableSizeCollisionDistance::UpdateInternal(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J, bool updateJacobian)
 {
     std::vector<CollisionProxy> proxies = cscene_->GetRobotToWorldCollisionDistance(world_margin_);
 

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/aico_solver.h
@@ -78,7 +78,7 @@ public:
 
     ///\brief Solves the problem
     ///@param solution Returned solution trajectory as a vector of joint configurations.
-    void Solve(Eigen::MatrixXd& solution);
+    void Solve(Eigen::MatrixXd& solution) override;
 
     ///\brief Binds the solver to a specific problem which must be pre-initalised
     ///@param pointer Shared pointer to the motion planning problem

--- a/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
+++ b/exotations/solvers/exotica_aico_solver/include/exotica_aico_solver/bayesian_ik_solver.h
@@ -51,7 +51,7 @@ public:
 
     /// \brief Solves the problem
     /// @param solution Returned end pose solution.
-    void Solve(Eigen::MatrixXd& solution);
+    void Solve(Eigen::MatrixXd& solution) override;
 
     /// \brief Binds the solver to a specific problem which must be pre-initalised
     /// @param pointer Shared pointer to the motion planning problem

--- a/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
@@ -144,7 +144,7 @@ void AICOSolver::Solve(Eigen::MatrixXd& solution)
         }
 
         // 0. Check maximum backtrack iterations
-        if (damping && sweep_ >= max_backtrack_iterations_)
+        if (static_cast<bool>(damping) && sweep_ >= max_backtrack_iterations_)
         {
             if (debug_) HIGHLIGHT("Maximum backtrack iterations reached, exiting.");
             prob_->termination_criterion = TerminationCriterion::BacktrackIterationLimit;
@@ -157,7 +157,7 @@ void AICOSolver::Solve(Eigen::MatrixXd& solution)
             // Check convergence if
             //    a) damping is on and the iteration has concluded (the sweep improved the cost)
             //    b) damping is off [each sweep equals one iteration]
-            if ((damping && sweep_improved_cost_) || !damping)
+            if ((static_cast<bool>(damping) && sweep_improved_cost_) || !static_cast<bool>(damping))
             {
                 // 1. Check step tolerance
                 // || x_t-x_t-1 || <= stepTolerance * max(1, || x_t ||)
@@ -391,7 +391,7 @@ void AICOSolver::UpdateTimestep(int t, bool update_fwd, bool update_bwd,
     if (update_fwd) UpdateFwdMessage(t);
     if (update_bwd) UpdateBwdMessage(t);
 
-    if (damping)
+    if (static_cast<bool>(damping))
     {
         Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
         AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * damping_reference_[t]);
@@ -412,7 +412,7 @@ void AICOSolver::UpdateTimestep(int t, bool update_fwd, bool update_bwd,
         if (update_fwd) UpdateFwdMessage(t);
         if (update_bwd) UpdateBwdMessage(t);
 
-        if (damping)
+        if (static_cast<bool>(damping))
         {
             Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
             AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * damping_reference_[t]);
@@ -544,7 +544,7 @@ double AICOSolver::Step()
     best_sweep_ = sweep_;
 
     // If damping (similar to line-search) is being used, consider reverting this step
-    if (damping) PerhapsUndoStep();
+    if (static_cast<bool>(damping)) PerhapsUndoStep();
 
     ++sweep_;
     if (sweep_improved_cost_)

--- a/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/aico_solver.cpp
@@ -144,7 +144,7 @@ void AICOSolver::Solve(Eigen::MatrixXd& solution)
         }
 
         // 0. Check maximum backtrack iterations
-        if (static_cast<bool>(damping) && sweep_ >= max_backtrack_iterations_)
+        if (damping != 0.0 && sweep_ >= max_backtrack_iterations_)
         {
             if (debug_) HIGHLIGHT("Maximum backtrack iterations reached, exiting.");
             prob_->termination_criterion = TerminationCriterion::BacktrackIterationLimit;
@@ -157,7 +157,7 @@ void AICOSolver::Solve(Eigen::MatrixXd& solution)
             // Check convergence if
             //    a) damping is on and the iteration has concluded (the sweep improved the cost)
             //    b) damping is off [each sweep equals one iteration]
-            if ((static_cast<bool>(damping) && sweep_improved_cost_) || !static_cast<bool>(damping))
+            if ((damping != 0.0 && sweep_improved_cost_) || !(damping != 0.0))
             {
                 // 1. Check step tolerance
                 // || x_t-x_t-1 || <= stepTolerance * max(1, || x_t ||)
@@ -391,7 +391,7 @@ void AICOSolver::UpdateTimestep(int t, bool update_fwd, bool update_bwd,
     if (update_fwd) UpdateFwdMessage(t);
     if (update_bwd) UpdateBwdMessage(t);
 
-    if (static_cast<bool>(damping))
+    if (damping != 0.0)
     {
         Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
         AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * damping_reference_[t]);
@@ -412,7 +412,7 @@ void AICOSolver::UpdateTimestep(int t, bool update_fwd, bool update_bwd,
         if (update_fwd) UpdateFwdMessage(t);
         if (update_bwd) UpdateBwdMessage(t);
 
-        if (static_cast<bool>(damping))
+        if (damping != 0.0)
         {
             Binv[t] = Sinv[t] + Vinv[t] + R[t] + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
             AinvBSymPosDef(b[t], Binv[t], Sinv[t] * s[t] + Vinv[t] * v[t] + r[t] + damping * damping_reference_[t]);
@@ -544,7 +544,7 @@ double AICOSolver::Step()
     best_sweep_ = sweep_;
 
     // If damping (similar to line-search) is being used, consider reverting this step
-    if (static_cast<bool>(damping)) PerhapsUndoStep();
+    if (damping != 0.0) PerhapsUndoStep();
 
     ++sweep_;
     if (sweep_improved_cost_)

--- a/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
@@ -126,7 +126,7 @@ void BayesianIKSolver::Solve(Eigen::MatrixXd& solution)
             // Check convergence if
             //    a) damping is on and the iteration has concluded (the sweep improved the cost)
             //    b) damping is off [each sweep equals one iteration]
-            if ((static_cast<bool>(damping) && sweep_improved_cost_) || !static_cast<bool>(damping))
+            if ((damping != 0.0 && sweep_improved_cost_) || !(damping != 0.0))
             {
                 // 1. Check step tolerance
                 // || x_t-x_t-1 || <= stepTolerance * max(1, || x_t ||)
@@ -303,7 +303,7 @@ void BayesianIKSolver::UpdateTimestep(bool update_fwd, bool update_bwd,
     if (update_fwd) UpdateFwdMessage();
     if (update_bwd) UpdateBwdMessage();
 
-    if (static_cast<bool>(damping))
+    if (damping != 0.0)
     {
         Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
         AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * damping_reference_);
@@ -324,7 +324,7 @@ void BayesianIKSolver::UpdateTimestep(bool update_fwd, bool update_bwd,
         if (update_fwd) UpdateFwdMessage();
         if (update_bwd) UpdateBwdMessage();
 
-        if (static_cast<bool>(damping))
+        if (damping != 0.0)
         {
             Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
             AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * damping_reference_);
@@ -396,7 +396,7 @@ double BayesianIKSolver::Step()
     best_sweep_ = sweep_;
 
     // If damping (similar to line-search) is being used, consider reverting this step
-    if (static_cast<bool>(damping)) PerhapsUndoStep();
+    if (damping != 0.0) PerhapsUndoStep();
 
     ++sweep_;
     if (sweep_improved_cost_)

--- a/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
+++ b/exotations/solvers/exotica_aico_solver/src/bayesian_ik_solver.cpp
@@ -126,7 +126,7 @@ void BayesianIKSolver::Solve(Eigen::MatrixXd& solution)
             // Check convergence if
             //    a) damping is on and the iteration has concluded (the sweep improved the cost)
             //    b) damping is off [each sweep equals one iteration]
-            if ((damping && sweep_improved_cost_) || !damping)
+            if ((static_cast<bool>(damping) && sweep_improved_cost_) || !static_cast<bool>(damping))
             {
                 // 1. Check step tolerance
                 // || x_t-x_t-1 || <= stepTolerance * max(1, || x_t ||)
@@ -303,7 +303,7 @@ void BayesianIKSolver::UpdateTimestep(bool update_fwd, bool update_bwd,
     if (update_fwd) UpdateFwdMessage();
     if (update_bwd) UpdateBwdMessage();
 
-    if (damping)
+    if (static_cast<bool>(damping))
     {
         Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
         AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * damping_reference_);
@@ -324,7 +324,7 @@ void BayesianIKSolver::UpdateTimestep(bool update_fwd, bool update_bwd,
         if (update_fwd) UpdateFwdMessage();
         if (update_bwd) UpdateBwdMessage();
 
-        if (damping)
+        if (static_cast<bool>(damping))
         {
             Binv = Sinv + Vinv + R + Eigen::MatrixXd::Identity(prob_->N, prob_->N) * damping;
             AinvBSymPosDef(b, Binv, Sinv * s + Vinv * v + r + damping * damping_reference_);
@@ -396,7 +396,7 @@ double BayesianIKSolver::Step()
     best_sweep_ = sweep_;
 
     // If damping (similar to line-search) is being used, consider reverting this step
-    if (damping) PerhapsUndoStep();
+    if (static_cast<bool>(damping)) PerhapsUndoStep();
 
     ++sweep_;
     if (sweep_improved_cost_)

--- a/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
+++ b/exotations/solvers/exotica_ddp_solver/include/exotica_ddp_solver/feasibility_driven_ddp_solver.h
@@ -52,8 +52,8 @@ protected:
     int NDX_;
     int last_T_ = -1;
 
-    void IncreaseRegularization();
-    void DecreaseRegularization();
+    void IncreaseRegularization() override;
+    void DecreaseRegularization() override;
     const Eigen::Vector2d& ExpectedImprovement();
     void UpdateExpectedImprovement();
     inline bool IsNaN(const double value)

--- a/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
+++ b/exotations/solvers/exotica_time_indexed_rrt_connect_solver/include/exotica_time_indexed_rrt_connect_solver/time_indexed_rrt_connect.h
@@ -170,7 +170,7 @@ public:
         tGoal_.reset(new NN<Motion *>());
     }
 
-    virtual void setup();
+    void setup() override;
 
 protected:
     /// \brief Representation of a motion

--- a/exotica_core/cmake/exotica.cmake
+++ b/exotica_core/cmake/exotica.cmake
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.0.2)
 
 message(STATUS "Compiling using C++ 14 (required by EXOTica)")
 set(CMAKE_CXX_STANDARD 14)
-add_compile_options(-Wfloat-conversion -Wall -Wno-maybe-uninitialized)
+add_compile_options(-Wfloat-conversion -Wall)
+# gcc only: -Wno-maybe-uninitialized
 # add_compile_options(-Werror)
 
 # MoveIt Core Robot Model isnt aligned :'(

--- a/exotica_core/cmake/generate_initializers.py
+++ b/exotica_core/cmake/generate_initializers.py
@@ -207,6 +207,10 @@ public:
         ret += add(d)
     ret += """    }
 
+    virtual ~""" + class_name + """()
+    {
+    }
+
     virtual Initializer GetTemplate() const
     {
         return (Initializer)""" + class_name + """();

--- a/exotica_core/include/exotica_core/kinematic_tree.h
+++ b/exotica_core/include/exotica_core/kinematic_tree.h
@@ -68,7 +68,7 @@ enum JointLimitType
 };
 
 constexpr double inf = std::numeric_limits<double>::infinity();
-constexpr double pi = std::atan(1) * 4;
+constexpr double pi = M_PI;
 
 inline KinematicRequestFlags operator|(KinematicRequestFlags a, KinematicRequestFlags b)
 {

--- a/exotica_core/include/exotica_core/motion_solver.h
+++ b/exotica_core/include/exotica_core/motion_solver.h
@@ -42,9 +42,9 @@ namespace exotica
 class MotionSolver : public Object, Uncopyable, public virtual InstantiableBase
 {
 public:
-    MotionSolver();
+    MotionSolver() = default;
     virtual ~MotionSolver() = default;
-    virtual void InstantiateBase(const Initializer& init);
+    void InstantiateBase(const Initializer& init) override;
     virtual void SpecifyProblem(PlanningProblemPtr pointer);
     virtual void Solve(Eigen::MatrixXd& solution) = 0;
     PlanningProblemPtr GetProblem() const { return problem_; }

--- a/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/bounded_end_pose_problem.h
@@ -44,7 +44,7 @@ public:
     BoundedEndPoseProblem();
     virtual ~BoundedEndPoseProblem();
 
-    virtual void Instantiate(const BoundedEndPoseProblemInitializer& init);
+    void Instantiate(const BoundedEndPoseProblemInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x);
 
     void SetGoal(const std::string& task_name, Eigen::VectorXdRefConst goal);

--- a/exotica_core/include/exotica_core/problems/end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/end_pose_problem.h
@@ -44,7 +44,7 @@ public:
     EndPoseProblem();
     virtual ~EndPoseProblem();
 
-    virtual void Instantiate(const EndPoseProblemInitializer& init);
+    void Instantiate(const EndPoseProblemInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x);
     bool IsValid() override;
 

--- a/exotica_core/include/exotica_core/problems/sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/sampling_problem.h
@@ -43,7 +43,7 @@ public:
     SamplingProblem();
     virtual ~SamplingProblem();
 
-    virtual void Instantiate(const SamplingProblemInitializer& init);
+    void Instantiate(const SamplingProblemInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x);
     bool IsValid(Eigen::VectorXdRefConst x);  // Not overriding on purpose - this updates and calls IsValid

--- a/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
+++ b/exotica_core/include/exotica_core/problems/time_indexed_sampling_problem.h
@@ -43,7 +43,7 @@ public:
     TimeIndexedSamplingProblem();
     virtual ~TimeIndexedSamplingProblem();
 
-    virtual void Instantiate(const TimeIndexedSamplingProblemInitializer& init);
+    void Instantiate(const TimeIndexedSamplingProblemInitializer& init) override;
 
     void Update(Eigen::VectorXdRefConst x, const double& t);
     using PlanningProblem::IsValid;

--- a/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
+++ b/exotica_core/include/exotica_core/problems/unconstrained_end_pose_problem.h
@@ -43,7 +43,7 @@ public:
     UnconstrainedEndPoseProblem();
     virtual ~UnconstrainedEndPoseProblem();
 
-    virtual void Instantiate(const UnconstrainedEndPoseProblemInitializer& init);
+    void Instantiate(const UnconstrainedEndPoseProblemInitializer& init) override;
     void Update(Eigen::VectorXdRefConst x);
 
     bool IsValid() override { return true; }

--- a/exotica_core/include/exotica_core/tasks.h
+++ b/exotica_core/include/exotica_core/tasks.h
@@ -54,6 +54,9 @@ struct TaskIndexing
 
 struct Task
 {
+    Task() = default;
+    virtual ~Task() = default;
+
     virtual void Initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& Phi);
 
     TaskMapMap task_maps;
@@ -71,6 +74,9 @@ protected:
 
 struct TimeIndexedTask : public Task
 {
+    TimeIndexedTask() = default;
+    virtual ~TimeIndexedTask() = default;
+
     virtual void Initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& Phi);
     void UpdateS();
 
@@ -120,6 +126,9 @@ struct TimeIndexedTask : public Task
 
 struct EndPoseTask : public Task
 {
+    EndPoseTask() = default;
+    virtual ~EndPoseTask() = default;
+
     virtual void Initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& Phi);
     void UpdateS();
     void Update(const TaskSpaceVector& big_Phi, Eigen::MatrixXdRefConst big_jacobian, HessianRefConst big_hessian);
@@ -145,6 +154,9 @@ struct EndPoseTask : public Task
 
 struct SamplingTask : public Task
 {
+    SamplingTask() = default;
+    virtual ~SamplingTask() = default;
+
     virtual void Initialize(const std::vector<exotica::Initializer>& inits, std::shared_ptr<PlanningProblem> prob, TaskSpaceVector& Phi);
     void UpdateS();
     void Update(const TaskSpaceVector& big_Phi);

--- a/exotica_core/src/dynamics_solver.cpp
+++ b/exotica_core/src/dynamics_solver.cpp
@@ -32,8 +32,6 @@
 
 namespace exotica
 {
-template class AbstractDynamicsSolver<double, Eigen::Dynamic, Eigen::Dynamic>;
-
 template <typename T, int NX, int NU>
 AbstractDynamicsSolver<T, NX, NU>::AbstractDynamicsSolver() = default;
 
@@ -471,4 +469,5 @@ const Eigen::Matrix<T, NX, NU>& AbstractDynamicsSolver<T, NX, NU>::get_Fu() cons
     return Fu_;
 }
 
+template class AbstractDynamicsSolver<double, Eigen::Dynamic, Eigen::Dynamic>;
 }  // namespace exotica

--- a/exotica_core/src/motion_solver.cpp
+++ b/exotica_core/src/motion_solver.cpp
@@ -41,10 +41,6 @@ void MotionSolver::InstantiateBase(const Initializer& init)
     SetNumberOfMaxIterations(MotionSolverInitializer(init).MaxIterations);
 }
 
-MotionSolver::MotionSolver()
-{
-}
-
 void MotionSolver::SpecifyProblem(PlanningProblemPtr pointer)
 {
     problem_ = pointer;


### PR DESCRIPTION
This PR fixes compilation under Clang. We've previously relied on a gcc quirk that prevented compilation in Clang. I've also gone ahead and fixed various issues, including incorrect overrides, missing/non-virtual destructors, etc.

This likely has an impact on #360 as it fixes Task destruction but I cannot verify without a reproduction case.

Note, the CI only tests gcc right now.