### PR TITLE
Fix segmentation fault on exiting Python

### DIFF
--- a/exotica_core/cmake/generate_initializers.py
+++ b/exotica_core/cmake/generate_initializers.py
@@ -4,21 +4,31 @@ import sys
 import os
 import re
 
+
 def to_camel_cased(name):
-    r = re.compile(r'([_\/:][a-z]|[_\/:][0-9])')
-    ret = ''
+    r = re.compile(r"([_\/:][a-z]|[_\/:][0-9])")
+    ret = ""
     first = True
     tokens = r.split(name, 1)
     while True:
         if len(tokens) > 1:
-            if tokens[1][0] == '_':
+            if tokens[1][0] == "_":
                 if first:
-                    ret += tokens[0][0].upper() + tokens[0][1:].lower() + tokens[1][1].upper()
+                    ret += (
+                        tokens[0][0].upper()
+                        + tokens[0][1:].lower()
+                        + tokens[1][1].upper()
+                    )
                 else:
                     ret += tokens[0].lower() + tokens[1][1].upper()
             else:
                 if first:
-                    ret += tokens[0][0].upper() + tokens[0][1:].lower() + tokens[1][0] + tokens[1][1].upper()
+                    ret += (
+                        tokens[0][0].upper()
+                        + tokens[0][1:].lower()
+                        + tokens[1][0]
+                        + tokens[1][1].upper()
+                    )
                 else:
                     ret += tokens[0].lower() + tokens[1][0] + tokens[1][1].upper()
             tokens = r.split(tokens[2], 1)
@@ -33,16 +43,27 @@ def to_camel_cased(name):
             return ret
         first = False
 
-def to_underscores(name, num_pass = 0):
-    r = re.compile(r'([A-Za-z][0-9]|[0-9][A-z]|[a-z][A-Z]|[A-Z][A-Z][a-z]|[_\/:][A-z])')
-    ret = ''
+
+def to_underscores(name, num_pass=0):
+    r = re.compile(r"([A-Za-z][0-9]|[0-9][A-z]|[a-z][A-Z]|[A-Z][A-Z][a-z]|[_\/:][A-z])")
+    ret = ""
     tokens = r.split(name, 1)
     while True:
         if len(tokens) > 1:
-            if tokens[1][0] == '/' or tokens[1][0] == ':' or tokens[1][0] == '_' or tokens[1][1] == '_':
+            if (
+                tokens[1][0] == "/"
+                or tokens[1][0] == ":"
+                or tokens[1][0] == "_"
+                or tokens[1][1] == "_"
+            ):
                 ret += tokens[0].lower() + tokens[1][0].lower() + tokens[1][1:].lower()
             else:
-                ret += tokens[0].lower() + tokens[1][0].lower() + '_' + tokens[1][1:].lower()
+                ret += (
+                    tokens[0].lower()
+                    + tokens[1][0].lower()
+                    + "_"
+                    + tokens[1][1:].lower()
+                )
             tokens = r.split(tokens[2], 1)
         else:
             ret += tokens[0].lower()
@@ -51,134 +72,198 @@ def to_underscores(name, num_pass = 0):
             else:
                 return ret
 
+
 def eprint(*args, **kwargs):
-    print(*args, file = sys.stderr, **kwargs)
+    print(*args, file=sys.stderr, **kwargs)
+
 
 def eprint(msg):
-    sys.stderr.write(msg+'\n')
+    sys.stderr.write(msg + "\n")
     sys.exit(2)
+
 
 def constructor_argument_list(data):
     ret = ""
     for d in data:
-        if 'Required' in d:
-            ret += " " + d['Type'] + " _" + (d['Name']) + default_argument_value(d) + ","
+        if "Required" in d:
+            ret += (
+                " " + d["Type"] + " _" + (d["Name"]) + default_argument_value(d) + ","
+            )
     return ret[0:-1]
 
+
 def constructor_list(data):
-    ret=""
+    ret = ""
     for d in data:
-        if 'Required' in d:
-            ret += ",\n        " + (d['Name']) + "(_" + (d['Name']) + ") "
+        if "Required" in d:
+            ret += ",\n        " + (d["Name"]) + "(_" + (d["Name"]) + ") "
     return ret
 
+
 def default_value(data):
-    if data['Value'] is None:
+    if data["Value"] is None:
         return ""
-    elif data['Value']=='{}':
+    elif data["Value"] == "{}":
         return ""
     else:
-        return data['Value']
+        return data["Value"]
+
 
 def default_argument_value(data):
-    if data['Value'] == None:
+    if data["Value"] == None:
         return ""
     else:
-        return " = "+data['Value']
+        return " = " + data["Value"]
+
 
 def is_required(data):
-    if data['Required']:
+    if data["Required"]:
         return "true"
     else:
         return "false"
 
+
 def default_constructor_list(data):
     ret = ""
     for d in data:
-        if 'Required' in d and not d['Required']:
-            ret += ",\n        " + (d['Name']) + "("+default_value(d) + ") "
+        if "Required" in d and not d["Required"]:
+            ret += ",\n        " + (d["Name"]) + "(" + default_value(d) + ") "
     return ret
+
 
 def needs_default_constructor(data):
     for d in data:
-        if d['Required']:
+        if d["Required"]:
             return True
     return False
 
+
 def declaration(data):
-    if 'Required' in data:
-      return "    " + data['Type'] + " " + (data['Name']) + ";\n"
+    if "Required" in data:
+        return "    " + data["Type"] + " " + (data["Name"]) + ";\n"
     else:
-      return ""
+        return ""
+
 
 def parser(type_in):
     parser = ""
-    if type_in == 'std::string':
+    if type_in == "std::string":
         return "boost::any_cast<" + type_in + ">(prop.Get())"
-    elif type_in == 'exotica::Initializer' or type_in == 'Initializer':
+    elif type_in == "exotica::Initializer" or type_in == "Initializer":
         return "prop.IsInitializerVectorType()?boost::any_cast<std::vector<exotica::Initializer>>(prop.Get()).at(0):boost::any_cast<exotica::Initializer>(prop.Get())"
-    elif type_in == 'std::vector<Initializer>' or type_in == 'std::vector<exotica::Initializer>':
+    elif (
+        type_in == "std::vector<Initializer>"
+        or type_in == "std::vector<exotica::Initializer>"
+    ):
         return "boost::any_cast<std::vector<exotica::Initializer>>(prop.Get())"
-    elif type_in == 'Eigen::VectorXd':
+    elif type_in == "Eigen::VectorXd":
         parser = "ParseVector<double,Eigen::Dynamic>"
-    elif type_in == 'Eigen::Vector4d':
+    elif type_in == "Eigen::Vector4d":
         parser = "ParseVector<double,4>"
-    elif type_in == 'Eigen::Vector3d':
+    elif type_in == "Eigen::Vector3d":
         parser = "ParseVector<double,3>"
-    elif type_in == 'Eigen::Vector2d':
-        parser = 'ParseVector<double,2>'
-    elif type_in == 'Eigen::VectorXi':
+    elif type_in == "Eigen::Vector2d":
+        parser = "ParseVector<double,2>"
+    elif type_in == "Eigen::VectorXi":
         parser = "ParseVector<int,Eigen::Dynamic>"
-    elif type_in == 'bool':
+    elif type_in == "bool":
         parser = "ParseBool"
-    elif type_in == 'double':
+    elif type_in == "double":
         parser = "ParseDouble"
-    elif type_in == 'int':
+    elif type_in == "int":
         parser = "ParseInt"
-    elif type_in == 'std::vector<std::string>':
+    elif type_in == "std::vector<std::string>":
         parser = "ParseList"
-    elif type_in == 'std::vector<int>':
+    elif type_in == "std::vector<int>":
         parser = "ParseIntList"
-    elif type_in == 'std::vector<bool>':
+    elif type_in == "std::vector<bool>":
         parser = "ParseBoolList"
     else:
         eprint("Unknown data type '" + type_in + "'")
         sys.exit(2)
 
-    return "prop.IsStringType()?" + parser + "(boost::any_cast<std::string>(prop.Get())):boost::any_cast<" + type_in + ">(prop.Get())"
+    return (
+        "prop.IsStringType()?"
+        + parser
+        + "(boost::any_cast<std::string>(prop.Get())):boost::any_cast<"
+        + type_in
+        + ">(prop.Get())"
+    )
 
 
 def copy(data):
-    if 'Required' in data:
-      return "        ret.properties_.emplace(\""+data['Name']+"\", Property(\""+data['Name']+"\", "+is_required(data)+", boost::any("+(data['Name'])+")));\n"
+    if "Required" in data:
+        return (
+            '        ret.properties_.emplace("'
+            + data["Name"]
+            + '", Property("'
+            + data["Name"]
+            + '", '
+            + is_required(data)
+            + ", "
+            + (data["Name"])
+            + "));\n"
+        )
     else:
-      return ""
+        return ""
+
 
 def add(data):
-    if 'Required' in data:
-      return "        if (other.HasProperty(\"" + data['Name'] + "\")) {const Property& prop=other.properties_.at(\"" + data['Name'] + "\"); if(prop.IsSet()) " + (data['Name']) + " = " + parser(data['Type']) + ";}\n"
+    if "Required" in data:
+        return (
+            '        if (other.HasProperty("'
+            + data["Name"]
+            + '")) { const Property& prop = other.properties_.at("'
+            + data["Name"]
+            + '"); if(prop.IsSet()) {'
+            + (data["Name"])
+            + " = "
+            + parser(data["Type"])
+            + ";} }\n"
+        )
     else:
-      return ""
+        return ""
+
 
 def check(data, name):
-    if 'Required' in data and data['Required']:
-      return "        if(!other.HasProperty(\"" + data['Name'] + "\") || !other.properties_.at(\"" + data['Name'] + "\").IsSet()) ThrowPretty(\"Initializer " + name + " requires property " + data['Name'] + " to be set!\");\n"
+    if "Required" in data and data["Required"]:
+        return (
+            '        if(!other.HasProperty("'
+            + data["Name"]
+            + '") || !other.properties_.at("'
+            + data["Name"]
+            + '").IsSet()) ThrowPretty("Initializer '
+            + name
+            + " requires property "
+            + data["Name"]
+            + ' to be set!");\n'
+        )
     else:
-      return ""
-
+        return ""
 
 
 def construct(namespace, class_name_orig, data, include):
     class_name = class_name_orig + "Initializer"
-    ret = """// This file was automatically generated. Do not edit this file!
-#ifndef INITIALIZER_""" + namespace.upper() + "_" + to_underscores(class_name).upper() + """_H
-#define INITIALIZER_""" + namespace.upper() + "_" + to_underscores(class_name).upper() + """_H
+    ret = (
+        """// This file was automatically generated. Do not edit this file!
+#ifndef INITIALIZER_"""
+        + namespace.upper()
+        + "_"
+        + to_underscores(class_name).upper()
+        + """_H
+#define INITIALIZER_"""
+        + namespace.upper()
+        + "_"
+        + to_underscores(class_name).upper()
+        + """_H
 
 #include <exotica_core/property.h>
 
 namespace exotica
 {
-inline std::vector<Initializer> Get"""+to_camel_cased(namespace)+"""Initializers();
+inline std::vector<Initializer> Get"""
+        + to_camel_cased(namespace)
+        + """Initializers();
 }
 
 namespace exotica
@@ -187,45 +272,70 @@ namespace exotica
 class """ + class_name + " : public InitializerBase"+"""
 {
 public:
-    static std::string GetContainerName() {return """+"\"exotica/"+class_name_orig+"\""+ """ ;}
+    static std::string GetContainerName() { return """
+        + '"exotica/'
+        + class_name_orig
+        + '"'
+        + """; }
 
     """
+    )
     if needs_default_constructor(data):
-        ret += class_name + "() : InitializerBase()" + default_constructor_list(data) + """
+        ret += (
+            class_name
+            + "() : InitializerBase()"
+            + default_constructor_list(data)
+            + """
     {
     }
 
     """
-    ret += class_name + "(" + constructor_argument_list(data) + ") : InitializerBase()" + constructor_list(data) + """
+        )
+    ret += (
+        class_name
+        + "("
+        + constructor_argument_list(data)
+        + ") : InitializerBase()"
+        + constructor_list(data)
+        + """
     {
     }
 
     """ + class_name + """(const Initializer& other) : """ + class_name + """()
     {
 """
+    )
     for d in data:
         ret += add(d)
-    ret += """    }
+    ret += (
+        """    }
 
-    virtual ~""" + class_name + """()
+    virtual ~"""
+        + class_name
+        + """()
     {
     }
 
     virtual Initializer GetTemplate() const
     {
-        return (Initializer)""" + class_name + """();
+        return (Initializer)"""
+        + class_name
+        + """();
     }
 
     virtual std::vector<Initializer> GetAllTemplates() const
     {
-        return Get""" + to_camel_cased(namespace) + """Initializers();
+        return Get"""
+        + to_camel_cased(namespace)
+        + """Initializers();
     }
 
     virtual void Check(const Initializer& other) const
     {
 """
+    )
     for d in data:
-        ret += check(d,class_name)
+        ret += check(d, class_name)
     ret += """    }
 
     operator Initializer()
@@ -240,18 +350,26 @@ public:
 """
     for d in data:
         ret += declaration(d)
-    ret += "};" + """
+    ret += (
+        "};"
+        + """
 
 }
 
-#include<""" + namespace + "/" + namespace + """_initializers_numerator.h>
+#include <"""
+        + namespace
+        + "/"
+        + namespace
+        + """_initializers_numerator.h>
 
 """
+    )
     for i in include:
-        ret += "#include <"+i+".h>\n"
+        ret += "#include <" + i + ".h>\n"
     ret += """
 #endif"""
     return ret
+
 
 def parse_line(line, line_number, function_name):
     # ignore lines with comments, otherwise comments including ';' will not be recognised
@@ -266,17 +384,26 @@ def parse_line(line, line_number, function_name):
         if last >= 0:
             line = line[0:last].strip()
         else:
-            line=line.strip()
+            line = line.strip()
 
     if len(line) == 0:
         return None
 
-    if line.startswith('include'):
-        return {'Include' : line[7:].strip().strip(">").strip("<").strip('"'), 'Code' : line.strip()}
+    if line.startswith("include"):
+        return {
+            "Include": line[7:].strip().strip(">").strip("<").strip('"'),
+            "Code": line.strip(),
+        }
     if line.startswith("extend"):
-        return {'Extends' : line[6:].strip().strip(">").strip("<").strip('"'), 'Code' : line.strip()}
+        return {
+            "Extends": line[6:].strip().strip(">").strip("<").strip('"'),
+            "Code": line.strip(),
+        }
     if line.startswith("class"):
-        return {'ClassName' : line[5:].strip().strip(">").strip("<").strip('"'), 'Code' : line.strip()}
+        return {
+            "ClassName": line[5:].strip().strip(">").strip("<").strip('"'),
+            "Code": line.strip(),
+        }
 
     if last == -1:
         eprint("Can't find ';' in '" + function_name + "', on line " + str(line_number))
@@ -288,7 +415,12 @@ def parse_line(line, line_number, function_name):
     elif line.startswith("Optional"):
         required = False
     else:
-        eprint("Can't parse 'Required/Optional' tag in '" + function_name + "', on line " + str(line_number))
+        eprint(
+            "Can't parse 'Required/Optional' tag in '"
+            + function_name
+            + "', on line "
+            + str(line_number)
+        )
         sys.exit(2)
 
     value = None
@@ -298,7 +430,7 @@ def parse_line(line, line_number, function_name):
         eq = line.find("=")
         has_default_arg = not (eq == -1)
         if has_default_arg:
-            value = line[eq + 1:last]
+            value = line[eq + 1 : last]
         else:
             # we need this to get the parameter name
             eq = last
@@ -312,7 +444,8 @@ def parse_line(line, line_number, function_name):
         name = line[name_start:last].strip()
         field_type = line[9:name_start].strip()
 
-    return {'Required' : required, 'Type' : field_type, 'Name' : name, 'Value' : value}
+    return {"Required": required, "Type": field_type, "Name": name, "Value": value}
+
 
 def parse_file(file_name):
     with open(file_name) as f:
@@ -327,31 +460,38 @@ def parse_file(file_name):
         i = i + 1
         d = parse_line(l, i, file_name)
         if d != None:
-            if 'Required' in d:
-                if d['Required'] == False:
+            if "Required" in d:
+                if d["Required"] == False:
                     optionalOnly = True
                 else:
                     if optionalOnly:
-                        eprint("Required properties_ have to come before Optional ones, in '" + file_name + "', on line " + str(i))
+                        eprint(
+                            "Required properties_ have to come before Optional ones, in '"
+                            + file_name
+                            + "', on line "
+                            + str(i)
+                        )
                         sys.exit(2)
                 data.append(d)
-            if 'Include' in d:
-                include.append(d['Include'])
-            if 'Extends' in d:
-                extends.append(d['Extends'])
-            if 'ClassName' in d:
-                names.append(d['ClassName'])
+            if "Include" in d:
+                include.append(d["Include"])
+            if "Extends" in d:
+                extends.append(d["Extends"])
+            if "ClassName" in d:
+                names.append(d["ClassName"])
     if len(names) != 1:
         eprint("Could not parse initializer class name in '" + file_name + "'!")
         eprint(names)
         sys.exit(2)
-    return {'Data' : data, 'Include' : include, 'Extends' : extends, 'ClassName' : names[0]}
+    return {"Data": data, "Include": include, "Extends": extends, "ClassName": names[0]}
+
 
 def contains_data(type_name, name, list_in):
     for d in list_in:
-        if d['Type'] == type_name and d['Name'] == name:
-            return d['Class']
+        if d["Type"] == type_name and d["Name"] == name:
+            return d["Class"]
     return False
+
 
 def contains_include(name, list_in):
     for d in list_in:
@@ -359,89 +499,108 @@ def contains_include(name, list_in):
             return True
     return False
 
+
 def contains_extends(name, list_in):
     for d in list_in:
         if d == name:
             return True
     return False
 
+
 def collect_extensions(input_files, search_dirs, content):
     file_content = parse_file(input_files)
-    class_name = file_content['ClassName']
-    if 'Extends' in file_content:
-        for e in file_content['Extends']:
-            if not contains_extends(e, content['Extends']):
+    class_name = file_content["ClassName"]
+    if "Extends" in file_content:
+        for e in file_content["Extends"]:
+            if not contains_extends(e, content["Extends"]):
                 file_name = None
-                ext = e.split('/')
+                ext = e.split("/")
                 for d in search_dirs:
-                    ff = d + '/share/' + ext[0] + '/init/' + ext[1] + '.in'
+                    ff = d + "/share/" + ext[0] + "/init/" + ext[1] + ".in"
                     if os.path.isfile(ff):
                         file_name = ff
                         break
                 if not file_name:
                     eprint("Cannot find extension '" + e + "'!")
-                content['Extends'].append(e)
+                content["Extends"].append(e)
                 content = collect_extensions(file_name, search_dirs, content)
 
-    if 'Data' in file_content:
-      for d in file_content['Data']:
-          cls = contains_data(d['Type'], d['Name'], content['Data'])
-          if cls:
-              for e in content['Data']:
-                if e['Name'] == d['Name']:
-                  e['Value'] = d['Value']
-          else:
-              d['Class'] = class_name
-              content['Data'].append(d)
-    if 'Include' in file_content:
-        for i in file_content['Include']:
-            if not contains_include(i, content['Include']):
-                content['Include'].append(i)
+    if "Data" in file_content:
+        for d in file_content["Data"]:
+            cls = contains_data(d["Type"], d["Name"], content["Data"])
+            if cls:
+                for e in content["Data"]:
+                    if e["Name"] == d["Name"]:
+                        e["Value"] = d["Value"]
+            else:
+                d["Class"] = class_name
+                content["Data"].append(d)
+    if "Include" in file_content:
+        for i in file_content["Include"]:
+            if not contains_include(i, content["Include"]):
+                content["Include"].append(i)
 
-    content['ClassName'] = class_name
+    content["ClassName"] = class_name
     return content
+
 
 def sort_data(data):
     a = []
     b = []
     for d in data:
-        if d['Required']:
+        if d["Required"]:
             a.append(d)
         else:
             b.append(d)
     return a + b
 
+
 def generate(input_files, output_files, namespace, search_dirs, devel_dir):
     print("Generating " + output_files)
-    content = collect_extensions(input_files, search_dirs, {'Data' : [], 'Include' : [], 'Extends' : []})
-    txt = construct(namespace, content['ClassName'], sort_data(content['Data']), content['Include'])
+    content = collect_extensions(
+        input_files, search_dirs, {"Data": [], "Include": [], "Extends": []}
+    )
+    txt = construct(
+        namespace, content["ClassName"], sort_data(content["Data"]), content["Include"]
+    )
     path = os.path.dirname(output_files)
     if not os.path.exists(path):
         os.makedirs(path)
     with open(output_files, "w") as f:
         f.write(txt)
-    return content['ClassName']
+    return content["ClassName"]
+
 
 def create_class_init_header(class_inits, file_name):
-    ret = """// This file was automatically generated. Do not edit this file!
-#ifndef INITIALIZE_PROJECT_HEADER_""" + namespace.upper() + """_H_$
-#define INITIALIZE_PROJECT_HEADER_""" + namespace.upper() + """_H_$
+    ret = (
+        """// This file was automatically generated. Do not edit this file!
+#ifndef INITIALIZE_PROJECT_HEADER_"""
+        + namespace.upper()
+        + """_H_$
+#define INITIALIZE_PROJECT_HEADER_"""
+        + namespace.upper()
+        + """_H_$
 
 #include <exotica_core/property.h>
 """
+    )
     for init in class_inits:
-        ret += '#include <' + namespace + '/' + init[0] + '_initializer.h>\n'
-    ret += """
+        ret += "#include <" + namespace + "/" + init[0] + "_initializer.h>\n"
+    ret += (
+        """
 
 namespace exotica
 {
 
-inline std::vector<Initializer> Get""" + to_camel_cased(namespace) + """Initializers()
+inline std::vector<Initializer> Get"""
+        + to_camel_cased(namespace)
+        + """Initializers()
 {
     std::vector<Initializer> ret;
 """
+    )
     for init in class_inits:
-        ret += '    ret.push_back(' + init[1] + 'Initializer().GetTemplate());\n'
+        ret += "    ret.push_back(" + init[1] + "Initializer().GetTemplate());\n"
     ret += """   return ret;
 }
 
@@ -455,22 +614,23 @@ inline std::vector<Initializer> Get""" + to_camel_cased(namespace) + """Initiali
     with open(file_name, "w") as f:
         f.write(ret)
 
+
 if __name__ == "__main__":
     if len(sys.argv) > 5:
         offset = 5
         n = int((len(sys.argv) - offset) / 2)
         namespace = sys.argv[1]
-        search_dirs = sys.argv[2].split(':')
+        search_dirs = sys.argv[2].split(":")
         devel_dir = sys.argv[3]
         class_inits_header_file = sys.argv[4]
-        if not os.path.exists(devel_dir + '/init'):
-            os.makedirs(devel_dir + '/init')
+        if not os.path.exists(devel_dir + "/init"):
+            os.makedirs(devel_dir + "/init")
 
         for i in range(0, n):
             input_files = sys.argv[offset + i]
             class_name = os.path.basename(sys.argv[offset + i][0:-3])
             with open(input_files, "r") as fi:
-                with open(devel_dir + '/init/' + class_name + '.in', "w") as f:
+                with open(devel_dir + "/init/" + class_name + ".in", "w") as f:
                     f.write(fi.read())
 
         class_inits = []
@@ -478,9 +638,16 @@ if __name__ == "__main__":
             input_files = sys.argv[offset + i]
             output_files = sys.argv[offset + n + i]
             class_file_name = os.path.basename(sys.argv[offset + i][0:-3])
-            class_inits.append((class_file_name, generate(input_files, output_files, namespace, search_dirs, devel_dir)))
+            class_inits.append(
+                (
+                    class_file_name,
+                    generate(
+                        input_files, output_files, namespace, search_dirs, devel_dir
+                    ),
+                )
+            )
 
         create_class_init_header(class_inits, class_inits_header_file)
     else:
-      eprint("Initializer generation failure: invalid arguments!")
-      sys.exit(1)
+        eprint("Initializer generation failure: invalid arguments!")
+        sys.exit(1)

--- a/exotica_core/cmake/generate_initializers.py
+++ b/exotica_core/cmake/generate_initializers.py
@@ -200,9 +200,9 @@ def copy(data):
             + data["Name"]
             + '", '
             + is_required(data)
-            + ", "
+            + ", boost::any("
             + (data["Name"])
-            + "));\n"
+            + ")));\n"
         )
     else:
         return ""
@@ -269,7 +269,10 @@ inline std::vector<Initializer> Get"""
 namespace exotica
 {
 
-class """ + class_name + " : public InitializerBase"+"""
+class """
+        + class_name
+        + " : public InitializerBase"
+        + """
 {
 public:
     static std::string GetContainerName() { return """
@@ -301,7 +304,11 @@ public:
     {
     }
 
-    """ + class_name + """(const Initializer& other) : """ + class_name + """()
+    """
+        + class_name
+        + """(const Initializer& other) : """
+        + class_name
+        + """()
     {
 """
     )

--- a/exotica_core/cmake/initializer_project_header.h.in
+++ b/exotica_core/cmake/initializer_project_header.h.in
@@ -2,12 +2,11 @@
 #ifndef INITIALIZEPROJECTHEADER_${PROJECT_NAME}_H_
 #define INITIALIZEPROJECTHEADER_${PROJECT_NAME}_H_
 
-#include<exotica_core/property.h>
+#include <exotica_core/property.h>
 ${_InitializerClassesIncludes}
 
 namespace exotica
 {
-
 inline std::vector<Initializer> get${PROJECT_NAME}Initializers()
 {
     std::vector<Initializer> ret;
@@ -15,7 +14,6 @@ inline std::vector<Initializer> get${PROJECT_NAME}Initializers()
 
     return ret;
 }
-
-}
+}  // namespace exotica
 
 #endif \\ INITIALIZEPROJECTHEADER_${PROJECT_NAME}_H_

--- a/exotica_core/include/exotica_core/property.h
+++ b/exotica_core/include/exotica_core/property.h
@@ -58,7 +58,7 @@ public:
     bool IsSet() const;
     bool IsStringType() const;
     bool IsInitializerVectorType() const;
-    std::string GetName() const;
+    const std::string& GetName() const;
     std::string GetType() const;
 
 private:
@@ -73,7 +73,7 @@ public:
     Initializer();
     Initializer(const std::string& name);
     Initializer(const std::string& name, const std::map<std::string, boost::any>& properties);
-    std::string GetName() const;
+    const std::string& GetName() const;
     void SetName(const std::string& name);
     void AddProperty(const Property& prop);
     boost::any GetProperty(const std::string& name) const;
@@ -88,6 +88,8 @@ public:
 class InitializerBase
 {
 public:
+    InitializerBase() = default;
+    virtual ~InitializerBase() = default;
     virtual void Check(const Initializer& other) const = 0;
     virtual Initializer GetTemplate() const = 0;
     virtual std::vector<Initializer> GetAllTemplates() const = 0;
@@ -96,6 +98,8 @@ public:
 class InstantiableBase
 {
 public:
+    InstantiableBase() = default;
+    virtual ~InstantiableBase() = default;
     virtual Initializer GetInitializerTemplate() = 0;
     virtual void InstantiateInternal(const Initializer& init) = 0;
     virtual void InstantiateBase(const Initializer& init) {}
@@ -106,7 +110,7 @@ template <class C, typename = typename std::enable_if<std::is_base_of<Initialize
 class Instantiable : public virtual InstantiableBase
 {
 public:
-    virtual void InstantiateInternal(const Initializer& init)
+    void InstantiateInternal(const Initializer& init) override
     {
         InstantiateBase(init);
         const C tmp(init);
@@ -114,12 +118,12 @@ public:
         Instantiate(tmp);
     }
 
-    virtual Initializer GetInitializerTemplate()
+    Initializer GetInitializerTemplate() override
     {
         return C().GetTemplate();
     }
 
-    virtual std::vector<Initializer> GetAllTemplates() const
+    std::vector<Initializer> GetAllTemplates() const override
     {
         return C().GetAllTemplates();
     }

--- a/exotica_core/include/exotica_core/tools.h
+++ b/exotica_core/include/exotica_core/tools.h
@@ -41,9 +41,17 @@
 #include <exotica_core/tools/uncopyable.h>
 #include <exotica_core/version.h>
 
-#include <geometric_shapes/shapes.h>
-#include <octomap/OcTree.h>
 #include <std_msgs/ColorRGBA.h>
+
+// Forward declarations
+namespace octomap
+{
+class OcTree;
+}
+namespace shapes
+{
+class Shape;
+}
 
 /**
  * \brief A double-wrapper MACRO functionality for generating unique object names: The actual functionality is provided by EX_UNIQ (for 'exotica unique')

--- a/exotica_core/src/property.cpp
+++ b/exotica_core/src/property.cpp
@@ -40,12 +40,12 @@ namespace exotica
 boost::any Property::Get() const { return value_; }
 Property::Property(const std::string& prop_name) : name_(prop_name), required_(true) {}
 Property::Property(const std::string& prop_name, bool is_required) : name_(prop_name), required_(is_required) {}
-Property::Property(const std::string& prop_name, bool is_required, boost::any val) : name_(prop_name), required_(is_required) { value_ = val; }
+Property::Property(const std::string& prop_name, bool is_required, boost::any val) : name_(prop_name), required_(is_required), value_(val) {}
 bool Property::IsRequired() const { return required_; }
 bool Property::IsSet() const { return !value_.empty(); }
 bool Property::IsStringType() const { return value_.type() == typeid(std::string); }
 bool Property::IsInitializerVectorType() const { return value_.type() == typeid(std::vector<exotica::Initializer>); }
-std::string Property::GetName() const { return name_; }
+const std::string& Property::GetName() const { return name_; }
 std::string Property::GetType() const { return GetTypeName(value_.type()); }
 Property::Property(std::initializer_list<boost::any> _val)
 {
@@ -72,7 +72,7 @@ Initializer::Initializer(const std::string& name, const std::map<std::string, bo
     }
 }
 
-std::string Initializer::GetName() const
+const std::string& Initializer::GetName() const
 {
     return name_;
 }

--- a/exotica_core/src/tools.cpp
+++ b/exotica_core/src/tools.cpp
@@ -34,6 +34,8 @@
 #include <regex>
 #include <typeinfo>  // The run-time type information (RTTI) Functionality of C++
 
+#include <geometric_shapes/shapes.h>
+#include <octomap/OcTree.h>
 #include "exotica_core/tools.h"
 
 #include <ros/package.h>

--- a/exotica_examples/resources/configs/dynamic_time_indexed/07_control_limited_ddp_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/07_control_limited_ddp_cartpole.xml
@@ -19,7 +19,6 @@
                         <ControlLimitsLow>-10</ControlLimitsLow>
                         <ControlLimitsHigh>10</ControlLimitsHigh>
                         <dt>0.02</dt>
-                        <!-- <Integrator>RK1</Integrator> -->
                     </CartpoleDynamicsSolver>
                 </DynamicsSolver>
             </Scene>

--- a/exotica_examples/resources/configs/dynamic_time_indexed/21_sparse_ddp_cartpole.xml
+++ b/exotica_examples/resources/configs/dynamic_time_indexed/21_sparse_ddp_cartpole.xml
@@ -24,7 +24,7 @@
                 <SRDF>{exotica_cartpole_dynamics_solver}/resources/cartpole.srdf</SRDF>
                 <SetRobotDescriptionRosParams>1</SetRobotDescriptionRosParams>
                 <DynamicsSolver>
-                    <CartpoleDynamicsSolver Name="solver" Integrator="SymplecticEuler">
+                    <CartpoleDynamicsSolver Name="solver">
                         <ControlLimitsLow>  -30.0</ControlLimitsLow>
                         <ControlLimitsHigh>  30.0</ControlLimitsHigh>
                         <dt>0.01</dt>

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -175,12 +175,12 @@ void AddInitializers(py::module& module)
     py::module inits = module.def_submodule("Initializers", "Initializers for core EXOTica classes.");
     inits.def("Initializer", &CreateInitializer);
     std::vector<Initializer> initializers = Setup::GetInitializers();
-    for (Initializer& i : initializers)
+    for (const Initializer& i : initializers)
     {
-        std::string full_name = i.GetName();
-        std::string name = full_name.substr(8);  // This removes the prefix "exotica/"
+        const std::string full_name = i.GetName();
+        const std::string name = full_name.substr(8);  // This removes the prefix "exotica/"
         known_initializers[full_name] = CreateInitializer(i);
-        inits.def((name + "Initializer").c_str(), [i]() { return CreateInitializer(i); }, (name + "Initializer constructor.").c_str());
+        inits.def((name + "Initializer").c_str(), [full_name]() { return CreateInitializer(known_initializers[full_name]); }, (name + "Initializer constructor.").c_str());
     }
 
     inits.def("load_xml", (Initializer(*)(std::string, bool)) & XMLLoader::Load, "Loads initializer from XML", py::arg("xml"), py::arg("parseAsXMLString") = false);
@@ -1589,6 +1589,7 @@ PYBIND11_MODULE(_pyexotica, module)
     AddInitializers(module);
 
     auto cleanup_exotica = []() {
+        known_initializers.clear();
         Setup::Destroy();
     };
     module.add_object("_cleanup", py::capsule(cleanup_exotica));

--- a/exotica_python/src/pyexotica.cpp
+++ b/exotica_python/src/pyexotica.cpp
@@ -40,6 +40,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <octomap/OcTree.h>
 #include <ros/package.h>
 
 #include <unsupported/Eigen/CXX11/Tensor>


### PR DESCRIPTION
This PR fixes the the long-prevailing segmentation fault at the end of a Python process which includes Exotica. The source of the issue was a destructor order in `Property` which is key for the `Initializer`s: The `boost::any` destructor particularly in conjunction with Eigen types did not exit cleanly. Processes finish faster (!) and cleaner now without a segmentation fault. I also moved the OcTree header (a large header-only type) to the implementation which reduces overall compile time considerably.