### PR TITLE
[exotica_python] Fail nicely when pip installed trimesh isnt available

### DIFF
--- a/exotica_python/package.xml
+++ b/exotica_python/package.xml
@@ -20,6 +20,10 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pyassimp</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tk</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-trimesh-pip</test_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-trimesh-pip</test_depend>
+  <!--
+    pip keys cannot be used for releases on the buildfarm cf. 
+    https://github.com/ros/rosdistro/pull/39892#issuecomment-1985640859
+  -->
+  <!-- <test_depend condition="$ROS_PYTHON_VERSION == 2">python-trimesh-pip</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-trimesh-pip</test_depend> -->
 </package>

--- a/exotica_python/test/test_mesh.py
+++ b/exotica_python/test/test_mesh.py
@@ -1,7 +1,12 @@
 import unittest
 
 import pyexotica as exo
-import trimesh
+try:
+    import trimesh
+except ImportError:
+    import warnings
+    warnings.warn("trimesh not found, skipping test")
+    exit()
 
 def validate_mesh(mesh):
     print(mesh, mesh.vertex_count, mesh.triangle_count)

--- a/exotica_python/test/test_mesh.py
+++ b/exotica_python/test/test_mesh.py
@@ -1,23 +1,28 @@
 import unittest
 
 import pyexotica as exo
+
 try:
     import trimesh
 except ImportError:
-    import warnings
-    warnings.warn("trimesh not found, skipping test")
-    exit()
+    from nose.plugins.skip import SkipTest
+
+    raise SkipTest("trimesh is not available, skipping related tests.")
+
 
 def validate_mesh(mesh):
     print(mesh, mesh.vertex_count, mesh.triangle_count)
     assert mesh.vertex_count == 33
     assert mesh.triangle_count == 62
 
+
 class TestPythonMeshCreation(unittest.TestCase):
     def test_create_mesh_from_resource_package_path(self):
         # Load mesh from resource path
         print(">>> Loading STL directly from package-path")
-        mesh = exo.Mesh.createMeshFromResource("package://exotica_examples/resources/cone.stl")
+        mesh = exo.Mesh.createMeshFromResource(
+            "package://exotica_examples/resources/cone.stl"
+        )
         validate_mesh(mesh)
 
     def test_create_mesh_from_resource_exotica_resource_path(self):
@@ -46,6 +51,7 @@ class TestPythonMeshCreation(unittest.TestCase):
         m = trimesh.load(exo.Tools.parse_path("{exotica_examples}/resources/cone.stl"))
         mesh = exo.Mesh.createMeshFromVertices(m.vertices, m.faces.flatten())
         validate_mesh(mesh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
pip keys cannot be used for release on the buildfarm, hence we fail with a warning when trimesh cannot be found. Also comments the key from package.xml to make release builds possible.